### PR TITLE
fix: Review fixes for widget cache-busting PR

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -104,11 +104,6 @@ export class ActorsMcpServer {
     // List of widgets that are ready to be served (with version hashes for cache-busting)
     private availableWidgets: Map<string, AvailableWidget> = new Map();
 
-    /** Returns the resolved available widgets map (used by tools for versioned widget metadata) */
-    getAvailableWidgets(): Map<string, AvailableWidget> {
-        return this.availableWidgets;
-    }
-
     constructor(options: ActorsMcpServerOptions = {}) {
         this.options = options;
 
@@ -193,6 +188,11 @@ export class ActorsMcpServer {
      */
     public listToolNames(): string[] {
         return Array.from(this.tools.keys());
+    }
+
+    /** Returns the resolved available widgets map (used by tools for versioned widget metadata) */
+    public getAvailableWidgets(): Map<string, AvailableWidget> {
+        return this.availableWidgets;
     }
 
     /**

--- a/src/resources/resource_service.ts
+++ b/src/resources/resource_service.ts
@@ -5,7 +5,7 @@ import log from '@apify/log';
 import { SKYFIRE_README_CONTENT } from '../const.js';
 import type { UiMode } from '../types.js';
 import type { AvailableWidget } from './widgets.js';
-import { stripWidgetVersion } from './widgets.js';
+import { getVersionedWidgetMeta, stripWidgetVersion } from './widgets.js';
 
 type ExtendedResourceContents = TextResourceContents & {
     html?: string;
@@ -54,9 +54,7 @@ export function createResourceService(options: ResourceServiceOptions): Resource
                     name: widget.name,
                     description: widget.description,
                     mimeType: 'text/html+skybridge',
-                    _meta: widget.versionedUri
-                        ? { ...widget.meta, 'openai/outputTemplate': widget.versionedUri }
-                        : widget.meta,
+                    _meta: getVersionedWidgetMeta(widget.uri, getAvailableWidgets()) ?? widget.meta,
                 });
             }
         }


### PR DESCRIPTION
## Summary
- Move `getAvailableWidgets()` from between class fields/constructor to the public methods section (after `listToolNames()`), consistent with class convention
- Add explicit `public` modifier to match the pattern used by all other public methods in `ActorsMcpServer`
- Replace inlined versioned meta construction in `resource_service.ts` with `getVersionedWidgetMeta()` call to eliminate logic duplication

## Test plan
- [x] `npm run type-check` passes (only pre-existing `readmeSummary` errors)
- [x] `npm run lint` passes
- [x] `npm run test:unit` — 248 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)