### PR TITLE
fix(ci): pass explicit token to git-cliff-release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,7 @@ jobs:
                     release_type: ${{ inputs.release_type }}
                     custom_version: ${{ inputs.custom_version }}
                     existing_changelog_path: CHANGELOG.md
+                    token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     update_changelog:
         needs: [ release_metadata ]


### PR DESCRIPTION
## Summary
- Fixes the `release_metadata` job failing with **401 Bad Credentials** during release workflow
- The `apify/workflows/git-cliff-release@main` action was falling back to the default `github.token`, which lacks sufficient permissions for the GitHub API calls made by `git-cliff`, `gh api graphql`, and `enhance_context.py`
- Passes `secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN` explicitly — the same token already used by other jobs in this workflow (e.g., `update_changelog`)