### PR TITLE
fix: soft-fail MCP server connection errors instead of throwing

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -5,7 +5,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import log from '@apify/log';
 
 import { TimeoutError } from '../errors.js';
-import { logHttpError } from '../utils/logging.js';
+import { getHttpStatusCode } from '../utils/logging.js';
 import { ACTORIZED_MCP_CONNECTION_TIMEOUT_MSEC } from './const.js';
 import { getMCPServerID } from './utils.js';
 
@@ -16,10 +16,8 @@ import { getMCPServerID } from './utils.js';
 export async function connectMCPClient(
     url: string, token: string, mcpSessionId?: string,
 ): Promise<Client | null> {
-    let client: Client;
     try {
-        client = await createMCPStreamableClient(url, token);
-        return client;
+        return await createMCPStreamableClient(url, token);
     } catch (error) {
         // If streamable HTTP transport fails on not timeout error, continue with SSE transport
         if (error instanceof TimeoutError) {
@@ -34,15 +32,21 @@ export async function connectMCPClient(
     }
 
     try {
-        client = await createMCPSSEClient(url, token);
-        return client;
+        return await createMCPSSEClient(url, token);
     } catch (error) {
         if (error instanceof TimeoutError) {
             log.warning('Connection to MCP server using SSE transport timed out', { url, mcpSessionId });
             return null;
         }
-        logHttpError(error, 'Failed to connect to MCP server using SSE transport', { url, mcpSessionId, cause: error });
-        throw error;
+        // External MCP server unavailability is operational, not a bug in our service
+        const statusCode = getHttpStatusCode(error);
+        log.softFail('Failed to connect to MCP server using SSE transport', {
+            url,
+            mcpSessionId,
+            statusCode,
+            error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
     }
 }
 


### PR DESCRIPTION
## Summary
- **Stops throwing** on external MCP server connection failures — `connectMCPClient` now returns `null` consistently (matching existing timeout behavior)
- **Downgrades log severity** from `logHttpError` (which emits `log.exception` for 500s) to `log.softFail` — external server unavailability is operational, not a bug in our service
- **Eliminates double-logging** — previously the error was logged in `connectMCPClient` via `logHttpError` and then again in every caller's catch block

## Problem
During bug duty, Mezmo was showing noisy errors:
- `Failed to load tools from MCP server`
- `Failed to connect to MCP server using SSE transport`
- `SSE error: Non-200 status code (500)`

These are caused by external MCP servers being temporarily unavailable — an expected operational condition, not a bug in our service.

## What changed

`src/mcp/client.ts` — `connectMCPClient` function:

1. Replaced `throw error` with `return null` when SSE transport fails (non-timeout)
2. Replaced `logHttpError(...)` with `log.softFail(...)` + `getHttpStatusCode` for structured context
3. Removed unused `let client` variable, using direct `return await` instead

All 4 callers already handle `null` returns gracefully — they log context and return error responses or empty arrays. No caller behavior changes.

closes https://github.com/apify/apify-mcp-server/issues/475