### PR TITLE
fix(web): add cache-busting for OpenAI widget resources

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -101,8 +101,13 @@ export class ActorsMcpServer {
     private telemetryEnabled: boolean | null = null;
     private telemetryEnv: TelemetryEnv = DEFAULT_TELEMETRY_ENV;
 
-    // List of widgets that are ready to be served
+    // List of widgets that are ready to be served (with version hashes for cache-busting)
     private availableWidgets: Map<string, AvailableWidget> = new Map();
+
+    /** Returns the resolved available widgets map (used by tools for versioned widget metadata) */
+    getAvailableWidgets(): Map<string, AvailableWidget> {
+        return this.availableWidgets;
+    }
 
     constructor(options: ActorsMcpServerOptions = {}) {
         this.options = options;

--- a/src/resources/resource_service.ts
+++ b/src/resources/resource_service.ts
@@ -5,6 +5,7 @@ import log from '@apify/log';
 import { SKYFIRE_README_CONTENT } from '../const.js';
 import type { UiMode } from '../types.js';
 import type { AvailableWidget } from './widgets.js';
+import { stripWidgetVersion } from './widgets.js';
 
 type ExtendedResourceContents = TextResourceContents & {
     html?: string;
@@ -49,11 +50,13 @@ export function createResourceService(options: ResourceServiceOptions): Resource
                     continue;
                 }
                 resources.push({
-                    uri: widget.uri,
+                    uri: widget.versionedUri ?? widget.uri,
                     name: widget.name,
                     description: widget.description,
                     mimeType: 'text/html+skybridge',
-                    _meta: widget.meta,
+                    _meta: widget.versionedUri
+                        ? { ...widget.meta, 'openai/outputTemplate': widget.versionedUri }
+                        : widget.meta,
                 });
             }
         }
@@ -73,7 +76,9 @@ export function createResourceService(options: ResourceServiceOptions): Resource
         }
 
         if (uiMode === 'openai' && uri.startsWith('ui://widget/')) {
-            const widget = getAvailableWidgets().get(uri);
+            // Strip version query param (e.g., ?v=abc123) to look up by base URI
+            const baseUri = stripWidgetVersion(uri);
+            const widget = getAvailableWidgets().get(baseUri);
 
             if (!widget || !widget.exists) {
                 return {

--- a/src/resources/widgets.ts
+++ b/src/resources/widgets.ts
@@ -2,8 +2,11 @@
  * Widget registry for MCP server UI widgets
  *
  * This module manages widget configuration and validates that widget files exist
- * at runtime.
+ * at runtime. Includes cache-busting via content hashing to ensure clients always
+ * fetch the latest widget version after deployments.
  */
+
+import { createHash } from 'node:crypto';
 
 import type { Resource } from '@modelcontextprotocol/sdk/types.js';
 
@@ -89,13 +92,45 @@ export const WIDGET_REGISTRY: Record<string, WidgetConfig> = {
 export type AvailableWidget = WidgetConfig & {
   jsPath: string;
   exists: boolean;
+  /** SHA-256 content hash (16 hex chars) of the widget JS file, used for cache-busting */
+  versionHash?: string;
+  /** Widget URI with version query parameter appended for cache-busting (e.g., ui://widget/search-actors.html?v=abc123) */
+  versionedUri?: string;
 };
+
+/** Number of hex characters to use from the SHA-256 hash for cache-busting */
+const VERSION_HASH_LENGTH = 16;
+
+/**
+ * Computes a truncated SHA-256 hash of the given content for cache-busting.
+ */
+export function computeContentHash(content: string): string {
+    return createHash('sha256').update(content).digest('hex').slice(0, VERSION_HASH_LENGTH);
+}
+
+/**
+ * Appends a version query parameter to a widget URI for cache-busting.
+ */
+export function appendWidgetVersion(uri: string, hash: string): string {
+    return `${uri}?v=${hash}`;
+}
+
+/**
+ * Strips the version query parameter from a widget URI, returning the base URI.
+ * This is used in readResource to normalize incoming URIs before map lookup.
+ */
+export function stripWidgetVersion(uri: string): string {
+    const queryIndex = uri.indexOf('?');
+    if (queryIndex === -1) return uri;
+    return uri.slice(0, queryIndex);
+}
 
 /**
  * Resolves available widgets by checking if their files exist on the filesystem.
+ * For existing widgets, computes a content hash of the JS file for cache-busting.
  *
  * @param baseDir - Base directory where the server code is located
- * @returns Map of widget URIs to their resolved state
+ * @returns Map of widget URIs to their resolved state (keyed by base URI without version)
  */
 export async function resolveAvailableWidgets(baseDir: string): Promise<Map<string, AvailableWidget>> {
     const fs = await import('node:fs');
@@ -108,10 +143,21 @@ export async function resolveAvailableWidgets(baseDir: string): Promise<Map<stri
         const jsPath = path.resolve(webDistPath, config.jsFilename);
         const exists = fs.existsSync(jsPath);
 
+        let versionHash: string | undefined;
+        let versionedUri: string | undefined;
+
+        if (exists) {
+            const jsContent = fs.readFileSync(jsPath, 'utf-8');
+            versionHash = computeContentHash(jsContent);
+            versionedUri = appendWidgetVersion(uri, versionHash);
+        }
+
         resolvedWidgets.set(uri, {
             ...config,
             jsPath,
             exists,
+            versionHash,
+            versionedUri,
         });
     }
 
@@ -126,4 +172,28 @@ export async function resolveAvailableWidgets(baseDir: string): Promise<Map<stri
  */
 export function getWidgetConfig(uri: string): WidgetConfig | undefined {
     return WIDGET_REGISTRY[uri];
+}
+
+/**
+ * Returns widget meta with a versioned `openai/outputTemplate` URI for cache-busting.
+ * Falls back to the base (unversioned) meta if the widget hasn't been resolved yet.
+ *
+ * @param baseUri - Base widget URI (e.g., WIDGET_URIS.SEARCH_ACTORS)
+ * @param availableWidgets - Map of resolved widgets (from resolveAvailableWidgets)
+ * @returns Widget meta with versioned outputTemplate, or undefined if widget not found
+ */
+export function getVersionedWidgetMeta(
+    baseUri: string,
+    availableWidgets: Map<string, AvailableWidget>,
+): WidgetConfig['meta'] | undefined {
+    const config = WIDGET_REGISTRY[baseUri];
+    if (!config) return undefined;
+
+    const resolved = availableWidgets.get(baseUri);
+    if (!resolved?.versionedUri) return config.meta;
+
+    return {
+        ...config.meta,
+        'openai/outputTemplate': resolved.versionedUri,
+    };
 }

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -17,7 +17,7 @@ import {
 import { getActorMCPServerPath, getActorMCPServerURL } from '../mcp/actors.js';
 import { connectMCPClient } from '../mcp/client.js';
 import { getMCPServerTools } from '../mcp/proxy.js';
-import { getWidgetConfig, WIDGET_URIS } from '../resources/widgets.js';
+import { getVersionedWidgetMeta, getWidgetConfig, WIDGET_URIS } from '../resources/widgets.js';
 import { actorDefinitionPrunedCache } from '../state.js';
 import type {
     ActorDefinitionStorage,
@@ -668,9 +668,9 @@ Do NOT proactively poll using ${HelperTools.ACTOR_RUNS_GET}. Wait for the widget
                 };
 
                 if (apifyMcpServer.options.uiMode === 'openai') {
-                    const widgetConfig = getWidgetConfig(WIDGET_URIS.ACTOR_RUN);
+                    const widgetMeta = getVersionedWidgetMeta(WIDGET_URIS.ACTOR_RUN, apifyMcpServer.getAvailableWidgets());
                     response._meta = {
-                        ...widgetConfig?.meta,
+                        ...widgetMeta,
                         'openai/widgetDescription': `Actor run progress for ${actorName}`,
                     };
                 }

--- a/src/tools/fetch-actor-details.ts
+++ b/src/tools/fetch-actor-details.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { ApifyClient } from '../apify-client.js';
 import { HelperTools } from '../const.js';
-import { getWidgetConfig, WIDGET_URIS } from '../resources/widgets.js';
+import { getVersionedWidgetMeta, getWidgetConfig, WIDGET_URIS } from '../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
 import {
     actorDetailsOutputOptionsSchema,
@@ -82,12 +82,12 @@ EXAMPLES:
 An interactive widget has been rendered with detailed Actor information.
 `];
 
-            const widgetConfig = getWidgetConfig(WIDGET_URIS.SEARCH_ACTORS);
+            const widgetMeta = getVersionedWidgetMeta(WIDGET_URIS.SEARCH_ACTORS, apifyMcpServer.getAvailableWidgets());
             return buildMCPResponse({
                 texts,
                 structuredContent,
                 _meta: {
-                    ...widgetConfig?.meta,
+                    ...widgetMeta,
                     'openai/widgetDescription': `Actor details for ${parsed.actor} from Apify Store`,
                 },
             });

--- a/src/tools/run.ts
+++ b/src/tools/run.ts
@@ -4,7 +4,7 @@ import log from '@apify/log';
 
 import { createApifyClientWithSkyfireSupport } from '../apify-client.js';
 import { HelperTools, TOOL_STATUS } from '../const.js';
-import { getWidgetConfig, WIDGET_URIS } from '../resources/widgets.js';
+import { getVersionedWidgetMeta, getWidgetConfig, WIDGET_URIS } from '../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
 import { compileSchema } from '../utils/ajv.js';
 import { logHttpError } from '../utils/logging.js';
@@ -137,13 +137,13 @@ USAGE EXAMPLES:
                     ? `Actor run ${parsed.runId} completed successfully with ${structuredContent.dataset.itemCount} items. A widget has been rendered with the details.`
                     : `Actor run ${parsed.runId} status: ${run.status}. A progress widget has been rendered.`;
 
-                const widgetConfig = getWidgetConfig(WIDGET_URIS.ACTOR_RUN);
+                const widgetMeta = getVersionedWidgetMeta(WIDGET_URIS.ACTOR_RUN, apifyMcpServer.getAvailableWidgets());
                 const usageMeta = buildUsageMeta(run);
                 return buildMCPResponse({
                     texts: [statusText],
                     structuredContent,
                     _meta: {
-                        ...widgetConfig?.meta,
+                        ...widgetMeta,
                         ...usageMeta,
                     },
                 });

--- a/src/tools/store_collection.ts
+++ b/src/tools/store_collection.ts
@@ -2,7 +2,7 @@ import type { ActorStoreList } from 'apify-client';
 import { z } from 'zod';
 
 import { HelperTools } from '../const.js';
-import { getWidgetConfig, WIDGET_URIS } from '../resources/widgets.js';
+import { getVersionedWidgetMeta, getWidgetConfig, WIDGET_URIS } from '../resources/widgets.js';
 import type { ActorPricingModel, InternalToolArgs, ToolEntry, ToolInputSchema } from '../types.js';
 import { formatActorForWidget, formatActorToActorCard, formatActorToStructuredCard, type WidgetActor } from '../utils/actor-card.js';
 import { searchAndFilterActors } from '../utils/actor-search.js';
@@ -182,12 +182,12 @@ An interactive widget has been rendered with the search results. The user can al
  ${actorsText}
 `];
 
-            const widgetConfig = getWidgetConfig(WIDGET_URIS.SEARCH_ACTORS);
+            const widgetMeta = getVersionedWidgetMeta(WIDGET_URIS.SEARCH_ACTORS, apifyMcpServer.getAvailableWidgets());
             return buildMCPResponse({
                 texts,
                 structuredContent,
                 _meta: {
-                    ...widgetConfig?.meta,
+                    ...widgetMeta,
                     'openai/widgetDescription': `Interactive actor search results showing ${actors.length} actors from Apify Store`,
                 },
             });

--- a/tests/unit/utils.widgets.test.ts
+++ b/tests/unit/utils.widgets.test.ts
@@ -7,8 +7,10 @@ import { type AvailableWidget, getWidgetConfig, resolveAvailableWidgets, WIDGET_
 vi.mock('node:fs', () => ({
     default: {
         existsSync: vi.fn(),
+        readFileSync: vi.fn(),
     },
     existsSync: vi.fn(),
+    readFileSync: vi.fn(),
 }));
 
 describe('Widget Utils', () => {
@@ -30,12 +32,14 @@ describe('Widget Utils', () => {
         it('should correctly identify existing and missing widgets', async () => {
             const fs = await import('node:fs');
             const mockExistsSync = vi.mocked(fs.existsSync);
+            const mockReadFileSync = vi.mocked(fs.readFileSync);
 
             // Mock behavior: search-actors exists, actor-run is missing
             mockExistsSync.mockImplementation((p) => {
                 if (typeof p === 'string' && p.includes('search-actors-widget.js')) return true;
                 return false;
             });
+            mockReadFileSync.mockReturnValue('console.log("widget code")');
 
             const baseDir = '/app/dist/mcp';
             const resolved = await resolveAvailableWidgets(baseDir);
@@ -45,15 +49,24 @@ describe('Widget Utils', () => {
             const searchWidget = resolved.get(WIDGET_URIS.SEARCH_ACTORS);
             expect(searchWidget?.exists).toBe(true);
             expect(searchWidget?.jsPath).toBe(path.resolve('/app/dist/web/dist/search-actors-widget.js'));
+            // Existing widgets should have a version hash and versioned URI
+            expect(searchWidget?.versionHash).toBeDefined();
+            expect(searchWidget?.versionHash).toHaveLength(16);
+            expect(searchWidget?.versionedUri).toBe(`${WIDGET_URIS.SEARCH_ACTORS}?v=${searchWidget?.versionHash}`);
 
             const runWidget = resolved.get(WIDGET_URIS.ACTOR_RUN);
             expect(runWidget?.exists).toBe(false);
+            // Missing widgets should not have version hash
+            expect(runWidget?.versionHash).toBeUndefined();
+            expect(runWidget?.versionedUri).toBeUndefined();
         });
 
         it('should handle path resolution correctly', async () => {
             const fs = await import('node:fs');
             const mockExistsSync = vi.mocked(fs.existsSync);
+            const mockReadFileSync = vi.mocked(fs.readFileSync);
             mockExistsSync.mockReturnValue(true);
+            mockReadFileSync.mockReturnValue('console.log("widget code")');
 
             const baseDir = '/test/path/dist/mcp';
             const resolved = await resolveAvailableWidgets(baseDir);


### PR DESCRIPTION
## Summary

OpenAI's MCP client caches widget content keyed by resource URI. Since our widget URIs were static (`ui://widget/search-actors.html`), deploying new widget code had no effect — users kept seeing stale cached versions. This was [confirmed by the community](https://community.openai.com/t/issues-refreshing-widgets-keep-getting-cached-versions/1120690).

**Fix**: Compute a SHA-256 content hash of each widget JS file at server init and append it as a query parameter (`?v=<hash>`). When widget code changes → hash changes → URI changes → OpenAI fetches fresh content.

## Technical Changes

- Compute per-widget content hash (SHA-256, 16 hex chars) during `resolveAvailableWidgets()` at server init
- Emit versioned URIs in `listResources()` and tool response `_meta` (`openai/outputTemplate`)
- Strip `?v=...` in `readResource()` before map lookup for backward compatibility with old URIs
- Add `getVersionedWidgetMeta()` helper used by all tool files for dynamic responses
- Expose `getAvailableWidgets()` getter on `ActorsMcpServer` so tools can access versioned metadata
- Updated unit tests with `readFileSync` mock and assertions for `versionHash`/`versionedUri`