### PR TITLE
chore: Clean up duplicate entries in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,45 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.6.2](https://github.com/apify/apify-mcp-server/releases/tag/v0.6.2) (2025-12-08)
 
-### 🐛 Bug Fixes
+### :wrench: General
 
-- Update node setup in releasing wf ([9a34990](https://github.com/apify/apify-mcp-server/commit/9a34990cee481c918ec21fa15f9b92779a1759f8)) by [@drobnikj](https://github.com/drobnikj)
-- Release workflow using --access public param ([fad9ad6](https://github.com/apify/apify-mcp-server/commit/fad9ad60fbfab311c55c9af28debf2544d3646a6)) by [@drobnikj](https://github.com/drobnikj)
-- Remove latest tag from npm publish release.yaml ([b1de40e](https://github.com/apify/apify-mcp-server/commit/b1de40e0ffd81e61a136ac1b1dabe9b5a9865f66)) by [@drobnikj](https://github.com/drobnikj)
-- Update node to v24 ([#356](https://github.com/apify/apify-mcp-server/pull/356)) ([17a349b](https://github.com/apify/apify-mcp-server/commit/17a349b085fb1b3773a677d2de09d9f2334f12c5)) by [@drobnikj](https://github.com/drobnikj)
-
-
-## [0.6.2](https://github.com/apify/apify-mcp-server/releases/tag/v0.6.2) (2025-12-08)
-
-### 🐛 Bug Fixes
-
-- Update node setup in releasing wf ([9a34990](https://github.com/apify/apify-mcp-server/commit/9a34990cee481c918ec21fa15f9b92779a1759f8)) by [@drobnikj](https://github.com/drobnikj)
-- Release workflow using --access public param ([fad9ad6](https://github.com/apify/apify-mcp-server/commit/fad9ad60fbfab311c55c9af28debf2544d3646a6)) by [@drobnikj](https://github.com/drobnikj)
-- Remove latest tag from npm publish release.yaml ([b1de40e](https://github.com/apify/apify-mcp-server/commit/b1de40e0ffd81e61a136ac1b1dabe9b5a9865f66)) by [@drobnikj](https://github.com/drobnikj)
-
-
-## [0.6.2](https://github.com/apify/apify-mcp-server/releases/tag/v0.6.2) (2025-12-08)
-
-### 🐛 Bug Fixes
-
-- Update node setup in releasing wf ([9a34990](https://github.com/apify/apify-mcp-server/commit/9a34990cee481c918ec21fa15f9b92779a1759f8)) by [@drobnikj](https://github.com/drobnikj)
-- Release workflow using --access public param ([fad9ad6](https://github.com/apify/apify-mcp-server/commit/fad9ad60fbfab311c55c9af28debf2544d3646a6)) by [@drobnikj](https://github.com/drobnikj)
-
-
-## [0.6.2](https://github.com/apify/apify-mcp-server/releases/tag/v0.6.2) (2025-12-08)
-
-### 🐛 Bug Fixes
-
-- Update node setup in releasing wf ([9a34990](https://github.com/apify/apify-mcp-server/commit/9a34990cee481c918ec21fa15f9b92779a1759f8)) by [@drobnikj](https://github.com/drobnikj)
-
-
-## [0.6.2](https://github.com/apify/apify-mcp-server/releases/tag/v0.6.2) (2025-12-08)
-
-### 🚀 Features
-
-- Trusted publishing of npm package ([d3cff7c](https://github.com/apify/apify-mcp-server/commit/d3cff7cdab36b82b984b8103ca85a7c565238940)) by [@drobnikj](https://github.com/drobnikj)
-- Trusted publishing of npm package ([#355](https://github.com/apify/apify-mcp-server/pull/355)) ([1f0b374](https://github.com/apify/apify-mcp-server/commit/1f0b374041a0717f798fce5e9a0353e7b22c9cce)) by [@drobnikj](https://github.com/drobnikj)
-
+- Update node to v24 ([#356](https://github.com/apify/apify-mcp-server/pull/356)) ([17a349b](https://github.com/apify/apify-mcp-server/commit/17a349b085fb1b3773a677d2de09d9f2334f12c5)) by @drobnikj
 
 ## [0.6.1](https://github.com/apify/apify-mcp-server/releases/tag/v0.6.1) (2025-12-05)
 


### PR DESCRIPTION
Removed duplicate entries for version 0.6.2 in CHANGELOG.