### PR TITLE
refactor: move tools to common/openai/ directories and freeze all tool definitions

### DIFF
--- a/src/index-internals.ts
+++ b/src/index-internals.ts
@@ -6,7 +6,7 @@ import { ApifyClient } from './apify-client.js';
 import { APIFY_FAVICON_URL, defaults, HelperTools, SERVER_NAME, SERVER_TITLE } from './const.js';
 import { processParamsGetTools } from './mcp/utils.js';
 import { getServerCard } from './server_card.js';
-import { addTool } from './tools/helpers.js';
+import { addTool } from './tools/common/helpers.js';
 import { defaultTools, getActorsAsTools, getUnauthEnabledToolCategories, toolCategories,
     toolCategoriesEnabledByDefault, unauthEnabledTools } from './tools/index.js';
 import { actorNameToToolName } from './tools/utils.js';

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -37,7 +37,7 @@ const defaultVariant = defaultCallActor as HelperTool;
  *
  * Note: The description may be overridden by tools-loader.ts at load time for openai mode.
  */
-export const callActor: ToolEntry = {
+export const callActor: ToolEntry = Object.freeze({
     ...defaultVariant,
     call: async (toolArgs: InternalToolArgs) => {
         const variant = (toolArgs.apifyMcpServer.options.uiMode === 'openai'
@@ -45,4 +45,4 @@ export const callActor: ToolEntry = {
             : defaultCallActor) as HelperTool;
         return variant.call(toolArgs);
     },
-};
+});

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -10,20 +10,20 @@
  */
 import type { ToolCategory } from '../types.js';
 import { callActor } from './actor.js';
-import { getDataset, getDatasetItems, getDatasetSchema } from './dataset.js';
-import { getUserDatasetsList } from './dataset_collection.js';
+import { getDataset, getDatasetItems, getDatasetSchema } from './common/dataset.js';
+import { getUserDatasetsList } from './common/dataset_collection.js';
+import { fetchApifyDocsTool } from './common/fetch-apify-docs.js';
+import { getActorOutput } from './common/get-actor-output.js';
+import { getHtmlSkeleton } from './common/get-html-skeleton.js';
+import { addTool } from './common/helpers.js';
+import { getKeyValueStore, getKeyValueStoreKeys, getKeyValueStoreRecord } from './common/key_value_store.js';
+import { getUserKeyValueStoresList } from './common/key_value_store_collection.js';
+import { abortActorRun, getActorRun, getActorRunLog } from './common/run.js';
+import { getUserRunsList } from './common/run_collection.js';
+import { searchApifyDocsTool } from './common/search-apify-docs.js';
 import { fetchActorDetailsTool } from './fetch-actor-details.js';
-import { fetchActorDetailsInternalTool } from './fetch-actor-details-internal.js';
-import { fetchApifyDocsTool } from './fetch-apify-docs.js';
-import { getActorOutput } from './get-actor-output.js';
-import { getHtmlSkeleton } from './get-html-skeleton.js';
-import { addTool } from './helpers.js';
-import { getKeyValueStore, getKeyValueStoreKeys, getKeyValueStoreRecord } from './key_value_store.js';
-import { getUserKeyValueStoresList } from './key_value_store_collection.js';
-import { abortActorRun, getActorRun, getActorRunLog } from './run.js';
-import { getUserRunsList } from './run_collection.js';
-import { searchActorsInternalTool } from './search-actors-internal.js';
-import { searchApifyDocsTool } from './search-apify-docs.js';
+import { fetchActorDetailsInternalTool } from './openai/fetch-actor-details-internal.js';
+import { searchActorsInternalTool } from './openai/search-actors-internal.js';
 import { searchActors } from './store_collection.js';
 
 export const toolCategories = {

--- a/src/tools/common/dataset.ts
+++ b/src/tools/common/dataset.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 
-import { createApifyClientWithSkyfireSupport } from '../apify-client.js';
-import { HelperTools, TOOL_STATUS } from '../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
-import { parseCommaSeparatedList } from '../utils/generic.js';
-import { buildMCPResponse } from '../utils/mcp.js';
-import { generateSchemaFromItems } from '../utils/schema-generation.js';
-import { datasetItemsOutputSchema } from './structured-output-schemas.js';
+import { createApifyClientWithSkyfireSupport } from '../../apify-client.js';
+import { HelperTools, TOOL_STATUS } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
+import { parseCommaSeparatedList } from '../../utils/generic.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
+import { generateSchemaFromItems } from '../../utils/schema-generation.js';
+import { datasetItemsOutputSchema } from '../structured-output-schemas.js';
 
 const getDatasetArgs = z.object({
     datasetId: z.string()
@@ -42,7 +42,7 @@ const getDatasetItemsArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/dataset-get
  */
-export const getDataset: ToolEntry = {
+export const getDataset: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.DATASET_GET,
     description: `Get metadata for a dataset (collection of structured data created by an Actor run).
@@ -83,12 +83,12 @@ USAGE EXAMPLES:
         }
         return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(v)}\n\`\`\`` }] };
     },
-} as const;
+} as const);
 
 /**
  * https://docs.apify.com/api/v2/dataset-items-get
  */
-export const getDatasetItems: ToolEntry = {
+export const getDatasetItems: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.DATASET_GET_ITEMS,
     description: `Retrieve dataset items with pagination, sorting, and field selection.
@@ -155,7 +155,7 @@ USAGE EXAMPLES:
 
         return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(v)}\n\`\`\`` }], structuredContent };
     },
-} as const;
+} as const);
 
 const getDatasetSchemaArgs = z.object({
     datasetId: z.string()
@@ -175,7 +175,7 @@ const getDatasetSchemaArgs = z.object({
 /**
  * Generates a JSON schema from dataset items
  */
-export const getDatasetSchema: ToolEntry = {
+export const getDatasetSchema: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.DATASET_SCHEMA_GET,
     description: `Generate a JSON schema from a sample of dataset items.
@@ -249,4 +249,4 @@ USAGE EXAMPLES:
             }],
         };
     },
-} as const;
+} as const);

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 
-import { ApifyClient } from '../apify-client.js';
-import { HelperTools } from '../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
+import { ApifyClient } from '../../apify-client.js';
+import { HelperTools } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
 
 const getUserDatasetsListArgs = z.object({
     offset: z.number()
@@ -24,7 +24,7 @@ const getUserDatasetsListArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/datasets-get
  */
-export const getUserDatasetsList: ToolEntry = {
+export const getUserDatasetsList: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.DATASET_LIST_GET,
     description: `List datasets (collections of Actor run data) for the authenticated user.
@@ -59,4 +59,4 @@ USAGE EXAMPLES:
         });
         return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(datasets)}\n\`\`\`` }] };
     },
-} as const;
+} as const);

--- a/src/tools/common/fetch-apify-docs.ts
+++ b/src/tools/common/fetch-apify-docs.ts
@@ -2,14 +2,14 @@ import { z } from 'zod';
 
 import log from '@apify/log';
 
-import { ALLOWED_DOC_DOMAINS, HelperTools, TOOL_STATUS } from '../const.js';
-import { fetchApifyDocsCache } from '../state.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
-import { htmlToMarkdown } from '../utils/html-to-md.js';
-import { logHttpError } from '../utils/logging.js';
-import { buildMCPResponse } from '../utils/mcp.js';
-import { fetchApifyDocsToolOutputSchema } from './structured-output-schemas.js';
+import { ALLOWED_DOC_DOMAINS, HelperTools, TOOL_STATUS } from '../../const.js';
+import { fetchApifyDocsCache } from '../../state.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
+import { htmlToMarkdown } from '../../utils/html-to-md.js';
+import { logHttpError } from '../../utils/logging.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
+import { fetchApifyDocsToolOutputSchema } from '../structured-output-schemas.js';
 
 const fetchApifyDocsToolArgsSchema = z.object({
     url: z.string()
@@ -17,7 +17,7 @@ const fetchApifyDocsToolArgsSchema = z.object({
         .describe(`URL of the Apify documentation page to fetch. This should be the full URL, including the protocol (e.g., https://docs.apify.com/).`),
 });
 
-export const fetchApifyDocsTool: ToolEntry = {
+export const fetchApifyDocsTool: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.DOCS_FETCH,
     description: `Fetch the full content of an Apify or Crawlee documentation page by its URL.
@@ -101,4 +101,4 @@ Please verify the URL is correct and accessible. You can search for available do
 
         return buildMCPResponse({ texts: [`Fetched content from ${url}:\n\n${markdown}`], structuredContent: { url, content: markdown } });
     },
-} as const;
+} as const);

--- a/src/tools/common/get-actor-output.ts
+++ b/src/tools/common/get-actor-output.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 
-import { createApifyClientWithSkyfireSupport } from '../apify-client.js';
-import { HelperTools, TOOL_MAX_OUTPUT_CHARS, TOOL_STATUS } from '../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
-import { getValuesByDotKeys, parseCommaSeparatedList } from '../utils/generic.js';
-import { buildMCPResponse } from '../utils/mcp.js';
-import { datasetItemsOutputSchema } from './structured-output-schemas.js';
+import { createApifyClientWithSkyfireSupport } from '../../apify-client.js';
+import { HelperTools, TOOL_MAX_OUTPUT_CHARS, TOOL_STATUS } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
+import { getValuesByDotKeys, parseCommaSeparatedList } from '../../utils/generic.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
+import { datasetItemsOutputSchema } from '../structured-output-schemas.js';
 
 /**
  * Zod schema for get-actor-output tool arguments
@@ -64,7 +64,7 @@ function cleanEmptyProperties(obj: unknown): unknown {
  * This tool is used specifically for retrieving Actor output.
  * It is a simplified version of the get-dataset-items tool.
  */
-export const getActorOutput: ToolEntry = {
+export const getActorOutput: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.ACTOR_OUTPUT_GET,
     description: `Retrieve the output dataset items of a specific Actor run using its datasetId.
@@ -159,4 +159,4 @@ Note: This tool is automatically included if the Apify MCP Server is configured 
 
         return { content: [{ type: 'text', text: outputText }], structuredContent };
     },
-} as const;
+} as const);

--- a/src/tools/common/get-html-skeleton.ts
+++ b/src/tools/common/get-html-skeleton.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 
-import { ApifyClient } from '../apify-client.js';
-import { HelperTools, RAG_WEB_BROWSER, TOOL_MAX_OUTPUT_CHARS, TOOL_STATUS } from '../const.js';
-import { getHtmlSkeletonCache } from '../state.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
-import { isValidHttpUrl } from '../utils/generic.js';
-import { stripHtml } from '../utils/html.js';
-import { buildMCPResponse } from '../utils/mcp.js';
+import { ApifyClient } from '../../apify-client.js';
+import { HelperTools, RAG_WEB_BROWSER, TOOL_MAX_OUTPUT_CHARS, TOOL_STATUS } from '../../const.js';
+import { getHtmlSkeletonCache } from '../../state.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
+import { isValidHttpUrl } from '../../utils/generic.js';
+import { stripHtml } from '../../utils/html.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
 
 type ScrapedPageItem = {
     crawl: {
@@ -35,7 +35,7 @@ const getHtmlSkeletonArgs = z.object({
         .describe('Chunk number to retrieve when getting the content. The content is split into chunks to prevent exceeding the maximum tool output length.'),
 });
 
-export const getHtmlSkeleton: ToolEntry = {
+export const getHtmlSkeleton: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.GET_HTML_SKELETON,
     description: `Retrieve the HTML skeleton (clean structure) of a webpage by stripping scripts, styles, and non-essential attributes.
@@ -123,4 +123,4 @@ USAGE EXAMPLES:
 
         return buildMCPResponse({ texts: [chunkContent + chunkInfo] });
     },
-} as const;
+} as const);

--- a/src/tools/common/helpers.ts
+++ b/src/tools/common/helpers.ts
@@ -1,16 +1,16 @@
 import { z } from 'zod';
 
-import { ApifyClient } from '../apify-client.js';
-import { HelperTools } from '../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
+import { ApifyClient } from '../../apify-client.js';
+import { HelperTools } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
 
 const addToolArgsSchema = z.object({
     actor: z.string()
         .min(1)
         .describe(`Actor ID or full name in the format "username/name", e.g., "apify/rag-web-browser".`),
 });
-export const addTool: ToolEntry = {
+export const addTool: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.ACTOR_ADD,
     description: `Add an Actor or MCP server to the Apify MCP Server as an available tool.
@@ -75,4 +75,4 @@ USAGE EXAMPLES:
             }],
         };
     },
-} as const;
+} as const);

--- a/src/tools/common/key_value_store.ts
+++ b/src/tools/common/key_value_store.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 
-import { createApifyClientWithSkyfireSupport } from '../apify-client.js';
-import { HelperTools } from '../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
+import { createApifyClientWithSkyfireSupport } from '../../apify-client.js';
+import { HelperTools } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
 
 const getKeyValueStoreArgs = z.object({
     storeId: z.string()
@@ -14,7 +14,7 @@ const getKeyValueStoreArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/key-value-store-get
  */
-export const getKeyValueStore: ToolEntry = {
+export const getKeyValueStore: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.KEY_VALUE_STORE_GET,
     description: `Get details about a key-value store by ID or username~store-name.
@@ -46,7 +46,7 @@ USAGE EXAMPLES:
         const store = await client.keyValueStore(parsed.storeId).get();
         return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(store)}\n\`\`\`` }] };
     },
-} as const;
+} as const);
 
 const getKeyValueStoreKeysArgs = z.object({
     storeId: z.string()
@@ -64,7 +64,7 @@ const getKeyValueStoreKeysArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/key-value-store-keys-get
  */
-export const getKeyValueStoreKeys: ToolEntry = {
+export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.KEY_VALUE_STORE_KEYS_GET,
     description: `List keys in a key-value store with optional pagination.
@@ -100,7 +100,7 @@ USAGE EXAMPLES:
         });
         return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(keys)}\n\`\`\`` }] };
     },
-} as const;
+} as const);
 
 const getKeyValueStoreRecordArgs = z.object({
     storeId: z.string()
@@ -114,7 +114,7 @@ const getKeyValueStoreRecordArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/key-value-store-record-get
  */
-export const getKeyValueStoreRecord: ToolEntry = {
+export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.KEY_VALUE_STORE_RECORD_GET,
     description: `Get a value stored in a key-value store under a specific key.
@@ -146,4 +146,4 @@ USAGE EXAMPLES:
         const record = await client.keyValueStore(parsed.storeId).getRecord(parsed.recordKey);
         return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(record)}\n\`\`\`` }] };
     },
-} as const;
+} as const);

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 
-import { ApifyClient } from '../apify-client.js';
-import { HelperTools } from '../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
+import { ApifyClient } from '../../apify-client.js';
+import { HelperTools } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
 
 const getUserKeyValueStoresListArgs = z.object({
     offset: z.number()
@@ -24,7 +24,7 @@ const getUserKeyValueStoresListArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/key-value-stores-get
  */
-export const getUserKeyValueStoresList: ToolEntry = {
+export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.KEY_VALUE_STORE_LIST_GET,
     description: `List key-value stores owned by the authenticated user.
@@ -59,4 +59,4 @@ USAGE EXAMPLES:
         });
         return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(stores)}\n\`\`\`` }] };
     },
-} as const;
+} as const);

--- a/src/tools/common/run.ts
+++ b/src/tools/common/run.ts
@@ -11,19 +11,19 @@
  */
 import { z } from 'zod';
 
-import { createApifyClientWithSkyfireSupport } from '../apify-client.js';
-import { HelperTools } from '../const.js';
-import type { HelperTool, InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
-import { defaultGetActorRun } from './default/get-actor-run.js';
-import { openaiGetActorRun } from './openai/get-actor-run.js';
+import { createApifyClientWithSkyfireSupport } from '../../apify-client.js';
+import { HelperTools } from '../../const.js';
+import type { HelperTool, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
+import { defaultGetActorRun } from '../default/get-actor-run.js';
+import { openaiGetActorRun } from '../openai/get-actor-run.js';
 
 const defaultVariant = defaultGetActorRun as HelperTool;
 
 /**
  * Adapter get-actor-run tool that dispatches to the correct mode-specific variant at runtime.
  */
-export const getActorRun: ToolEntry = {
+export const getActorRun: ToolEntry = Object.freeze({
     ...defaultVariant,
     call: async (toolArgs: InternalToolArgs) => {
         const variant = (toolArgs.apifyMcpServer.options.uiMode === 'openai'
@@ -31,7 +31,7 @@ export const getActorRun: ToolEntry = {
             : defaultGetActorRun) as HelperTool;
         return variant.call(toolArgs);
     },
-};
+});
 
 // --- Mode-independent tools below ---
 
@@ -47,7 +47,7 @@ const GetRunLogArgs = z.object({
  * https://docs.apify.com/api/v2/actor-run-get
  *  /v2/actor-runs/{runId}/log{?token}
  */
-export const getActorRunLog: ToolEntry = {
+export const getActorRunLog: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.ACTOR_RUNS_LOG,
     description: `Retrieve recent log lines for a specific Actor run.
@@ -82,7 +82,7 @@ USAGE EXAMPLES:
         const text = lines.slice(lines.length - parsed.lines - 1, lines.length).join('\n');
         return { content: [{ type: 'text', text }] };
     },
-} as const;
+} as const);
 
 const abortRunArgs = z.object({
     runId: z.string()
@@ -94,7 +94,7 @@ const abortRunArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/actor-run-abort-post
  */
-export const abortActorRun: ToolEntry = {
+export const abortActorRun: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.ACTOR_RUNS_ABORT,
     description: `Abort an Actor run that is currently starting or running.
@@ -128,4 +128,4 @@ USAGE EXAMPLES:
         const v = await client.run(parsed.runId).abort({ gracefully: parsed.gracefully });
         return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(v)}\n\`\`\`` }] };
     },
-} as const;
+} as const);

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
-import { ApifyClient } from '../apify-client.js';
-import { HelperTools } from '../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
-import { buildMCPResponse } from '../utils/mcp.js';
+import { ApifyClient } from '../../apify-client.js';
+import { HelperTools } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
 
 const getUserRunsListArgs = z.object({
     offset: z.number()
@@ -25,7 +25,7 @@ const getUserRunsListArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/act-runs-get
  */
-export const getUserRunsList: ToolEntry = {
+export const getUserRunsList: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.ACTOR_RUN_LIST_GET,
     description: `List Actor runs for the authenticated user with optional filtering and sorting.
@@ -55,4 +55,4 @@ USAGE EXAMPLES:
             texts: [`\`\`\`json\n${JSON.stringify(runs)}\n\`\`\``],
         });
     },
-} as const;
+} as const);

--- a/src/tools/common/search-apify-docs.ts
+++ b/src/tools/common/search-apify-docs.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
-import { DOCS_SOURCES, HelperTools } from '../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { compileSchema } from '../utils/ajv.js';
-import { searchDocsBySourceCached } from '../utils/apify-docs.js';
-import { buildMCPResponse } from '../utils/mcp.js';
-import { searchApifyDocsToolOutputSchema } from './structured-output-schemas.js';
+import { DOCS_SOURCES, HelperTools } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
+import { searchDocsBySourceCached } from '../../utils/apify-docs.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
+import { searchApifyDocsToolOutputSchema } from '../structured-output-schemas.js';
 
 /**
  * Build docSource parameter description dynamically from DOCS_SOURCES
@@ -65,7 +65,7 @@ You can increase this limit if you need more results, but keep in mind that the 
 Use this to paginate through the search results. For example, if you want to get the next 5 results, set the offset to 5 and limit to 5.`),
 });
 
-export const searchApifyDocsTool: ToolEntry = {
+export const searchApifyDocsTool: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.DOCS_SEARCH,
     description: buildToolDescription(),
@@ -126,4 +126,4 @@ ${results.map((result) => {
         // We put the instructions at the end so that they are more likely to be acknowledged by the LLM
         return buildMCPResponse({ texts: [textResult, instructions], structuredContent });
     },
-} as const;
+} as const);

--- a/src/tools/default/call-actor.ts
+++ b/src/tools/default/call-actor.ts
@@ -54,7 +54,7 @@ EXAMPLES:
  * Supports both sync (default) and async execution.
  * Does not include widget metadata in responses.
  */
-export const defaultCallActor: ToolEntry = {
+export const defaultCallActor: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.ACTOR_CALL,
     description: CALL_ACTOR_DEFAULT_DESCRIPTION,
@@ -153,4 +153,4 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH},
             });
         }
     },
-};
+} as const);

--- a/src/tools/default/fetch-actor-details.ts
+++ b/src/tools/default/fetch-actor-details.ts
@@ -17,7 +17,7 @@ import {
  * Default mode fetch-actor-details tool.
  * Returns full text response with output schema fetch.
  */
-export const defaultFetchActorDetails: ToolEntry = {
+export const defaultFetchActorDetails: ToolEntry = Object.freeze({
     ...fetchActorDetailsMetadata,
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyToken, apifyMcpServer, mcpSessionId } = toolArgs;
@@ -53,4 +53,4 @@ export const defaultFetchActorDetails: ToolEntry = {
 
         return buildMCPResponse({ texts, structuredContent: responseStructuredContent });
     },
-} as const;
+} as const);

--- a/src/tools/default/get-actor-run.ts
+++ b/src/tools/default/get-actor-run.ts
@@ -13,7 +13,7 @@ import {
  * Default mode get-actor-run tool.
  * Returns full JSON dump of the run without widget metadata.
  */
-export const defaultGetActorRun: ToolEntry = {
+export const defaultGetActorRun: ToolEntry = Object.freeze({
     ...getActorRunMetadata,
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyToken, apifyMcpServer, mcpSessionId } = toolArgs;
@@ -53,4 +53,4 @@ Please verify the run ID and ensure that the run exists.`],
             });
         }
     },
-} as const;
+} as const);

--- a/src/tools/default/search-actors.ts
+++ b/src/tools/default/search-actors.ts
@@ -12,7 +12,7 @@ import {
  * Default mode search-actors tool.
  * Returns text-based actor cards without widget metadata.
  */
-export const defaultSearchActors: ToolEntry = {
+export const defaultSearchActors: ToolEntry = Object.freeze({
     ...searchActorsMetadata,
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyToken, userRentedActorIds, apifyMcpServer } = toolArgs;
@@ -67,4 +67,4 @@ IMPORTANT: You MUST always do a second search with broader, more generic keyword
             structuredContent,
         });
     },
-} as const;
+} as const);

--- a/src/tools/fetch-actor-details.ts
+++ b/src/tools/fetch-actor-details.ts
@@ -18,7 +18,7 @@ const defaultVariant = defaultFetchActorDetails as HelperTool;
 /**
  * Adapter fetch-actor-details tool that dispatches to the correct mode-specific variant at runtime.
  */
-export const fetchActorDetailsTool: ToolEntry = {
+export const fetchActorDetailsTool: ToolEntry = Object.freeze({
     ...defaultVariant,
     call: async (toolArgs: InternalToolArgs) => {
         const variant = (toolArgs.apifyMcpServer.options.uiMode === 'openai'
@@ -26,4 +26,4 @@ export const fetchActorDetailsTool: ToolEntry = {
             : defaultFetchActorDetails) as HelperTool;
         return variant.call(toolArgs);
     },
-};
+});

--- a/src/tools/openai/call-actor.ts
+++ b/src/tools/openai/call-actor.ts
@@ -53,7 +53,7 @@ EXAMPLES:
  * Always runs asynchronously — starts the run and returns immediately with widget metadata.
  * The widget automatically tracks progress and updates the UI.
  */
-export const openaiCallActor: ToolEntry = {
+export const openaiCallActor: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.ACTOR_CALL,
     description: CALL_ACTOR_OPENAI_DESCRIPTION,
@@ -139,4 +139,4 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH},
             });
         }
     },
-};
+} as const);

--- a/src/tools/openai/fetch-actor-details-internal.ts
+++ b/src/tools/openai/fetch-actor-details-internal.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
-import { ApifyClient } from '../apify-client.js';
-import { HelperTools } from '../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
+import { ApifyClient } from '../../apify-client.js';
+import { HelperTools } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import {
     actorDetailsOutputOptionsSchema,
     buildActorDetailsTextResponse,
@@ -10,10 +10,10 @@ import {
     buildCardOptions,
     fetchActorDetails,
     resolveOutputOptions,
-} from '../utils/actor-details.js';
-import { compileSchema } from '../utils/ajv.js';
-import { buildMCPResponse } from '../utils/mcp.js';
-import { actorDetailsOutputSchema } from './structured-output-schemas.js';
+} from '../../utils/actor-details.js';
+import { compileSchema } from '../../utils/ajv.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
+import { actorDetailsOutputSchema } from '../structured-output-schemas.js';
 
 const fetchActorDetailsInternalArgsSchema = z.object({
     actor: z.string()
@@ -23,7 +23,7 @@ const fetchActorDetailsInternalArgsSchema = z.object({
         .describe('Specify which information to include in the response to save tokens.'),
 });
 
-export const fetchActorDetailsInternalTool: ToolEntry = {
+export const fetchActorDetailsInternalTool: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.ACTOR_GET_DETAILS_INTERNAL,
     openaiOnly: true,
@@ -80,4 +80,4 @@ but the user did NOT explicitly ask for Actor details presentation.`,
 
         return buildMCPResponse({ texts, structuredContent });
     },
-} as const;
+} as const);

--- a/src/tools/openai/fetch-actor-details.ts
+++ b/src/tools/openai/fetch-actor-details.ts
@@ -18,7 +18,7 @@ import {
  * OpenAI mode fetch-actor-details tool.
  * Returns simplified structured content with interactive widget metadata.
  */
-export const openaiFetchActorDetails: ToolEntry = {
+export const openaiFetchActorDetails: ToolEntry = Object.freeze({
     ...fetchActorDetailsMetadata,
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyToken } = toolArgs;
@@ -58,4 +58,4 @@ An interactive widget has been rendered with detailed Actor information.
             },
         });
     },
-} as const;
+} as const);

--- a/src/tools/openai/get-actor-run.ts
+++ b/src/tools/openai/get-actor-run.ts
@@ -14,7 +14,7 @@ import {
  * OpenAI mode get-actor-run tool.
  * Returns abbreviated text with widget metadata for interactive progress display.
  */
-export const openaiGetActorRun: ToolEntry = {
+export const openaiGetActorRun: ToolEntry = Object.freeze({
     ...getActorRunMetadata,
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyToken, apifyMcpServer, mcpSessionId } = toolArgs;
@@ -59,4 +59,4 @@ Please verify the run ID and ensure that the run exists.`],
             });
         }
     },
-} as const;
+} as const);

--- a/src/tools/openai/search-actors-internal.ts
+++ b/src/tools/openai/search-actors-internal.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
-import { HelperTools } from '../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
-import { searchAndFilterActors } from '../utils/actor-search.js';
-import { compileSchema } from '../utils/ajv.js';
-import { buildMCPResponse } from '../utils/mcp.js';
-import { actorSearchInternalOutputSchema } from './structured-output-schemas.js';
+import { HelperTools } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { searchAndFilterActors } from '../../utils/actor-search.js';
+import { compileSchema } from '../../utils/ajv.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
+import { actorSearchInternalOutputSchema } from '../structured-output-schemas.js';
 
 const searchActorsInternalArgsSchema = z.object({
     limit: z.number()
@@ -27,7 +27,7 @@ const searchActorsInternalArgsSchema = z.object({
         .describe('Filter the results by the specified category.'),
 });
 
-export const searchActorsInternalTool: ToolEntry = {
+export const searchActorsInternalTool: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.STORE_SEARCH_INTERNAL,
     openaiOnly: true,
@@ -83,4 +83,4 @@ Returns only minimal fields (fullName, title, description) needed for subsequent
             },
         });
     },
-};
+});

--- a/src/tools/openai/search-actors.ts
+++ b/src/tools/openai/search-actors.ts
@@ -13,7 +13,7 @@ import {
  * OpenAI mode search-actors tool.
  * Returns widget-formatted actors with interactive widget metadata.
  */
-export const openaiSearchActors: ToolEntry = {
+export const openaiSearchActors: ToolEntry = Object.freeze({
     ...searchActorsMetadata,
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyToken, userRentedActorIds, apifyMcpServer } = toolArgs;
@@ -81,4 +81,4 @@ An interactive widget has been rendered with the search results. The user can al
             },
         });
     },
-} as const;
+} as const);

--- a/src/tools/store_collection.ts
+++ b/src/tools/store_collection.ts
@@ -18,7 +18,7 @@ const defaultVariant = defaultSearchActors as HelperTool;
 /**
  * Adapter search-actors tool that dispatches to the correct mode-specific variant at runtime.
  */
-export const searchActors: ToolEntry = {
+export const searchActors: ToolEntry = Object.freeze({
     ...defaultVariant,
     call: async (toolArgs: InternalToolArgs) => {
         const variant = (toolArgs.apifyMcpServer.options.uiMode === 'openai'
@@ -26,4 +26,4 @@ export const searchActors: ToolEntry = {
             : defaultSearchActors) as HelperTool;
         return variant.call(toolArgs);
     },
-};
+});

--- a/src/utils/tools-loader.ts
+++ b/src/utils/tools-loader.ts
@@ -10,10 +10,10 @@ import log from '@apify/log';
 
 import { defaults, HelperTools } from '../const.js';
 import { callActor, getCallActorDescription } from '../tools/actor.js';
-import { getActorOutput } from '../tools/get-actor-output.js';
-import { addTool } from '../tools/helpers.js';
+import { getActorOutput } from '../tools/common/get-actor-output.js';
+import { addTool } from '../tools/common/helpers.js';
+import { getActorRun } from '../tools/common/run.js';
 import { getActorsAsTools, toolCategories, toolCategoriesEnabledByDefault } from '../tools/index.js';
-import { getActorRun } from '../tools/run.js';
 import type { ActorStore, Input, InternalToolArgs, ToolCategory, ToolEntry, UiMode } from '../types.js';
 import { getExpectedToolsByCategories } from './tool-categories-helpers.js';
 

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -55,15 +55,9 @@
             }
         },
         "node_modules/@apify/ui-library": {
-<<<<<<< HEAD
             "version": "1.124.0",
             "resolved": "https://registry.npmjs.org/@apify/ui-library/-/ui-library-1.124.0.tgz",
             "integrity": "sha512-DgmHutxIApHHQgtpE74/48VahT9hqF826DXnEnkq8irBUYjmsl4aDCNxAK6pAghHkZzmmeIB5B2tZQwwiqqaMQ==",
-=======
-            "version": "1.121.0",
-            "resolved": "https://registry.npmjs.org/@apify/ui-library/-/ui-library-1.121.0.tgz",
-            "integrity": "sha512-z10peQwoj7BOnrV0Z/V3dYf4h80RFI5Wu/VG9kKWA+Gzh2iT5SzQnp4ZiepbW4b40JQv0TCFLOUR6S97B44d5g==",
->>>>>>> master
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/ui-icons": "^1.27.2",
@@ -774,6 +768,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
             "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -943,6 +938,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -1791,6 +1787,7 @@
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -2920,6 +2917,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -3137,6 +3135,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -3672,6 +3671,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -5,7 +5,7 @@ import log from '@apify/log';
 
 import { ApifyClient } from '../../src/apify-client.js';
 import { ActorsMcpServer } from '../../src/index.js';
-import { addTool } from '../../src/tools/helpers.js';
+import { addTool } from '../../src/tools/common/helpers.js';
 import { getActorsAsTools } from '../../src/tools/index.js';
 import { actorNameToToolName } from '../../src/tools/utils.js';
 import type { Input } from '../../src/types.js';


### PR DESCRIPTION
## Summary

- Move 11 mode-independent tools to `src/tools/common/`
- Move 2 openai-only internal tools to `src/tools/openai/`
- Update all import paths in 4 consumer files (categories.ts, tools-loader.ts, index-internals.ts, integration test)
- Wrap all 30 tool definitions with `Object.freeze()` for runtime immutability

## Details

### File moves

**→ `src/tools/common/`** (mode-independent, used in all modes):
- `dataset.ts`, `dataset_collection.ts`
- `fetch-apify-docs.ts`, `search-apify-docs.ts`
- `get-actor-output.ts`, `get-html-skeleton.ts`
- `helpers.ts`
- `key_value_store.ts`, `key_value_store_collection.ts`
- `run.ts`, `run_collection.ts`

**→ `src/tools/openai/`** (already had openai variants here):
- `fetch-actor-details-internal.ts`
- `search-actors-internal.ts`

### Object.freeze

All 30 tool definition exports across 24 files are now wrapped with `Object.freeze()`. This prevents accidental mutation of shared tool objects at runtime — a pattern that has caused production bugs when Skyfire mode mutates tool descriptions/schemas in-place.

### Verification

- ✅ `npm run type-check` — 0 errors
- ✅ `npm run lint` — 0 errors  
- ✅ `npm run test:unit` — 248 tests pass
- ✅ `npm run check:dead-code` — 0 new dead exports

## Part of

PR #3c in the [tool mode separation plan](./res/tool-mode-separation-plan.md). Targets `feat/tool-mode-tool-split` (PR #3b).