### PR TITLE
fix: optimize dataset items truncation logic

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -43,8 +43,11 @@ export const defaults = {
 
 // Actor output const
 export const ACTOR_OUTPUT_MAX_CHARS_PER_ITEM = 5_000;
-export const ACTOR_OUTPUT_TRUNCATED_MESSAGE = `Output was truncated because it will not fit into context.`
-    + `There is no reason to call this tool again! You can use ${HelperTools.DATASET_GET_ITEMS} tool to get more items from the dataset.`;
+export const ACTOR_OUTPUT_TRUNCATED_MESSAGE = `Output was truncated because it will not fit into context.
+    There is no reason to call this tool again!
+    You can use ${HelperTools.DATASET_GET_ITEMS} tool to get more items from the dataset.
+    The items were truncated from the back, so if using the ${HelperTools.DATASET_GET_ITEMS} tool,
+    you can skip the first N items that you already have.`;
 
 export const ACTOR_ADDITIONAL_INSTRUCTIONS = `Never call/execute tool/Actor unless confirmed by the user.
      Workflow: When an Actor runs, it processes data and stores results in Apify storage,


### PR DESCRIPTION
closes https://github.com/apify/actors-mcp-server/issues/121

Before we just truncated the stringified dataset JSON, which almost always broke the JSON structure and tool result context (not all fields were present). This new logic pops dataset items one by one from the back either until the max character limit is reached or until only one item is remaining. Then, we improve the truncated info message by guiding the LLM to use the truncated count and offset in the get dataset items tool. This logic keeps the JSON structure valid and ensures that the tool/Actor results fit into the LLM context.

Note: Specific/bad Actors may have weird output schemas and can technically dump the whole output into a single huge dataset item, but I think we should not handle this case - the Actor creator should ensure user and LLM friendly output.