### PR TITLE
fix: dockerhub init unauth server start and tool list

### DIFF
--- a/src/apify-client.ts
+++ b/src/apify-client.ts
@@ -31,6 +31,7 @@ export class ApifyClient extends _ApifyClient {
          * for server start and listing of tools.
          */
         if (options.token?.toLowerCase() === 'your-apify-token') {
+            // eslint-disable-next-line no-param-reassign
             delete options.token;
         }
 


### PR DESCRIPTION
In order to publish the server to dockerhub it needs to be able to pass their build task. This task build the docker image and starts the container with the server and tries to list the tools, which Apify server was failing at because of the dummy token passed where the Apify API was throwing an error. Changed the logic to delete the dummy token and use the API as unauth which is sufficient for loading the Actor tools and listing.