### PR TITLE
fix: prevent get-actor-run loop after call-actor tool

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -235,6 +235,9 @@ These tools are called **Actors**. They enable you to extract structured data fr
 
 When you call \`${HelperTools.ACTOR_CALL}\` in async mode (UI mode), the response will include a widget that automatically polls for status updates. You must NOT call \`${HelperTools.ACTOR_RUNS_GET}\` or any other tool after this - your task is complete. The widget handles everything automatically.
 
+CRITICAL: Never call \`${HelperTools.ACTOR_RUNS_GET}\` to get more items or to satisfy a requested limit. It does NOT return output items.
+If the preview is short or the user asked for more items, STOP and tell the user to use \`${HelperTools.ACTOR_OUTPUT_GET}\` with the datasetId.
+
 This is FORBIDDEN and will result in unnecessary duplicate polling. Always stop after receiving the \`${HelperTools.ACTOR_CALL}\` response in UI mode.
 
 ## Tool dependencies and disambiguation

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -555,7 +555,7 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
                 if (apifyMcpServer.options.uiMode === 'openai') {
                     responseText += `
 
-CRITICAL: DO NOT call ${HelperTools.ACTOR_RUNS_GET} or any other tool for this run. The widget below automatically tracks progress and refreshes status every few seconds until completion. Your task is complete - take NO further action.`;
+CRITICAL: DO NOT call ${HelperTools.ACTOR_RUNS_GET} or any other tool for this run. The widget below automatically tracks progress and refreshes status every few seconds until completion. Do NOT use ${HelperTools.ACTOR_RUNS_GET} to get more items or to satisfy a requested limit. Your task is complete - take NO further action.`;
                 }
 
                 const response: { content: { type: 'text'; text: string }[]; structuredContent?: unknown; _meta?: unknown } = {

--- a/src/tools/run.ts
+++ b/src/tools/run.ts
@@ -34,6 +34,7 @@ export const getActorRun: ToolEntry = {
 The results will include run metadata (status, timestamps), performance stats, and resource IDs (datasetId, keyValueStoreId, requestQueueId).
 
 CRITICAL WARNING: NEVER call this tool immediately after call-actor in UI mode. The call-actor response includes a widget that automatically polls for updates. Calling this tool after call-actor is FORBIDDEN and unnecessary.
+This tool does NOT return output items. Do NOT use it to satisfy a requested limit or to get more results.
 
 USAGE:
 - Use ONLY when user explicitly asks about a specific run's status or details.

--- a/src/utils/actor-response.ts
+++ b/src/utils/actor-response.ts
@@ -43,7 +43,8 @@ ${JSON.stringify(displaySchema)}
 
 Above this text block is a preview of the Actor output containing ${result.previewItems.length} item(s).${itemCount !== result.previewItems.length ? ` You have access only to a limited preview of the Actor output. Do not present this as the full output, as you have only ${result.previewItems.length} item(s) available instead of the full ${itemCount} item(s). Be aware of this and inform users about the currently loaded count and the total available output items count.` : ''}
 
-If you need to retrieve additional data, use the "get-actor-output" tool with: datasetId: "${datasetId}". Be sure to limit the number of results when using the "get-actor-output" tool, since you never know how large the items may be, and they might exceed the output limits.
+Do NOT call "get-actor-run" to get more items or to satisfy a requested limit. It does NOT return output items.
+If you need more data, use the "get-actor-output" tool with: datasetId: "${datasetId}". Be sure to limit the number of results when using the "get-actor-output" tool, since you never know how large the items may be, and they might exceed the output limits.
 `;
 
     const itemsPreviewText = result.previewItems.length > 0


### PR DESCRIPTION
While testing I found that certain actors would still trigger the `get-actor-run` after `call-actor` tool call so I added a bit more tighter instructions around `get-actor-run` invocation. 