### PR TITLE
refactor: extract shared core logic into src/tools/core/ modules

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -54,6 +54,7 @@ import { createResourceService } from '../resources/resource_service.js';
 import type { AvailableWidget } from '../resources/widgets.js';
 import { resolveAvailableWidgets } from '../resources/widgets.js';
 import { getTelemetryEnv, trackToolCall } from '../telemetry.js';
+import { buildActorResponseContent } from '../tools/core/actor-response.js';
 import { callActorGetDataset, defaultTools, getActorsAsTools, toolCategories } from '../tools/index.js';
 import { decodeDotPropertyNames } from '../tools/utils.js';
 import type {
@@ -68,7 +69,6 @@ import type {
     ToolEntry,
     ToolStatus,
 } from '../types.js';
-import { buildActorResponseContent } from '../utils/actor-response.js';
 import { logHttpError, redactSkyfirePayId } from '../utils/logging.js';
 import { buildMCPResponse, buildUsageMeta } from '../utils/mcp.js';
 import { createProgressTracker } from '../utils/progress.js';

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -1,407 +1,35 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import type { ActorCallOptions, ActorRun } from 'apify-client';
 import { z } from 'zod';
 
 import log from '@apify/log';
 
 import { ApifyClient, createApifyClientWithSkyfireSupport } from '../apify-client.js';
 import {
-    ACTOR_MAX_MEMORY_MBYTES,
     CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG,
     HelperTools,
-    RAG_WEB_BROWSER,
-    RAG_WEB_BROWSER_ADDITIONAL_DESC,
-    TOOL_MAX_OUTPUT_CHARS,
     TOOL_STATUS,
 } from '../const.js';
-import { getActorMCPServerPath, getActorMCPServerURL } from '../mcp/actors.js';
 import { connectMCPClient } from '../mcp/client.js';
-import { getMCPServerTools } from '../mcp/proxy.js';
 import { getWidgetConfig, WIDGET_URIS } from '../resources/widgets.js';
-import { actorDefinitionPrunedCache } from '../state.js';
 import type {
-    ActorDefinitionStorage,
-    ActorInfo,
-    ActorStore,
-    ActorTool,
-    ApifyToken,
-    DatasetItem,
     InternalToolArgs,
     ToolEntry,
     ToolInputSchema,
     UiMode,
 } from '../types.js';
-import { ensureOutputWithinCharLimit, getActorDefinitionStorageFieldNames, getActorMcpUrlCached } from '../utils/actor.js';
-import { buildActorResponseContent } from '../utils/actor-response.js';
-import { ajv, compileSchema } from '../utils/ajv.js';
-import { logHttpError, redactSkyfirePayId } from '../utils/logging.js';
+import { getActorMcpUrlCached } from '../utils/actor.js';
+import { compileSchema } from '../utils/ajv.js';
+import { logHttpError } from '../utils/logging.js';
 import { buildMCPResponse, buildUsageMeta } from '../utils/mcp.js';
-import type { ProgressTracker } from '../utils/progress.js';
-import type { JsonSchemaProperty } from '../utils/schema-generation.js';
-import { generateSchemaFromItems } from '../utils/schema-generation.js';
-import { getActorDefinition } from './build.js';
-import { buildEnrichedCallActorOutputSchema, callActorOutputSchema } from './structured-output-schemas.js';
-import { actorNameToToolName, buildActorInputSchema, fixedAjvCompile, isActorInfoMcpServer } from './utils.js';
+import { callActorGetDataset } from './core/actor-execution.js';
+import { buildActorResponseContent } from './core/actor-response.js';
+import { getActorsAsTools } from './core/actor-tools-factory.js';
+import { callActorOutputSchema } from './structured-output-schemas.js';
+import { actorNameToToolName } from './utils.js';
 
-// Define a named return type for callActorGetDataset
-export type CallActorGetDatasetResult = {
-    runId: string;
-    datasetId: string;
-    itemCount: number;
-    schema: JsonSchemaProperty;
-    previewItems: DatasetItem[];
-    usageTotalUsd?: number;
-    usageUsd?: Record<string, number>;
-};
-
-/**
- * Calls an Apify Actor and retrieves metadata about the dataset results.
- *
- * This function executes an Actor and returns summary information instead with a result items preview of the full dataset
- * to prevent overwhelming responses. The actual data can be retrieved using the get-actor-output tool.
- *
- * It requires the `APIFY_TOKEN` environment variable to be set.
- * If the `APIFY_IS_AT_HOME` the dataset items are pushed to the Apify dataset.
- *
- * @param {string} actorName - The name of the Actor to call.
- * @param {unknown} input - The input to pass to the actor.
- * @param {ApifyClient} apifyClient - The Apify client to use for authentication.
- * @returns {Promise<CallActorGetDatasetResult | null>} - A promise that resolves to an object containing the actor run and dataset items.
- * @throws {Error} - Throws an error if the `APIFY_TOKEN` is not set
- */
-export async function callActorGetDataset(options: {
-    actorName: string;
-    input: unknown;
-    apifyClient: ApifyClient;
-    callOptions?: ActorCallOptions;
-    progressTracker?: ProgressTracker | null;
-    abortSignal?: AbortSignal;
-    previewOutput?: boolean;
-    mcpSessionId?: string;
-}): Promise<CallActorGetDatasetResult | null> {
-    const {
-        actorName,
-        input,
-        apifyClient,
-        callOptions,
-        progressTracker,
-        abortSignal,
-        previewOutput = true,
-        mcpSessionId,
-    } = options;
-    const CLIENT_ABORT = Symbol('CLIENT_ABORT'); // Just internal symbol to identify client abort
-    const actorClient = apifyClient.actor(actorName);
-
-    // Start the actor run
-    const actorRun: ActorRun = await actorClient.start(input, callOptions);
-
-    // Start progress tracking if tracker is provided
-    if (progressTracker) {
-        progressTracker.startActorRunUpdates(actorRun.id, apifyClient, actorName);
-    }
-
-    // Create abort promise that handles both API abort and race rejection
-    const abortPromise = async () => new Promise<typeof CLIENT_ABORT>((resolve) => {
-        abortSignal?.addEventListener('abort', async () => {
-            // Abort the actor run via API
-            try {
-                await apifyClient.run(actorRun.id).abort({ gracefully: false });
-            } catch (e) {
-                logHttpError(e, 'Error aborting Actor run', { runId: actorRun.id });
-            }
-            // Reject to stop waiting
-            resolve(CLIENT_ABORT);
-        }, { once: true });
-    });
-
-    // Wait for completion or cancellation
-    const potentialAbortedRun = await Promise.race([
-        apifyClient.run(actorRun.id).waitForFinish(),
-        ...(abortSignal ? [abortPromise()] : []),
-    ]);
-
-    if (potentialAbortedRun === CLIENT_ABORT) {
-        log.info('Actor run aborted by client', { actorName, mcpSessionId, input: redactSkyfirePayId(input) });
-        return null;
-    }
-    const completedRun = potentialAbortedRun as ActorRun;
-
-    // Process the completed run
-    const dataset = apifyClient.dataset(completedRun.defaultDatasetId);
-    const [datasetItems, defaultBuild] = await Promise.all([
-        dataset.listItems(),
-        (await actorClient.defaultBuild()).get(),
-    ]);
-
-    // Generate schema using the shared utility
-    const generatedSchema = generateSchemaFromItems(datasetItems.items, {
-        clean: true,
-        arrayMode: 'all',
-    });
-    const schema = generatedSchema || { type: 'object', properties: {} };
-
-    /**
-     * Get important fields that are using in any dataset view as they MAY be used in filtering to ensure the output fits
-     * the tool output limits. Client has to use the get-actor-output tool to retrieve the full dataset or filtered out fields.
-     */
-    const storageDefinition = defaultBuild?.actorDefinition?.storages?.dataset as ActorDefinitionStorage | undefined;
-    const importantProperties = getActorDefinitionStorageFieldNames(storageDefinition || {});
-    const previewItems = previewOutput
-        ? ensureOutputWithinCharLimit(datasetItems.items, importantProperties, TOOL_MAX_OUTPUT_CHARS)
-        : [];
-
-    return {
-        runId: actorRun.id,
-        datasetId: completedRun.defaultDatasetId,
-        itemCount: datasetItems.count,
-        schema,
-        previewItems,
-        usageTotalUsd: completedRun.usageTotalUsd,
-        usageUsd: completedRun.usageUsd as Record<string, number> | undefined,
-    };
-}
-
-/**
- * This function is used to fetch normal non-MCP server Actors as a tool.
- *
- * Fetches Actor input schemas by Actor IDs or Actor full names and creates MCP tools.
- *
- * This function retrieves the input schemas for the specified Actors and compiles them into MCP tools.
- * It uses the AJV library to validate the input schemas.
- *
- * Tool name can't contain /, so it is replaced with _
- *
- * The input schema processing workflow:
- * 1. Properties are marked as required using markInputPropertiesAsRequired() to add "REQUIRED" prefix to descriptions
- * 2. Nested properties are built by analyzing editor type (proxy, requestListSources) using buildNestedProperties()
- * 3. Properties are filtered using filterSchemaProperties()
- * 4. Properties are shortened using shortenProperties()
- * 5. Enums are added to descriptions with examples using addEnumsToDescriptionsWithExamples()
- *
- * @param {ActorInfo[]} actorsInfo - An array of ActorInfo objects with webServerMcpPath, definition, and Actor.
- * @returns {Promise<ToolEntry[]>} - A promise that resolves to an array of MCP tools.
- */
-export async function getNormalActorsAsTools(
-    actorsInfo: ActorInfo[],
-    options?: { mcpSessionId?: string; actorStore?: ActorStore },
-): Promise<ToolEntry[]> {
-    const { mcpSessionId, actorStore } = options ?? {};
-    const tools: ToolEntry[] = [];
-
-    for (const actorInfo of actorsInfo) {
-        const { definition } = actorInfo;
-
-        if (!definition) continue;
-
-        const isRag = definition.actorFullName === RAG_WEB_BROWSER;
-        const { inputSchema } = buildActorInputSchema(definition.actorFullName, definition.input, isRag);
-
-        let description = `This tool calls the Actor "${definition.actorFullName}" and retrieves its output results.
-Use this tool instead of the "${HelperTools.ACTOR_CALL}" if user requests this specific Actor.
-Actor description: ${definition.description}`;
-        if (isRag) {
-            description += RAG_WEB_BROWSER_ADDITIONAL_DESC;
-        }
-
-        const memoryMbytes = Math.min(
-            definition.defaultRunOptions?.memoryMbytes || ACTOR_MAX_MEMORY_MBYTES,
-            ACTOR_MAX_MEMORY_MBYTES,
-        );
-
-        let ajvValidate;
-        try {
-            ajvValidate = fixedAjvCompile(ajv, { ...inputSchema, additionalProperties: true });
-        } catch (e) {
-            log.error('Failed to compile schema', {
-                actorName: definition.actorFullName,
-                mcpSessionId,
-                error: e,
-            });
-            continue;
-        }
-
-        tools.push({
-            type: 'actor',
-            name: actorNameToToolName(definition.actorFullName),
-            actorFullName: definition.actorFullName,
-            description,
-            inputSchema: inputSchema as ToolInputSchema,
-            // reuse the common output schema
-            outputSchema: callActorOutputSchema,
-            ajvValidate,
-            requiresSkyfirePayId: true,
-            memoryMbytes,
-            icons: definition.pictureUrl
-                ? [{ src: definition.pictureUrl, mimeType: 'image/png' }]
-                : undefined,
-            annotations: {
-                title: definition.actorFullName,
-                readOnlyHint: false,
-                destructiveHint: true,
-                openWorldHint: true,
-            },
-            // Allow long-running tasks for Actor tools, make it optional for now
-            execution: {
-                taskSupport: 'optional',
-            },
-        });
-    }
-
-    // Enrich output schemas with field-level detail if actorStore is available
-    if (actorStore) {
-        await enrichActorToolOutputSchemas(tools, actorStore);
-    }
-
-    return tools;
-}
-
-/**
- * Enriches actor tool output schemas with field-level detail from the ActorStore.
- * Uses Promise.allSettled to ensure individual failures don't block other tools.
- */
-async function enrichActorToolOutputSchemas(tools: ToolEntry[], actorStore: ActorStore): Promise<void> {
-    const enrichPromises = tools
-        .filter((tool): tool is ActorTool => tool.type === 'actor')
-        .map(async (tool) => {
-            try {
-                const itemProperties = await actorStore.getActorOutputSchema(tool.actorFullName);
-                if (itemProperties && Object.keys(itemProperties).length > 0) {
-                    // eslint-disable-next-line no-param-reassign
-                    tool.outputSchema = buildEnrichedCallActorOutputSchema(itemProperties);
-                }
-            } catch (error) {
-                log.debug('Failed to enrich output schema for Actor', {
-                    actorName: tool.actorFullName,
-                    error: error instanceof Error ? error.message : String(error),
-                });
-            }
-        });
-
-    await Promise.allSettled(enrichPromises);
-}
-
-async function getMCPServersAsTools(
-    actorsInfo: ActorInfo[],
-    apifyToken: ApifyToken,
-    mcpSessionId?: string,
-): Promise<ToolEntry[]> {
-    /**
-     * This is case for the Skyfire request without any Apify token, we do not support
-     * standby Actors in this case, so we can skip MCP servers since they would fail anyway (they are standby Actors).
-    */
-    if (apifyToken === null || apifyToken === undefined) {
-        return [];
-    }
-
-    // Process all actors in parallel
-    const actorToolPromises = actorsInfo.map(async (actorInfo) => {
-        const actorId = actorInfo.definition.id;
-        if (!actorInfo.webServerMcpPath) {
-            log.warning('Actor does not have a web server MCP path, skipping', {
-                actorFullName: actorInfo.definition.actorFullName,
-                actorId,
-                mcpSessionId,
-            });
-            return [];
-        }
-
-        const mcpServerUrl = await getActorMCPServerURL(
-            actorInfo.definition.id, // Real ID of the Actor
-            actorInfo.webServerMcpPath,
-        );
-        log.debug('Retrieved MCP server URL for Actor', {
-            actorFullName: actorInfo.definition.actorFullName,
-            actorId,
-            mcpServerUrl,
-            mcpSessionId,
-        });
-
-        let client: Client | null = null;
-        try {
-            client = await connectMCPClient(mcpServerUrl, apifyToken, mcpSessionId);
-            if (!client) {
-                // Skip this Actor, connectMCPClient will log the error
-                return [];
-            }
-            return await getMCPServerTools(actorId, client, mcpServerUrl);
-        } catch (error) {
-            logHttpError(error, 'Failed to load tools from MCP server', {
-                actorFullName: actorInfo.definition.actorFullName,
-                actorId,
-                mcpSessionId,
-            });
-            return [];
-        } finally {
-            if (client) await client.close();
-        }
-    });
-
-    // Wait for all actors to be processed in parallel
-    const actorToolsArrays = await Promise.all(actorToolPromises);
-    return actorToolsArrays.flat();
-}
-
-export async function getActorsAsTools(
-    actorIdsOrNames: string[],
-    apifyClient: ApifyClient,
-    options?: { mcpSessionId?: string; actorStore?: ActorStore },
-): Promise<ToolEntry[]> {
-    const { mcpSessionId, actorStore } = options ?? {};
-    log.debug('Fetching Actors as tools', { actorNames: actorIdsOrNames, mcpSessionId });
-
-    const actorsInfo: (ActorInfo | null)[] = await Promise.all(
-        actorIdsOrNames.map(async (actorIdOrName) => {
-            const actorDefinitionWithInfoCached = actorDefinitionPrunedCache.get(actorIdOrName);
-            if (actorDefinitionWithInfoCached) {
-                return {
-                    definition: actorDefinitionWithInfoCached.definition,
-                    actor: actorDefinitionWithInfoCached.info,
-                    webServerMcpPath: getActorMCPServerPath(actorDefinitionWithInfoCached.definition),
-
-                } as ActorInfo;
-            }
-
-            try {
-                const actorDefinitionWithInfo = await getActorDefinition(actorIdOrName, apifyClient);
-                if (!actorDefinitionWithInfo) {
-                    log.softFail('Actor not found or definition is not available', { actorName: actorIdOrName, mcpSessionId, statusCode: 404 });
-                    return null;
-                }
-                // Cache the Actor definition with info
-                actorDefinitionPrunedCache.set(actorIdOrName, actorDefinitionWithInfo);
-                return {
-                    definition: actorDefinitionWithInfo.definition,
-                    actor: actorDefinitionWithInfo.info,
-                    webServerMcpPath: getActorMCPServerPath(actorDefinitionWithInfo.definition),
-                } as ActorInfo;
-            } catch (error) {
-                logHttpError(error, 'Failed to fetch Actor definition', {
-                    actorName: actorIdOrName,
-                    mcpSessionId,
-                });
-                return null;
-            }
-        }),
-    );
-
-    const clonedActors = structuredClone(actorsInfo);
-
-    // Filter out nulls - actorInfo can be null if the Actor was not found or an error occurred
-    const nonNullActors = clonedActors.filter((actorInfo): actorInfo is ActorInfo => Boolean(actorInfo));
-
-    // Separate Actors with MCP servers and normal Actors
-    // for MCP servers if mcp path is configured and also if the Actor standby mode is enabled
-    const actorMCPServersInfo = nonNullActors.filter((actorInfo) => isActorInfoMcpServer(actorInfo));
-    // all others
-    const normalActorsInfo = nonNullActors.filter((actorInfo) => !isActorInfoMcpServer(actorInfo));
-
-    const [normalTools, mcpServerTools] = await Promise.all([
-        getNormalActorsAsTools(normalActorsInfo, { mcpSessionId, actorStore }),
-        getMCPServersAsTools(actorMCPServersInfo, apifyClient.token, mcpSessionId),
-    ]);
-
-    return [...normalTools, ...mcpServerTools];
-}
+// Re-exports to maintain backward compatibility and support other modules
+export { callActorGetDataset, type CallActorGetDatasetResult } from './core/actor-execution.js';
+export { getActorsAsTools } from './core/actor-tools-factory.js';
 
 const callActorArgs = z.object({
     actor: z.string()
@@ -531,8 +159,6 @@ export const callActor: ToolEntry = {
         }
 
         try {
-            const apifyClient = createApifyClientWithSkyfireSupport(apifyMcpServer, args, apifyToken);
-
             // Determine execution mode: always async when UI mode is enabled, otherwise respect the parameter
             const isAsync = apifyMcpServer.options.uiMode === 'openai'
                 ? true
@@ -595,6 +221,8 @@ export const callActor: ToolEntry = {
                     if (client) await client.close();
                 }
             }
+
+            const apifyClient = createApifyClientWithSkyfireSupport(apifyMcpServer, args, apifyToken);
 
             // Handle regular Actor calls - fetch actor early to provide schema in error messages
             const [actor] = await getActorsAsTools([actorName], apifyClient, { mcpSessionId });

--- a/src/tools/core/actor-execution.ts
+++ b/src/tools/core/actor-execution.ts
@@ -1,0 +1,130 @@
+import type { ActorCallOptions, ActorRun } from 'apify-client';
+
+import log from '@apify/log';
+
+import type { ApifyClient } from '../../apify-client.js';
+import { TOOL_MAX_OUTPUT_CHARS } from '../../const.js';
+import type { ActorDefinitionStorage, DatasetItem } from '../../types.js';
+import { ensureOutputWithinCharLimit, getActorDefinitionStorageFieldNames } from '../../utils/actor.js';
+import { logHttpError, redactSkyfirePayId } from '../../utils/logging.js';
+import type { ProgressTracker } from '../../utils/progress.js';
+import type { JsonSchemaProperty } from '../../utils/schema-generation.js';
+import { generateSchemaFromItems } from '../../utils/schema-generation.js';
+
+// Define a named return type for callActorGetDataset
+export type CallActorGetDatasetResult = {
+    runId: string;
+    datasetId: string;
+    itemCount: number;
+    schema: JsonSchemaProperty;
+    previewItems: DatasetItem[];
+    usageTotalUsd?: number;
+    usageUsd?: Record<string, number>;
+};
+
+/**
+ * Calls an Apify Actor and retrieves metadata about the dataset results.
+ *
+ * This function executes an Actor and returns summary information instead with a result items preview of the full dataset
+ * to prevent overwhelming responses. The actual data can be retrieved using the get-actor-output tool.
+ *
+ * It requires the `APIFY_TOKEN` environment variable to be set.
+ * If the `APIFY_IS_AT_HOME` the dataset items are pushed to the Apify dataset.
+ *
+ * @param {string} actorName - The name of the Actor to call.
+ * @param {unknown} input - The input to pass to the actor.
+ * @param {ApifyClient} apifyClient - The Apify client to use for authentication.
+ * @returns {Promise<CallActorGetDatasetResult | null>} - A promise that resolves to an object containing the actor run and dataset items.
+ * @throws {Error} - Throws an error if the `APIFY_TOKEN` is not set
+ */
+export async function callActorGetDataset(options: {
+    actorName: string;
+    input: unknown;
+    apifyClient: ApifyClient;
+    callOptions?: ActorCallOptions;
+    progressTracker?: ProgressTracker | null;
+    abortSignal?: AbortSignal;
+    previewOutput?: boolean;
+    mcpSessionId?: string;
+}): Promise<CallActorGetDatasetResult | null> {
+    const {
+        actorName,
+        input,
+        apifyClient,
+        callOptions,
+        progressTracker,
+        abortSignal,
+        previewOutput = true,
+        mcpSessionId,
+    } = options;
+    const CLIENT_ABORT = Symbol('CLIENT_ABORT'); // Just internal symbol to identify client abort
+    const actorClient = apifyClient.actor(actorName);
+
+    // Start the actor run
+    const actorRun: ActorRun = await actorClient.start(input, callOptions);
+
+    // Start progress tracking if tracker is provided
+    if (progressTracker) {
+        progressTracker.startActorRunUpdates(actorRun.id, apifyClient, actorName);
+    }
+
+    // Create abort promise that handles both API abort and race rejection
+    const abortPromise = async () => new Promise<typeof CLIENT_ABORT>((resolve) => {
+        abortSignal?.addEventListener('abort', async () => {
+            // Abort the actor run via API
+            try {
+                await apifyClient.run(actorRun.id).abort({ gracefully: false });
+            } catch (e) {
+                logHttpError(e, 'Error aborting Actor run', { runId: actorRun.id });
+            }
+            // Reject to stop waiting
+            resolve(CLIENT_ABORT);
+        }, { once: true });
+    });
+
+    // Wait for completion or cancellation
+    const potentialAbortedRun = await Promise.race([
+        apifyClient.run(actorRun.id).waitForFinish(),
+        ...(abortSignal ? [abortPromise()] : []),
+    ]);
+
+    if (potentialAbortedRun === CLIENT_ABORT) {
+        log.info('Actor run aborted by client', { actorName, mcpSessionId, input: redactSkyfirePayId(input) });
+        return null;
+    }
+    const completedRun = potentialAbortedRun as ActorRun;
+
+    // Process the completed run
+    const dataset = apifyClient.dataset(completedRun.defaultDatasetId);
+    const [datasetItems, defaultBuild] = await Promise.all([
+        dataset.listItems(),
+        (await actorClient.defaultBuild()).get(),
+    ]);
+
+    // Generate schema using the shared utility
+    const generatedSchema = generateSchemaFromItems(datasetItems.items, {
+        clean: true,
+        arrayMode: 'all',
+    });
+    const schema = generatedSchema || { type: 'object', properties: {} };
+
+    /**
+     * Get important fields that are using in any dataset view as they MAY be used in filtering to ensure the output fits
+     * the tool output limits. Client has to use the get-actor-output tool to retrieve the full dataset or filtered out fields.
+     */
+    const storageDefinition = defaultBuild?.actorDefinition?.storages?.dataset as ActorDefinitionStorage | undefined;
+    const importantProperties = getActorDefinitionStorageFieldNames(storageDefinition || {});
+    const previewItems = previewOutput
+        ? ensureOutputWithinCharLimit(datasetItems.items, importantProperties, TOOL_MAX_OUTPUT_CHARS)
+        : [];
+
+    return {
+        runId: actorRun.id,
+        datasetId: completedRun.defaultDatasetId,
+        itemCount: datasetItems.count,
+        schema,
+        previewItems,
+        usageTotalUsd: completedRun.usageTotalUsd,
+        usageUsd: completedRun.usageUsd as Record<string, number> | undefined,
+    };
+}

--- a/src/tools/core/actor-response.ts
+++ b/src/tools/core/actor-response.ts
@@ -1,5 +1,5 @@
-import type { CallActorGetDatasetResult } from '../tools/actor.js';
-import type { DatasetItem } from '../types.js';
+import type { DatasetItem } from '../../types.js';
+import type { CallActorGetDatasetResult } from './actor-execution.js';
 
 /**
  * Result from buildActorResponseContent function.

--- a/src/tools/core/actor-tools-factory.ts
+++ b/src/tools/core/actor-tools-factory.ts
@@ -1,0 +1,270 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+import log from '@apify/log';
+
+import type { ApifyClient } from '../../apify-client.js';
+import {
+    ACTOR_MAX_MEMORY_MBYTES,
+    HelperTools,
+    RAG_WEB_BROWSER,
+    RAG_WEB_BROWSER_ADDITIONAL_DESC,
+} from '../../const.js';
+import { getActorMCPServerPath, getActorMCPServerURL } from '../../mcp/actors.js';
+import { connectMCPClient } from '../../mcp/client.js';
+import { getMCPServerTools } from '../../mcp/proxy.js';
+import { actorDefinitionPrunedCache } from '../../state.js';
+import type {
+    ActorInfo,
+    ActorStore,
+    ActorTool,
+    ApifyToken,
+    ToolEntry,
+    ToolInputSchema,
+} from '../../types.js';
+import { ajv } from '../../utils/ajv.js';
+import { logHttpError } from '../../utils/logging.js';
+import { getActorDefinition } from '../build.js';
+import { buildEnrichedCallActorOutputSchema, callActorOutputSchema } from '../structured-output-schemas.js';
+import { actorNameToToolName, buildActorInputSchema, fixedAjvCompile, isActorInfoMcpServer } from '../utils.js';
+
+/**
+ * Enriches actor tool output schemas with field-level detail from the ActorStore.
+ * Uses Promise.allSettled to ensure individual failures don't block other tools.
+ */
+export async function enrichActorToolOutputSchemas(tools: ToolEntry[], actorStore: ActorStore): Promise<void> {
+    const enrichPromises = tools
+        .filter((tool): tool is ActorTool => tool.type === 'actor')
+        .map(async (tool) => {
+            try {
+                const itemProperties = await actorStore.getActorOutputSchema(tool.actorFullName);
+                if (itemProperties && Object.keys(itemProperties).length > 0) {
+                    // eslint-disable-next-line no-param-reassign
+                    tool.outputSchema = buildEnrichedCallActorOutputSchema(itemProperties);
+                }
+            } catch (error) {
+                log.debug('Failed to enrich output schema for Actor', {
+                    actorName: tool.actorFullName,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            }
+        });
+
+    await Promise.allSettled(enrichPromises);
+}
+
+/**
+ * This function is used to fetch normal non-MCP server Actors as a tool.
+ *
+ * Fetches Actor input schemas by Actor IDs or Actor full names and creates MCP tools.
+ *
+ * This function retrieves the input schemas for the specified Actors and compiles them into MCP tools.
+ * It uses the AJV library to validate the input schemas.
+ *
+ * Tool name can't contain /, so it is replaced with _
+ *
+ * The input schema processing workflow:
+ * 1. Properties are marked as required using markInputPropertiesAsRequired() to add "REQUIRED" prefix to descriptions
+ * 2. Nested properties are built by analyzing editor type (proxy, requestListSources) using buildNestedProperties()
+ * 3. Properties are filtered using filterSchemaProperties()
+ * 4. Properties are shortened using shortenProperties()
+ * 5. Enums are added to descriptions with examples using addEnumsToDescriptionsWithExamples()
+ *
+ * @param {ActorInfo[]} actorsInfo - An array of ActorInfo objects with webServerMcpPath, definition, and Actor.
+ * @returns {Promise<ToolEntry[]>} - A promise that resolves to an array of MCP tools.
+ */
+export async function getNormalActorsAsTools(
+    actorsInfo: ActorInfo[],
+    options?: { mcpSessionId?: string; actorStore?: ActorStore },
+): Promise<ToolEntry[]> {
+    const { mcpSessionId, actorStore } = options ?? {};
+    const tools: ToolEntry[] = [];
+
+    for (const actorInfo of actorsInfo) {
+        const { definition } = actorInfo;
+
+        if (!definition) continue;
+
+        const isRag = definition.actorFullName === RAG_WEB_BROWSER;
+        const { inputSchema } = buildActorInputSchema(definition.actorFullName, definition.input, isRag);
+
+        let description = `This tool calls the Actor "${definition.actorFullName}" and retrieves its output results.
+Use this tool instead of the "${HelperTools.ACTOR_CALL}" if user requests this specific Actor.
+Actor description: ${definition.description}`;
+        if (isRag) {
+            description += RAG_WEB_BROWSER_ADDITIONAL_DESC;
+        }
+
+        const memoryMbytes = Math.min(
+            definition.defaultRunOptions?.memoryMbytes || ACTOR_MAX_MEMORY_MBYTES,
+            ACTOR_MAX_MEMORY_MBYTES,
+        );
+
+        let ajvValidate;
+        try {
+            ajvValidate = fixedAjvCompile(ajv, { ...inputSchema, additionalProperties: true });
+        } catch (e) {
+            log.error('Failed to compile schema', {
+                actorName: definition.actorFullName,
+                mcpSessionId,
+                error: e,
+            });
+            continue;
+        }
+
+        tools.push({
+            type: 'actor',
+            name: actorNameToToolName(definition.actorFullName),
+            actorFullName: definition.actorFullName,
+            description,
+            inputSchema: inputSchema as ToolInputSchema,
+            // reuse the common output schema
+            outputSchema: callActorOutputSchema,
+            ajvValidate,
+            requiresSkyfirePayId: true,
+            memoryMbytes,
+            icons: definition.pictureUrl
+                ? [{ src: definition.pictureUrl, mimeType: 'image/png' }]
+                : undefined,
+            annotations: {
+                title: definition.actorFullName,
+                readOnlyHint: false,
+                destructiveHint: true,
+                openWorldHint: true,
+            },
+            // Allow long-running tasks for Actor tools, make it optional for now
+            execution: {
+                taskSupport: 'optional',
+            },
+        });
+    }
+
+    // Enrich output schemas with field-level detail if actorStore is available
+    if (actorStore) {
+        await enrichActorToolOutputSchemas(tools, actorStore);
+    }
+
+    return tools;
+}
+
+export async function getMCPServersAsTools(
+    actorsInfo: ActorInfo[],
+    apifyToken: ApifyToken,
+    mcpSessionId?: string,
+): Promise<ToolEntry[]> {
+    /**
+     * This is case for the Skyfire request without any Apify token, we do not support
+     * standby Actors in this case, so we can skip MCP servers since they would fail anyway (they are standby Actors).
+    */
+    if (apifyToken === null || apifyToken === undefined) {
+        return [];
+    }
+
+    // Process all actors in parallel
+    const actorToolPromises = actorsInfo.map(async (actorInfo) => {
+        const actorId = actorInfo.definition.id;
+        if (!actorInfo.webServerMcpPath) {
+            log.warning('Actor does not have a web server MCP path, skipping', {
+                actorFullName: actorInfo.definition.actorFullName,
+                actorId,
+                mcpSessionId,
+            });
+            return [];
+        }
+
+        const mcpServerUrl = await getActorMCPServerURL(
+            actorInfo.definition.id, // Real ID of the Actor
+            actorInfo.webServerMcpPath,
+        );
+        log.debug('Retrieved MCP server URL for Actor', {
+            actorFullName: actorInfo.definition.actorFullName,
+            actorId,
+            mcpServerUrl,
+            mcpSessionId,
+        });
+
+        let client: Client | null = null;
+        try {
+            client = await connectMCPClient(mcpServerUrl, apifyToken, mcpSessionId);
+            if (!client) {
+                // Skip this Actor, connectMCPClient will log the error
+                return [];
+            }
+            return await getMCPServerTools(actorId, client, mcpServerUrl);
+        } catch (error) {
+            logHttpError(error, 'Failed to load tools from MCP server', {
+                actorFullName: actorInfo.definition.actorFullName,
+                actorId,
+                mcpSessionId,
+            });
+            return [];
+        } finally {
+            if (client) await client.close();
+        }
+    });
+
+    // Wait for all actors to be processed in parallel
+    const actorToolsArrays = await Promise.all(actorToolPromises);
+    return actorToolsArrays.flat();
+}
+
+export async function getActorsAsTools(
+    actorIdsOrNames: string[],
+    apifyClient: ApifyClient,
+    options?: { mcpSessionId?: string; actorStore?: ActorStore },
+): Promise<ToolEntry[]> {
+    const { mcpSessionId, actorStore } = options ?? {};
+    log.debug('Fetching Actors as tools', { actorNames: actorIdsOrNames, mcpSessionId });
+
+    const actorsInfo: (ActorInfo | null)[] = await Promise.all(
+        actorIdsOrNames.map(async (actorIdOrName) => {
+            const actorDefinitionWithInfoCached = actorDefinitionPrunedCache.get(actorIdOrName);
+            if (actorDefinitionWithInfoCached) {
+                return {
+                    definition: actorDefinitionWithInfoCached.definition,
+                    actor: actorDefinitionWithInfoCached.info,
+                    webServerMcpPath: getActorMCPServerPath(actorDefinitionWithInfoCached.definition),
+
+                } as ActorInfo;
+            }
+
+            try {
+                const actorDefinitionWithInfo = await getActorDefinition(actorIdOrName, apifyClient);
+                if (!actorDefinitionWithInfo) {
+                    log.softFail('Actor not found or definition is not available', { actorName: actorIdOrName, mcpSessionId, statusCode: 404 });
+                    return null;
+                }
+                // Cache the Actor definition with info
+                actorDefinitionPrunedCache.set(actorIdOrName, actorDefinitionWithInfo);
+                return {
+                    definition: actorDefinitionWithInfo.definition,
+                    actor: actorDefinitionWithInfo.info,
+                    webServerMcpPath: getActorMCPServerPath(actorDefinitionWithInfo.definition),
+                } as ActorInfo;
+            } catch (error) {
+                logHttpError(error, 'Failed to fetch Actor definition', {
+                    actorName: actorIdOrName,
+                    mcpSessionId,
+                });
+                return null;
+            }
+        }),
+    );
+
+    const clonedActors = structuredClone(actorsInfo);
+
+    // Filter out nulls - actorInfo can be null if the Actor was not found or an error occurred
+    const nonNullActors = clonedActors.filter((actorInfo): actorInfo is ActorInfo => Boolean(actorInfo));
+
+    // Separate Actors with MCP servers and normal Actors
+    // for MCP servers if mcp path is configured and also if the Actor standby mode is enabled
+    const actorMCPServersInfo = nonNullActors.filter((actorInfo) => isActorInfoMcpServer(actorInfo));
+    // all others
+    const normalActorsInfo = nonNullActors.filter((actorInfo) => !isActorInfoMcpServer(actorInfo));
+
+    const [normalTools, mcpServerTools] = await Promise.all([
+        getNormalActorsAsTools(normalActorsInfo, { mcpSessionId, actorStore }),
+        getMCPServersAsTools(actorMCPServersInfo, apifyClient.token, mcpSessionId),
+    ]);
+
+    return [...normalTools, ...mcpServerTools];
+}

--- a/src/tools/store_collection.ts
+++ b/src/tools/store_collection.ts
@@ -1,9 +1,8 @@
-import type { ActorStoreList } from 'apify-client';
 import { z } from 'zod';
 
 import { HelperTools } from '../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../resources/widgets.js';
-import type { ActorPricingModel, InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
 import { formatActorForWidget, formatActorToActorCard, formatActorToStructuredCard, type WidgetActor } from '../utils/actor-card.js';
 import { searchAndFilterActors } from '../utils/actor-search.js';
 import { compileSchema } from '../utils/ajv.js';
@@ -45,28 +44,6 @@ Examples:
         .describe('Filter the results by the specified category.'),
 });
 
-/**
- * Filters out actors with the 'FLAT_PRICE_PER_MONTH' pricing model (rental actors),
- * unless the actor's ID is present in the user's rented actor IDs list.
- *
- * This is necessary because the Store list API does not support filtering by multiple pricing models at once.
- *
- * @param actors - Array of ActorStorePruned objects to filter.
- * @param userRentedActorIds - Array of Actor IDs that the user has rented.
- * @returns Array of Actors excluding those with 'FLAT_PRICE_PER_MONTH' pricing model (= rental Actors),
- *  except for Actors that the user has rented (whose IDs are in userRentedActorIds).
- */
-export function filterRentalActors(
-    actors: ActorStoreList[],
-    userRentedActorIds: string[],
-): ActorStoreList[] {
-    // Store list API does not support filtering by two pricing models at once,
-    // so we filter the results manually after fetching them.
-    return actors.filter((actor) => (
-        actor.currentPricingInfo.pricingModel as ActorPricingModel) !== 'FLAT_PRICE_PER_MONTH'
-        || userRentedActorIds.includes(actor.id),
-    );
-}
 /**
  * https://docs.apify.com/api/v2/store-get
  */

--- a/tests/unit/tools.structured-output-schemas.test.ts
+++ b/tests/unit/tools.structured-output-schemas.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getNormalActorsAsTools } from '../../src/tools/actor.js';
+import { getNormalActorsAsTools } from '../../src/tools/core/actor-tools-factory.js';
 import { buildEnrichedCallActorOutputSchema, callActorOutputSchema } from '../../src/tools/structured-output-schemas.js';
 import type { ActorInfo, ActorStore, ActorTool } from '../../src/types.js';
 


### PR DESCRIPTION
## Summary
- Extract mode-agnostic business logic from tool handlers into `src/tools/core/` modules
- Fix circular dependency (`utils/actor-search.ts` → `tools/store_collection.ts`)
- Pure refactor — zero behavioral changes

## Changes

### New files
| File | Content |
|------|---------|
| `src/tools/core/actor-execution.ts` | `callActorGetDataset()` + `CallActorGetDatasetResult` type |
| `src/tools/core/actor-tools-factory.ts` | `getActorsAsTools()`, `getNormalActorsAsTools()`, `getMCPServersAsTools()`, `enrichActorToolOutputSchemas()` |
| `src/tools/core/actor-response.ts` | `buildActorResponseContent()` (moved from `utils/`) |

### Modified files
| File | Change |
|------|--------|
| `src/tools/actor.ts` | Removed extracted functions, added re-exports for backward compat |
| `src/tools/store_collection.ts` | Removed `filterRentalActors` (moved to utils) |
| `src/utils/actor-search.ts` | Absorbed `filterRentalActors`, removed reverse import from `tools/` |
| `src/mcp/server.ts` | Updated `actor-response` import path |
| `tests/unit/tools.structured-output-schemas.test.ts` | Updated `getNormalActorsAsTools` import path |

### Deleted files
| File | Reason |
|------|--------|
| `src/utils/actor-response.ts` | Moved to `src/tools/core/actor-response.ts` |

## Review focus
- Are extraction boundaries clean? Does the core layer have zero presentation/mode concerns?
- Is the circular dependency fully resolved?
- All re-exports preserved for backward compatibility?

## Verification
```
✅ npm run type-check — passes
✅ npm run lint — passes  
✅ npm run test:unit — 248 tests pass
```

Part of [tool mode separation plan](https://github.com/apify/apify-mcp-server/pull/465). PR #2 of 7.