### PR TITLE
fix: add Sentry session tracking for crash-free rate metrics

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -23,3 +23,16 @@ Sentry.init({
     sendDefaultPii: true,
     enabled: !isTelemetryDisabled,
 });
+
+// Start a Sentry session for this CLI invocation so crash-free rate metrics work.
+// Without explicit session tracking, Sentry has zero sessions and crash-free % is always 0%.
+if (!isTelemetryDisabled) {
+    Sentry.startSession();
+    Sentry.captureSession();
+
+    // End the session cleanly when the process exits normally.
+    // If the process crashes, Sentry automatically marks the session as crashed.
+    process.on('beforeExit', () => {
+        Sentry.endSession();
+    });
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -115,6 +115,9 @@ export async function createMcpStdioClient(
         APIFY_TOKEN: process.env.APIFY_TOKEN as string,
     };
 
+    // Default telemetry to disabled for tests to avoid sending Sentry sessions and events
+    const telemetryEnabled = telemetry?.enabled ?? false;
+
     // Set environment variables instead of command line arguments when useEnv is true
     if (useEnv) {
         if (actors !== undefined) {
@@ -126,9 +129,7 @@ export async function createMcpStdioClient(
         if (tools !== undefined) {
             env.TOOLS = tools.join(',');
         }
-        if (telemetry?.enabled !== undefined) {
-            env.TELEMETRY_ENABLED = telemetry.enabled.toString();
-        }
+        env.TELEMETRY_ENABLED = telemetryEnabled.toString();
         if (telemetry?.env !== undefined) {
             env.TELEMETRY_ENV = telemetry.env;
         }
@@ -149,10 +150,8 @@ export async function createMcpStdioClient(
         if (tools !== undefined) {
             args.push('--tools', tools.join(','));
         }
-        if (telemetry?.enabled === false) {
-            args.push('--telemetry-enabled', 'false');
-        }
-        if (telemetry?.env !== undefined && telemetry?.enabled !== false) {
+        args.push('--telemetry-enabled', telemetryEnabled.toString());
+        if (telemetry?.env !== undefined && telemetryEnabled) {
             args.push('--telemetry-env', telemetry.env);
         }
         if (uiMode !== undefined) {


### PR DESCRIPTION
## Summary
- Sentry crash-free % was always 0% because the stdio CLI never called `Sentry.startSession()` — without sessions, Sentry has no denominator to calculate crash-free rate against
- Adds `startSession()`/`captureSession()` on init and `endSession()` on clean exit, gated behind `!isTelemetryDisabled` so it respects the existing telemetry opt-out
- Ensures integration tests always pass `--telemetry-enabled false` to the spawned stdio process (previously only passed when explicitly set, meaning most tests ran with telemetry enabled by default)

## Testing
- `npm run type-check` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅ (248 tests)