### PR TITLE
fix: migrate custom request parameters to _meta structure for SDK compatibility

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,13 @@ export default [
                     ],
                 },
             ],
+            // Allow _meta as it's a standard MCP protocol field for metadata
+            'no-underscore-dangle': [
+                'error',
+                {
+                    allow: ['_meta'],
+                },
+            ],
         },
         languageOptions: {
             // Use ES modules (import/export syntax)

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -33,7 +33,7 @@ import { DEFAULT_TELEMETRY_ENV, TELEMETRY_ENV } from './const.js';
 import { processInput } from './input.js';
 import { ActorsMcpServer } from './mcp/server.js';
 import { getTelemetryEnv } from './telemetry.js';
-import type { Input, TelemetryEnv, ToolSelector } from './types.js';
+import type { ApifyRequestParams, Input, TelemetryEnv, ToolSelector } from './types.js';
 import { parseCommaSeparatedList } from './utils/generic.js';
 import { loadToolsFromInput } from './utils/tools-loader.js';
 
@@ -201,8 +201,9 @@ async function main() {
         // Inject session ID into all requests for task isolation and session tracking.
         // CRITICAL: Always create params object if missing (some requests like listTasks/getTasks don't have params),
         // otherwise mcpSessionId injection fails, breaking session isolation in multi-node setups.
-        const params = (msgRecord.params || {}) as Record<string, unknown>;
-        params.mcpSessionId = mcpSessionId;
+        const params = (msgRecord.params || {}) as ApifyRequestParams;
+        params._meta ??= {};
+        params._meta.mcpSessionId = mcpSessionId;
         msgRecord.params = params;
 
         // Call the original onmessage handler

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -205,10 +205,9 @@ Actor description: ${definition.description}`;
                 openWorldHint: true,
             },
             // Allow long running tasks for Actor tools, make it optional for now
-            // TEMP: disable for now as it causes issues with session id error for stdio transport
-            // execution: {
-            //     taskSupport: 'optional',
-            // },
+            execution: {
+                taskSupport: 'optional',
+            },
         });
     }
     return tools;

--- a/src/types.ts
+++ b/src/types.ts
@@ -411,3 +411,27 @@ export type StructuredActorCard = {
     modifiedAt?: string;
     isDeprecated: boolean;
 }
+
+/**
+ * MCP request parameters with Apify-specific extensions.
+ * Extends the standard MCP params object with Apify custom fields in the _meta object.
+ */
+export type ApifyRequestParams = {
+    /**
+     * Metadata object for MCP and Apify-specific fields.
+     */
+    _meta?: {
+        /** Session ID for tracking MCP requests across the Apify server */
+        mcpSessionId?: string;
+        /** Apify API token for authentication */
+        apifyToken?: string;
+        /** List of Actor IDs that the user has rented */
+        userRentedActorIds?: string[];
+        /** Progress token for out-of-band progress notifications (standard MCP) */
+        progressToken?: string | number;
+        /** Allow other metadata fields */
+        [key: string]: unknown;
+    };
+    /** Allow any other request parameters */
+    [key: string]: unknown;
+};


### PR DESCRIPTION
This solves the issue with missing session id when the stdio server is executed through `npx`. Instead of putting the custom props into the `params` in request we use the `_meta` fields. The issue seems that for some reason the npx uses a newer version of SDK that seems to strip the request for custom params, I was able to replicate the error but could not really confirm the root cause.