### PR TITLE
fix: increase timeout for abort tests to reduce flakiness

### DIFF
--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -847,7 +847,7 @@ export function createIntegrationTestsSuite(
                 .catch(() => undefined);
 
             // Abort right away
-            setTimeout(() => controller.abort(), 1000);
+            setTimeout(() => controller.abort(), 3000);
 
             // Ensure the request completes/cancels before proceeding
             await requestPromise;
@@ -866,7 +866,7 @@ export function createIntegrationTestsSuite(
                     return run.status === 'ABORTED' || run.status === 'ABORTING';
                 }
                 return false;
-            }, { timeout: 3000, interval: 500 });
+            }, { timeout: 10000, interval: 500 });
         });
 
         // Cancellation test using call-actor tool: start a long-running actor via call-actor and cancel immediately, then verify it was aborted
@@ -892,7 +892,7 @@ export function createIntegrationTestsSuite(
                 .catch(() => undefined);
 
             // Abort right away
-            setTimeout(() => controller.abort(), 1000);
+            setTimeout(() => controller.abort(), 3000);
 
             // Ensure the request completes/cancels before proceeding
             await requestPromise;
@@ -911,7 +911,7 @@ export function createIntegrationTestsSuite(
                     return run.status === 'ABORTED' || run.status === 'ABORTING';
                 }
                 return false;
-            }, { timeout: 3000, interval: 500 });
+            }, { timeout: 10000, interval: 500 });
         });
 
         // Environment variable tests - only applicable to stdio transport


### PR DESCRIPTION
closes https://github.com/apify/apify-mcp-server/issues/261