### PR TITLE
fix: Forward custom headers to actorized MCP servers

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -617,6 +617,7 @@ export class ActorsMcpServer {
             const metaApifyToken = meta?.apifyToken;
             const apifyToken = (metaApifyToken || this.options.token || process.env.APIFY_TOKEN) as string;
             const userRentedActorIds = meta?.userRentedActorIds;
+            const customHeaders = meta?.customHeaders as Record<string, string> | undefined;
             // mcpSessionId was injected upstream it is important and required for long running tasks as the store uses it and there is not other way to pass it
             const mcpSessionId = meta?.mcpSessionId;
             if (!mcpSessionId) {
@@ -727,6 +728,7 @@ Please remove the "task" parameter from the tool call request or use a different
                         extra,
                         mcpSessionId,
                         userRentedActorIds,
+                        customHeaders,
                     });
                 });
 
@@ -765,6 +767,7 @@ Please remove the "task" parameter from the tool call request or use a different
                         apifyToken,
                         userRentedActorIds,
                         progressTracker,
+                        customHeaders,
                     }) as object;
 
                     if (progressTracker) {
@@ -788,7 +791,7 @@ Please remove the "task" parameter from the tool call request or use a different
                 if (tool.type === 'actor-mcp') {
                     let client: Client | null = null;
                     try {
-                        client = await connectMCPClient(tool.serverUrl, apifyToken);
+                        client = await connectMCPClient(tool.serverUrl, apifyToken, customHeaders);
                         if (!client) {
                             const msg = `Failed to connect to MCP server at "${tool.serverUrl}".
 Please verify the server URL is correct and accessible, and ensure you have a valid Apify token with appropriate permissions.`;
@@ -951,8 +954,9 @@ Please verify the tool name and ensure the tool is properly registered.`;
         extra: RequestHandlerExtra<Request, Notification>;
         mcpSessionId: string | undefined;
         userRentedActorIds?: string[];
+        customHeaders?: Record<string, string>;
     }): Promise<void> {
-        const { taskId, tool, args, apifyToken, progressToken, extra, mcpSessionId, userRentedActorIds } = params;
+        const { taskId, tool, args, apifyToken, progressToken, extra, mcpSessionId, userRentedActorIds, customHeaders } = params;
         let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
         const startTime = Date.now();
 
@@ -1011,6 +1015,7 @@ Please verify the tool name and ensure the tool is properly registered.`;
                     apifyToken,
                     userRentedActorIds,
                     progressTracker,
+                    customHeaders,
                 }) as object;
 
                 if (progressTracker) {

--- a/src/tools/fetch-actor-details.ts
+++ b/src/tools/fetch-actor-details.ts
@@ -21,6 +21,7 @@ async function getMcpToolsMessage(
     apifyClient: ApifyClient,
     apifyToken: string,
     apifyMcpServer: ActorsMcpServer,
+    customHeaders?: Record<string, string>,
 ): Promise<string> {
     const mcpServerUrl = await getActorMcpUrlCached(actorName, apifyClient);
 
@@ -35,7 +36,7 @@ async function getMcpToolsMessage(
     }
 
     // Connect and list tools
-    const client = await connectMCPClient(mcpServerUrl, apifyToken);
+    const client = await connectMCPClient(mcpServerUrl, apifyToken, customHeaders);
     if (!client) {
         return `Failed to connect to MCP server for Actor '${actorName}'.`;
     }
@@ -109,7 +110,7 @@ EXAMPLES:
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyMcpServer } = toolArgs;
+        const { args, apifyToken, apifyMcpServer, customHeaders } = toolArgs;
         const parsed = fetchActorDetailsToolArgsSchema.parse(args);
         const apifyClient = new ApifyClient({ token: apifyToken });
 
@@ -193,7 +194,7 @@ View the interactive widget below for detailed Actor information.
 
         // Handle MCP tools
         if (parsed.output.mcpTools) {
-            const message = await getMcpToolsMessage(parsed.actor, apifyClient, apifyToken, apifyMcpServer);
+            const message = await getMcpToolsMessage(parsed.actor, apifyClient, apifyToken, apifyMcpServer, customHeaders);
             texts.push(message);
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,8 @@ export type InternalToolArgs = {
     userRentedActorIds?: string[];
     /** Optional progress tracker for long running internal tools, like call-actor */
     progressTracker?: ProgressTracker | null;
+    /** Custom headers to forward to downstream MCP servers */
+    customHeaders?: Record<string, string>;
 };
 
 /**


### PR DESCRIPTION
Fixes issue #324 where only the first HTTP header was forwarded to
custom MCP actors through the Apify MCP proxy service.

Changes:
- Extract custom headers from incoming HTTP requests in actor server
- Pass custom headers through MCP protocol via _meta field
- Update connectMCPClient to accept optional customHeaders parameter
- Modify SSE and StreamableHTTP transports to forward custom headers
- Add customHeaders field to InternalToolArgs type
- Pass custom headers through tool execution chain

This allows users to pass multiple authentication tokens and custom
headers to their actorized MCP servers, enabling multi-service
authentication and other use cases requiring custom headers.

Closes #324