### PR TITLE
fix: return empty object instead of undefined for outputSchema

### DIFF
--- a/src/utils/actor-details.ts
+++ b/src/utils/actor-details.ts
@@ -346,7 +346,7 @@ export async function buildActorDetailsTextResponse(options: {
         actorInfo: needsCard ? details.actorCardStructured : undefined,
         readme: output.readme ? formattedReadme : undefined,
         inputSchema: output.inputSchema ? details.inputSchema : undefined,
-        outputSchema: output.outputSchema ? actorOutputSchema : undefined,
+        outputSchema: output.outputSchema ? (actorOutputSchema ?? {}) : undefined,
     };
 
     return { texts, structuredContent };


### PR DESCRIPTION
## Summary

Fixes schema validation error when `outputSchema` is requested but no data is available.

## Problem

When calling `fetch-actor-details` with `output: { outputSchema: true }` but no output schema data exists (e.g., no recent successful runs), the response included `outputSchema: undefined` which violated the tool's output schema validation requiring `type: 'object'`.

**Error:** `Structured content does not match the tool's output schema: data/outputSchema must be object`

## Solution

Return an empty object `{}` instead of `undefined` when no output schema data is available:

```typescript
outputSchema: output.outputSchema ? (actorOutputSchema ?? {}) : undefined
```

This satisfies the schema validation while indicating "no data available".