### PR TITLE
feat: Add missing destructiveHint annotations to tools

### DIFF
--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -202,6 +202,7 @@ Actor description: ${definition.description}`;
                 : undefined,
             annotations: {
                 title: definition.actorFullName,
+                destructiveHint: false,
                 openWorldHint: true,
             },
             // Allow long running tasks for Actor tools, make it optional for now
@@ -395,6 +396,7 @@ EXAMPLES:
     }),
     annotations: {
         title: 'Call Actor',
+        destructiveHint: false,
         openWorldHint: true,
     },
     call: async (toolArgs: InternalToolArgs) => {

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -28,6 +28,7 @@ USAGE EXAMPLES:
     ajvValidate: compileSchema(z.toJSONSchema(addToolArgsSchema)),
     annotations: {
         title: 'Add tool',
+        destructiveHint: false,
         openWorldHint: true,
     },
     // TODO: I don't like that we are passing apifyMcpServer and mcpServer to the tool

--- a/src/tools/run.ts
+++ b/src/tools/run.ts
@@ -119,6 +119,7 @@ USAGE EXAMPLES:
     ajvValidate: compileSchema(z.toJSONSchema(abortRunArgs)),
     annotations: {
         title: 'Abort Actor run',
+        destructiveHint: true,
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {


### PR DESCRIPTION
## Summary

Adds missing `destructiveHint` annotations to 4 tools that already had partial annotations (`title`, `openWorldHint`):

- **Abort Actor run** (`src/tools/run.ts`): Added `destructiveHint: true` - terminates running processes (irreversible)
- **Add tool** (`src/tools/helpers.ts`): Added `destructiveHint: false` - registers tools (additive operation)
- **Call Actor** (`src/tools/actor.ts`): Added `destructiveHint: false` - creates new runs (additive)
- **Dynamic Actor tools** (`src/tools/actor.ts`): Added `destructiveHint: false` - execute actors

## Why

The `destructiveHint` annotation helps LLM clients understand whether a tool performs destructive operations, enabling better safety prompting and user confirmation flows.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes  
- [x] `npm run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)