### PR TITLE
fix: error when content type is json

### DIFF
--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -363,7 +363,7 @@ The step parameter enforces this workflow - you cannot call an Actor without fir
                         return {
                             content: [
                                 { type: 'text', text: `Input validation failed for Actor '${actorName}': ${errors.map((e) => e.message).join(', ')}` },
-                                { type: 'text', text: `Input Schema:\n${JSON.stringify(actor.tool.inputSchema, null, 2)}` },
+                                { type: 'text', text: `Input Schema:\n${JSON.stringify(actor.tool.inputSchema)}` },
                             ],
                         };
                     }

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -363,7 +363,7 @@ The step parameter enforces this workflow - you cannot call an Actor without fir
                         return {
                             content: [
                                 { type: 'text', text: `Input validation failed for Actor '${actorName}': ${errors.map((e) => e.message).join(', ')}` },
-                                { type: 'json', json: actor.tool.inputSchema },
+                                { type: 'text', text: `Input Schema:\n${JSON.stringify(actor.tool.inputSchema, null, 2)}` },
                             ],
                         };
                     }


### PR DESCRIPTION
Fixes https://github.com/apify/apify-mcp-server/issues/264

It was a simple issue, type JSON is not allowed, it must be text.