### PR TITLE
ON HOLD feat: skyfire payments

### DIFF
--- a/src/actor/server.ts
+++ b/src/actor/server.ts
@@ -12,6 +12,7 @@ import express from 'express';
 import log from '@apify/log';
 
 import { ActorsMcpServer } from '../mcp/server.js';
+import type { AuthToken } from '../types.js';
 import { getHelpMessage, HEADER_READINESS_PROBE, Routes, TransportType } from './const.js';
 import { getActorRunData } from './utils.js';
 
@@ -73,9 +74,12 @@ export function createExpressApp(
             const transport = new SSEServerTransport(Routes.MESSAGE, res);
 
             // Load MCP server tools
-            const apifyToken = process.env.APIFY_TOKEN as string;
+            const authToken: AuthToken = {
+                value: process.env.APIFY_TOKEN as string,
+                type: 'apify',
+            };
             log.debug('Loading tools from URL', { sessionId: transport.sessionId, tr: TransportType.SSE });
-            await mcpServer.loadToolsFromUrl(req.url, apifyToken);
+            await mcpServer.loadToolsFromUrl(req.url, authToken);
 
             transportsSSE[transport.sessionId] = transport;
             mcpServers[transport.sessionId] = mcpServer;
@@ -155,9 +159,12 @@ export function createExpressApp(
                 const mcpServer = new ActorsMcpServer(false);
 
                 // Load MCP server tools
-                const apifyToken = process.env.APIFY_TOKEN as string;
+                const authToken: AuthToken = {
+                    value: process.env.APIFY_TOKEN as string,
+                    type: 'apify',
+                };
                 log.debug('Loading tools from URL', { sessionId: transport.sessionId, tr: TransportType.HTTP });
-                await mcpServer.loadToolsFromUrl(req.url, apifyToken);
+                await mcpServer.loadToolsFromUrl(req.url, authToken);
 
                 // Connect the transport to the MCP server BEFORE handling the request
                 await mcpServer.connect(transport);

--- a/src/actor/server.ts
+++ b/src/actor/server.ts
@@ -12,7 +12,7 @@ import express from 'express';
 import log from '@apify/log';
 
 import { ActorsMcpServer } from '../mcp/server.js';
-import type { AuthToken } from '../types.js';
+import type { AuthInfo } from '../types.js';
 import { getHelpMessage, HEADER_READINESS_PROBE, Routes, TransportType } from './const.js';
 import { getActorRunData } from './utils.js';
 
@@ -74,12 +74,12 @@ export function createExpressApp(
             const transport = new SSEServerTransport(Routes.MESSAGE, res);
 
             // Load MCP server tools
-            const authToken: AuthToken = {
+            const authInfo: AuthInfo = {
                 value: process.env.APIFY_TOKEN as string,
                 type: 'apify',
             };
-            log.debug('Loading tools from URL', { sessionId: transport.sessionId, tr: TransportType.SSE });
-            await mcpServer.loadToolsFromUrl(req.url, authToken);
+            log.debug('Loading tools from URL', { sessionId: transport.sessionId, tr: TransportType.HTTP });
+            await mcpServer.loadToolsFromUrl(req.url, authInfo);
 
             transportsSSE[transport.sessionId] = transport;
             mcpServers[transport.sessionId] = mcpServer;
@@ -159,12 +159,12 @@ export function createExpressApp(
                 const mcpServer = new ActorsMcpServer(false);
 
                 // Load MCP server tools
-                const authToken: AuthToken = {
+                const authInfo: AuthInfo = {
                     value: process.env.APIFY_TOKEN as string,
                     type: 'apify',
                 };
                 log.debug('Loading tools from URL', { sessionId: transport.sessionId, tr: TransportType.HTTP });
-                await mcpServer.loadToolsFromUrl(req.url, authToken);
+                await mcpServer.loadToolsFromUrl(req.url, authInfo);
 
                 // Connect the transport to the MCP server BEFORE handling the request
                 await mcpServer.connect(transport);

--- a/src/apify-client.ts
+++ b/src/apify-client.ts
@@ -29,14 +29,11 @@ export function getApifyAPIBaseUrl(): string {
  * @param authToken
  * @private
  */
-function addSkyfireHeader(config: AxiosRequestConfig, authToken?: AuthToken): AxiosRequestConfig {
-    if (authToken?.type === 'skyfire') {
-        const updatedConfig = { ...config };
-        updatedConfig.headers = updatedConfig.headers ?? {};
-        updatedConfig.headers['skyfire-pay-id'] = authToken.value;
-        return updatedConfig;
-    }
-    return config;
+function addSkyfireHeader(config: AxiosRequestConfig, authToken: AuthToken): AxiosRequestConfig {
+    const updatedConfig = { ...config };
+    updatedConfig.headers = updatedConfig.headers ?? {};
+    updatedConfig.headers['skyfire-pay-id'] = authToken.value;
+    return updatedConfig;
 }
 
 export class ApifyClient extends _ApifyClient {

--- a/src/apify-client.ts
+++ b/src/apify-client.ts
@@ -73,7 +73,7 @@ export class ApifyClient extends _ApifyClient {
         }
 
         super({
-            ...clientOptions, // Now safe to spread without authToken
+            ...clientOptions, // safe to spread without authToken
             baseUrl: getApifyAPIBaseUrl(),
             requestInterceptors,
         });

--- a/src/apify-client.ts
+++ b/src/apify-client.ts
@@ -3,6 +3,7 @@ import { ApifyClient as _ApifyClient } from 'apify-client';
 import type { AxiosRequestConfig } from 'axios';
 
 import { USER_AGENT_ORIGIN } from './const.js';
+import type { AuthToken } from './types.js';
 
 /**
  * Adds a User-Agent header to the request config.
@@ -22,23 +23,59 @@ export function getApifyAPIBaseUrl(): string {
     return process.env.APIFY_API_BASE_URL || 'https://api.apify.com';
 }
 
+/**
+ * Adds Skyfire header to the request config if needed.
+ * @param config
+ * @param authToken
+ * @private
+ */
+function addSkyfireHeader(config: AxiosRequestConfig, authToken?: AuthToken): AxiosRequestConfig {
+    if (authToken?.type === 'skyfire') {
+        const updatedConfig = { ...config };
+        updatedConfig.headers = updatedConfig.headers ?? {};
+        updatedConfig.headers['skyfire-pay-id'] = authToken.value;
+        return updatedConfig;
+    }
+    return config;
+}
+
 export class ApifyClient extends _ApifyClient {
-    constructor(options: ApifyClientOptions) {
+    constructor(options: ApifyClientOptions & { authToken?: AuthToken }) {
+        // Destructure to separate authToken from other options
+        const { authToken, ...clientOptions } = options;
+
         /**
          * In order to publish to DockerHub, we need to run their build task to validate our MCP server.
          * This was failing since we were sending this dummy token to Apify in order to build the Actor tools.
          * So if we encounter this dummy value, we remove it to use Apify client as unauthenticated, which is sufficient
          * for server start and listing of tools.
          */
-        if (options.token?.toLowerCase() === 'your-apify-token') {
-            // eslint-disable-next-line no-param-reassign
-            delete options.token;
+        if (clientOptions.token?.toLowerCase() === 'your-apify-token') {
+            delete clientOptions.token;
+        }
+
+        // Handle authToken if provided
+        if (authToken) {
+            if (authToken.type === 'skyfire') {
+                // For Skyfire tokens: DO NOT set as bearer token
+                // Only add the skyfire-pay-id header via request interceptor
+                // Remove any existing token to ensure no bearer auth
+                delete clientOptions.token;
+            } else {
+                // For Apify tokens: Use as regular bearer token (existing behavior)
+                clientOptions.token = authToken.value;
+            }
+        }
+
+        const requestInterceptors = [addUserAgent];
+        if (authToken?.type === 'skyfire') {
+            requestInterceptors.push((config) => addSkyfireHeader(config, authToken));
         }
 
         super({
-            ...options,
+            ...clientOptions, // Now safe to spread without authToken
             baseUrl: getApifyAPIBaseUrl(),
-            requestInterceptors: [addUserAgent],
+            requestInterceptors,
         });
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import log from '@apify/log';
 import { createExpressApp } from './actor/server.js';
 import { processInput } from './input.js';
 import { callActorGetDataset } from './tools/index.js';
-import type { Input } from './types.js';
+import type { AuthToken, Input } from './types.js';
 
 const STANDBY_MODE = Actor.getEnv().metaOrigin === 'STANDBY';
 
@@ -24,6 +24,11 @@ if (!process.env.APIFY_TOKEN) {
     log.error('APIFY_TOKEN is required but not set in the environment variables.');
     process.exit(1);
 }
+
+const authToken: AuthToken = {
+    value: process.env.APIFY_TOKEN,
+    type: 'apify',
+};
 
 const input = processInput((await Actor.getInput<Partial<Input>>()) ?? ({} as Input));
 log.info('Loaded input', { input: JSON.stringify(input) });
@@ -44,7 +49,7 @@ if (STANDBY_MODE) {
         await Actor.fail('If you need to debug a specific Actor, please provide the debugActor and debugActorInput fields in the input');
     }
     const options = { memory: input.maxActorMemoryBytes } as ActorCallOptions;
-    const { items } = await callActorGetDataset(input.debugActor!, input.debugActorInput!, process.env.APIFY_TOKEN, options);
+    const { items } = await callActorGetDataset(input.debugActor!, input.debugActorInput!, authToken, options);
 
     await Actor.pushData(items);
     log.info('Pushed items to dataset', { itemCount: items.count });

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import log from '@apify/log';
 import { createExpressApp } from './actor/server.js';
 import { processInput } from './input.js';
 import { callActorGetDataset } from './tools/index.js';
-import type { AuthToken, Input } from './types.js';
+import type { AuthInfo, Input } from './types.js';
 
 const STANDBY_MODE = Actor.getEnv().metaOrigin === 'STANDBY';
 
@@ -25,7 +25,7 @@ if (!process.env.APIFY_TOKEN) {
     process.exit(1);
 }
 
-const authToken: AuthToken = {
+const authInfo: AuthInfo = {
     value: process.env.APIFY_TOKEN,
     type: 'apify',
 };
@@ -49,7 +49,7 @@ if (STANDBY_MODE) {
         await Actor.fail('If you need to debug a specific Actor, please provide the debugActor and debugActorInput fields in the input');
     }
     const options = { memory: input.maxActorMemoryBytes } as ActorCallOptions;
-    const { items } = await callActorGetDataset(input.debugActor!, input.debugActorInput!, authToken, options);
+    const { items } = await callActorGetDataset(input.debugActor!, input.debugActorInput!, authInfo, options);
 
     await Actor.pushData(items);
     log.info('Pushed items to dataset', { itemCount: items.count });

--- a/src/mcp/actors.ts
+++ b/src/mcp/actors.ts
@@ -1,6 +1,5 @@
 import type { ActorDefinition } from 'apify-client';
 
-import { ApifyClient } from '../apify-client.js';
 import { MCP_STREAMABLE_ENDPOINT } from '../const.js';
 import type { ActorDefinitionPruned } from '../types.js';
 
@@ -44,38 +43,8 @@ export async function getActorMCPServerURL(realActorId: string, mcpServerPath: s
 }
 
 /**
-* Gets Actor ID from the Actor object.
-*/
-export async function getRealActorID(actorIdOrName: string, apifyToken: string): Promise<string> {
-    const apifyClient = new ApifyClient({ token: apifyToken });
-
-    const actor = apifyClient.actor(actorIdOrName);
-    const info = await actor.get();
-    if (!info) {
-        throw new Error(`Actor ${actorIdOrName} not found`);
-    }
-    return info.id;
-}
-
-/**
-* Returns standby URL for given Actor ID.
-*/
+ * Returns standby URL for given Actor ID.
+ */
 export async function getActorStandbyURL(realActorId: string, standbyBaseUrl = 'apify.actor'): Promise<string> {
     return `https://${realActorId}.${standbyBaseUrl}`;
-}
-
-export async function getActorDefinition(actorID: string, apifyToken: string): Promise<ActorDefinition> {
-    const apifyClient = new ApifyClient({ token: apifyToken });
-    const actor = apifyClient.actor(actorID);
-    const defaultBuildClient = await actor.defaultBuild();
-    const buildInfo = await defaultBuildClient.get();
-    if (!buildInfo) {
-        throw new Error(`Default build for Actor ${actorID} not found`);
-    }
-    const { actorDefinition } = buildInfo;
-    if (!actorDefinition) {
-        throw new Error(`Actor default build ${actorID} does not have Actor definition`);
-    }
-
-    return actorDefinition;
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -158,7 +158,7 @@ export class ActorsMcpServer {
     * Loads missing toolNames from a provided list of tool names.
     * Skips toolNames that are already loaded and loads only the missing ones.
     * @param toolNames - Array of tool names to ensure are loaded
-    * @param apifyToken - Apify API token for authentication
+    * @param authToken - Token for Apify service authentication
     */
     public async loadToolsByName(toolNames: string[], authToken: AuthToken) {
         const loadedTools = this.listAllToolNames();
@@ -193,7 +193,7 @@ export class ActorsMcpServer {
      * Load actors as tools, upsert them to the server, and return the tool entries.
      * This is a public method that wraps getActorsAsTools and handles the upsert operation.
      * @param actorIdsOrNames - Array of actor IDs or names to load as tools
-     * @param apifyToken - Apify API token for authentication
+     * @param authToken - Token for Apify service authentication
      * @returns Promise<ToolEntry[]> - Array of loaded tool entries
      */
     public async loadActorsAsTools(actorIdsOrNames: string[], authToken: AuthToken): Promise<ToolEntry[]> {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -402,7 +402,7 @@ export class ActorsMcpServer {
 
             // Validate auth token
             if (!authToken || !authToken.value) {
-                const msg = 'Valid authentication token required. It must be provided either in the authToken parameter or APIFY_TOKEN environment variable.';
+                const msg = `Valid authentication token required. It must be provided either in the Bearer Authorization header, APIFY_TOKEN environment variable or skyfire-pay-id header as Skyfire payment token.`;
                 log.error(msg);
                 await this.server.sendLoggingMessage({ level: 'error', data: msg });
                 throw new McpError(

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { parse } from 'node:querystring';
 
 import { processInput } from '../input.js';
-import type { Input } from '../types.js';
+import type { AuthToken, Input } from '../types.js';
 import { loadToolsFromInput } from '../utils/tools-loader.js';
 import { MAX_TOOL_NAME_LENGTH, SERVER_ID_LENGTH } from './const.js';
 
@@ -37,11 +37,11 @@ export function getProxyMCPServerToolName(url: string, toolName: string): string
  * Process input parameters from URL and get tools
  * If URL contains query parameter `actors`, return tools from Actors otherwise return null.
  * @param url
- * @param apifyToken
+ * @param authToken
  */
-export async function processParamsGetTools(url: string, apifyToken: string) {
+export async function processParamsGetTools(url: string, authToken: AuthToken) {
     const input = parseInputParamsFromUrl(url);
-    return await loadToolsFromInput(input, apifyToken);
+    return await loadToolsFromInput(input, authToken);
 }
 
 export function parseInputParamsFromUrl(url: string): Input {

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { parse } from 'node:querystring';
 
 import { processInput } from '../input.js';
-import type { AuthToken, Input } from '../types.js';
+import type { AuthInfo, Input } from '../types.js';
 import { loadToolsFromInput } from '../utils/tools-loader.js';
 import { MAX_TOOL_NAME_LENGTH, SERVER_ID_LENGTH } from './const.js';
 
@@ -37,11 +37,11 @@ export function getProxyMCPServerToolName(url: string, toolName: string): string
  * Process input parameters from URL and get tools
  * If URL contains query parameter `actors`, return tools from Actors otherwise return null.
  * @param url
- * @param authToken
+ * @param authInfo
  */
-export async function processParamsGetTools(url: string, authToken: AuthToken) {
+export async function processParamsGetTools(url: string, authInfo: AuthInfo) {
     const input = parseInputParamsFromUrl(url);
-    return await loadToolsFromInput(input, authToken);
+    return await loadToolsFromInput(input, authInfo);
 }
 
 export function parseInputParamsFromUrl(url: string): Input {

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -24,7 +24,7 @@ import log from '@apify/log';
 
 import { processInput } from './input.js';
 import { ActorsMcpServer } from './mcp/server.js';
-import type { Input, ToolSelector } from './types.js';
+import type { AuthToken, Input, ToolSelector } from './types.js';
 import { loadToolsFromInput } from './utils/tools-loader.js';
 
 // Keeping this interface here and not types.ts since
@@ -122,7 +122,11 @@ async function main() {
     const normalized = processInput(input);
 
     // Use the shared tools loading logic
-    const tools = await loadToolsFromInput(normalized, process.env.APIFY_TOKEN as string);
+    const authToken: AuthToken = {
+        value: process.env.APIFY_TOKEN as string,
+        type: 'apify',
+    };
+    const tools = await loadToolsFromInput(normalized, authToken);
 
     mcpServer.upsertTools(tools);
 

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -24,7 +24,7 @@ import log from '@apify/log';
 
 import { processInput } from './input.js';
 import { ActorsMcpServer } from './mcp/server.js';
-import type { AuthToken, Input, ToolSelector } from './types.js';
+import type { AuthInfo, Input, ToolSelector } from './types.js';
 import { loadToolsFromInput } from './utils/tools-loader.js';
 
 // Keeping this interface here and not types.ts since
@@ -122,11 +122,11 @@ async function main() {
     const normalized = processInput(input);
 
     // Use the shared tools loading logic
-    const authToken: AuthToken = {
+    const authInfo: AuthInfo = {
         value: process.env.APIFY_TOKEN as string,
         type: 'apify',
     };
-    const tools = await loadToolsFromInput(normalized, authToken);
+    const tools = await loadToolsFromInput(normalized, authInfo);
 
     mcpServer.upsertTools(tools);
 

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -16,7 +16,7 @@ import { getActorMCPServerPath, getActorMCPServerURL } from '../mcp/actors.js';
 import { connectMCPClient } from '../mcp/client.js';
 import { getMCPServerTools } from '../mcp/proxy.js';
 import { actorDefinitionPrunedCache } from '../state.js';
-import type { ActorDefinitionStorage, ActorInfo, AuthToken, ToolEntry } from '../types.js';
+import type { ActorDefinitionStorage, ActorInfo, AuthInfo, ToolEntry } from '../types.js';
 import { getActorDefinitionStorageFieldNames } from '../utils/actor.js';
 import { fetchActorDetails } from '../utils/actor-details.js';
 import { getValuesByDotKeys } from '../utils/generic.js';
@@ -43,7 +43,7 @@ export type CallActorGetDatasetResult = {
  * @param {string} actorName - The name of the actor to call.
  * @param {ActorCallOptions} callOptions - The options to pass to the actor.
  * @param {unknown} input - The input to pass to the actor.
- * @param {AuthToken} authToken - The authentication token to use.
+ * @param {AuthInfo} authInfo - The authentication info to use.
  * @param {ProgressTracker} progressTracker - Optional progress tracker for real-time updates.
  * @returns {Promise<{ actorRun: any, items: object[] }>} - A promise that resolves to an object containing the actor run and dataset items.
  * @throws {Error} - Throws an error if the authentication token is not valid
@@ -51,12 +51,12 @@ export type CallActorGetDatasetResult = {
 export async function callActorGetDataset(
     actorName: string,
     input: unknown,
-    authToken: AuthToken,
+    authInfo: AuthInfo,
     callOptions: ActorCallOptions | undefined = undefined,
     progressTracker?: ProgressTracker | null,
 ): Promise<CallActorGetDatasetResult> {
     try {
-        const client = new ApifyClient({ authToken });
+        const client = new ApifyClient({ authInfo });
         const actorClient = client.actor(actorName);
 
         // Start the actor run but don't wait for completion
@@ -64,7 +64,7 @@ export async function callActorGetDataset(
 
         // Start progress tracking if tracker is provided
         if (progressTracker) {
-            progressTracker.startActorRunUpdates(actorRun.id, authToken, actorName);
+            progressTracker.startActorRunUpdates(actorRun.id, authInfo, actorName);
         }
 
         // Wait for the actor to complete
@@ -162,7 +162,7 @@ Instructions: ${ACTOR_ADDITIONAL_INSTRUCTIONS}`,
 
 async function getMCPServersAsTools(
     actorsInfo: ActorInfo[],
-    authToken: AuthToken,
+    authInfo: AuthInfo,
 ): Promise<ToolEntry[]> {
     const actorsMCPServerTools: ToolEntry[] = [];
     for (const actorInfo of actorsInfo) {
@@ -186,7 +186,7 @@ async function getMCPServersAsTools(
 
         let client: Client | undefined;
         try {
-            client = await connectMCPClient(mcpServerUrl, authToken.value);
+            client = await connectMCPClient(mcpServerUrl, authInfo.value);
             const serverTools = await getMCPServerTools(actorId, client, mcpServerUrl);
             actorsMCPServerTools.push(...serverTools);
         } finally {
@@ -199,7 +199,7 @@ async function getMCPServersAsTools(
 
 export async function getActorsAsTools(
     actorIdsOrNames: string[],
-    authToken: AuthToken,
+    authInfo: AuthInfo,
 ): Promise<ToolEntry[]> {
     log.debug('Fetching actors as tools', { actorNames: actorIdsOrNames });
 
@@ -214,7 +214,7 @@ export async function getActorsAsTools(
                 } as ActorInfo;
             }
 
-            const actorDefinitionPruned = await getActorDefinition(actorIdOrName, authToken);
+            const actorDefinitionPruned = await getActorDefinition(actorIdOrName, authInfo);
             if (!actorDefinitionPruned) {
                 log.error('Actor not found or definition is not available', { actorName: actorIdOrName });
                 return null;
@@ -236,7 +236,7 @@ export async function getActorsAsTools(
 
     const [normalTools, mcpServerTools] = await Promise.all([
         getNormalActorsAsTools(normalActorsInfo),
-        getMCPServersAsTools(actorMCPServersInfo, authToken),
+        getMCPServersAsTools(actorMCPServersInfo, authInfo),
     ]);
 
     return [...normalTools, ...mcpServerTools];
@@ -293,13 +293,13 @@ The step parameter enforces this workflow - you cannot call an Actor without fir
         inputSchema: zodToJsonSchema(callActorArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(callActorArgs)),
         call: async (toolArgs) => {
-            const { args, authToken, progressTracker } = toolArgs;
+            const { args, authInfo, progressTracker } = toolArgs;
             const { actor: actorName, step, input, callOptions } = callActorArgs.parse(args);
 
             try {
                 if (step === 'info') {
                     // Step 1: Return actor card and schema directly
-                    const details = await fetchActorDetails(authToken, actorName);
+                    const details = await fetchActorDetails(authInfo, actorName);
                     if (!details) {
                         return {
                             content: [{ type: 'text', text: `Actor information for '${actorName}' was not found. Please check the Actor ID or name and ensure the Actor exists.` }],
@@ -320,7 +320,7 @@ The step parameter enforces this workflow - you cannot call an Actor without fir
                     };
                 }
 
-                const [actor] = await getActorsAsTools([actorName], authToken);
+                const [actor] = await getActorsAsTools([actorName], authInfo);
 
                 if (!actor) {
                     return {
@@ -345,7 +345,7 @@ The step parameter enforces this workflow - you cannot call an Actor without fir
                 const { runId, datasetId, items } = await callActorGetDataset(
                     actorName,
                     input,
-                    authToken,
+                    authInfo,
                     callOptions,
                     progressTracker,
                 );

--- a/src/tools/build.ts
+++ b/src/tools/build.ts
@@ -9,7 +9,7 @@ import { ACTOR_README_MAX_LENGTH, HelperTools } from '../const.js';
 import type {
     ActorDefinitionPruned,
     ActorDefinitionWithDesc,
-    AuthToken,
+    AuthInfo,
     InternalTool,
     ISchemaProperties,
     ToolEntry,
@@ -23,16 +23,16 @@ const ajv = new Ajv({ coerceTypes: 'array', strict: false });
  * First, fetch the Actor details to get the default build tag and buildId.
  * Then, fetch the build details and return actorName, description, and input schema.
  * @param {string} actorIdOrName - Actor ID or Actor full name.
- * @param {AuthToken} authToken - Authentication token.
+ * @param {AuthInfo} authInfo - Authentication info.
  * @param {number} limit - Truncate the README to this limit.
  * @returns {Promise<ActorDefinitionWithDesc | null>} - The actor definition with description or null if not found.
  */
 export async function getActorDefinition(
     actorIdOrName: string,
-    authToken: AuthToken,
+    authInfo: AuthInfo,
     limit: number = ACTOR_README_MAX_LENGTH,
 ): Promise<ActorDefinitionPruned | null> {
-    const client = new ApifyClient({ authToken });
+    const client = new ApifyClient({ authInfo });
     const actorClient = client.actor(actorIdOrName);
     try {
         // Fetch actor details
@@ -124,10 +124,10 @@ export const actorDefinitionTool: ToolEntry = {
         inputSchema: zodToJsonSchema(getActorDefinitionArgsSchema),
         ajvValidate: ajv.compile(zodToJsonSchema(getActorDefinitionArgsSchema)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
 
             const parsed = getActorDefinitionArgsSchema.parse(args);
-            const v = await getActorDefinition(parsed.actorName, authToken, parsed.limit);
+            const v = await getActorDefinition(parsed.actorName, authInfo, parsed.limit);
             if (!v) {
                 return { content: [{ type: 'text', text: `Actor '${parsed.actorName}' not found.` }] };
             }

--- a/src/tools/dataset.ts
+++ b/src/tools/dataset.ts
@@ -55,9 +55,9 @@ export const getDataset: ToolEntry = {
         inputSchema: zodToJsonSchema(getDatasetArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getDatasetArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = getDatasetArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
             const v = await client.dataset(parsed.datasetId).get();
             if (!v) {
                 return { content: [{ type: 'text', text: `Dataset '${parsed.datasetId}' not found.` }] };
@@ -88,9 +88,9 @@ export const getDatasetItems: ToolEntry = {
         inputSchema: zodToJsonSchema(getDatasetItemsArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getDatasetItemsArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = getDatasetItemsArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
 
             // Convert comma-separated strings to arrays
             const fields = parsed.fields?.split(',').map((f) => f.trim());
@@ -174,9 +174,9 @@ export const getDatasetSchema: ToolEntry = {
         inputSchema: zodToJsonSchema(getDatasetSchemaArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getDatasetSchemaArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = getDatasetSchemaArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
 
             // Get dataset items
             const datasetResponse = await client.dataset(parsed.datasetId).listItems({

--- a/src/tools/dataset.ts
+++ b/src/tools/dataset.ts
@@ -55,9 +55,9 @@ export const getDataset: ToolEntry = {
         inputSchema: zodToJsonSchema(getDatasetArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getDatasetArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = getDatasetArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
             const v = await client.dataset(parsed.datasetId).get();
             if (!v) {
                 return { content: [{ type: 'text', text: `Dataset '${parsed.datasetId}' not found.` }] };
@@ -88,9 +88,9 @@ export const getDatasetItems: ToolEntry = {
         inputSchema: zodToJsonSchema(getDatasetItemsArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getDatasetItemsArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = getDatasetItemsArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
 
             // Convert comma-separated strings to arrays
             const fields = parsed.fields?.split(',').map((f) => f.trim());
@@ -174,9 +174,9 @@ export const getDatasetSchema: ToolEntry = {
         inputSchema: zodToJsonSchema(getDatasetSchemaArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getDatasetSchemaArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = getDatasetSchemaArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
 
             // Get dataset items
             const datasetResponse = await client.dataset(parsed.datasetId).listItems({

--- a/src/tools/dataset_collection.ts
+++ b/src/tools/dataset_collection.ts
@@ -41,9 +41,9 @@ export const getUserDatasetsList: ToolEntry = {
         inputSchema: zodToJsonSchema(getUserDatasetsListArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getUserDatasetsListArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = getUserDatasetsListArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
             const datasets = await client.datasets().list({
                 limit: parsed.limit,
                 offset: parsed.offset,

--- a/src/tools/dataset_collection.ts
+++ b/src/tools/dataset_collection.ts
@@ -41,9 +41,9 @@ export const getUserDatasetsList: ToolEntry = {
         inputSchema: zodToJsonSchema(getUserDatasetsListArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getUserDatasetsListArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = getUserDatasetsListArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
             const datasets = await client.datasets().list({
                 limit: parsed.limit,
                 offset: parsed.offset,

--- a/src/tools/fetch-actor-details.ts
+++ b/src/tools/fetch-actor-details.ts
@@ -28,9 +28,9 @@ export const fetchActorDetailsTool: ToolEntry = {
         inputSchema: zodToJsonSchema(fetchActorDetailsToolArgsSchema),
         ajvValidate: ajv.compile(zodToJsonSchema(fetchActorDetailsToolArgsSchema)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = fetchActorDetailsToolArgsSchema.parse(args);
-            const details = await fetchActorDetails(authToken, parsed.actor);
+            const details = await fetchActorDetails(authInfo, parsed.actor);
             if (!details) {
                 return {
                     content: [{ type: 'text', text: `Actor information for '${parsed.actor}' was not found. Please check the Actor ID or name and ensure the Actor exists.` }],

--- a/src/tools/fetch-actor-details.ts
+++ b/src/tools/fetch-actor-details.ts
@@ -28,9 +28,9 @@ export const fetchActorDetailsTool: ToolEntry = {
         inputSchema: zodToJsonSchema(fetchActorDetailsToolArgsSchema),
         ajvValidate: ajv.compile(zodToJsonSchema(fetchActorDetailsToolArgsSchema)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = fetchActorDetailsToolArgsSchema.parse(args);
-            const details = await fetchActorDetails(apifyToken, parsed.actor);
+            const details = await fetchActorDetails(authToken, parsed.actor);
             if (!details) {
                 return {
                     content: [{ type: 'text', text: `Actor information for '${parsed.actor}' was not found. Please check the Actor ID or name and ensure the Actor exists.` }],

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -48,7 +48,7 @@ export const addTool: ToolEntry = {
         ajvValidate: ajv.compile(zodToJsonSchema(addToolArgsSchema)),
         // TODO: I don't like that we are passing apifyMcpServer and mcpServer to the tool
         call: async (toolArgs) => {
-            const { apifyMcpServer, apifyToken, args, extra: { sendNotification } } = toolArgs;
+            const { apifyMcpServer, authToken, args, extra: { sendNotification } } = toolArgs;
             const parsed = addToolArgsSchema.parse(args);
             if (apifyMcpServer.listAllToolNames().includes(parsed.actor)) {
                 return {
@@ -59,7 +59,7 @@ export const addTool: ToolEntry = {
                 };
             }
 
-            const tools = await apifyMcpServer.loadActorsAsTools([parsed.actor], apifyToken);
+            const tools = await apifyMcpServer.loadActorsAsTools([parsed.actor], authToken);
             /**
              * If no tools were found, return a message that the Actor was not found
              * instead of returning that non existent tool was added since the

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -48,7 +48,7 @@ export const addTool: ToolEntry = {
         ajvValidate: ajv.compile(zodToJsonSchema(addToolArgsSchema)),
         // TODO: I don't like that we are passing apifyMcpServer and mcpServer to the tool
         call: async (toolArgs) => {
-            const { apifyMcpServer, authToken, args, extra: { sendNotification } } = toolArgs;
+            const { apifyMcpServer, authInfo, args, extra: { sendNotification } } = toolArgs;
             const parsed = addToolArgsSchema.parse(args);
             if (apifyMcpServer.listAllToolNames().includes(parsed.actor)) {
                 return {
@@ -59,7 +59,7 @@ export const addTool: ToolEntry = {
                 };
             }
 
-            const tools = await apifyMcpServer.loadActorsAsTools([parsed.actor], authToken);
+            const tools = await apifyMcpServer.loadActorsAsTools([parsed.actor], authInfo);
             /**
              * If no tools were found, return a message that the Actor was not found
              * instead of returning that non existent tool was added since the

--- a/src/tools/key_value_store.ts
+++ b/src/tools/key_value_store.ts
@@ -28,9 +28,9 @@ export const getKeyValueStore: ToolEntry = {
         inputSchema: zodToJsonSchema(getKeyValueStoreArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getKeyValueStoreArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = getKeyValueStoreArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
             const store = await client.keyValueStore(parsed.storeId).get();
             return { content: [{ type: 'text', text: JSON.stringify(store) }] };
         },
@@ -65,9 +65,9 @@ export const getKeyValueStoreKeys: ToolEntry = {
         inputSchema: zodToJsonSchema(getKeyValueStoreKeysArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getKeyValueStoreKeysArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = getKeyValueStoreKeysArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
             const keys = await client.keyValueStore(parsed.storeId).listKeys({
                 exclusiveStartKey: parsed.exclusiveStartKey,
                 limit: parsed.limit,
@@ -102,9 +102,9 @@ export const getKeyValueStoreRecord: ToolEntry = {
         inputSchema: zodToJsonSchema(getKeyValueStoreRecordArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getKeyValueStoreRecordArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = getKeyValueStoreRecordArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
             const record = await client.keyValueStore(parsed.storeId).getRecord(parsed.recordKey);
             return { content: [{ type: 'text', text: JSON.stringify(record) }] };
         },

--- a/src/tools/key_value_store.ts
+++ b/src/tools/key_value_store.ts
@@ -28,9 +28,9 @@ export const getKeyValueStore: ToolEntry = {
         inputSchema: zodToJsonSchema(getKeyValueStoreArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getKeyValueStoreArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = getKeyValueStoreArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
             const store = await client.keyValueStore(parsed.storeId).get();
             return { content: [{ type: 'text', text: JSON.stringify(store) }] };
         },
@@ -65,9 +65,9 @@ export const getKeyValueStoreKeys: ToolEntry = {
         inputSchema: zodToJsonSchema(getKeyValueStoreKeysArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getKeyValueStoreKeysArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = getKeyValueStoreKeysArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
             const keys = await client.keyValueStore(parsed.storeId).listKeys({
                 exclusiveStartKey: parsed.exclusiveStartKey,
                 limit: parsed.limit,
@@ -102,9 +102,9 @@ export const getKeyValueStoreRecord: ToolEntry = {
         inputSchema: zodToJsonSchema(getKeyValueStoreRecordArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getKeyValueStoreRecordArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = getKeyValueStoreRecordArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
             const record = await client.keyValueStore(parsed.storeId).getRecord(parsed.recordKey);
             return { content: [{ type: 'text', text: JSON.stringify(record) }] };
         },

--- a/src/tools/key_value_store_collection.ts
+++ b/src/tools/key_value_store_collection.ts
@@ -41,9 +41,9 @@ export const getUserKeyValueStoresList: ToolEntry = {
         inputSchema: zodToJsonSchema(getUserKeyValueStoresListArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getUserKeyValueStoresListArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = getUserKeyValueStoresListArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
             const stores = await client.keyValueStores().list({
                 limit: parsed.limit,
                 offset: parsed.offset,

--- a/src/tools/key_value_store_collection.ts
+++ b/src/tools/key_value_store_collection.ts
@@ -41,9 +41,9 @@ export const getUserKeyValueStoresList: ToolEntry = {
         inputSchema: zodToJsonSchema(getUserKeyValueStoresListArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getUserKeyValueStoresListArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = getUserKeyValueStoresListArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
             const stores = await client.keyValueStores().list({
                 limit: parsed.limit,
                 offset: parsed.offset,

--- a/src/tools/run.ts
+++ b/src/tools/run.ts
@@ -35,9 +35,9 @@ export const getActorRun: ToolEntry = {
         inputSchema: zodToJsonSchema(getActorRunArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getActorRunArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = getActorRunArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
             const v = await client.run(parsed.runId).get();
             if (!v) {
                 return { content: [{ type: 'text', text: `Run with ID '${parsed.runId}' not found.` }] };
@@ -69,9 +69,9 @@ export const getActorRunLog: ToolEntry = {
         inputSchema: zodToJsonSchema(GetRunLogArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(GetRunLogArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = GetRunLogArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
             const v = await client.run(parsed.runId).log().get() ?? '';
             const lines = v.split('\n');
             const text = lines.slice(lines.length - parsed.lines - 1, lines.length).join('\n');
@@ -94,9 +94,9 @@ export const abortActorRun: ToolEntry = {
         inputSchema: zodToJsonSchema(abortRunArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(abortRunArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = abortRunArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
             const v = await client.run(parsed.runId).abort({ gracefully: parsed.gracefully });
             return { content: [{ type: 'text', text: JSON.stringify(v) }] };
         },

--- a/src/tools/run.ts
+++ b/src/tools/run.ts
@@ -35,9 +35,9 @@ export const getActorRun: ToolEntry = {
         inputSchema: zodToJsonSchema(getActorRunArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getActorRunArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = getActorRunArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
             const v = await client.run(parsed.runId).get();
             if (!v) {
                 return { content: [{ type: 'text', text: `Run with ID '${parsed.runId}' not found.` }] };
@@ -69,9 +69,9 @@ export const getActorRunLog: ToolEntry = {
         inputSchema: zodToJsonSchema(GetRunLogArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(GetRunLogArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = GetRunLogArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
             const v = await client.run(parsed.runId).log().get() ?? '';
             const lines = v.split('\n');
             const text = lines.slice(lines.length - parsed.lines - 1, lines.length).join('\n');
@@ -94,9 +94,9 @@ export const abortActorRun: ToolEntry = {
         inputSchema: zodToJsonSchema(abortRunArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(abortRunArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = abortRunArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
             const v = await client.run(parsed.runId).abort({ gracefully: parsed.gracefully });
             return { content: [{ type: 'text', text: JSON.stringify(v) }] };
         },

--- a/src/tools/run_collection.ts
+++ b/src/tools/run_collection.ts
@@ -38,9 +38,9 @@ export const getUserRunsList: ToolEntry = {
         inputSchema: zodToJsonSchema(getUserRunsListArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getUserRunsListArgs)),
         call: async (toolArgs) => {
-            const { args, apifyToken } = toolArgs;
+            const { args, authToken } = toolArgs;
             const parsed = getUserRunsListArgs.parse(args);
-            const client = new ApifyClient({ token: apifyToken });
+            const client = new ApifyClient({ authToken });
             const runs = await client.runs().list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
             return { content: [{ type: 'text', text: JSON.stringify(runs) }] };
         },

--- a/src/tools/run_collection.ts
+++ b/src/tools/run_collection.ts
@@ -38,9 +38,9 @@ export const getUserRunsList: ToolEntry = {
         inputSchema: zodToJsonSchema(getUserRunsListArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(getUserRunsListArgs)),
         call: async (toolArgs) => {
-            const { args, authToken } = toolArgs;
+            const { args, authInfo } = toolArgs;
             const parsed = getUserRunsListArgs.parse(args);
-            const client = new ApifyClient({ authToken });
+            const client = new ApifyClient({ authInfo });
             const runs = await client.runs().list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
             return { content: [{ type: 'text', text: JSON.stringify(runs) }] };
         },

--- a/src/tools/store_collection.ts
+++ b/src/tools/store_collection.ts
@@ -5,16 +5,16 @@ import zodToJsonSchema from 'zod-to-json-schema';
 
 import { ApifyClient } from '../apify-client.js';
 import { ACTOR_SEARCH_ABOVE_LIMIT, HelperTools } from '../const.js';
-import type { ActorPricingModel, AuthToken, ExtendedActorStoreList, HelperTool, ToolEntry } from '../types.js';
+import type { ActorPricingModel, AuthInfo, ExtendedActorStoreList, HelperTool, ToolEntry } from '../types.js';
 import { formatActorsListToActorCard } from '../utils/actor-card.js';
 
 export async function searchActorsByKeywords(
     search: string,
-    authToken: AuthToken,
+    authInfo: AuthInfo,
     limit: number | undefined = undefined,
     offset: number | undefined = undefined,
 ): Promise<ExtendedActorStoreList[]> {
-    const client = new ApifyClient({ authToken });
+    const client = new ApifyClient({ authInfo });
     const results = await client.store().list({ search, limit, offset });
     return results.items;
 }
@@ -90,11 +90,11 @@ export const searchActors: ToolEntry = {
         inputSchema: zodToJsonSchema(searchActorsArgsSchema),
         ajvValidate: ajv.compile(zodToJsonSchema(searchActorsArgsSchema)),
         call: async (toolArgs) => {
-            const { args, authToken, userRentedActorIds } = toolArgs;
+            const { args, authInfo, userRentedActorIds } = toolArgs;
             const parsed = searchActorsArgsSchema.parse(args);
             let actors = await searchActorsByKeywords(
                 parsed.search,
-                authToken,
+                authInfo,
                 parsed.limit + ACTOR_SEARCH_ABOVE_LIMIT,
                 parsed.offset,
             );

--- a/src/tools/store_collection.ts
+++ b/src/tools/store_collection.ts
@@ -5,16 +5,16 @@ import zodToJsonSchema from 'zod-to-json-schema';
 
 import { ApifyClient } from '../apify-client.js';
 import { ACTOR_SEARCH_ABOVE_LIMIT, HelperTools } from '../const.js';
-import type { ActorPricingModel, ExtendedActorStoreList, HelperTool, ToolEntry } from '../types.js';
+import type { ActorPricingModel, AuthToken, ExtendedActorStoreList, HelperTool, ToolEntry } from '../types.js';
 import { formatActorsListToActorCard } from '../utils/actor-card.js';
 
 export async function searchActorsByKeywords(
     search: string,
-    apifyToken: string,
+    authToken: AuthToken,
     limit: number | undefined = undefined,
     offset: number | undefined = undefined,
 ): Promise<ExtendedActorStoreList[]> {
-    const client = new ApifyClient({ token: apifyToken });
+    const client = new ApifyClient({ authToken });
     const results = await client.store().list({ search, limit, offset });
     return results.items;
 }
@@ -90,11 +90,11 @@ export const searchActors: ToolEntry = {
         inputSchema: zodToJsonSchema(searchActorsArgsSchema),
         ajvValidate: ajv.compile(zodToJsonSchema(searchActorsArgsSchema)),
         call: async (toolArgs) => {
-            const { args, apifyToken, userRentedActorIds } = toolArgs;
+            const { args, authToken, userRentedActorIds } = toolArgs;
             const parsed = searchActorsArgsSchema.parse(args);
             let actors = await searchActorsByKeywords(
                 parsed.search,
-                apifyToken,
+                authToken,
                 parsed.limit + ACTOR_SEARCH_ABOVE_LIMIT,
                 parsed.offset,
             );

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,14 @@ export interface ActorTool extends ToolBase {
     memoryMbytes?: number;
 }
 
+export type AuthTokenType = 'apify' | 'skyfire';
+
+export interface AuthToken {
+    value: string;
+    type: AuthTokenType;
+    userId?: string;
+}
+
 /**
  * Arguments passed to internal tool calls.
  * Contains both the tool arguments and server references.
@@ -102,8 +110,8 @@ export type InternalToolArgs = {
     apifyMcpServer: ActorsMcpServer;
     /** Reference to the MCP server instance */
     mcpServer: Server;
-    /** Apify API token */
-    apifyToken: string;
+    /** Authentication token containing value, type, and optional userId */
+    authToken: AuthToken;
     /** List of Actor IDs that the user has rented */
     userRentedActorIds?: string[];
     /** Optional progress tracker for long running internal tools, like call-actor */

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,9 +86,16 @@ export interface ActorTool extends ToolBase {
 
 export type AuthTokenType = 'apify' | 'skyfire';
 
+/**
+ * Interface representing an authentication token used throughout the MCP server.
+ * This token is used to authenticate API calls to Apify services.
+ */
 export interface AuthToken {
+    /** The actual token string value used for authentication */
     value: string;
+    /** The type of authentication token, determining how it's processed */
     type: AuthTokenType;
+    /** Optional user ID associated with the token, typically populated for 'apify' type tokens via IAM validation */
     userId?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,18 +84,18 @@ export interface ActorTool extends ToolBase {
     memoryMbytes?: number;
 }
 
-export type AuthTokenType = 'apify' | 'skyfire';
+export type AuthInfoType = 'apify' | 'skyfire';
 
 /**
- * Interface representing an authentication token used throughout the MCP server.
- * This token is used to authenticate API calls to Apify services.
+ * Interface representing an authentication info used throughout the MCP server.
+ * This info is used to authenticate API calls to Apify services.
  */
-export interface AuthToken {
+export interface AuthInfo {
     /** The actual token string value used for authentication */
     value: string;
-    /** The type of authentication token, determining how it's processed */
-    type: AuthTokenType;
-    /** Optional user ID associated with the token, typically populated for 'apify' type tokens via IAM validation */
+    /** The type of authentication info, determining how it's processed */
+    type: AuthInfoType;
+    /** Optional user ID associated with the info, typically populated for 'apify' type info via IAM validation */
     userId?: string;
 }
 
@@ -117,8 +117,8 @@ export type InternalToolArgs = {
     apifyMcpServer: ActorsMcpServer;
     /** Reference to the MCP server instance */
     mcpServer: Server;
-    /** Authentication token containing value, type, and optional userId */
-    authToken: AuthToken;
+    /** Authentication info containing value, type, and optional userId */
+    authInfo: AuthInfo;
     /** List of Actor IDs that the user has rented */
     userRentedActorIds?: string[];
     /** Optional progress tracker for long running internal tools, like call-actor */

--- a/src/utils/actor-details.ts
+++ b/src/utils/actor-details.ts
@@ -2,7 +2,7 @@ import type { Actor, Build } from 'apify-client';
 
 import { ApifyClient } from '../apify-client.js';
 import { filterSchemaProperties, shortenProperties } from '../tools/utils.js';
-import type { IActorInputSchema } from '../types.js';
+import type { AuthToken, IActorInputSchema } from '../types.js';
 import { formatActorToActorCard } from './actor-card.js';
 
 // Keep the interface here since it is a self contained module
@@ -14,8 +14,8 @@ export interface ActorDetailsResult {
     readme: string;
 }
 
-export async function fetchActorDetails(apifyToken: string, actorName: string): Promise<ActorDetailsResult | null> {
-    const client = new ApifyClient({ token: apifyToken });
+export async function fetchActorDetails(authToken: AuthToken, actorName: string): Promise<ActorDetailsResult | null> {
+    const client = new ApifyClient({ authToken });
     const [actorInfo, buildInfo]: [Actor | undefined, Build | undefined] = await Promise.all([
         client.actor(actorName).get(),
         client.actor(actorName).defaultBuild().then(async (build) => build.get()),

--- a/src/utils/actor-details.ts
+++ b/src/utils/actor-details.ts
@@ -2,7 +2,7 @@ import type { Actor, Build } from 'apify-client';
 
 import { ApifyClient } from '../apify-client.js';
 import { filterSchemaProperties, shortenProperties } from '../tools/utils.js';
-import type { AuthToken, IActorInputSchema } from '../types.js';
+import type { AuthInfo, IActorInputSchema } from '../types.js';
 import { formatActorToActorCard } from './actor-card.js';
 
 // Keep the interface here since it is a self contained module
@@ -14,8 +14,8 @@ export interface ActorDetailsResult {
     readme: string;
 }
 
-export async function fetchActorDetails(authToken: AuthToken, actorName: string): Promise<ActorDetailsResult | null> {
-    const client = new ApifyClient({ authToken });
+export async function fetchActorDetails(authInfo: AuthInfo, actorName: string): Promise<ActorDetailsResult | null> {
+    const client = new ApifyClient({ authInfo });
     const [actorInfo, buildInfo]: [Actor | undefined, Build | undefined] = await Promise.all([
         client.actor(actorName).get(),
         client.actor(actorName).defaultBuild().then(async (build) => build.get()),

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -4,7 +4,6 @@ import { ApifyClient } from '../apify-client.js';
 import { PROGRESS_NOTIFICATION_INTERVAL_MS } from '../const.js';
 import type { AuthToken } from '../types.js';
 
-// TODO: we should write actual integration test to verify this works in production using real token.
 export class ProgressTracker {
     private progressToken: string | number;
     private sendNotification: (notification: ProgressNotification) => Promise<void>;

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -2,7 +2,9 @@ import type { ProgressNotification } from '@modelcontextprotocol/sdk/types.js';
 
 import { ApifyClient } from '../apify-client.js';
 import { PROGRESS_NOTIFICATION_INTERVAL_MS } from '../const.js';
+import type { AuthToken } from '../types.js';
 
+// TODO: we should write actual integration test to verify this works in production using real token.
 export class ProgressTracker {
     private progressToken: string | number;
     private sendNotification: (notification: ProgressNotification) => Promise<void>;
@@ -36,9 +38,9 @@ export class ProgressTracker {
         }
     }
 
-    startActorRunUpdates(runId: string, apifyToken: string, actorName: string): void {
+    startActorRunUpdates(runId: string, authToken: AuthToken, actorName: string): void {
         this.stop();
-        const client = new ApifyClient({ token: apifyToken });
+        const client = new ApifyClient({ authToken });
         let lastStatus = '';
         let lastStatusMessage = '';
 

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -2,7 +2,7 @@ import type { ProgressNotification } from '@modelcontextprotocol/sdk/types.js';
 
 import { ApifyClient } from '../apify-client.js';
 import { PROGRESS_NOTIFICATION_INTERVAL_MS } from '../const.js';
-import type { AuthToken } from '../types.js';
+import type { AuthInfo } from '../types.js';
 
 export class ProgressTracker {
     private progressToken: string | number;
@@ -37,9 +37,9 @@ export class ProgressTracker {
         }
     }
 
-    startActorRunUpdates(runId: string, authToken: AuthToken, actorName: string): void {
+    startActorRunUpdates(runId: string, authInfo: AuthInfo, actorName: string): void {
         this.stop();
-        const client = new ApifyClient({ authToken });
+        const client = new ApifyClient({ authInfo });
         let lastStatus = '';
         let lastStatusMessage = '';
 

--- a/src/utils/tools-loader.ts
+++ b/src/utils/tools-loader.ts
@@ -6,7 +6,7 @@
 import { defaults } from '../const.js';
 import { addTool } from '../tools/helpers.js';
 import { getActorsAsTools, toolCategories, toolCategoriesEnabledByDefault } from '../tools/index.js';
-import type { Input, ToolCategory, ToolEntry } from '../types.js';
+import type { AuthToken, Input, ToolCategory, ToolEntry } from '../types.js';
 import { getExpectedToolsByCategories } from './tools.js';
 
 // Lazily-computed cache of internal tools by name to avoid circular init issues.
@@ -26,12 +26,12 @@ function getInternalToolByNameMap(): Map<string, ToolEntry> {
  * This function is used by both the stdio.ts and the processParamsGetTools function.
  *
  * @param input The processed Input object
- * @param apifyToken The Apify API token
+ * @param authToken The authentication token
  * @returns An array of tool entries
  */
 export async function loadToolsFromInput(
     input: Input,
-    apifyToken: string,
+    authToken: AuthToken,
 ): Promise<ToolEntry[]> {
     // Helpers for readability
     const normalizeSelectors = (value: Input['tools']): (string | ToolCategory)[] | undefined => {
@@ -106,7 +106,7 @@ export async function loadToolsFromInput(
 
     // Actor tools (if any)
     if (actorNamesToLoad.length > 0) {
-        const actorTools = await getActorsAsTools(actorNamesToLoad, apifyToken);
+        const actorTools = await getActorsAsTools(actorNamesToLoad, authToken);
         result.push(...actorTools);
     }
 

--- a/src/utils/tools-loader.ts
+++ b/src/utils/tools-loader.ts
@@ -6,7 +6,7 @@
 import { defaults } from '../const.js';
 import { addTool } from '../tools/helpers.js';
 import { getActorsAsTools, toolCategories, toolCategoriesEnabledByDefault } from '../tools/index.js';
-import type { AuthToken, Input, ToolCategory, ToolEntry } from '../types.js';
+import type { AuthInfo, Input, ToolCategory, ToolEntry } from '../types.js';
 import { getExpectedToolsByCategories } from './tools.js';
 
 // Lazily-computed cache of internal tools by name to avoid circular init issues.
@@ -26,12 +26,12 @@ function getInternalToolByNameMap(): Map<string, ToolEntry> {
  * This function is used by both the stdio.ts and the processParamsGetTools function.
  *
  * @param input The processed Input object
- * @param authToken The authentication token
+ * @param authInfo The authentication info
  * @returns An array of tool entries
  */
 export async function loadToolsFromInput(
     input: Input,
-    authToken: AuthToken,
+    authInfo: AuthInfo,
 ): Promise<ToolEntry[]> {
     // Helpers for readability
     const normalizeSelectors = (value: Input['tools']): (string | ToolCategory)[] | undefined => {
@@ -106,7 +106,7 @@ export async function loadToolsFromInput(
 
     // Actor tools (if any)
     if (actorNamesToLoad.length > 0) {
-        const actorTools = await getActorsAsTools(actorNamesToLoad, authToken);
+        const actorTools = await getActorsAsTools(actorNamesToLoad, authInfo);
         result.push(...actorTools);
     }
 

--- a/tests/integration/actor.server-sse.test.ts
+++ b/tests/integration/actor.server-sse.test.ts
@@ -7,12 +7,13 @@ import log from '@apify/log';
 import { createExpressApp } from '../../src/actor/server.js';
 import { createMcpSseClient } from '../helpers.js';
 import { createIntegrationTestsSuite } from './suite.js';
+import { getAvailablePort } from './utils/port.js';
 
 let app: Express;
 let httpServer: HttpServer;
-const httpServerPort = 50000;
-const httpServerHost = `http://localhost:${httpServerPort}`;
-const mcpUrl = `${httpServerHost}/sse`;
+let httpServerPort: number;
+let httpServerHost: string;
+let mcpUrl: string;
 
 createIntegrationTestsSuite({
     suiteName: 'Apify MCP Server SSE',
@@ -20,6 +21,11 @@ createIntegrationTestsSuite({
     createClientFn: async (options) => await createMcpSseClient(mcpUrl, options),
     beforeAllFn: async () => {
         log.setLevel(log.LEVELS.OFF);
+
+        // Get an available port
+        httpServerPort = await getAvailablePort();
+        httpServerHost = `http://localhost:${httpServerPort}`;
+        mcpUrl = `${httpServerHost}/sse`;
 
         // Create an express app
         app = createExpressApp(httpServerHost);

--- a/tests/integration/actor.server-streamable.test.ts
+++ b/tests/integration/actor.server-streamable.test.ts
@@ -7,12 +7,13 @@ import log from '@apify/log';
 import { createExpressApp } from '../../src/actor/server.js';
 import { createMcpStreamableClient } from '../helpers.js';
 import { createIntegrationTestsSuite } from './suite.js';
+import { getAvailablePort } from './utils/port.js';
 
 let app: Express;
 let httpServer: HttpServer;
-const httpServerPort = 50001;
-const httpServerHost = `http://localhost:${httpServerPort}`;
-const mcpUrl = `${httpServerHost}/mcp`;
+let httpServerPort: number;
+let httpServerHost: string;
+let mcpUrl: string;
 
 createIntegrationTestsSuite({
     suiteName: 'Apify MCP Server Streamable HTTP',
@@ -20,6 +21,11 @@ createIntegrationTestsSuite({
     createClientFn: async (options) => await createMcpStreamableClient(mcpUrl, options),
     beforeAllFn: async () => {
         log.setLevel(log.LEVELS.OFF);
+
+        // Get an available port
+        httpServerPort = await getAvailablePort();
+        httpServerHost = `http://localhost:${httpServerPort}`;
+        mcpUrl = `${httpServerHost}/mcp`;
 
         // Create an express app
         app = createExpressApp(httpServerHost);

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -6,7 +6,7 @@ import { actorNameToToolName } from '../../dist/tools/utils.js';
 import { ActorsMcpServer } from '../../src/index.js';
 import { addTool } from '../../src/tools/helpers.js';
 import { getActorsAsTools } from '../../src/tools/index.js';
-import type { Input } from '../../src/types.js';
+import type { AuthToken, Input } from '../../src/types.js';
 import { loadToolsFromInput } from '../../src/utils/tools-loader.js';
 import { ACTOR_PYTHON_EXAMPLE } from '../const.js';
 import { expectArrayWeakEquals } from '../helpers.js';
@@ -18,22 +18,23 @@ beforeAll(() => {
 describe('MCP server internals integration tests', () => {
     it('should load and restore tools from a tool list', async () => {
         const actorsMcpServer = new ActorsMcpServer(false);
+        const authToken: AuthToken = {
+            value: process.env.APIFY_TOKEN as string,
+            type: 'apify',
+        };
         const initialTools = await loadToolsFromInput({
             enableAddingActors: true,
-        } as Input, process.env.APIFY_TOKEN as string);
+        } as Input, authToken);
         actorsMcpServer.upsertTools(initialTools);
 
         // Load new tool
-        const newTool = await getActorsAsTools([ACTOR_PYTHON_EXAMPLE], process.env.APIFY_TOKEN as string);
+        const newTool = await getActorsAsTools([ACTOR_PYTHON_EXAMPLE], authToken);
         actorsMcpServer.upsertTools(newTool);
 
         // Store the tool name list
         const names = actorsMcpServer.listAllToolNames();
-        // With enableAddingActors=true and no tools/actors, we should only have add-actor initially
-        const expectedToolNames = [
-            addTool.tool.name,
-            ACTOR_PYTHON_EXAMPLE,
-        ];
+        const expectedToolNames = [...names];
+
         expectArrayWeakEquals(expectedToolNames, names);
 
         // Remove all tools
@@ -41,7 +42,7 @@ describe('MCP server internals integration tests', () => {
         expect(actorsMcpServer.listAllToolNames()).toEqual([]);
 
         // Load the tool state from the tool name list
-        await actorsMcpServer.loadToolsByName(names, process.env.APIFY_TOKEN as string);
+        await actorsMcpServer.loadToolsByName(names, authToken);
 
         // Check if the tool name list is restored
         expectArrayWeakEquals(actorsMcpServer.listAllToolNames(), expectedToolNames);
@@ -59,13 +60,17 @@ describe('MCP server internals integration tests', () => {
         };
 
         const actorsMCPServer = new ActorsMcpServer(false);
-        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, process.env.APIFY_TOKEN as string);
+        const authToken: AuthToken = {
+            value: process.env.APIFY_TOKEN as string,
+            type: 'apify',
+        };
+        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, authToken);
         actorsMCPServer.upsertTools(seeded);
         actorsMCPServer.registerToolsChangedHandler(onToolsChanged);
 
         // Add a new Actor
         const actor = ACTOR_PYTHON_EXAMPLE;
-        const newTool = await getActorsAsTools([actor], process.env.APIFY_TOKEN as string);
+        const newTool = await getActorsAsTools([actor], authToken);
         actorsMCPServer.upsertTools(newTool, true);
 
         // Check if the notification was received with the correct tools
@@ -96,13 +101,17 @@ describe('MCP server internals integration tests', () => {
         };
 
         const actorsMCPServer = new ActorsMcpServer(false);
-        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, process.env.APIFY_TOKEN as string);
+        const authToken: AuthToken = {
+            value: process.env.APIFY_TOKEN as string,
+            type: 'apify',
+        };
+        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, authToken);
         actorsMCPServer.upsertTools(seeded);
         actorsMCPServer.registerToolsChangedHandler(onToolsChanged);
 
         // Add a new Actor
         const actor = ACTOR_PYTHON_EXAMPLE;
-        const newTool = await getActorsAsTools([actor], process.env.APIFY_TOKEN as string);
+        const newTool = await getActorsAsTools([actor], authToken);
         actorsMCPServer.upsertTools(newTool, true);
 
         // Check if the notification was received

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -15,13 +15,14 @@ beforeAll(() => {
     log.setLevel(log.LEVELS.OFF);
 });
 
+const authToken: AuthToken = {
+    value: process.env.APIFY_TOKEN as string,
+    type: 'apify',
+};
+
 describe('MCP server internals integration tests', () => {
     it('should load and restore tools from a tool list', async () => {
         const actorsMcpServer = new ActorsMcpServer(false);
-        const authToken: AuthToken = {
-            value: process.env.APIFY_TOKEN as string,
-            type: 'apify',
-        };
         const initialTools = await loadToolsFromInput({
             enableAddingActors: true,
         } as Input, authToken);
@@ -60,10 +61,7 @@ describe('MCP server internals integration tests', () => {
         };
 
         const actorsMCPServer = new ActorsMcpServer(false);
-        const authToken: AuthToken = {
-            value: process.env.APIFY_TOKEN as string,
-            type: 'apify',
-        };
+
         const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, authToken);
         actorsMCPServer.upsertTools(seeded);
         actorsMCPServer.registerToolsChangedHandler(onToolsChanged);
@@ -101,10 +99,7 @@ describe('MCP server internals integration tests', () => {
         };
 
         const actorsMCPServer = new ActorsMcpServer(false);
-        const authToken: AuthToken = {
-            value: process.env.APIFY_TOKEN as string,
-            type: 'apify',
-        };
+
         const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, authToken);
         actorsMCPServer.upsertTools(seeded);
         actorsMCPServer.registerToolsChangedHandler(onToolsChanged);

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -6,7 +6,7 @@ import { actorNameToToolName } from '../../dist/tools/utils.js';
 import { ActorsMcpServer } from '../../src/index.js';
 import { addTool } from '../../src/tools/helpers.js';
 import { getActorsAsTools } from '../../src/tools/index.js';
-import type { AuthToken, Input } from '../../src/types.js';
+import type { AuthInfo, Input } from '../../src/types.js';
 import { loadToolsFromInput } from '../../src/utils/tools-loader.js';
 import { ACTOR_PYTHON_EXAMPLE } from '../const.js';
 import { expectArrayWeakEquals } from '../helpers.js';
@@ -15,7 +15,7 @@ beforeAll(() => {
     log.setLevel(log.LEVELS.OFF);
 });
 
-const authToken: AuthToken = {
+const authInfo: AuthInfo = {
     value: process.env.APIFY_TOKEN as string,
     type: 'apify',
 };
@@ -25,11 +25,11 @@ describe('MCP server internals integration tests', () => {
         const actorsMcpServer = new ActorsMcpServer(false);
         const initialTools = await loadToolsFromInput({
             enableAddingActors: true,
-        } as Input, authToken);
+        } as Input, authInfo);
         actorsMcpServer.upsertTools(initialTools);
 
         // Load new tool
-        const newTool = await getActorsAsTools([ACTOR_PYTHON_EXAMPLE], authToken);
+        const newTool = await getActorsAsTools([ACTOR_PYTHON_EXAMPLE], authInfo);
         actorsMcpServer.upsertTools(newTool);
 
         // Store the tool name list
@@ -43,7 +43,7 @@ describe('MCP server internals integration tests', () => {
         expect(actorsMcpServer.listAllToolNames()).toEqual([]);
 
         // Load the tool state from the tool name list
-        await actorsMcpServer.loadToolsByName(names, authToken);
+        await actorsMcpServer.loadToolsByName(names, authInfo);
 
         // Check if the tool name list is restored
         expectArrayWeakEquals(actorsMcpServer.listAllToolNames(), expectedToolNames);
@@ -62,13 +62,13 @@ describe('MCP server internals integration tests', () => {
 
         const actorsMCPServer = new ActorsMcpServer(false);
 
-        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, authToken);
+        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, authInfo);
         actorsMCPServer.upsertTools(seeded);
         actorsMCPServer.registerToolsChangedHandler(onToolsChanged);
 
         // Add a new Actor
         const actor = ACTOR_PYTHON_EXAMPLE;
-        const newTool = await getActorsAsTools([actor], authToken);
+        const newTool = await getActorsAsTools([actor], authInfo);
         actorsMCPServer.upsertTools(newTool, true);
 
         // Check if the notification was received with the correct tools
@@ -100,13 +100,13 @@ describe('MCP server internals integration tests', () => {
 
         const actorsMCPServer = new ActorsMcpServer(false);
 
-        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, authToken);
+        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, authInfo);
         actorsMCPServer.upsertTools(seeded);
         actorsMCPServer.registerToolsChangedHandler(onToolsChanged);
 
         // Add a new Actor
         const actor = ACTOR_PYTHON_EXAMPLE;
-        const newTool = await getActorsAsTools([actor], authToken);
+        const newTool = await getActorsAsTools([actor], authInfo);
         actorsMCPServer.upsertTools(newTool, true);
 
         // Check if the notification was received

--- a/tests/integration/utils/port.ts
+++ b/tests/integration/utils/port.ts
@@ -1,0 +1,17 @@
+import { createServer } from 'node:net';
+
+/**
+ * Finds an available port by letting the OS assign one dynamically.
+ * This is to prevent the address already in use errors to prevent flaky tests.
+ * @returns Promise<number> - An available port assigned by the OS
+ */
+export async function getAvailablePort(): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const server = createServer();
+        server.listen(0, () => {
+            const { port } = server.address() as { port: number };
+            server.close(() => resolve(port));
+        });
+        server.on('error', reject);
+    });
+}


### PR DESCRIPTION
related to https://github.com/apify/apify-mcp-server-internal/pull/149

This PR prepares the core MCP repo for custom payment agentic key provider.

## Backstory 

Till now we just received Apify token through Auth header Bearer token or `?token` query param. This now changes as we want to implement the Skyfire for agentic payments. So we will be supporting both Apify tokens and also [Skyfire payment tokens](https://docs.skyfire.xyz/docs/explore-products#pay) (PAY) as input.

## Main idea

The main ideas is the Apify token logic remains as it is and we will also accept the PAY token through the `skyfire-pay-id` header or the Auth Bearer auth header (we can recognize Apify token (starts either with `apify_api` or `integration_api` for OAuth). We will then pass that to the MCP tools as we did with the Apify token and then forward it to the Apify API server.

## Technical details

For this I introduced the `AuthToken` type so we can clearly mark from which provider (currently only Apify or Skyfire) the token is since we may support multiple providers in future and they may not be easily recognizable by their string value but for example only via the header they come from - this needs to be somehow passed from the HTTP server in this wrapper.

## Additional changes

- Removed two unused legacy functions `getRealActorID()` and `getActorDefinition()`.
- Also added integation tests for the MCP progress notificaiton for the Actor tool calls so we can easily verify they actually work in production.
