### PR TITLE
fix: Evals, add retry to Phoenix calls

### DIFF
--- a/evals/config.ts
+++ b/evals/config.ts
@@ -6,17 +6,16 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import log from '@apify/log';
+
 // Re-export shared config
 export { OPENROUTER_CONFIG, sanitizeHeaderValue, validateEnvVars, getRequiredEnvVars } from './shared/config.js';
 
 // Read version from test-cases.json
 function getTestCasesVersion(): string {
-    const currentFilename = fileURLToPath(import.meta.url);
-    const currentDirname = dirname(currentFilename);
-    const testCasesPath = join(currentDirname, 'test-cases.json');
-    const testCasesContent = readFileSync(testCasesPath, 'utf-8');
-    const testCases = JSON.parse(testCasesContent);
-    return testCases.version;
+    const dir = dirname(fileURLToPath(import.meta.url));
+    const raw = readFileSync(join(dir, 'test-cases.json'), 'utf-8');
+    return JSON.parse(raw).version;
 }
 
 // Evaluator names
@@ -185,8 +184,7 @@ export function validatePhoenixEnvVars(): boolean {
         .map(([key]) => key);
 
     if (missing.length > 0) {
-        // eslint-disable-next-line no-console
-        console.error(`Missing required environment variables: ${missing.join(', ')}`);
+        log.error(`Missing required environment variables: ${missing.join(', ')}`);
         return false;
     }
 

--- a/evals/evaluation-utils.ts
+++ b/evals/evaluation-utils.ts
@@ -79,7 +79,7 @@ export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
 
         messages.push({
             role: 'user',
-            content: `${query}`,
+            content: query,
         });
 
         log.info(`Messages to model: ${JSON.stringify(messages)}`);
@@ -105,7 +105,6 @@ export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
 
 export function createClassifierEvaluator() {
     const openai = createOpenAI({
-        // custom settings, e.g.
         baseURL: process.env.OPENROUTER_BASE_URL,
         apiKey: process.env.OPENROUTER_API_KEY,
     });

--- a/evals/run-evaluation.ts
+++ b/evals/run-evaluation.ts
@@ -201,8 +201,8 @@ async function main(datasetName: string): Promise<number> {
         },
     });
 
-    // Resolve dataset by name -> id (retry to handle transient Phoenix issues)
-    // I've also considered the retry package but I figured this simple loop with delay would be enough and tranparent
+    // Considered using a retry package, but opted for this simple loop with delay for clarity and transparency.
+    // A helper like withRetry could be used, but it would not significantly reduce code complexity here.
     let datasetId: string | undefined;
     for (let attempt = 1; attempt <= PHOENIX_MAX_RETRIES; attempt++) {
         try {


### PR DESCRIPTION
Add retry to ensure that Phoenix dataset can be retrieved.

I also considered using a retry package, but opted for this simple loop with delay for clarity and transparency. A helper like `withRetry` could be used, but it would not significantly reduce code complexity here.