### PR TITLE
ci: auto set dxt version on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.get_sha.outputs.commit_sha || steps.commit.outputs.commit_long_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
 
         steps:
             -   name: Checkout repository
@@ -91,7 +91,6 @@ jobs:
 
             -   name: Get commit SHA
                 id: get_sha
-                if: steps.commit.outputs.commit_long_sha != ''
                 run: echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
     create_github_release:
@@ -101,9 +100,17 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
+            -   name: Validate commit SHA
+                run: |
+                    COMMIT_SHA="${{ needs.update_changelog.changelog_commitish }}"
+                    if [ -z "$COMMIT_SHA" ]; then
+                        echo "ERROR: changelog_commitish is empty!"
+                        exit 1
+                    fi
+                    echo "Using commit SHA: $COMMIT_SHA"
             -   uses: actions/checkout@v4
                 with:
-                    ref: ${{ needs.update_changelog.changelog_commitish }}
+                    ref: ${{ needs.update_changelog.changelog_commitish || github.sha }}
             -   name: Log current commit SHA
                 run: |
                     CURRENT_SHA=$(git rev-parse HEAD)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,29 +125,29 @@ jobs:
                     files: |
                         actors-mcp-server.dxt
 
-    publish_to_npm:
-        name: Publish to NPM
-        needs: [ update_changelog ]
-        runs-on: ubuntu-latest
-        steps:
-            -   uses: actions/checkout@v4
-                with:
-                    ref: ${{ needs.update_changelog.changelog_commitish }}
-            -   name: Use Node.js 22
-                uses: actions/setup-node@v4
-                with:
-                    node-version: 22
-                    cache: 'npm'
-                    cache-dependency-path: 'package-lock.json'
-            -   name: Install dependencies
-                run: |
-                    echo "access=public" >> .npmrc
-                    echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-                    npm ci
-            -   name: Build module
-                run: npm run build
-            -   name: Publish to NPM
-                run: npm publish --tag latest
+    #publish_to_npm:
+    #    name: Publish to NPM
+    #    needs: [ update_changelog ]
+    #    runs-on: ubuntu-latest
+    #    steps:
+    #        -   uses: actions/checkout@v4
+    #            with:
+    #                ref: ${{ needs.update_changelog.changelog_commitish }}
+    #        -   name: Use Node.js 22
+    #            uses: actions/setup-node@v4
+    #            with:
+    #                node-version: 22
+    #                cache: 'npm'
+    #                cache-dependency-path: 'package-lock.json'
+    #        -   name: Install dependencies
+    #            run: |
+    #                echo "access=public" >> .npmrc
+    #                echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+    #                npm ci
+    #        -   name: Build module
+    #            run: npm run build
+    #        -   name: Publish to NPM
+    #            run: npm publish --tag latest
 
 env:
     NODE_AUTH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
+            changelog_commitish: ${{ steps.get_sha.outputs.commit_sha }}
 
         steps:
             -   name: Checkout repository
@@ -91,7 +91,16 @@ jobs:
 
             -   name: Get commit SHA
                 id: get_sha
-                run: echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+                run: |
+                    COMMIT_SHA=$(git rev-parse HEAD)
+                    echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+                    echo "Captured SHA: $COMMIT_SHA"
+
+            -   name: Debug final SHA
+                run: |
+                    echo "Final changelog_commitish: ${{ steps.get_sha.outputs.commit_sha }}"
+                    echo "Commit action SHA: ${{ steps.commit.outputs.commit_long_sha }}"
+                    echo "Git HEAD: $(git rev-parse HEAD)"
 
     create_github_release:
         name: Create github release
@@ -110,7 +119,7 @@ jobs:
                     echo "Using commit SHA: $COMMIT_SHA"
             -   uses: actions/checkout@v4
                 with:
-                    ref: ${{ needs.update_changelog.changelog_commitish || github.sha }}
+                    ref: ${{ needs.update_changelog.changelog_commitish }}
             -   name: Log current commit SHA
                 run: |
                     CURRENT_SHA=$(git rev-parse HEAD)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
+            changelog_commitish: ${{ steps.get_sha.outputs.commit_sha }}
 
         steps:
             -   name: Checkout repository
@@ -81,6 +81,10 @@ jobs:
                     author_name: Apify Release Bot
                     author_email: noreply@apify.com
                     message: "chore(release): Update changelog, package.json and manifest.json versions [skip ci]"
+
+            -   name: Get commit SHA
+                id: get_sha
+                run: echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
     create_github_release:
         name: Create github release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.get_sha.outputs.commit_sha }}
+            changelog_commitish: ${{ steps.get_sha.outputs.commit_sha || steps.commit.outputs.commit_long_sha || github.sha }}
 
         steps:
             -   name: Checkout repository
@@ -82,8 +82,16 @@ jobs:
                     author_email: noreply@apify.com
                     message: "chore(release): Update changelog, package.json and manifest.json versions [skip ci]"
 
+            -   name: Debug commit info
+                run: |
+                    echo "Commit long SHA: ${{ steps.commit.outputs.commit_long_sha }}"
+                    echo "Current HEAD: $(git rev-parse HEAD)"
+                    echo "Git log (last 2 commits):"
+                    git log --oneline -2
+
             -   name: Get commit SHA
                 id: get_sha
+                if: steps.commit.outputs.commit_long_sha != ''
                 run: echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
     create_github_release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,25 +82,11 @@ jobs:
                     author_email: noreply@apify.com
                     message: "chore(release): Update changelog, package.json and manifest.json versions [skip ci]"
 
-            -   name: Debug commit info
-                run: |
-                    echo "Commit long SHA: ${{ steps.commit.outputs.commit_long_sha }}"
-                    echo "Current HEAD: $(git rev-parse HEAD)"
-                    echo "Git log (last 2 commits):"
-                    git log --oneline -2
-
             -   name: Get commit SHA
                 id: get_sha
                 run: |
                     COMMIT_SHA=$(git rev-parse HEAD)
                     echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-                    echo "Captured SHA: $COMMIT_SHA"
-
-            -   name: Debug final SHA
-                run: |
-                    echo "Final changelog_commitish: ${{ steps.get_sha.outputs.commit_sha }}"
-                    echo "Commit action SHA: ${{ steps.commit.outputs.commit_long_sha }}"
-                    echo "Git HEAD: $(git rev-parse HEAD)"
 
     create_github_release:
         name: Create github release
@@ -179,29 +165,29 @@ jobs:
                     files: |
                         actors-mcp-server.dxt
 
-    #publish_to_npm:
-    #    name: Publish to NPM
-    #    needs: [ update_changelog ]
-    #    runs-on: ubuntu-latest
-    #    steps:
-    #        -   uses: actions/checkout@v4
-    #            with:
-    #                ref: ${{ needs.update_changelog.outputs.changelog_commitish }}
-    #        -   name: Use Node.js 22
-    #            uses: actions/setup-node@v4
-    #            with:
-    #                node-version: 22
-    #                cache: 'npm'
-    #                cache-dependency-path: 'package-lock.json'
-    #        -   name: Install dependencies
-    #            run: |
-    #                echo "access=public" >> .npmrc
-    #                echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-    #                npm ci
-    #        -   name: Build module
-    #            run: npm run build
-    #        -   name: Publish to NPM
-    #            run: npm publish --tag latest
+    publish_to_npm:
+        name: Publish to NPM
+        needs: [ update_changelog ]
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    ref: ${{ needs.update_changelog.outputs.changelog_commitish }}
+            -   name: Use Node.js 22
+                uses: actions/setup-node@v4
+                with:
+                    node-version: 22
+                    cache: 'npm'
+                    cache-dependency-path: 'package-lock.json'
+            -   name: Install dependencies
+                run: |
+                    echo "access=public" >> .npmrc
+                    echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+                    npm ci
+            -   name: Build module
+                run: npm run build
+            -   name: Publish to NPM
+                run: npm publish --tag latest
 
 env:
     NODE_AUTH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.get_sha.outputs.commit_sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
 
         steps:
             -   name: Checkout repository
@@ -81,12 +81,6 @@ jobs:
                     author_name: Apify Release Bot
                     author_email: noreply@apify.com
                     message: "chore(release): Update changelog, package.json and manifest.json versions [skip ci]"
-
-            -   name: Get commit SHA
-                id: get_sha
-                run: |
-                    COMMIT_SHA=$(git rev-parse HEAD)
-                    echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
 
     create_github_release:
         name: Create github release
@@ -165,29 +159,29 @@ jobs:
                     files: |
                         actors-mcp-server.dxt
 
-    publish_to_npm:
-        name: Publish to NPM
-        needs: [ update_changelog ]
-        runs-on: ubuntu-latest
-        steps:
-            -   uses: actions/checkout@v4
-                with:
-                    ref: ${{ needs.update_changelog.outputs.changelog_commitish }}
-            -   name: Use Node.js 22
-                uses: actions/setup-node@v4
-                with:
-                    node-version: 22
-                    cache: 'npm'
-                    cache-dependency-path: 'package-lock.json'
-            -   name: Install dependencies
-                run: |
-                    echo "access=public" >> .npmrc
-                    echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-                    npm ci
-            -   name: Build module
-                run: npm run build
-            -   name: Publish to NPM
-                run: npm publish --tag latest
+    #publish_to_npm:
+    #    name: Publish to NPM
+    #    needs: [ update_changelog ]
+    #    runs-on: ubuntu-latest
+    #    steps:
+    #        -   uses: actions/checkout@v4
+    #            with:
+    #                ref: ${{ needs.update_changelog.outputs.changelog_commitish }}
+    #        -   name: Use Node.js 22
+    #            uses: actions/setup-node@v4
+    #            with:
+    #                node-version: 22
+    #                cache: 'npm'
+    #                cache-dependency-path: 'package-lock.json'
+    #        -   name: Install dependencies
+    #            run: |
+    #                echo "access=public" >> .npmrc
+    #                echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+    #                npm ci
+    #        -   name: Build module
+    #            run: npm run build
+    #        -   name: Publish to NPM
+    #            run: npm publish --tag latest
 
 env:
     NODE_AUTH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,25 +89,18 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
-            -   name: Validate commit SHA
-                run: |
-                    COMMIT_SHA="${{ needs.update_changelog.outputs.changelog_commitish }}"
-                    if [ -z "$COMMIT_SHA" ]; then
-                        echo "ERROR: changelog_commitish is empty!"
-                        exit 1
-                    fi
-                    echo "Using commit SHA: $COMMIT_SHA"
             -   uses: actions/checkout@v4
                 with:
                     ref: ${{ needs.update_changelog.outputs.changelog_commitish }}
-            -   name: Log current commit SHA
+            -   name: Verify commit SHA
                 run: |
                     CURRENT_SHA=$(git rev-parse HEAD)
                     EXPECTED_SHA="${{ needs.update_changelog.outputs.changelog_commitish }}"
                     echo "Expected commit SHA: $EXPECTED_SHA"
                     echo "Actual checked out SHA: $CURRENT_SHA"
                     if [ "$EXPECTED_SHA" != "$CURRENT_SHA" ]; then
-                        echo "WARNING: Checked out SHA differs from expected!"
+                        echo "ERROR: Checked out SHA differs from expected!"
+                        exit 1
                     else
                         echo "✓ Commit SHA matches expected"
                     fi
@@ -159,29 +152,56 @@ jobs:
                     files: |
                         actors-mcp-server.dxt
 
-    #publish_to_npm:
-    #    name: Publish to NPM
-    #    needs: [ update_changelog ]
-    #    runs-on: ubuntu-latest
-    #    steps:
-    #        -   uses: actions/checkout@v4
-    #            with:
-    #                ref: ${{ needs.update_changelog.outputs.changelog_commitish }}
-    #        -   name: Use Node.js 22
-    #            uses: actions/setup-node@v4
-    #            with:
-    #                node-version: 22
-    #                cache: 'npm'
-    #                cache-dependency-path: 'package-lock.json'
-    #        -   name: Install dependencies
-    #            run: |
-    #                echo "access=public" >> .npmrc
-    #                echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-    #                npm ci
-    #        -   name: Build module
-    #            run: npm run build
-    #        -   name: Publish to NPM
-    #            run: npm publish --tag latest
+    publish_to_npm:
+        name: Publish to NPM
+        needs: [ release_metadata, update_changelog ]
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    ref: ${{ needs.update_changelog.outputs.changelog_commitish }}
+            -   name: Verify commit SHA
+                run: |
+                    CURRENT_SHA=$(git rev-parse HEAD)
+                    EXPECTED_SHA="${{ needs.update_changelog.outputs.changelog_commitish }}"
+                    echo "Expected commit SHA: $EXPECTED_SHA"
+                    echo "Actual checked out SHA: $CURRENT_SHA"
+                    if [ "$EXPECTED_SHA" != "$CURRENT_SHA" ]; then
+                        echo "ERROR: Checked out SHA differs from expected!"
+                        exit 1
+                    else
+                        echo "✓ Commit SHA matches expected"
+                    fi
+            -   name: Verify manifest.json version
+                run: |
+                    EXPECTED_VERSION="${{ needs.release_metadata.outputs.version_number }}"
+                    ACTUAL_VERSION=$(jq -r '.version' manifest.json)
+
+                     echo "Expected version: $EXPECTED_VERSION"
+                     echo "Actual version in manifest.json: $ACTUAL_VERSION"
+                     echo "Current commit SHA: ${{ needs.update_changelog.outputs.changelog_commitish }}"
+
+                     if [ "$EXPECTED_VERSION" != "$ACTUAL_VERSION" ]; then
+                        echo "ERROR: Version mismatch! Expected $EXPECTED_VERSION but found $ACTUAL_VERSION in manifest.json"
+                        exit 1
+                     fi
+
+                     echo "✓ Version check passed: manifest.json has correct version $ACTUAL_VERSION"
+            -   name: Use Node.js 22
+                uses: actions/setup-node@v4
+                with:
+                    node-version: 22
+                    cache: 'npm'
+                    cache-dependency-path: 'package-lock.json'
+            -   name: Install dependencies
+                run: |
+                    echo "access=public" >> .npmrc
+                    echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+                    npm ci
+            -   name: Build module
+                run: npm run build
+            -   name: Publish to NPM
+                run: npm publish --tag latest
 
 env:
     NODE_AUTH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,9 @@ jobs:
             -   name: Update package version in package.json
                 run: npm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
 
+            -   name: Update manifest.json version
+                run: jq '.version = "${{ needs.release_metadata.outputs.version_number }}"' manifest.json > manifest.json.tmp && mv manifest.json.tmp manifest.json
+
             -   name: Update CHANGELOG.md
                 uses: DamianReeves/write-file-action@master
                 with:
@@ -77,7 +80,7 @@ jobs:
                 with:
                     author_name: Apify Release Bot
                     author_email: noreply@apify.com
-                    message: "chore(release): Update changelog and package version [skip ci]"
+                    message: "chore(release): Update changelog, package.json and manifest.json versions [skip ci]"
 
     create_github_release:
         name: Create github release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,6 +96,32 @@ jobs:
             -   uses: actions/checkout@v4
                 with:
                     ref: ${{ needs.update_changelog.changelog_commitish }}
+            -   name: Log current commit SHA
+                run: |
+                    CURRENT_SHA=$(git rev-parse HEAD)
+                    EXPECTED_SHA="${{ needs.update_changelog.changelog_commitish }}"
+                    echo "Expected commit SHA: $EXPECTED_SHA"
+                    echo "Actual checked out SHA: $CURRENT_SHA"
+                    if [ "$EXPECTED_SHA" != "$CURRENT_SHA" ]; then
+                        echo "WARNING: Checked out SHA differs from expected!"
+                    else
+                        echo "✓ Commit SHA matches expected"
+                    fi
+            -   name: Verify manifest.json version
+                run: |
+                    EXPECTED_VERSION="${{ needs.release_metadata.outputs.version_number }}"
+                    ACTUAL_VERSION=$(jq -r '.version' manifest.json)
+
+                    echo "Expected version: $EXPECTED_VERSION"
+                    echo "Actual version in manifest.json: $ACTUAL_VERSION"
+                    echo "Current commit SHA: ${{ needs.update_changelog.changelog_commitish }}"
+
+                    if [ "$EXPECTED_VERSION" != "$ACTUAL_VERSION" ]; then
+                        echo "ERROR: Version mismatch! Expected $EXPECTED_VERSION but found $ACTUAL_VERSION in manifest.json"
+                        exit 1
+                    fi
+
+                    echo "✓ Version check passed: manifest.json has correct version $ACTUAL_VERSION"
             -   name: Use Node.js 22
                 uses: actions/setup-node@v4
                 with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,7 +111,7 @@ jobs:
         steps:
             -   name: Validate commit SHA
                 run: |
-                    COMMIT_SHA="${{ needs.update_changelog.changelog_commitish }}"
+                    COMMIT_SHA="${{ needs.update_changelog.outputs.changelog_commitish }}"
                     if [ -z "$COMMIT_SHA" ]; then
                         echo "ERROR: changelog_commitish is empty!"
                         exit 1
@@ -119,11 +119,11 @@ jobs:
                     echo "Using commit SHA: $COMMIT_SHA"
             -   uses: actions/checkout@v4
                 with:
-                    ref: ${{ needs.update_changelog.changelog_commitish }}
+                    ref: ${{ needs.update_changelog.outputs.changelog_commitish }}
             -   name: Log current commit SHA
                 run: |
                     CURRENT_SHA=$(git rev-parse HEAD)
-                    EXPECTED_SHA="${{ needs.update_changelog.changelog_commitish }}"
+                    EXPECTED_SHA="${{ needs.update_changelog.outputs.changelog_commitish }}"
                     echo "Expected commit SHA: $EXPECTED_SHA"
                     echo "Actual checked out SHA: $CURRENT_SHA"
                     if [ "$EXPECTED_SHA" != "$CURRENT_SHA" ]; then
@@ -136,11 +136,11 @@ jobs:
                     EXPECTED_VERSION="${{ needs.release_metadata.outputs.version_number }}"
                     ACTUAL_VERSION=$(jq -r '.version' manifest.json)
 
-                    echo "Expected version: $EXPECTED_VERSION"
-                    echo "Actual version in manifest.json: $ACTUAL_VERSION"
-                    echo "Current commit SHA: ${{ needs.update_changelog.changelog_commitish }}"
+                     echo "Expected version: $EXPECTED_VERSION"
+                     echo "Actual version in manifest.json: $ACTUAL_VERSION"
+                     echo "Current commit SHA: ${{ needs.update_changelog.outputs.changelog_commitish }}"
 
-                    if [ "$EXPECTED_VERSION" != "$ACTUAL_VERSION" ]; then
+                     if [ "$EXPECTED_VERSION" != "$ACTUAL_VERSION" ]; then
                         echo "ERROR: Version mismatch! Expected $EXPECTED_VERSION but found $ACTUAL_VERSION in manifest.json"
                         exit 1
                     fi
@@ -186,7 +186,7 @@ jobs:
     #    steps:
     #        -   uses: actions/checkout@v4
     #            with:
-    #                ref: ${{ needs.update_changelog.changelog_commitish }}
+    #                ref: ${{ needs.update_changelog.outputs.changelog_commitish }}
     #        -   name: Use Node.js 22
     #            uses: actions/setup-node@v4
     #            with:


### PR DESCRIPTION
closes https://github.com/apify/apify-mcp-server/issues/229

Added automatic version update also for the `manifest.json`. Also figured out we were accessing the new git committed ref with the `.json` updates incorrectly and it could cause we were releasing packages with wrong version number. Fixed this and also added checks to prevent this in future. 