### PR TITLE
feat(stdio): allow unauthenticated access for public tools

### DIFF
--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -169,10 +169,6 @@ const requiresAuthentication = isApiTokenRequired({
     enableAddingActors,
 });
 
-if (!requiresAuthentication) {
-    log.info('Running in unauthenticated mode (only public tools requested)');
-}
-
 // Validate environment
 if (requiresAuthentication && !apifyToken) {
     log.error('APIFY_TOKEN is required but not set in the environment variables or in ~/.apify/auth.json');

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,4 +1,5 @@
 import { getUnauthEnabledToolCategories, toolCategories, unauthEnabledTools } from '../tools/index.js';
+import type { ToolCategory } from '../types.js';
 
 /**
  * Determines if an API token is required based on requested tools and actors.
@@ -17,11 +18,12 @@ export function isApiTokenRequired(params: {
     }
 
     const unauthTokenSet = new Set(unauthEnabledTools);
-    const unauthCategorySet = new Set(getUnauthEnabledToolCategories());
+    // Convert ToolCategory[] to Set<string> for comparison with string keys
+    const unauthCategorySet = new Set<string>(getUnauthEnabledToolCategories() as ToolCategory[]);
 
     const areAllToolsSafe = toolCategoryKeys.every((key) => {
         // If it is a safe category
-        if (unauthCategorySet.has(key as any)) return true;
+        if (unauthCategorySet.has(key)) return true;
         // If it is a safe tool
         if (unauthTokenSet.has(key)) return true;
 

--- a/tests/unit/utils.auth.test.ts
+++ b/tests/unit/utils.auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+
 import { isApiTokenRequired } from '../../src/utils/auth.js';
 
 describe('isApiTokenRequired', () => {


### PR DESCRIPTION
This PR updates the server startup logic to allow running without an APIFY_TOKEN if only public tools (like search-apify-docs, fetch-apify-docs) are requested.

Currently, using the MCP server requires an API token even for strictly public operations (like searching documentation). This creates unnecessary friction for users who just want to use the documentation tools without setting up a full Apify account/token immediately.

With this change, the server checks the requested tools at startup. If they are all "public safe," it bypasses the token check.

## Reproduction / Context

Previously, trying to load the docs tool without a token would crash the server immediately with this error, which blocks new users from trying out the public features:

![image](https://github.com/user-attachments/assets/48c0561c-172f-42cc-b57d-35b5d1ef868f)

Configuration used:

![image](https://github.com/user-attachments/assets/ca6a5798-94af-42d6-8ef7-a9025479b321)

Users had to provide a key just to make it work:

![image](https://github.com/user-attachments/assets/08f92b41-5dd0-4df5-a533-e98ec35eaeba)

Which resulted in valid tool access, proving the token wasn't actually needed:

![image](https://github.com/user-attachments/assets/c0ec66d5-e6c7-4bdc-9a92-b28f88adad00)

## Related Context

This change simplifies the setup process discussed in apify/apify-docs#2203. Currently, users trying to set up the MCP server via stdio must provide an `APIFY_TOKEN` even for purely public tools, and the server accepts any non-empty string as a valid token just to establish the connection. This PR properly removes that hacky workaround requirement, allowing public tools to run without any token config.
