### PR TITLE
feat: tools dump

### DIFF
--- a/src/index-internals.ts
+++ b/src/index-internals.ts
@@ -3,10 +3,11 @@
 */
 
 import { defaults, HelperTools } from './const.js';
-import { parseInputParamsFromUrl } from './mcp/utils.js';
-import { addRemoveTools, defaultTools, toolCategories, toolCategoriesEnabledByDefault } from './tools/index.js';
+import { parseInputParamsFromUrl, processParamsGetTools } from './mcp/utils.js';
+import { addRemoveTools, defaultTools, getActorsAsTools, toolCategories, toolCategoriesEnabledByDefault } from './tools/index.js';
 import { actorNameToToolName } from './tools/utils.js';
 import type { ToolCategory } from './types.js';
+import { getToolPublicFieldOnly } from './utils/tools.js';
 
 export {
     parseInputParamsFromUrl,
@@ -18,4 +19,7 @@ export {
     toolCategories,
     toolCategoriesEnabledByDefault,
     type ToolCategory,
+    processParamsGetTools,
+    getActorsAsTools,
+    getToolPublicFieldOnly,
 };

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -30,6 +30,7 @@ import { addRemoveTools, callActorGetDataset, defaultTools, getActorsAsTools, to
 import { actorNameToToolName, decodeDotPropertyNames } from '../tools/utils.js';
 import type { ActorMcpTool, ActorTool, HelperTool, ToolEntry } from '../types.js';
 import { createProgressTracker } from '../utils/progress.js';
+import { getToolPublicFieldOnly } from '../utils/tools.js';
 import { connectMCPClient } from './client.js';
 import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC } from './const.js';
 import { processParamsGetTools } from './utils.js';
@@ -390,7 +391,7 @@ export class ActorsMcpServer {
          * @returns {object} - The response object containing the tools.
          */
         this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-            const tools = Array.from(this.tools.values()).map((tool) => (tool.tool));
+            const tools = Array.from(this.tools.values()).map((tool) => getToolPublicFieldOnly(tool.tool));
             return { tools };
         });
 

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,0 +1,13 @@
+import type { ToolBase } from '../types.js';
+
+/**
+ * Returns a public version of the tool containing only fields that should be exposed publicly.
+ * Used for the tools list request.
+ */
+export function getToolPublicFieldOnly(tool: ToolBase) {
+    return {
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+    };
+}


### PR DESCRIPTION
Exposes required internal functions for the `?dumpJson=1`  query param the we want to add to `apify-mcp-server`.

**Also fixed a potential future issue where we are whole tool objects in the tools list request handler.**

related to https://github.com/apify/actors-mcp-server/issues/185