### PR TITLE
feat: expose Apify run costs in MCP response _meta

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -864,7 +864,13 @@ Please verify the server URL is correct and accessible, and ensure you have a va
                         }
 
                         const { content, structuredContent } = buildActorResponseContent(tool.actorFullName, callResult);
-                        return { content, structuredContent };
+                        return {
+                            content,
+                            structuredContent,
+                            ...(callResult.usageTotalUsd !== undefined && {
+                                _meta: { apifyUsageTotalUsd: callResult.usageTotalUsd, apifyUsageUsd: callResult.usageUsd },
+                            }),
+                        };
                     } finally {
                         if (progressTracker) {
                             progressTracker.stop();
@@ -1054,7 +1060,13 @@ Please verify the tool name and ensure the tool is properly registered.`;
                     result = {};
                 } else {
                     const { content, structuredContent } = buildActorResponseContent(tool.actorFullName, callResult);
-                    result = { content, structuredContent };
+                    result = {
+                        content,
+                        structuredContent,
+                        ...(callResult.usageTotalUsd !== undefined && {
+                            _meta: { apifyUsageTotalUsd: callResult.usageTotalUsd, apifyUsageUsd: callResult.usageUsd },
+                        }),
+                    };
                 }
 
                 if (progressTracker) {

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -39,6 +39,8 @@ export type CallActorGetDatasetResult = {
     itemCount: number;
     schema: JsonSchemaProperty;
     previewItems: DatasetItem[];
+    usageTotalUsd?: number;
+    usageUsd?: Record<string, number>;
 };
 
 /**
@@ -135,6 +137,8 @@ export async function callActorGetDataset(
         itemCount: datasetItems.count,
         schema,
         previewItems,
+        usageTotalUsd: completedRun.usageTotalUsd,
+        usageUsd: completedRun.usageUsd as Record<string, number> | undefined,
     };
 }
 
@@ -625,7 +629,13 @@ Do NOT proactively poll using ${HelperTools.ACTOR_RUNS_GET}. Wait for the widget
 
             const { content, structuredContent } = buildActorResponseContent(actorName, callResult, previewOutput);
 
-            return { content, structuredContent };
+            return {
+                content,
+                structuredContent,
+                ...(callResult.usageTotalUsd !== undefined && {
+                    _meta: { apifyUsageTotalUsd: callResult.usageTotalUsd, apifyUsageUsd: callResult.usageUsd },
+                }),
+            };
         } catch (error) {
             logHttpError(error, 'Failed to call Actor', { actorName, async: async ?? (apifyMcpServer.options.uiMode === 'openai') });
             // Let the server classify the error; we only mark it as an MCP error response

--- a/src/tools/run.ts
+++ b/src/tools/run.ts
@@ -143,6 +143,10 @@ USAGE EXAMPLES:
                     structuredContent,
                     _meta: {
                         ...widgetConfig?.meta,
+                        ...(run.usageTotalUsd !== undefined && {
+                            apifyUsageTotalUsd: run.usageTotalUsd,
+                            apifyUsageUsd: run.usageUsd,
+                        }),
                     },
                 });
             }
@@ -151,7 +155,14 @@ USAGE EXAMPLES:
                 `# Actor Run Information\n\`\`\`json\n${JSON.stringify(run, null, 2)}\n\`\`\``,
             ];
 
-            return buildMCPResponse({ texts, structuredContent });
+            return buildMCPResponse({
+                texts,
+                structuredContent,
+                _meta: run.usageTotalUsd !== undefined ? {
+                    apifyUsageTotalUsd: run.usageTotalUsd,
+                    apifyUsageUsd: run.usageUsd as Record<string, number> | undefined,
+                } : undefined,
+            });
         } catch (error) {
             logHttpError(error, 'Failed to get Actor run', { runId: parsed.runId });
             return buildMCPResponse({

--- a/src/tools/structured-output-schemas.ts
+++ b/src/tools/structured-output-schemas.ts
@@ -223,6 +223,7 @@ export const callActorOutputSchema = {
             description: 'Dataset items from the Actor run (sync mode only, may be truncated due to size limits)',
         },
         instructions: { type: 'string', description: 'Instructions for the LLM on how to process or retrieve additional data' },
+        usageTotalUsd: { type: 'number', description: 'Total cost of the Actor run in USD (sync mode only)' },
     },
     required: ['runId'],
 };
@@ -243,6 +244,7 @@ export const getActorRunOutputSchema = {
             type: 'object' as const,
             description: 'Run statistics (compute units, memory, duration, etc.)',
         },
+        usageTotalUsd: { type: 'number', description: 'Total cost of the Actor run in USD' },
         dataset: {
             type: 'object' as const,
             description: 'Dataset information (only for completed runs with results)',


### PR DESCRIPTION
## Summary
- Adds `apifyUsageTotalUsd` and `apifyUsageUsd` to the `_meta` field of MCP tool responses for actor runs
- Enables LiteLLM `async_post_mcp_tool_call_hook` to read and record Apify costs per tool call
- Covers all response paths: `call-actor` (sync), server actor tool handler, and `get-actor-run`

## Test plan
- [x] `npm run build` passes
- [x] All 213 unit tests pass