### PR TITLE
fix: upgrade server.json schema to 2025-12-11 and remove deprecated status

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,8 +1,7 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.apify/apify-mcp-server",
   "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡",
-  "status": "active",
   "repository": {
     "url": "https://github.com/apify/apify-mcp-server",
     "source": "github"


### PR DESCRIPTION
## Summary
Updates `server.json` to be compliant with the latest MCP schema (2025-12-11).

## Changes
- Updated `$schema` URL to `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`.
- Removed the deprecated `status` field.

This fixes the validation error: `deprecated schema detected: https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json`.