### PR TITLE
fix: improve workflow evals and tool instructions for search and call-actor

### DIFF
--- a/evals/workflows/test-cases.json
+++ b/evals/workflows/test-cases.json
@@ -53,7 +53,7 @@
     {
       "id": "call-tiktok-scraper",
       "category": "call",
-      "query": "Showe me 1 latest post from natgeo tik tok using Apify",
+      "query": "Show me 1 latest post from natgeo tik tok using Apify",
       "reference": "The agent must find tik tok scraper, call it for natgeo profile, return the latest post and present it to the user."
     },
     {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "inspector:stdio": "npx @modelcontextprotocol/inspector -e APIFY_TOKEN=$APIFY_TOKEN -- node dist/stdio.js",
     "evals:create-dataset": "tsx evals/create-dataset.ts",
     "evals:run": "tsx evals/run-evaluation.ts",
-    "evals:workflow": "tsx evals/workflows/run-workflow-evals.ts"
+    "evals:workflow": "npm run build && tsx evals/workflows/run-workflow-evals.ts"
   },
   "author": "Apify",
   "license": "MIT"

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -412,7 +412,7 @@ For MCP server Actors, use format "actorName:toolName" to call a specific tool (
         .describe('The input JSON to pass to the Actor. Required.'),
     async: z.boolean()
         .optional()
-        .describe(`When true: starts the run and returns immediately with runId. When false or not provided: waits for completion and returns results immediately. Default: true when UI mode is enabled (enforced), false otherwise. Note: When UI mode is enabled, async is always true regardless of this parameter and the widget automatically tracks progress.`),
+        .describe(`When true: starts the run and returns immediately with runId. When false or not provided: waits for completion and returns results immediately. Default: true when UI mode is enabled (enforced), false otherwise. IMPORTANT: Only set async to true if the user explicitly asks to run the Actor in the background or does not need immediate results. When the user asks for data or results, always use async: false (default) so the results are returned immediately.`),
     previewOutput: z.boolean()
         .optional()
         .describe('When true (default): includes preview items. When false: metadata only (reduces context). Use when fetching fields via get-actor-output.'),
@@ -468,8 +468,8 @@ USAGE:
 - Use the generic call-actor tool only if a dedicated tool does not exist for your Actor.
 
 - This tool supports async execution via the \`async\` parameter:
-  - **When \`async: false\` or not provided** (default when UI mode is disabled): Waits for completion and returns results immediately with dataset preview.
-  - **When \`async: true\`** (enforced when UI mode is enabled): Starts the run and returns immediately with runId and a widget that automatically tracks progress. DO NOT call ${HelperTools.ACTOR_RUNS_GET} or any other tool after this - your task is complete. Note: UI mode always enforces async execution for optimal user experience.
+  - **When \`async: false\` or not provided** (default): Waits for completion and returns results immediately with dataset preview. Use this whenever the user asks for data or results.
+  - **When \`async: true\`**: Starts the run and returns immediately with runId. Only use this when the user explicitly asks to run the Actor in the background or does not need immediate results. When UI mode is enabled, async is always enforced and the widget automatically tracks progress.
 
 EXAMPLES:
 - user_input: Get instagram posts using apify/instagram-scraper`;

--- a/src/tools/store_collection.ts
+++ b/src/tools/store_collection.ts
@@ -92,8 +92,8 @@ Do NOT use this tool when user wants immediate data retrieval - use apify-slash-
 IMPORTANT: There is a high chance that a relevant Actor already exists in the Apify Store so find it first before considering alternative solutions!
 
 Usage:
-- Use the most direct query possible.
-- The search is smart enough to return all relevant actors from one query.
+- ALWAYS prefer broad, generic keywords - use just the platform name (e.g., "TikTok" instead of "TikTok posts", "Instagram" instead of "Instagram scraper").
+- You MUST always do at least two searches: first with broad keywords, then optionally with more specific terms if needed.
 
 Important limitations: This tool does not return full Actor documentation, input schemas, or detailed usage instructions - only summary information.
 For complete Actor details, use the ${HelperTools.ACTOR_GET_DETAILS} tool.
@@ -135,8 +135,7 @@ Returns list of Actor cards with the following info:
         });
         if (actors.length === 0) {
             const instructions = `No Actors were found for the search query "${parsed.keywords}".
-Try a different query with different keywords, or adjust the limit and offset parameters.
-You can also try using more specific or alternative keywords related to your search topic.`;
+You MUST retry with broader, more generic keywords - use just the platform name (e.g., "TikTok" instead of "TikTok posts") before concluding no Actor exists.`;
             const structuredContent = {
                 actors: [],
                 query: parsed.keywords,
@@ -162,7 +161,7 @@ You can also try using more specific or alternative keywords related to your sea
             query: parsed.keywords,
             count: actors.length,
             instructions: `If you need more detailed information about any of these Actors, including their input schemas and usage instructions, please use the ${HelperTools.ACTOR_GET_DETAILS} tool with the specific Actor name.
- If the search did not return relevant results, consider refining your keywords, use broader terms or removing less important words from the keywords.`,
+IMPORTANT: You MUST always do a second search with broader, more generic keywords (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure you haven't missed a better Actor.`,
         };
 
         // Add widget format actors when widget mode is enabled
@@ -206,7 +205,7 @@ An interactive widget has been rendered with the search results. The user can al
  ${actorsText}
 
 If you need detailed info for a user-facing request, use ${HelperTools.ACTOR_GET_DETAILS}. For helper/internal schema lookups without UI, use ${HelperTools.ACTOR_GET_DETAILS_INTERNAL}.
- If the search did not return relevant results, consider refining your keywords, use broader terms or removing less important words from the keywords.
+IMPORTANT: You MUST always do a second search with broader, more generic keywords (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure you haven't missed a better Actor.
  `;
 
         return buildMCPResponse({


### PR DESCRIPTION
## Summary
- **Simplified workflow test cases**: removed ~30 redundant/overlapping eval cases (-239 lines), consolidated into a focused set covering all key categories (search, call, fetch, add)
- **search-actors tool**: instruct agent to always prefer broad, generic keywords (e.g. "TikTok" instead of "TikTok posts") and always do at least two search rounds — added to both tool description and tool result text
- **call-actor tool**: clarify that `async: true` should only be used when the user explicitly asks to run in the background, not when they want immediate results
- **evals:workflow script**: add `npm run build` step before running evals
- Fix typo in tiktok eval test case query