### PR TITLE
feat(gpt-apps): add web scaffold and placeholder widgets

### DIFF
--- a/src/web/.gitignore
+++ b/src/web/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.DS_Store

--- a/src/web/build.js
+++ b/src/web/build.js
@@ -1,0 +1,147 @@
+import { promises as fs } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import autoprefixer from 'autoprefixer';
+import * as esbuild from 'esbuild';
+import postcss from 'postcss';
+import tailwindcss from 'tailwindcss';
+
+const filename = fileURLToPath(import.meta.url);
+const dirName = dirname(filename);
+
+const widgets = [
+    { name: 'search-actors-widget', entry: 'src/widgets/search-actors-widget.tsx' },
+    { name: 'actor-run-widget', entry: 'src/widgets/actor-run-widget.tsx' },
+];
+
+// Check if we're in dev mode
+const isDev = process.argv.includes('--watch');
+
+// Plugin to process and inline CSS with Tailwind
+const inlineCssPlugin = {
+    name: 'inline-css',
+    setup(build) {
+        build.onLoad({ filter: /\.css$/ }, async (args) => {
+            const cssContent = await fs.readFile(args.path, 'utf8');
+
+            // Process CSS through PostCSS with Tailwind
+            const result = await postcss([
+                tailwindcss,
+                autoprefixer,
+            ]).process(cssContent, {
+                from: args.path,
+                to: undefined,
+            });
+
+            const processedCss = result.css;
+
+            // Return processed CSS as a JS module that injects it into the document
+            return {
+                contents: `
+          const css = ${JSON.stringify(processedCss)};
+          if (typeof document !== 'undefined') {
+            const style = document.createElement('style');
+            style.textContent = css;
+            document.head.appendChild(style);
+          }
+          export default css;
+        `,
+                loader: 'js',
+            };
+        });
+    },
+};
+
+async function buildWidget(widget, watch = false) {
+    console.log(`${watch ? 'Watching' : 'Building'} ${widget.name}...`);
+
+    const buildOptions = {
+        entryPoints: [resolve(dirName, widget.entry)],
+        bundle: true,
+        minify: !watch,
+        format: 'esm',
+        target: 'es2020',
+        outfile: resolve(dirName, 'dist', `${widget.name}.js`),
+        plugins: [inlineCssPlugin],
+        define: {
+            'process.env.NODE_ENV': watch ? '"development"' : '"production"',
+        },
+        loader: {
+            '.tsx': 'tsx',
+            '.ts': 'ts',
+        },
+        logLevel: 'info',
+        sourcemap: watch ? 'inline' : false,
+    };
+
+    try {
+        if (watch) {
+            const context = await esbuild.context(buildOptions);
+            await context.watch();
+            console.log(`👀 Watching ${widget.name} for changes...`);
+            return context;
+        }
+        await esbuild.build(buildOptions);
+        console.log(`✓ ${widget.name} built successfully`);
+    } catch (error) {
+        console.error(`Failed to build ${widget.name}:`, error);
+        throw error;
+    }
+}
+
+async function buildAll() {
+    // Clean and create dist folder
+    const distPath = resolve(dirName, 'dist');
+    try {
+        await fs.rm(distPath, { recursive: true, force: true });
+    } catch (err) {
+    // Ignore if doesn't exist
+    }
+    await fs.mkdir(distPath, { recursive: true });
+
+    if (isDev) {
+        console.log('🚀 Starting development mode...\n');
+
+        // Build and watch all widgets
+        const contexts = [];
+        for (const widget of widgets) {
+            const ctx = await buildWidget(widget, true);
+            contexts.push(ctx);
+        }
+
+        // Start a simple HTTP server using esbuild's serve
+        const ctx = await esbuild.context({
+            entryPoints: [],
+        });
+
+        const { host, port } = await ctx.serve({
+            servedir: dirName,
+            port: 3000,
+        });
+
+        console.log(`\n✓ Dev server running at http://${host}:${port}/`);
+        console.log(`📄 Open http://${host}:${port}/index.html to preview\n`);
+
+        // Keep the process running
+        process.on('SIGINT', async () => {
+            console.log('\n\n👋 Shutting down...');
+            await ctx.dispose();
+            for (const c of contexts) {
+                await c.dispose();
+            }
+            process.exit(0);
+        });
+    } else {
+    // Production build
+        for (const widget of widgets) {
+            await buildWidget(widget, false);
+        }
+        console.log('\n✓ All widgets built successfully!');
+    }
+}
+
+buildAll().catch((err) => {
+    console.error('Build failed:', err);
+    process.exit(1);
+});

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Actor Search Widget - Dev Preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/dist/search-actors-widget.js"></script>
+  </body>
+</html>
+

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -1,0 +1,1758 @@
+{
+    "name": "@apify/mcp-web-widget",
+    "version": "0.1.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@apify/mcp-web-widget",
+            "version": "0.1.0",
+            "license": "ISC",
+            "dependencies": {
+                "react": "^18.3.1",
+                "react-dom": "^18.3.1"
+            },
+            "devDependencies": {
+                "@types/react": "^19.2.7",
+                "@types/react-dom": "^19.2.3",
+                "autoprefixer": "^10.4.20",
+                "esbuild": "^0.24.2",
+                "postcss": "^8.4.49",
+                "tailwindcss": "^3.4.17",
+                "typescript": "^5.6.3"
+            }
+        },
+        "node_modules/@alloc/quick-lru": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+            "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+            "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+            "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+            "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+            "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+            "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+            "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+            "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+            "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+            "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+            "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+            "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+            "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+            "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+            "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+            "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+            "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+            "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+            "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+            "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+            "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+            "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+            "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+            "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+            "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+            "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@types/react": {
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+            "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+            "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^19.2.0"
+            }
+        },
+        "node_modules/any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/arg": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/autoprefixer": {
+            "version": "10.4.23",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
+            "integrity": "sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.1",
+                "caniuse-lite": "^1.0.30001760",
+                "fraction.js": "^5.3.4",
+                "picocolors": "^1.1.1",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "bin": {
+                "autoprefixer": "bin/autoprefixer"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.9.8",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.8.tgz",
+            "integrity": "sha512-Y1fOuNDowLfgKOypdc9SPABfoWXuZHBOyCS4cD52IeZBhr4Md6CLLs6atcxVrzRmQ06E7hSlm5bHHApPKR/byA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.js"
+            }
+        },
+        "node_modules/binary-extensions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/camelcase-css": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+            "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001760",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
+            "integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/chokidar/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/commander": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/didyoumean": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/dlv": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.267",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+            "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/esbuild": {
+            "version": "0.24.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+            "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.24.2",
+                "@esbuild/android-arm": "0.24.2",
+                "@esbuild/android-arm64": "0.24.2",
+                "@esbuild/android-x64": "0.24.2",
+                "@esbuild/darwin-arm64": "0.24.2",
+                "@esbuild/darwin-x64": "0.24.2",
+                "@esbuild/freebsd-arm64": "0.24.2",
+                "@esbuild/freebsd-x64": "0.24.2",
+                "@esbuild/linux-arm": "0.24.2",
+                "@esbuild/linux-arm64": "0.24.2",
+                "@esbuild/linux-ia32": "0.24.2",
+                "@esbuild/linux-loong64": "0.24.2",
+                "@esbuild/linux-mips64el": "0.24.2",
+                "@esbuild/linux-ppc64": "0.24.2",
+                "@esbuild/linux-riscv64": "0.24.2",
+                "@esbuild/linux-s390x": "0.24.2",
+                "@esbuild/linux-x64": "0.24.2",
+                "@esbuild/netbsd-arm64": "0.24.2",
+                "@esbuild/netbsd-x64": "0.24.2",
+                "@esbuild/openbsd-arm64": "0.24.2",
+                "@esbuild/openbsd-x64": "0.24.2",
+                "@esbuild/sunos-x64": "0.24.2",
+                "@esbuild/win32-arm64": "0.24.2",
+                "@esbuild/win32-ia32": "0.24.2",
+                "@esbuild/win32-x64": "0.24.2"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fast-glob/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/fraction.js": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+            "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/rawify"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/jiti": {
+            "version": "1.21.7",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+            "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "bin/jiti.js"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT"
+        },
+        "node_modules/lilconfig": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antonk52"
+            }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.27",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-hash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pirates": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/postcss-import": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+            "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.0.0",
+                "read-cache": "^1.0.0",
+                "resolve": "^1.1.7"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.0.0"
+            }
+        },
+        "node_modules/postcss-js": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+            "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "camelcase-css": "^2.0.1"
+            },
+            "engines": {
+                "node": "^12 || ^14 || >= 16"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4.21"
+            }
+        },
+        "node_modules/postcss-load-config": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+            "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "lilconfig": "^3.1.1"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "jiti": ">=1.21.0",
+                "postcss": ">=8.0.9",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                },
+                "postcss": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/postcss-nested": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+            "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "postcss-selector-parser": "^6.1.1"
+            },
+            "engines": {
+                "node": ">=12.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.14"
+            }
+        },
+        "node_modules/postcss-selector-parser": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+            "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/postcss-value-parser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/react": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.2"
+            },
+            "peerDependencies": {
+                "react": "^18.3.1"
+            }
+        },
+        "node_modules/read-cache": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+            "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pify": "^2.3.0"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.11",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
+        "node_modules/scheduler": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sucrase": {
+            "version": "3.35.1",
+            "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+            "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.2",
+                "commander": "^4.0.0",
+                "lines-and-columns": "^1.1.6",
+                "mz": "^2.7.0",
+                "pirates": "^4.0.1",
+                "tinyglobby": "^0.2.11",
+                "ts-interface-checker": "^0.1.9"
+            },
+            "bin": {
+                "sucrase": "bin/sucrase",
+                "sucrase-node": "bin/sucrase-node"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tailwindcss": {
+            "version": "3.4.19",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+            "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@alloc/quick-lru": "^5.2.0",
+                "arg": "^5.0.2",
+                "chokidar": "^3.6.0",
+                "didyoumean": "^1.2.2",
+                "dlv": "^1.1.3",
+                "fast-glob": "^3.3.2",
+                "glob-parent": "^6.0.2",
+                "is-glob": "^4.0.3",
+                "jiti": "^1.21.7",
+                "lilconfig": "^3.1.3",
+                "micromatch": "^4.0.8",
+                "normalize-path": "^3.0.0",
+                "object-hash": "^3.0.0",
+                "picocolors": "^1.1.1",
+                "postcss": "^8.4.47",
+                "postcss-import": "^15.1.0",
+                "postcss-js": "^4.0.1",
+                "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+                "postcss-nested": "^6.2.0",
+                "postcss-selector-parser": "^6.1.2",
+                "resolve": "^1.22.8",
+                "sucrase": "^3.35.0"
+            },
+            "bin": {
+                "tailwind": "lib/cli.js",
+                "tailwindcss": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/thenify": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0"
+            }
+        },
+        "node_modules/thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "thenify": ">= 3.1.0 < 4"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/ts-interface-checker": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+            "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/update-browserslist-db": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true,
+            "license": "MIT"
+        }
+    }
+}

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@apify/mcp-web-widget",
+    "version": "0.1.0",
+    "type": "module",
+    "scripts": {
+        "dev": "node build.js --watch",
+        "build": "node build.js"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "description": "",
+    "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+    },
+    "devDependencies": {
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "autoprefixer": "^10.4.20",
+        "esbuild": "^0.24.2",
+        "postcss": "^8.4.49",
+        "tailwindcss": "^3.4.17",
+        "typescript": "^5.6.3"
+    }
+}

--- a/src/web/postcss.config.js
+++ b/src/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    },
+};

--- a/src/web/src/components/layout/WidgetLayout.tsx
+++ b/src/web/src/components/layout/WidgetLayout.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useMaxHeight } from "../../hooks/use-max-height";
+import { cn } from "../../utils/cn";
+
+interface WidgetLayoutProps {
+    children: React.ReactNode;
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+export const WidgetLayout: React.FC<WidgetLayoutProps> = ({ children, className = "", style = {} }) => {
+    const maxHeight = useMaxHeight();
+
+    return (
+        <div
+            className={cn("flex flex-col gap-6 items-start pb-10 pt-4 px-5 w-full overflow-y-auto", className)}
+            style={{
+                fontFamily: "SF Pro, -apple-system, BlinkMacSystemFont, sans-serif",
+                maxHeight: maxHeight ? `${maxHeight}px` : undefined,
+                ...style,
+            }}
+        >
+            {children}
+        </div>
+    );
+};

--- a/src/web/src/components/ui/Alert.tsx
+++ b/src/web/src/components/ui/Alert.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+import { cn } from "../../utils/cn";
+
+import { Heading } from "./Heading";
+import { Text } from "./Text";
+
+interface AlertProps {
+    variant?: "success" | "error" | "warning";
+    title?: string;
+    children: React.ReactNode;
+    className?: string;
+}
+
+const variantStyles = {
+    success: {
+        backgroundColor: "var(--color-success-bg)",
+        borderColor: "var(--color-success-border)",
+        titleColor: "var(--color-success)",
+    },
+    error: {
+        backgroundColor: "var(--color-error-bg)",
+        borderColor: "var(--color-error-border)",
+        titleColor: "var(--color-error)",
+    },
+    warning: {
+        backgroundColor: "var(--color-warning-soft)",
+        borderColor: "var(--color-warning)",
+        titleColor: "var(--color-warning)",
+    },
+};
+
+export const Alert: React.FC<AlertProps> = ({ variant = "error", title, children, className = "" }) => {
+    const styles = variantStyles[variant];
+
+    return (
+        <div
+            className={cn("rounded-xl p-4", className)}
+            style={{
+                backgroundColor: styles.backgroundColor,
+                border: `1px solid ${styles.borderColor}`,
+            }}
+        >
+            {title && (
+                <Heading as="h3" size="md" className="mb-1" tone="inherit" style={{ color: styles.titleColor }}>
+                    {title}
+                </Heading>
+            )}
+            <Text as="div" size="sm">
+                {children}
+            </Text>
+        </div>
+    );
+};
+

--- a/src/web/src/components/ui/Badge.tsx
+++ b/src/web/src/components/ui/Badge.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { cn } from "../../utils/cn";
+
+interface BadgeProps {
+    variant?: "success" | "danger" | "warning" | "secondary";
+    children: React.ReactNode;
+    className?: string;
+}
+
+export const Badge: React.FC<BadgeProps> = ({ variant = "secondary", children, className = "" }) => {
+    const getVariantStyles = (): React.CSSProperties => {
+        switch (variant) {
+            case "success":
+                return {
+                    backgroundColor: "var(--color-success-soft)",
+                    color: "var(--color-success)",
+                };
+            case "danger":
+                return {
+                    backgroundColor: "var(--color-error-soft)",
+                    color: "var(--color-error)",
+                };
+            case "warning":
+                return {
+                    backgroundColor: "var(--color-warning-soft)",
+                    color: "var(--color-warning)",
+                };
+            default: // secondary
+                return {
+                    backgroundColor: "var(--color-secondary-soft)",
+                    color: "var(--color-text-primary)",
+                };
+        }
+    };
+
+    return (
+        <span
+            className={cn("px-2 py-1 rounded text-xs font-medium", className)}
+            style={getVariantStyles()}
+        >
+            {children}
+        </span>
+    );
+};
+

--- a/src/web/src/components/ui/Button.tsx
+++ b/src/web/src/components/ui/Button.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+
+import { cn } from "../../utils/cn";
+
+import { LoadingSpinner } from "./LoadingSpinner";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: "primary" | "secondary";
+    size?: "sm" | "md";
+    loading?: boolean;
+    children: React.ReactNode;
+}
+
+const variantStyles = {
+    primary: {
+        backgroundColor: "var(--color-button-bg)",
+        color: "var(--color-button-text)",
+        border: "none",
+    },
+    secondary: {
+        backgroundColor: "transparent",
+        color: "var(--color-text-primary)",
+        borderColor: "var(--color-border)",
+    },
+};
+
+const sizeClasses = {
+    sm: "px-3 py-1.5 text-sm",
+    md: "px-4 py-2",
+};
+
+export const Button: React.FC<ButtonProps> = ({
+    variant = "primary",
+    size = "md",
+    loading = false,
+    disabled,
+    children,
+    className = "",
+    style = {},
+    ...props
+}) => {
+    const isDisabled = disabled || loading;
+
+    const hoverClass = variant === "secondary" && "hover:bg-[var(--color-card-bg-alt)]";
+    const opacityClass = variant === "secondary" ? "hover:opacity-80" : "hover:opacity-90";
+
+    return (
+        <button
+            {...props}
+            disabled={isDisabled}
+            className={cn(
+                "rounded-lg border disabled:opacity-50 disabled:cursor-not-allowed transition-opacity flex items-center gap-2",
+                hoverClass,
+                opacityClass,
+                sizeClasses[size],
+                className
+            )}
+            style={{
+                ...variantStyles[variant],
+                ...style,
+            }}
+        >
+            {loading ? (
+                <span className="flex items-center gap-1.5">
+                    <LoadingSpinner size={size === "sm" ? "sm" : "md"} />
+                    {children}
+                </span>
+            ) : (
+                children
+            )}
+        </button>
+    );
+};
+

--- a/src/web/src/components/ui/Card.tsx
+++ b/src/web/src/components/ui/Card.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+import { cn } from "../../utils/cn";
+
+type CardVariant = "default" | "alt" | "code";
+type CardPadding = "none" | "sm" | "md" | "lg";
+type CardRounded = "none" | "lg" | "2xl" | "3xl";
+type CardShadow = "none" | "sm" | "md";
+
+const variantClass: Record<CardVariant, string> = {
+    default: "bg-[var(--color-card-bg)]",
+    alt: "bg-[var(--color-card-bg-alt)]",
+    code: "bg-[var(--color-code-bg)]",
+};
+
+const paddingClass: Record<CardPadding, string | undefined> = {
+    none: undefined,
+    sm: "p-4",
+    md: "p-5",
+    lg: "p-6",
+};
+
+const roundedClass: Record<CardRounded, string | undefined> = {
+    none: undefined,
+    lg: "rounded-lg",
+    "2xl": "rounded-2xl",
+    "3xl": "rounded-3xl",
+};
+
+
+const shadowClass: Record<CardShadow, string | undefined> = {
+    none: undefined,
+    sm: "shadow-[0_1px_2px_rgba(0,0,0,0.06),0_4px_12px_rgba(0,0,0,0.04)]",
+    md: "shadow-[0_1px_3px_rgba(0,0,0,0.08),0_8px_24px_rgba(0,0,0,0.06)]",
+};
+
+type CardProps = React.HTMLAttributes<HTMLElement> & {
+    as?: React.ElementType;
+    variant?: CardVariant;
+    padding?: CardPadding;
+    rounded?: CardRounded;
+    shadow?: CardShadow;
+};
+
+export function Card({
+    as: Component = "div",
+    variant = "default",
+    padding = "none",
+    rounded = "2xl",
+    shadow = "sm",
+    className,
+    ...props
+}: CardProps) {
+    return <Component className={cn(variantClass[variant], paddingClass[padding], roundedClass[rounded], shadowClass[shadow], className)} {...props} />;
+}
+

--- a/src/web/src/components/ui/Heading.tsx
+++ b/src/web/src/components/ui/Heading.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { cn } from "../../utils/cn";
+
+type HeadingSize = "2xl" | "xl" | "lg" | "md" | "sm";
+type Weight = "normal" | "medium" | "semibold" | "bold";
+type Tone = "primary" | "secondary" | "tertiary" | "inherit";
+
+const sizeClass: Record<HeadingSize, string> = {
+    "2xl": "text-2xl leading-8",
+    xl: "text-xl leading-7",
+    lg: "text-lg leading-6",
+    md: "text-base leading-6",
+    sm: "text-sm leading-5",
+};
+
+const weightClass: Record<Weight, string> = {
+    normal: "font-normal",
+    medium: "font-medium",
+    semibold: "font-semibold",
+    bold: "font-bold",
+};
+
+const toneClass: Record<Tone, string | undefined> = {
+    primary: "text-[var(--color-text-primary)]",
+    secondary: "text-[var(--color-text-secondary)]",
+    tertiary: "text-[var(--color-text-tertiary)]",
+    inherit: undefined,
+};
+
+interface HeadingProps extends React.HTMLAttributes<HTMLElement> {
+    as?: React.ElementType;
+    size?: HeadingSize;
+    weight?: Weight;
+    tone?: Tone;
+}
+
+export function Heading({ as: Component = "h2", size = "lg", weight = "semibold", tone = "primary", className, ...props }: HeadingProps) {
+    return <Component className={cn(sizeClass[size], weightClass[weight], toneClass[tone], className)} {...props} />;
+}

--- a/src/web/src/components/ui/Icons.tsx
+++ b/src/web/src/components/ui/Icons.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+interface IconProps {
+    className?: string;
+    size?: number;
+}
+
+export const ArrowLeft: React.FC<IconProps> = ({ className = "" }) => (
+    <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" className={className}>
+        <path fillRule="evenodd" d="M5.293 12.707a1 1 0 0 1 0-1.414l5-5a1 1 0 1 1 1.414 1.414L8.414 11H18a1 1 0 1 1 0 2H8.414l3.293 3.293a1 1 0 0 1-1.414 1.414l-5-5Z" clipRule="evenodd" />
+    </svg>
+);
+
+export const Cube: React.FC<IconProps> = ({ className = "" }) => (
+    <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" className={className}>
+        <path fillRule="evenodd" d="M12.5 3.444a1 1 0 0 0-1 0l-6.253 3.61 6.768 3.807 6.955-3.682-6.47-3.735Zm7.16 5.632L13 12.602v7.666l6.16-3.556a1 1 0 0 0 .5-.867V9.076ZM11 20.268v-7.683L4.34 8.839v7.006a1 1 0 0 0 .5.867L11 20.268Zm-.5-18.557a3 3 0 0 1 3 0l6.66 3.846a3 3 0 0 1 1.5 2.598v7.69a3 3 0 0 1-1.5 2.598L13.5 22.29a3 3 0 0 1-3 0l-6.66-3.846a3 3 0 0 1-1.5-2.598v-7.69a3 3 0 0 1 1.5-2.598L10.5 1.71Z" clipRule="evenodd" />
+    </svg>
+);
+
+export const MembersFilled: React.FC<IconProps> = ({ className = "" }) => (
+    <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" className={className}>
+        <path d="M2.22222 20C1.54721 20 1 19.4563 1 18.7857C1 16.7307 1.99227 15.1645 3.42364 14.1533C4.81866 13.1677 6.60907 12.7143 8.33333 12.7143C10.0576 12.7143 11.848 13.1677 13.243 14.1533C14.6744 15.1645 15.6667 16.7307 15.6667 18.7857C15.6667 19.4563 15.1195 20 14.4444 20C12.7348 20 3.93184 20 2.22222 20Z" fill="currentColor" />
+        <path d="M17.5 18.7857C17.5 16.4257 16.487 14.5332 14.998 13.2166C15.7888 12.8756 16.655 12.7143 17.5 12.7143C18.7932 12.7143 20.136 13.0921 21.1823 13.9134C22.2558 14.7561 23 16.0613 23 17.7738C23 18.3327 22.5896 18.7857 22.0833 18.7857H17.5Z" fill="currentColor" />
+        <path d="M8.33333 3C5.97078 3 4.05556 4.90279 4.05556 7.25C4.05556 9.59721 5.97078 11.5 8.33333 11.5C10.6959 11.5 12.6111 9.59721 12.6111 7.25C12.6111 4.90279 10.6959 3 8.33333 3Z" fill="currentColor" />
+        <path d="M17.5 5.42857C15.8125 5.42857 14.4444 6.78771 14.4444 8.46429C14.4444 10.1409 15.8125 11.5 17.5 11.5C19.1875 11.5 20.5556 10.1409 20.5556 8.46429C20.5556 6.78771 19.1875 5.42857 17.5 5.42857Z" fill="currentColor" />
+    </svg>
+);
+
+export const Play: React.FC<IconProps> = ({ className = "" }) => (
+    <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" className={className}>
+        <path d="M9.5 9.33165V14.6683C9.5 15.4595 10.3752 15.9373 11.0408 15.5095L15.1915 12.8412C15.8038 12.4475 15.8038 11.5524 15.1915 11.1588L11.0408 8.49047C10.3752 8.06265 9.5 8.54049 9.5 9.33165Z" fill="currentColor" />
+        <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2ZM4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12Z" fill="currentColor" />
+    </svg>
+);
+
+export const Check: React.FC<IconProps> = ({ className = "" }) => (
+    <svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" className={className}>
+        <path fillRule="evenodd" d="M19.916 4.626a1 1 0 0 1 .208 1.4l-9 13.5a1 1 0 0 1-1.614.116l-6-6a1 1 0 1 1 1.414-1.414l5.226 5.226 8.45-12.675a1 1 0 0 1 1.316-.408Z" clipRule="evenodd" />
+    </svg>
+);
+

--- a/src/web/src/components/ui/JsonPreview.tsx
+++ b/src/web/src/components/ui/JsonPreview.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import { Text } from "./Text";
+
+type JsonPreviewProps = {
+    value: unknown;
+    title?: string;
+    maxHeight?: number;
+};
+
+export const JsonPreview: React.FC<JsonPreviewProps> = ({ value, title, maxHeight = 300 }) => {
+    const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+
+    return (
+        <div className="flex flex-col gap-2">
+            {title ? (
+                <Text as="span" size="xs" weight="medium" tone="secondary">
+                    {title}
+                </Text>
+            ) : null}
+
+            <div
+                className="rounded-lg overflow-x-auto bg-[var(--color-card-bg)] border border-[var(--color-border)]"
+                style={{
+                    maxHeight,
+                    overflowY: "auto",
+                }}
+            >
+                <pre className="text-xs whitespace-pre-wrap font-mono p-2 rounded bg-[var(--color-code-bg)]">
+                    <code className="text-[var(--color-code-orange)]">{text}</code>
+                </pre>
+            </div>
+        </div>
+    );
+};

--- a/src/web/src/components/ui/ListItemFrame.tsx
+++ b/src/web/src/components/ui/ListItemFrame.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { cn } from "../../utils/cn";
+
+type ListItemFrameProps = {
+    children: React.ReactNode;
+    isFirst?: boolean;
+    isLast?: boolean;
+    className?: string;
+};
+
+export const ListItemFrame: React.FC<ListItemFrameProps> = ({ children, isFirst, isLast, className }) => {
+    return (
+        <div
+            className={cn(
+                "flex flex-col gap-4 items-start justify-center px-4 w-full",
+                isFirst ? "pt-4" : "pt-3",
+                isLast ? "pb-4" : "pb-3",
+                !isLast && "border-b border-[var(--color-border)]",
+                className
+            )}
+        >
+            {children}
+        </div>
+    );
+};

--- a/src/web/src/components/ui/LoadingSpinner.tsx
+++ b/src/web/src/components/ui/LoadingSpinner.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import { cn } from "../../utils/cn";
+
+interface LoadingSpinnerProps {
+    size?: "sm" | "md" | "lg";
+    className?: string;
+}
+
+const sizeClasses = {
+    sm: "h-3 w-3",
+    md: "h-4 w-4",
+    lg: "h-6 w-6",
+};
+
+export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ size = "md", className = "" }) => {
+    return (
+        <svg className={cn("animate-spin", sizeClasses[size], className)} fill="none" viewBox="0 0 24 24">
+            <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+            />
+            <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+        </svg>
+    );
+};
+

--- a/src/web/src/components/ui/ProgressBar.tsx
+++ b/src/web/src/components/ui/ProgressBar.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import { cn } from "../../utils/cn";
+
+interface ProgressBarProps {
+    variant?: "warning" | "success" | "error";
+    className?: string;
+}
+
+const variantColors = {
+    warning: "var(--color-warning)",
+    success: "var(--color-success)",
+    error: "var(--color-error)",
+};
+
+export const ProgressBar: React.FC<ProgressBarProps> = ({ variant = "warning", className = "" }) => {
+    return (
+        <div className={cn("w-full", className)}>
+            <div className="h-1 rounded-full overflow-hidden" style={{ backgroundColor: "var(--color-border)" }}>
+                <div
+                    className="h-full rounded-full animate-pulse"
+                    style={{
+                        backgroundColor: variantColors[variant],
+                        width: "100%",
+                        animation: "pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite",
+                    }}
+                />
+            </div>
+        </div>
+    );
+};
+

--- a/src/web/src/components/ui/SkeletonBlock.tsx
+++ b/src/web/src/components/ui/SkeletonBlock.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { cn } from "../../utils/cn";
+
+interface SkeletonBlockProps {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export const SkeletonBlock: React.FC<SkeletonBlockProps> = ({ className, style }) => {
+  return (
+    <div
+      className={cn("animate-pulse rounded", className)}
+      style={{
+        backgroundColor: "var(--color-code-bg)",
+        ...style,
+      }}
+    />
+  );
+};

--- a/src/web/src/components/ui/Text.tsx
+++ b/src/web/src/components/ui/Text.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { cn } from "../../utils/cn";
+
+type TextSize = "xs" | "sm" | "md" | "lg";
+type Weight = "normal" | "medium" | "semibold" | "bold";
+type Tone = "primary" | "secondary" | "tertiary" | "inherit";
+
+const sizeClass: Record<TextSize, string> = {
+    xs: "text-xs leading-4",
+    sm: "text-sm leading-5",
+    md: "text-base leading-6",
+    lg: "text-lg leading-7",
+};
+
+const weightClass: Record<Weight, string> = {
+    normal: "font-normal",
+    medium: "font-medium",
+    semibold: "font-semibold",
+    bold: "font-bold",
+};
+
+const toneClass: Record<Tone, string | undefined> = {
+    primary: "text-[var(--color-text-primary)]",
+    secondary: "text-[var(--color-text-secondary)]",
+    tertiary: "text-[var(--color-text-tertiary)]",
+    inherit: undefined,
+};
+
+interface TextProps extends React.HTMLAttributes<HTMLElement> {
+    as?: React.ElementType;
+    size?: TextSize;
+    weight?: Weight;
+    tone?: Tone;
+    truncate?: boolean;
+}
+
+export function Text({ as: Component = "p", size = "md", weight = "normal", tone = "primary", truncate = false, className, ...props }: TextProps) {
+    return <Component className={cn(sizeClass[size], weightClass[weight], toneClass[tone], truncate && "truncate", className)} {...props} />;
+}

--- a/src/web/src/hooks/use-display-mode.ts
+++ b/src/web/src/hooks/use-display-mode.ts
@@ -1,0 +1,6 @@
+import { useOpenAiGlobal } from "../hooks/use-open-ai-global";
+import type { DisplayMode } from "../types";
+
+export const useDisplayMode = (): DisplayMode | null => {
+  return useOpenAiGlobal("displayMode");
+};

--- a/src/web/src/hooks/use-max-height.ts
+++ b/src/web/src/hooks/use-max-height.ts
@@ -1,0 +1,5 @@
+import { useOpenAiGlobal } from "../hooks/use-open-ai-global";
+
+export const useMaxHeight = (): number | null => {
+  return useOpenAiGlobal("maxHeight");
+};

--- a/src/web/src/hooks/use-open-ai-global.ts
+++ b/src/web/src/hooks/use-open-ai-global.ts
@@ -1,0 +1,37 @@
+import { useSyncExternalStore } from "react";
+import {
+  SET_GLOBALS_EVENT_TYPE,
+  SetGlobalsEvent,
+} from "../types";
+import type { OpenAiGlobals } from "../types";
+
+export function useOpenAiGlobal<K extends keyof OpenAiGlobals>(
+  key: K
+): OpenAiGlobals[K] | null {
+  return useSyncExternalStore(
+    (onChange) => {
+      if (typeof window === "undefined") {
+        return () => { };
+      }
+
+      const handleSetGlobal = (event: SetGlobalsEvent) => {
+        const value = event.detail.globals[key];
+        if (value === undefined) {
+          return;
+        }
+
+        onChange();
+      };
+
+      window.addEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobal, {
+        passive: true,
+      });
+
+      return () => {
+        window.removeEventListener(SET_GLOBALS_EVENT_TYPE, handleSetGlobal);
+      };
+    },
+    () => window.openai?.[key] ?? null,
+    () => window.openai?.[key] ?? null
+  );
+}

--- a/src/web/src/hooks/use-widget-props.ts
+++ b/src/web/src/hooks/use-widget-props.ts
@@ -1,0 +1,17 @@
+import { useOpenAiGlobal } from "./use-open-ai-global";
+
+/**
+ * Hook to access tool output (props) from the MCP server
+ */
+export function useWidgetProps<T extends Record<string, unknown>>(
+  defaultState?: T | (() => T)
+): T {
+  const props = useOpenAiGlobal("toolOutput") as T;
+
+  const fallback =
+    typeof defaultState === "function"
+      ? (defaultState as () => T | null)()
+      : defaultState ?? null;
+
+  return props ?? fallback;
+}

--- a/src/web/src/hooks/use-widget-state.ts
+++ b/src/web/src/hooks/use-widget-state.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Hook to manage widget state with persistence
+ * Based on https://developers.openai.com/apps-sdk/build/custom-ux#persist-component-state-expose-context-to-chatgpt
+ */
+export function useWidgetState<T extends Record<string, unknown>>(
+  defaultState: T | (() => T)
+): [T, (state: T) => Promise<void>] {
+  const initialState =
+    typeof defaultState === "function"
+      ? (defaultState as () => T)()
+      : defaultState;
+
+  const [state, setState] = useState<T>(initialState);
+
+  // Restore cached state on mount
+  useEffect(() => {
+    if (window.openai?.widgetState) {
+      setState(window.openai.widgetState as T);
+    }
+  }, []);
+
+  // Persist state changes
+  const setWidgetState = async (newState: T) => {
+    setState(newState);
+    if (window.openai?.setWidgetState) {
+      await window.openai.setWidgetState(newState);
+    }
+  };
+
+  return [state, setWidgetState];
+}

--- a/src/web/src/index.css
+++ b/src/web/src/index.css
@@ -1,0 +1,131 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+  /* Theme-aware brand colors */
+  :root {
+    --color-code-orange: #FF6B00;
+    --color-code-bg: rgba(13, 13, 13, 0.05);
+    --color-code-text: #5d5d5d;
+    --color-type-blue-bg: rgba(72, 170, 255, 0.1);
+    --color-type-blue: #48aaff;
+    --color-card-bg: #ffffff;
+    --color-card-bg-alt: #ffffff;
+    --color-text-primary: #0d0d0d;
+    --color-text-secondary: #5d5d5d;
+    --color-text-tertiary: #999;
+    --color-border: #e0e0e0;
+    --color-button-bg: #212121;
+    --color-button-text: #ffffff;
+    --color-success: #40c977;
+    --color-success-soft: rgba(64, 201, 119, 0.1);
+    --color-success-bg: #f0fff0;
+    --color-success-border: #c0ffc0;
+    --color-error: #ef4444;
+    --color-error-soft: rgba(239, 68, 68, 0.1);
+    --color-error-bg: #fff5f5;
+    --color-error-border: #ffdddd;
+    --color-warning: #ff9013;
+    --color-warning-soft: rgba(255, 144, 19, 0.1);
+    --color-secondary-soft: rgba(0, 0, 0, 0.05);
+  }
+
+  [data-theme="dark"] {
+    --color-code-orange: #FF9013;
+    --color-code-bg: #414141;
+    --color-code-text: #cdcdcd;
+    --color-type-blue-bg: rgba(72, 170, 255, 0.2);
+    --color-type-blue: #48aaff;
+    --color-card-bg: #303030;
+    --color-card-bg-alt: #212121;
+    --color-text-primary: #ffffff;
+    --color-text-secondary: #cdcdcd;
+    --color-text-tertiary: #7a7a7a;
+    --color-border: #303030;
+    --color-button-bg: #303030;
+    --color-button-text: #ffffff;
+    --color-success: #40c977;
+    --color-success-soft: rgba(64, 201, 119, 0.2);
+    --color-success-bg: #1a2a1a;
+    --color-success-border: #2a4a2a;
+    --color-error: #ef4444;
+    --color-error-soft: rgba(239, 68, 68, 0.2);
+    --color-error-bg: #2a1a1a;
+    --color-error-border: #4a2a2a;
+    --color-warning: #ff9013;
+    --color-warning-soft: rgba(255, 144, 19, 0.2);
+    --color-secondary-soft: rgba(255, 255, 255, 0.05);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --color-code-orange: #FF9013;
+      --color-code-bg: #414141;
+      --color-code-text: #cdcdcd;
+      --color-type-blue-bg: rgba(72, 170, 255, 0.2);
+      --color-type-blue: #48aaff;
+      --color-card-bg: #303030;
+      --color-card-bg-alt: #212121;
+      --color-text-primary: #ffffff;
+      --color-text-secondary: #cdcdcd;
+      --color-text-tertiary: #7a7a7a;
+      --color-border: #303030;
+      --color-button-bg: #303030;
+      --color-button-text: #ffffff;
+      --color-success: #40c977;
+      --color-success-soft: rgba(64, 201, 119, 0.2);
+      --color-success-bg: #1a2a1a;
+      --color-success-border: #2a4a2a;
+      --color-error: #ef4444;
+      --color-error-soft: rgba(239, 68, 68, 0.2);
+      --color-error-bg: #2a1a1a;
+      --color-error-border: #4a2a2a;
+      --color-warning: #ff9013;
+      --color-warning-soft: rgba(255, 144, 19, 0.2);
+      --color-secondary-soft: rgba(255, 255, 255, 0.05);
+    }
+  }
+
+@layer utilities {
+  .overflow-auto > *,
+  .overflow-scroll > *,
+  .overflow-x-auto > *,
+  .overflow-y-auto > * {
+    scrollbar-color: auto;
+  }
+
+  /* Base style for scrollable elements */
+  .overflow-auto,
+  .overflow-scroll,
+  .overflow-x-auto,
+  .overflow-y-auto,
+  .overflow-x-scroll,
+  .overflow-y-scroll {
+    scrollbar-color: rgb(0, 0, 0, 0.1) transparent;
+
+    @media (prefers-color-scheme: dark) {
+      scrollbar-color: rgb(255, 255, 255, 0.1) transparent;
+    }
+  }
+
+  /* Hover state directly on the scrollable element */
+  .overflow-auto:hover,
+  .overflow-scroll:hover,
+  .overflow-x-auto:hover,
+  .overflow-y-auto:hover {
+    scrollbar-color: rgb(0, 0, 0, 0.2) transparent;
+
+    @media (prefers-color-scheme: dark) {
+      scrollbar-color: rgb(255, 255, 255, 0.2) transparent;
+    }
+  }
+}

--- a/src/web/src/types.ts
+++ b/src/web/src/types.ts
@@ -1,0 +1,160 @@
+export type OpenAiGlobals<
+  ToolInput = UnknownObject,
+  ToolOutput = UnknownObject,
+  ToolResponseMetadata = UnknownObject,
+  WidgetState = UnknownObject
+> = {
+  // visuals
+  theme: Theme;
+
+  userAgent: UserAgent;
+  locale: string;
+
+  // layout
+  maxHeight: number;
+  displayMode: DisplayMode;
+  safeArea: SafeArea;
+
+  // state
+  toolInput: ToolInput;
+  toolOutput: ToolOutput | null;
+  toolResponseMetadata: ToolResponseMetadata | null;
+  widgetState: WidgetState | null;
+  setWidgetState: (state: WidgetState) => Promise<void>;
+};
+
+// currently copied from types.ts in chatgpt/web-sandbox.
+// Will eventually use a public package.
+type API = {
+  callTool: CallTool;
+  sendFollowUpMessage: (args: { prompt: string; }) => Promise<void>;
+  openExternal(payload: { href: string; }): void;
+
+  // Layout controls
+  requestDisplayMode: RequestDisplayMode;
+  requestModal: (args: { title?: string; params?: UnknownObject; }) => Promise<unknown>;
+  requestClose: () => Promise<void>;
+};
+
+export type UnknownObject = Record<string, unknown>;
+
+export type Theme = "light" | "dark";
+
+export type SafeAreaInsets = {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+};
+
+export type SafeArea = {
+  insets: SafeAreaInsets;
+};
+
+export type DeviceType = "mobile" | "tablet" | "desktop" | "unknown";
+
+export type UserAgent = {
+  device: { type: DeviceType; };
+  capabilities: {
+    hover: boolean;
+    touch: boolean;
+  };
+};
+
+/** Display mode */
+export type DisplayMode = "pip" | "inline" | "fullscreen";
+export type RequestDisplayMode = (args: { mode: DisplayMode; }) => Promise<{
+  /**
+   * The granted display mode. The host may reject the request.
+   * For mobile, PiP is always coerced to fullscreen.
+   */
+  mode: DisplayMode;
+}>;
+
+export type CallToolResponse = {
+  result: string;
+  isError?: boolean;
+  content?: Array<{ type: string; text?: string; }>;
+  structuredContent?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+};
+
+/** Calling APIs */
+export type CallTool = (
+  name: string,
+  args: Record<string, unknown>
+) => Promise<CallToolResponse>;
+
+/** Extra events */
+export const SET_GLOBALS_EVENT_TYPE = "openai:set_globals";
+export class SetGlobalsEvent extends CustomEvent<{
+  globals: Partial<OpenAiGlobals>;
+}> {
+  readonly type = SET_GLOBALS_EVENT_TYPE;
+}
+
+/**
+ * Global oai object injected by the web sandbox for communicating with chatgpt host page.
+ */
+declare global {
+  interface Window {
+    openai: API & OpenAiGlobals;
+  }
+
+  interface WindowEventMap {
+    [SET_GLOBALS_EVENT_TYPE]: SetGlobalsEvent;
+  }
+}
+
+// --- App Specific Types ---
+
+export interface PricingInfo {
+    pricingModel: string;
+    pricePerResultUsd: number;
+    monthlyChargeUsd: number;
+}
+
+export interface ActorStats {
+  totalBuilds: number;
+  totalRuns: number;
+  totalUsers: number;
+  totalBookmarks: number;
+}
+
+export interface ActorDetails {
+  actorInfo: {
+    id: string;
+    name: string;
+    username: string;
+    title?: string;
+    description: string;
+    pictureUrl?: string;
+    stats?: ActorStats;
+    currentPricingInfo?: PricingInfo;
+    userActorRuns?: {
+      successRate: number | null;
+    };
+  };
+  actorCard: string;
+  readme: string;
+  inputSchema?: {
+    type: string;
+    properties: Record<string, unknown>;
+  };
+}
+
+export interface Actor {
+  id: string;
+  name: string;
+  username: string;
+  fullName?: string;
+  title?: string;
+  description: string;
+  categories?: string[];
+  pictureUrl?: string;
+  stats?: ActorStats;
+  currentPricingInfo?: PricingInfo;
+  userActorRuns?: {
+    successRate: number | null;
+  };
+}

--- a/src/web/src/utils/cn.ts
+++ b/src/web/src/utils/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+    return classes.filter(Boolean).join(" ");
+}

--- a/src/web/src/utils/formatting.ts
+++ b/src/web/src/utils/formatting.ts
@@ -1,0 +1,57 @@
+import { PricingInfo } from '../types';
+
+export const formatPricing = (pricing: PricingInfo): string => {
+    if (pricing.pricingModel === "FREE") return "Free";
+    if (pricing.pricingModel === "FLAT_PRICE_PER_MONTH") {
+        return `$${pricing.monthlyChargeUsd}/month`;
+    }
+    if (pricing.pricingModel === "PRICE_PER_DATASET_ITEM") {
+        return `$${pricing.pricePerResultUsd}/result`;
+    }
+    if (pricing.pricingModel === "PAY_PER_EVENT") {
+        return "Pay per use";
+    }
+    return "N/A";
+};
+
+export const formatNumber = (num: number): string => {
+    try {
+        if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
+        if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
+        return num.toString();
+    } catch (error) {
+        console.error("Error formatting number:", error);
+        return "N/A";
+    }
+};
+
+export const formatDuration = (startedAt: string, finishedAt?: string): string => {
+    const start = new Date(startedAt).getTime();
+    const end = finishedAt ? new Date(finishedAt).getTime() : Date.now();
+    const durationMs = end - start;
+
+    const seconds = Math.floor(durationMs / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+
+    if (hours > 0) {
+        return `${hours}h ${minutes % 60}m ${seconds % 60}s`;
+    }
+    if (minutes > 0) {
+        return `${minutes}m ${seconds % 60}s`;
+    }
+    return `${seconds}s`;
+};
+
+export const formatBytes = (bytes: number): string => {
+    if (bytes >= 1024 * 1024 * 1024) {
+        return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+    }
+    if (bytes >= 1024 * 1024) {
+        return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+    }
+    if (bytes >= 1024) {
+        return `${(bytes / 1024).toFixed(2)} KB`;
+    }
+    return `${bytes} B`;
+};

--- a/src/web/src/utils/init-widget.tsx
+++ b/src/web/src/utils/init-widget.tsx
@@ -1,0 +1,57 @@
+import "../index.css";
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+function resolveTheme(): "light" | "dark" {
+    const t = window.openai?.theme;
+    if (t === "dark") return "dark";
+    if (t === "light") return "light";
+    return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyTheme(theme: "light" | "dark") {
+    document.documentElement.setAttribute("data-theme", theme);
+    document.documentElement.classList.toggle("dark", theme === "dark");
+}
+
+export const renderWidget = (Component: React.FC) => {
+    const initWidget = () => {
+        const rootElement = document.getElementById("root");
+        if (!rootElement) return;
+
+        applyTheme(resolveTheme());
+
+        const mq = window.matchMedia("(prefers-color-scheme: dark)");
+        const onSystemThemeChange = (e: MediaQueryListEvent) => {
+            const t = window.openai?.theme;
+            if (t !== "dark" && t !== "light") {
+                applyTheme(e.matches ? "dark" : "light");
+            }
+        };
+        mq.addEventListener("change", onSystemThemeChange);
+
+        let lastTheme = resolveTheme();
+        const checkTheme = () => {
+            const current = resolveTheme();
+            if (current !== lastTheme) {
+                lastTheme = current;
+                applyTheme(current);
+            }
+        };
+
+        window.setInterval(checkTheme, 1000);
+
+        const root = createRoot(rootElement);
+        root.render(
+            <React.StrictMode>
+                <Component />
+            </React.StrictMode>
+        );
+    };
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", initWidget, { once: true });
+    } else {
+        initWidget();
+    }
+};

--- a/src/web/src/utils/mock-openai.ts
+++ b/src/web/src/utils/mock-openai.ts
@@ -1,0 +1,90 @@
+import { OpenAiGlobals } from "../types";
+
+interface MockOpenAiConfig {
+    toolOutput?: any;
+    callTool?: (name: string, args: any) => Promise<any>;
+    initialWidgetState?: any;
+}
+
+export const setupMockOpenAi = (config: MockOpenAiConfig = {}) => {
+    if (typeof window === "undefined" || window.openai) return;
+
+    console.log("Setting up mock openai");
+
+    window.openai = {
+        // API methods
+        callTool: async (name: string, args: any) => {
+            console.log(`Mock callTool: ${name}`, args);
+            if (config.callTool) {
+                return config.callTool(name, args);
+            }
+            alert(`Would call tool: ${name}\nWith args: ${JSON.stringify(args, null, 2)}`);
+            return { result: "mock result" };
+        },
+        sendFollowUpMessage: async (args: { prompt: string }) => {
+            console.log("Mock sendFollowUpMessage:", args);
+        },
+        openExternal: (payload: { href: string }) => {
+            console.log("Mock openExternal:", payload);
+            window.open(payload.href, "_blank");
+        },
+        requestDisplayMode: async (args: { mode: any }) => {
+            console.log("Mock requestDisplayMode:", args);
+            return { mode: args.mode };
+        },
+        requestModal: async (args: any) => {
+            console.log("Mock requestModal:", args);
+            return null;
+        },
+        requestClose: async () => {
+            console.log("Mock requestClose");
+        },
+
+        // OpenAiGlobals properties
+        theme: "dark",
+        userAgent: {
+            device: { type: "desktop" },
+            capabilities: { hover: true, touch: false },
+        },
+        locale: "en-US",
+        maxHeight: 800,
+        displayMode: "inline",
+        safeArea: {
+            insets: { top: 0, bottom: 0, left: 0, right: 0 },
+        },
+        toolInput: {},
+        toolOutput: config.toolOutput || {},
+        toolResponseMetadata: null,
+        widgetState: config.initialWidgetState || {
+            isPolling: false,
+            lastUpdateTime: Date.now(),
+        },
+        setWidgetState: async (state: any) => {
+            console.log("Mock setWidgetState:", state);
+            if (window.openai) {
+                window.openai.widgetState = { ...window.openai.widgetState, ...state };
+            }
+        },
+    } as unknown as OpenAiGlobals & any; // Casting to avoid complex type mocking of every single method signature match perfectly
+
+    // Helper to simulate async data loading if needed
+    if (config.toolOutput && Object.keys(config.toolOutput).length === 0) {
+        // This part is a bit tricky to generalize, usually the caller handles delayed data updates
+        // by dispatching events. We can expose a helper for that.
+    }
+};
+
+export const updateMockOpenAiState = (updates: Partial<OpenAiGlobals>) => {
+    if (typeof window === "undefined" || !window.openai) return;
+    
+    // Update local state
+    Object.assign(window.openai, updates);
+    
+    // Dispatch event to notify listeners (hooks)
+    window.dispatchEvent(
+        new CustomEvent("openai:set_globals", {
+            detail: { globals: updates },
+        })
+    );
+};
+

--- a/src/web/src/widgets/actor-run-widget.tsx
+++ b/src/web/src/widgets/actor-run-widget.tsx
@@ -1,0 +1,3 @@
+import { renderWidget } from "../utils/init-widget";
+
+renderWidget(() => <div>Actor Run Widget placeholder</div>);

--- a/src/web/src/widgets/search-actors-widget.tsx
+++ b/src/web/src/widgets/search-actors-widget.tsx
@@ -1,0 +1,3 @@
+import { renderWidget } from "../utils/init-widget";
+
+renderWidget(() => <div>Search Actors Widget placeholder</div>);

--- a/src/web/tailwind.config.js
+++ b/src/web/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+    content: [
+        './src/**/*.{js,ts,jsx,tsx}',
+    ],
+    theme: {
+        extend: {},
+    },
+    plugins: [],
+};

--- a/src/web/tsconfig.json
+++ b/src/web/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": []
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
**Summary**

This PR introduces the initial GPT Apps web scaffold, foundation for rendering GPT Apps widgets in the browser. Goal was to set up the project structure and shared UI components.

**Changes**
- Added initial web project setup under src/web
- Introduced build configuration for widget bundles
- Added shared UI and layout components
- Added minimal placeholder widget components to mimic the structure

**Notes**
- Widget components in this PR are intentionally placeholders (will be added in following PR)
- No real widget logic, data handling, or UX is implemented yet

**Next steps**
- Replace placeholder widgets with real widget/page implementations