### PR TITLE
refactor: replace duplicated tool categories with unified mode-aware resolver

### DIFF
--- a/src/actor/server.ts
+++ b/src/actor/server.ts
@@ -16,7 +16,8 @@ import { parseBooleanOrNull } from '@apify/utilities';
 
 import { ApifyClient } from '../apify_client.js';
 import { ActorsMcpServer } from '../mcp/server.js';
-import type { ApifyRequestParams, UiMode } from '../types.js';
+import type { ApifyRequestParams } from '../types.js';
+import { parseUiMode } from '../types.js';
 import { getHelpMessage, HEADER_READINESS_PROBE, Routes, TransportType } from './const.js';
 import { getActorRunData } from './utils.js';
 
@@ -90,8 +91,7 @@ export function createExpressApp(
                 ?? parseBooleanOrNull(process.env.TELEMETRY_ENABLED)
                 ?? true;
 
-            const uiModeParam = urlParams.get('ui') as UiMode | undefined;
-            const uiMode = uiModeParam ?? process.env.UI_MODE as UiMode | undefined;
+            const uiMode = parseUiMode(urlParams.get('ui')) ?? parseUiMode(process.env.UI_MODE);
 
             // Extract payment mode parameter - if payment=skyfire, enable skyfire mode
             const paymentParam = urlParams.get('payment');
@@ -223,8 +223,7 @@ export function createExpressApp(
                     ?? parseBooleanOrNull(process.env.TELEMETRY_ENABLED)
                     ?? true;
 
-                const uiModeParam = urlParams.get('ui') as UiMode | undefined;
-                const uiMode = uiModeParam ?? process.env.UI_MODE as UiMode | undefined;
+                const uiMode = parseUiMode(urlParams.get('ui')) ?? parseUiMode(process.env.UI_MODE);
 
                 // Extract payment mode parameter - if payment=skyfire, enable skyfire mode
                 const paymentParam = urlParams.get('payment');

--- a/src/index_internals.ts
+++ b/src/index_internals.ts
@@ -7,10 +7,11 @@ import { APIFY_FAVICON_URL, defaults, HelperTools, SERVER_NAME, SERVER_TITLE } f
 import { processParamsGetTools } from './mcp/utils.js';
 import { getServerCard } from './server_card.js';
 import { addTool } from './tools/common/add_actor.js';
-import { defaultTools, getActorsAsTools, getUnauthEnabledToolCategories, toolCategories,
+import { getActorsAsTools, getCategoryTools, getDefaultTools, getUnauthEnabledToolCategories,
     toolCategoriesEnabledByDefault, unauthEnabledTools } from './tools/index.js';
 import { actorNameToToolName } from './tools/utils.js';
-import type { ActorStore, ServerCard, ToolCategory, UiMode } from './types.js';
+import type { ActorStore, ServerCard, ServerMode, ToolCategory, UiMode } from './types.js';
+import { parseUiMode, SERVER_MODES } from './types.js';
 import { parseCommaSeparatedList, parseQueryParamList, readJsonFile } from './utils/generic.js';
 import { redactSkyfirePayId } from './utils/logging.js';
 import { getExpectedToolNamesByCategories } from './utils/tool_categories_helpers.js';
@@ -28,9 +29,12 @@ export {
     SERVER_NAME,
     SERVER_TITLE,
     defaults,
-    defaultTools,
+    getDefaultTools,
     addTool,
-    toolCategories,
+    getCategoryTools,
+    parseUiMode,
+    SERVER_MODES,
+    type ServerMode,
     toolCategoriesEnabledByDefault,
     type ActorStore,
     type ServerCard,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -51,7 +51,7 @@ import type { AvailableWidget } from '../resources/widgets.js';
 import { resolveAvailableWidgets } from '../resources/widgets.js';
 import { getTelemetryEnv, trackToolCall } from '../telemetry.js';
 import { defaultActorExecutor } from '../tools/default/actor_executor.js';
-import { defaultTools, getActorsAsTools, toolCategories } from '../tools/index.js';
+import { getActorsAsTools, getCategoryTools, getDefaultTools } from '../tools/index.js';
 import { openaiActorExecutor } from '../tools/openai/actor_executor.js';
 import { decodeDotPropertyNames } from '../tools/utils.js';
 import type {
@@ -62,6 +62,7 @@ import type {
     ActorTool,
     ApifyRequestParams,
     HelperTool,
+    ServerMode,
     TelemetryEnv,
     ToolCallTelemetryProperties,
     ToolEntry,
@@ -80,6 +81,12 @@ import { connectMCPClient } from './client.js';
 import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC, LOG_LEVEL_MAP } from './const.js';
 import { isTaskCancelled, processParamsGetTools } from './utils.js';
 
+/** Mode → actor executor. Add new modes here. */
+const actorExecutorsByMode: Record<ServerMode, ActorExecutor> = {
+    default: defaultActorExecutor,
+    openai: openaiActorExecutor,
+};
+
 type ToolsChangedHandler = (toolNames: string[]) => void;
 
 /**
@@ -94,6 +101,8 @@ export class ActorsMcpServer {
     public readonly options: ActorsMcpServerOptions;
     public readonly taskStore: TaskStore;
     public readonly actorStore?: ActorStore;
+    /** Resolved server mode — normalized once at construction from options.uiMode. */
+    public readonly serverMode: ServerMode;
     /** Mode-specific executor for direct actor tools (`type: 'actor'`). */
     private readonly actorExecutor: ActorExecutor;
 
@@ -116,9 +125,8 @@ export class ActorsMcpServer {
             throw new Error('Task store must be provided for non-stdio transport types');
         }
         this.actorStore = options.actorStore;
-        this.actorExecutor = options.uiMode === 'openai'
-            ? openaiActorExecutor
-            : defaultActorExecutor;
+        this.serverMode = options.uiMode ?? 'default';
+        this.actorExecutor = actorExecutorsByMode[this.serverMode];
 
         const { setupSigintHandler = true } = options;
         this.server = new Server(
@@ -150,7 +158,7 @@ export class ActorsMcpServer {
                     prompts: { },
                     logging: {},
                 },
-                instructions: getServerInstructions(options.uiMode),
+                instructions: getServerInstructions(this.serverMode),
             },
         );
         this.setupTelemetry();
@@ -270,8 +278,8 @@ export class ActorsMcpServer {
         const actorsToLoad: string[] = [];
         const toolsToLoad: ToolEntry[] = [];
         const internalToolMap = new Map([
-            ...defaultTools,
-            ...Object.values(toolCategories).flat(),
+            ...getDefaultTools(this.serverMode),
+            ...Object.values(getCategoryTools(this.serverMode)).flat(),
         ].map((tool) => [tool.name, tool]));
 
         for (const tool of toolNames) {
@@ -317,7 +325,7 @@ export class ActorsMcpServer {
      * Used primarily for SSE.
      */
     public async loadToolsFromUrl(url: string, apifyClient: ApifyClient) {
-        const tools = await processParamsGetTools(url, apifyClient, this.options.uiMode, this.actorStore);
+        const tools = await processParamsGetTools(url, apifyClient, this.serverMode, this.actorStore);
         if (tools.length > 0) {
             log.debug('Loading tools from query parameters');
             this.upsertTools(tools, false);
@@ -413,7 +421,7 @@ export class ActorsMcpServer {
     private setupResourceHandlers(): void {
         const resourceService = createResourceService({
             skyfireMode: this.options.skyfireMode,
-            uiMode: this.options.uiMode,
+            mode: this.serverMode,
             getAvailableWidgets: () => this.availableWidgets,
         });
 
@@ -572,7 +580,7 @@ export class ActorsMcpServer {
          */
         this.server.setRequestHandler(ListToolsRequestSchema, async () => {
             const tools = Array.from(this.tools.values()).map((tool) => getToolPublicFieldOnly(tool, {
-                uiMode: this.options.uiMode,
+                mode: this.serverMode,
                 filterOpenAiMeta: true,
             }));
             return { tools };
@@ -1139,7 +1147,7 @@ Please verify the tool name and ensure the tool is properly registered.`;
      * Resolves widgets and determines which ones are ready to be served.
      */
     private async resolveWidgets(): Promise<void> {
-        if (this.options.uiMode !== 'openai') {
+        if (this.serverMode !== 'openai') {
             return;
         }
 

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -5,7 +5,7 @@ import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/int
 import type { ApifyClient } from 'apify-client';
 
 import { processInput } from '../input.js';
-import type { ActorStore, Input, UiMode } from '../types.js';
+import type { ActorStore, Input, ServerMode } from '../types.js';
 import { loadToolsFromInput } from '../utils/tools_loader.js';
 import { MAX_TOOL_NAME_LENGTH, SERVER_ID_LENGTH } from './const.js';
 
@@ -41,11 +41,11 @@ export function getProxyMCPServerToolName(url: string, toolName: string): string
  * If URL contains query parameter `actors`, return tools from Actors otherwise return null.
  * @param url The URL to process
  * @param apifyClient The Apify client instance
- * @param uiMode UI mode from server options
+ * @param mode Server mode for tool variant resolution
  */
-export async function processParamsGetTools(url: string, apifyClient: ApifyClient, uiMode?: UiMode, actorStore?: ActorStore) {
+export async function processParamsGetTools(url: string, apifyClient: ApifyClient, mode: ServerMode, actorStore?: ActorStore) {
     const input = parseInputParamsFromUrl(url);
-    return await loadToolsFromInput(input, apifyClient, uiMode, actorStore);
+    return await loadToolsFromInput(input, apifyClient, mode, actorStore);
 }
 
 export function parseInputParamsFromUrl(url: string): Input {

--- a/src/resources/resource_service.ts
+++ b/src/resources/resource_service.ts
@@ -3,7 +3,7 @@ import type { ListResourcesResult, ListResourceTemplatesResult, ReadResourceResu
 import log from '@apify/log';
 
 import { SKYFIRE_README_CONTENT } from '../const.js';
-import type { UiMode } from '../types.js';
+import type { ServerMode } from '../types.js';
 import type { AvailableWidget } from './widgets.js';
 
 type ExtendedResourceContents = TextResourceContents & {
@@ -23,12 +23,12 @@ type ResourceService = {
 
 type ResourceServiceOptions = {
     skyfireMode?: boolean;
-    uiMode?: UiMode;
+    mode: ServerMode;
     getAvailableWidgets: () => Map<string, AvailableWidget>;
 };
 
 export function createResourceService(options: ResourceServiceOptions): ResourceService {
-    const { skyfireMode, uiMode, getAvailableWidgets } = options;
+    const { skyfireMode, mode, getAvailableWidgets } = options;
 
     const listResources = async (): Promise<ListResourcesResult> => {
         const resources: Resource[] = [];
@@ -43,7 +43,7 @@ export function createResourceService(options: ResourceServiceOptions): Resource
             });
         }
 
-        if (uiMode === 'openai') {
+        if (mode === 'openai') {
             for (const widget of getAvailableWidgets().values()) {
                 if (!widget.exists) {
                     continue;
@@ -72,7 +72,7 @@ export function createResourceService(options: ResourceServiceOptions): Resource
             };
         }
 
-        if (uiMode === 'openai' && uri.startsWith('ui://widget/')) {
+        if (mode === 'openai' && uri.startsWith('ui://widget/')) {
             const widget = getAvailableWidgets().get(uri);
 
             if (!widget || !widget.exists) {

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -202,7 +202,7 @@ async function main() {
 
     const apifyClient = new ApifyClient({ token: apifyToken });
     // Use the shared tools loading logic
-    const tools = await loadToolsFromInput(normalizedInput, apifyClient, argv.ui);
+    const tools = await loadToolsFromInput(normalizedInput, apifyClient, argv.ui ?? 'default');
 
     mcpServer.upsertTools(tools);
 

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -7,8 +7,13 @@
  *
  * The final tool ordering presented to MCP clients is determined by tools-loader.ts,
  * which also auto-injects get-actor-run and get-actor-output right after call-actor.
+ *
+ * Each tool entry can be:
+ * - A plain ToolEntry — mode-independent, always included
+ * - A mode map (e.g. { default: ToolEntry, openai: ToolEntry }) — resolver picks entry[mode]
+ * - A partial mode map (e.g. { openai: ToolEntry }) — included only for listed modes
  */
-import type { ToolEntry, UiMode } from '../types.js';
+import type { ServerMode, ToolEntry } from '../types.js';
 import { abortActorRun } from './common/abort_actor_run.js';
 import { addTool } from './common/add_actor.js';
 import { getUserDatasetsList } from './common/dataset_collection.js';
@@ -37,31 +42,47 @@ import { openaiSearchActors } from './openai/search_actors.js';
 import { searchActorsInternalTool } from './openai/search_actors_internal.js';
 
 /**
- * Static tool categories using adapter tools that dispatch at runtime based on uiMode.
+ * A mode map: maps one or more ServerMode keys to their ToolEntry variant.
+ * - All modes present → each mode gets its own implementation
+ * - Subset of modes → tool is only included for those modes
+ */
+type ModeMap = Partial<Record<ServerMode, ToolEntry>>;
+
+/** A category tool entry: plain ToolEntry (mode-independent) or a mode map. */
+type CategoryToolEntry = ToolEntry | ModeMap;
+
+/** A plain ToolEntry always has a `name` property; mode maps never do. */
+function isModeMap(entry: CategoryToolEntry): entry is ModeMap {
+    return !('name' in entry);
+}
+
+/**
+ * Unified tool category definitions — single source of truth.
  *
- * @deprecated Use {@link buildCategories} instead, which returns mode-resolved tool variants
- * directly without runtime dispatching. This static map will be removed once the tools-loader
- * is refactored to use buildCategories().
+ * Each entry is either a plain ToolEntry (mode-independent) or a mode map
+ * with ServerMode keys mapping to their ToolEntry variant.
+ *
+ * Use {@link getCategoryTools} to resolve entries into concrete ToolEntry arrays for a given mode.
  */
 export const toolCategories = {
     experimental: [
         addTool,
     ],
     actors: [
-        defaultSearchActors,
-        defaultFetchActorDetails,
-        defaultCallActor,
+        { default: defaultSearchActors, openai: openaiSearchActors },
+        { default: defaultFetchActorDetails, openai: openaiFetchActorDetails },
+        { default: defaultCallActor, openai: openaiCallActor },
     ],
     ui: [
-        searchActorsInternalTool,
-        fetchActorDetailsInternalTool,
+        { openai: searchActorsInternalTool },
+        { openai: fetchActorDetailsInternalTool },
     ],
     docs: [
         searchApifyDocsTool,
         fetchApifyDocsTool,
     ],
     runs: [
-        defaultGetActorRun,
+        { default: defaultGetActorRun, openai: openaiGetActorRun },
         getUserRunsList,
         getActorRunLog,
         abortActorRun,
@@ -80,64 +101,55 @@ export const toolCategories = {
     dev: [
         getHtmlSkeleton,
     ],
-} satisfies Record<string, ToolEntry[]>;
+} satisfies Record<string, CategoryToolEntry[]>;
 
 /**
- * Canonical list of all tool category names, derived from the toolCategories map
- * so there is a single source of truth for category definitions.
+ * Canonical list of all tool category names, derived from toolCategories keys.
  */
 export const CATEGORY_NAMES = Object.keys(toolCategories) as (keyof typeof toolCategories)[];
 
-/** Map from category name to an array of tool entries. */
+/** Set of known category names for O(1) membership checks. */
+export const CATEGORY_NAME_SET: ReadonlySet<string> = new Set<string>(CATEGORY_NAMES);
+
+/** Map from category name to an array of resolved tool entries. */
 export type ToolCategoryMap = Record<(typeof CATEGORY_NAMES)[number], ToolEntry[]>;
 
 /**
- * Build tool categories for a given UI mode.
+ * Resolve a single category's tool entries for the given server mode.
  *
- * Returns the same category names as {@link toolCategories}, but with mode-resolved
- * tool variants: openai mode gets openai-specific implementations (async execution,
- * widget metadata), default mode gets standard implementations.
- *
- * This eliminates the need for runtime adapter dispatch — each tool is the correct
- * variant for its mode from the start.
+ * For each entry:
+ * - Plain ToolEntry (has `name`) → always included, mode-independent
+ * - ModeMap → look up `entry[mode]`; included only if the mode key exists
  */
-export function buildCategories(uiMode?: UiMode): ToolCategoryMap {
-    const isOpenai = uiMode === 'openai';
-    return {
-        experimental: [
-            addTool,
-        ],
-        actors: isOpenai
-            ? [openaiSearchActors, openaiFetchActorDetails, openaiCallActor]
-            : [defaultSearchActors, defaultFetchActorDetails, defaultCallActor],
-        ui: isOpenai
-            ? [searchActorsInternalTool, fetchActorDetailsInternalTool]
-            : [],
-        docs: [
-            searchApifyDocsTool,
-            fetchApifyDocsTool,
-        ],
-        runs: [
-            isOpenai ? openaiGetActorRun : defaultGetActorRun,
-            getUserRunsList,
-            getActorRunLog,
-            abortActorRun,
-        ],
-        storage: [
-            getDataset,
-            getDatasetItems,
-            getDatasetSchema,
-            getActorOutput,
-            getKeyValueStore,
-            getKeyValueStoreKeys,
-            getKeyValueStoreRecord,
-            getUserDatasetsList,
-            getUserKeyValueStoresList,
-        ],
-        dev: [
-            getHtmlSkeleton,
-        ],
-    };
+function resolveCategoryEntries(entries: readonly CategoryToolEntry[], mode: ServerMode): ToolEntry[] {
+    const result: ToolEntry[] = [];
+    for (const entry of entries) {
+        if (isModeMap(entry)) {
+            const tool = entry[mode];
+            if (tool) {
+                result.push(tool);
+            }
+        } else {
+            result.push(entry);
+        }
+    }
+    return result;
+}
+
+/**
+ * Resolve tool categories for a given server mode.
+ *
+ * Returns mode-resolved tool variants: openai mode gets openai-specific implementations
+ * (async execution, widget metadata), default mode gets standard implementations.
+ * Openai-only tools are excluded in default mode.
+ *
+ * @param mode - Required. Use `'default'` or `'openai'`.
+ *   Made explicit (no default value) to prevent accidentally serving wrong-mode tools.
+ */
+export function getCategoryTools(mode: ServerMode): ToolCategoryMap {
+    return Object.fromEntries(
+        CATEGORY_NAMES.map((name) => [name, resolveCategoryEntries(toolCategories[name], mode)]),
+    ) as ToolCategoryMap;
 }
 
 export const toolCategoriesEnabledByDefault: (typeof CATEGORY_NAMES)[number][] = [

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,7 +1,7 @@
 import { HelperTools } from '../const.js';
-import type { ToolCategory } from '../types.js';
+import type { ServerMode, ToolCategory, ToolEntry } from '../types.js';
 import { getExpectedToolsByCategories } from '../utils/tool_categories_helpers.js';
-import { buildCategories, CATEGORY_NAMES, toolCategories, toolCategoriesEnabledByDefault } from './categories.js';
+import { CATEGORY_NAME_SET, CATEGORY_NAMES, getCategoryTools, toolCategories, toolCategoriesEnabledByDefault } from './categories.js';
 import { callActorGetDataset } from './core/actor_execution.js';
 import { getActorsAsTools } from './core/actor_tools_factory.js';
 
@@ -14,18 +14,25 @@ export const unauthEnabledTools: string[] = [
 
 // Re-export from categories.ts
 // This is actually needed to avoid circular dependency issues
-export { buildCategories, CATEGORY_NAMES, toolCategories, toolCategoriesEnabledByDefault };
+export { CATEGORY_NAME_SET, CATEGORY_NAMES, getCategoryTools, toolCategories, toolCategoriesEnabledByDefault };
 
-// Computed here (not in helper file) to avoid module initialization issues
-export const defaultTools = getExpectedToolsByCategories(toolCategoriesEnabledByDefault);
+/**
+ * Returns the tool entries for the default-enabled categories resolved for the given mode.
+ * Computed here (not in helper file) to avoid module initialization issues.
+ */
+export function getDefaultTools(mode: ServerMode): ToolEntry[] {
+    return getExpectedToolsByCategories(toolCategoriesEnabledByDefault, mode);
+}
 
 /**
  * Returns the list of tool categories that are enabled for unauthenticated users.
  * A category is included only if all tools in it are in the unauthEnabledTools list.
+ * Tool names are identical across all server modes, so no mode parameter is needed.
  */
 export function getUnauthEnabledToolCategories(): ToolCategory[] {
     const unauthEnabledToolsSet = new Set(unauthEnabledTools);
-    return (Object.entries(toolCategories) as [ToolCategory, typeof toolCategories[ToolCategory]][])
+    const categories = getCategoryTools('default');
+    return (Object.entries(categories) as [ToolCategory, ToolEntry[]][])
         .filter(([, tools]) => tools.every((tool) => unauthEnabledToolsSet.has(tool.name)))
         .map(([category]) => category);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,7 @@ export type ToolBase = z.infer<typeof ToolSchema> & {
     /**
      * Whether this tool is only available in OpenAI UI mode.
      * @deprecated No longer used for filtering. Mode-specific tools are resolved at build time
-     * via buildCategories(uiMode). Will be removed in a future release.
+     * via getCategoryTools(mode). Will be removed in a future release.
      */
     openaiOnly?: boolean;
 };
@@ -391,9 +391,35 @@ export type ToolCallTelemetryProperties = {
 };
 
 /**
- * UI mode for tool responses.
+ * Server mode controls which tool variants are served.
+ *
+ * - `'default'` — standard MCP tools for generic clients
+ * - `'openai'` — OpenAI-specific tool variants (async execution, widget metadata, internal tools)
+ *
+ * Every call site that resolves tool categories must pass an explicit ServerMode value.
+ * This prevents accidentally serving wrong-mode tools.
  */
-export type UiMode = 'openai';
+export type ServerMode = 'default' | 'openai';
+
+/** All valid server modes, for iteration in tests and caches. */
+export const SERVER_MODES: readonly ServerMode[] = ['default', 'openai'] as const;
+
+/**
+ * UI mode for tool responses — the external-facing subset of ServerMode.
+ * Derived from ServerMode: excludes 'default' since the absence of a UI mode means default.
+ */
+export type UiMode = Exclude<ServerMode, 'default'>;
+
+/** Set of valid UiMode values for O(1) membership checks at runtime. */
+const UI_MODES: ReadonlySet<string> = new Set<string>(SERVER_MODES.filter((m): m is UiMode => m !== 'default'));
+
+/**
+ * Parse an untrusted string into a valid UiMode, returning `undefined` for invalid values.
+ * Use at ingestion boundaries (URL params, env vars) to prevent invalid modes from propagating.
+ */
+export function parseUiMode(value: string | null | undefined): UiMode | undefined {
+    return value && UI_MODES.has(value) ? (value as UiMode) : undefined;
+}
 
 /**
  * Parameters for executing a direct actor tool (`type: 'actor'`).
@@ -428,7 +454,7 @@ export type ActorExecutionResult = {
 
 /**
  * Executor for direct actor tools (`type: 'actor'`).
- * Selected at server construction time based on uiMode.
+ * Selected at server construction time based on serverMode.
  * Default mode runs synchronously; OpenAI mode runs async with widget metadata.
  */
 export type ActorExecutor = {
@@ -534,7 +560,8 @@ export type ActorsMcpServerOptions = {
     /**
      * UI mode for tool responses.
      * - 'openai': OpenAI specific widget rendering
-     * If not specified, there will be no widget rendering.
+     * If not specified, defaults to 'default' mode (no widget rendering).
+     * Normalized to {@link ServerMode} at server construction.
      */
     uiMode?: UiMode;
 }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,8 +1,10 @@
-import { getUnauthEnabledToolCategories, toolCategories, unauthEnabledTools } from '../tools/index.js';
+import { CATEGORY_NAME_SET, getUnauthEnabledToolCategories, unauthEnabledTools } from '../tools/index.js';
 import type { ToolCategory } from '../types.js';
 
 /**
  * Determines if an API token is required based on requested tools and actors.
+ * Tool names and category membership are identical across all server modes,
+ * so no mode parameter is needed.
  */
 export function isApiTokenRequired(params: {
     toolCategoryKeys?: string[];
@@ -28,7 +30,7 @@ export function isApiTokenRequired(params: {
         if (unauthTokenSet.has(key)) return true;
 
         // If it is a known category but not safe -> unsafe
-        if (key in toolCategories) return false;
+        if (CATEGORY_NAME_SET.has(key)) return false;
 
         // Otherwise it is likely an Actor name -> unsafe
         return false;

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -1,20 +1,21 @@
 /**
  * Server instructions entry point.
- * Selects the appropriate instructions based on UI mode.
+ * Selects the appropriate instructions based on server mode.
  */
 
-import type { UiMode } from '../../types.js';
+import type { ServerMode } from '../../types.js';
 import { getDefaultInstructions } from './default.js';
 import { getOpenaiInstructions } from './openai.js';
 
+/** Mode → instructions builder. Add new modes here. */
+const instructionsByMode: Record<ServerMode, () => string> = {
+    default: getDefaultInstructions,
+    openai: getOpenaiInstructions,
+};
+
 /**
- * Build server instructions for the given UI mode.
- *
- * @param uiMode - The UI mode ('openai' or undefined for default)
- * @returns Server instructions string
+ * Build server instructions for the given server mode.
  */
-export function getServerInstructions(uiMode?: UiMode): string {
-    return uiMode === 'openai'
-        ? getOpenaiInstructions()
-        : getDefaultInstructions();
+export function getServerInstructions(mode: ServerMode): string {
+    return instructionsByMode[mode]();
 }

--- a/src/utils/tool_categories_helpers.ts
+++ b/src/utils/tool_categories_helpers.ts
@@ -2,20 +2,22 @@
  * Helper functions for working with tool categories.
  * Separated from tools.ts to break circular dependency: tools/index.ts → utils/tools.ts → tools/categories.ts → tools/index.ts
  */
-import { toolCategories } from '../tools/categories.js';
-import type { ToolCategory, ToolEntry } from '../types.js';
+import { getCategoryTools } from '../tools/categories.js';
+import type { ServerMode, ToolCategory, ToolEntry } from '../types.js';
 
 /**
- * Returns the tool objects for the given category names using toolCategories.
+ * Returns the tool objects for the given category names resolved for the specified mode.
  */
-export function getExpectedToolsByCategories(categories: ToolCategory[]): ToolEntry[] {
+export function getExpectedToolsByCategories(categories: ToolCategory[], mode: ServerMode): ToolEntry[] {
+    const resolved = getCategoryTools(mode);
     return categories
-        .flatMap((category) => toolCategories[category] || []);
+        .flatMap((category) => resolved[category] || []);
 }
 
 /**
- * Returns the tool names for the given category names using getExpectedToolsByCategories.
+ * Returns the tool names for the given category names.
+ * Tool names are identical across all server modes, so no mode parameter is needed.
  */
 export function getExpectedToolNamesByCategories(categories: ToolCategory[]): string[] {
-    return getExpectedToolsByCategories(categories).map((tool) => tool.name);
+    return getExpectedToolsByCategories(categories, 'default').map((tool) => tool.name);
 }

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -4,10 +4,10 @@ import {
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../const.js';
-import type { ActorsMcpServerOptions, HelperTool, ToolBase, ToolEntry } from '../types.js';
+import type { HelperTool, ServerMode, ToolBase, ToolEntry } from '../types.js';
 
 type ToolPublicFieldOptions = {
-    uiMode?: ActorsMcpServerOptions['uiMode'];
+    mode?: ServerMode;
     filterOpenAiMeta?: boolean;
 };
 
@@ -32,8 +32,8 @@ function stripOpenAiMeta(meta?: ToolBase['_meta']) {
  * Used for the tools list request.
  */
 export function getToolPublicFieldOnly(tool: ToolBase, options: ToolPublicFieldOptions = {}) {
-    const { uiMode, filterOpenAiMeta = false } = options;
-    const meta = filterOpenAiMeta && uiMode !== 'openai'
+    const { mode, filterOpenAiMeta = false } = options;
+    const meta = filterOpenAiMeta && mode !== 'openai'
         ? stripOpenAiMeta(tool._meta)
         : tool._meta;
 

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -8,11 +8,12 @@ import type { ApifyClient } from 'apify';
 import log from '@apify/log';
 
 import { defaults, HelperTools } from '../const.js';
-import { buildCategories, CATEGORY_NAMES, toolCategoriesEnabledByDefault } from '../tools/categories.js';
+import { CATEGORY_NAMES, getCategoryTools, toolCategoriesEnabledByDefault } from '../tools/categories.js';
 import { addTool } from '../tools/common/add_actor.js';
 import { getActorOutput } from '../tools/common/get_actor_output.js';
 import { getActorsAsTools } from '../tools/index.js';
-import type { ActorStore, Input, ToolCategory, ToolEntry, UiMode } from '../types.js';
+import type { ActorStore, Input, ServerMode, ToolCategory, ToolEntry } from '../types.js';
+import { SERVER_MODES } from '../types.js';
 
 /**
  * Set of all known internal tool names across ALL modes.
@@ -24,8 +25,8 @@ function getAllInternalToolNames(): Set<string> {
     if (!ALL_INTERNAL_TOOL_NAMES_CACHE) {
         const allNames = new Set<string>();
         // Collect tool names from both modes to ensure complete classification
-        for (const mode of [undefined, 'openai' as UiMode]) {
-            const categories = buildCategories(mode);
+        for (const mode of SERVER_MODES) {
+            const categories = getCategoryTools(mode);
             for (const name of CATEGORY_NAMES) {
                 for (const tool of categories[name]) {
                     allNames.add(tool.name);
@@ -43,17 +44,17 @@ function getAllInternalToolNames(): Set<string> {
  *
  * @param input The processed Input object
  * @param apifyClient The Apify client instance
- * @param uiMode Optional UI mode.
+ * @param mode Server mode for tool variant resolution
  * @returns An array of tool entries
  */
 export async function loadToolsFromInput(
     input: Input,
     apifyClient: ApifyClient,
-    uiMode?: UiMode,
+    mode: ServerMode,
     actorStore?: ActorStore,
 ): Promise<ToolEntry[]> {
     // Build mode-resolved categories — tools are already the correct variant for this mode
-    const categories = buildCategories(uiMode);
+    const categories = getCategoryTools(mode);
 
     // Helpers for readability
     const normalizeSelectors = (value: Input['tools']): (string | ToolCategory)[] | undefined => {
@@ -155,7 +156,7 @@ export async function loadToolsFromInput(
     }
 
     // In openai mode, unconditionally add UI-specific tools (regardless of selectors)
-    if (uiMode === 'openai') {
+    if (mode === 'openai') {
         result.push(...categories.ui);
     }
 
@@ -170,7 +171,7 @@ export async function loadToolsFromInput(
      * Insert them right after call-actor to follow the logical workflow order:
      * search → details → call → run status → output → docs → actor tools
      *
-     * Uses mode-resolved variants from buildCategories() for get-actor-run.
+     * Uses mode-resolved variants from getCategoryTools() for get-actor-run.
      */
     const hasCallActor = result.some((entry) => entry.name === HelperTools.ACTOR_CALL);
     const hasActorTools = result.some((entry) => entry.type === 'actor');
@@ -179,7 +180,7 @@ export async function loadToolsFromInput(
     const hasGetActorOutput = result.some((entry) => entry.name === HelperTools.ACTOR_OUTPUT_GET);
 
     const toolsToInject: ToolEntry[] = [];
-    if (!hasGetActorRun && (hasCallActor || uiMode === 'openai')) {
+    if (!hasGetActorRun && (hasCallActor || mode === 'openai')) {
         // Use mode-resolved get-actor-run variant
         const modeGetActorRun = modeToolByName.get(HelperTools.ACTOR_RUNS_GET);
         if (modeGetActorRun) toolsToInject.push(modeGetActorRun);

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -23,7 +23,7 @@ describe('MCP server internals integration tests', () => {
         const apifyClient = new ApifyClient({ token: process.env.APIFY_TOKEN });
         const initialTools = await loadToolsFromInput({
             enableAddingActors: true,
-        } as Input, apifyClient);
+        } as Input, apifyClient, 'default');
         actorsMcpServer.upsertTools(initialTools);
 
         // Load new tool
@@ -64,7 +64,7 @@ describe('MCP server internals integration tests', () => {
 
         const actorsMCPServer = new ActorsMcpServer({ setupSigintHandler: false, taskStore: new InMemoryTaskStore() });
         const apifyClient = new ApifyClient({ token: process.env.APIFY_TOKEN });
-        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, apifyClient);
+        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, apifyClient, 'default');
         actorsMCPServer.upsertTools(seeded);
         actorsMCPServer.registerToolsChangedHandler(onToolsChanged);
 
@@ -102,7 +102,7 @@ describe('MCP server internals integration tests', () => {
 
         const actorsMCPServer = new ActorsMcpServer({ setupSigintHandler: false, taskStore: new InMemoryTaskStore() });
         const apifyClient = new ApifyClient({ token: process.env.APIFY_TOKEN });
-        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, apifyClient);
+        const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, apifyClient, 'default');
         actorsMCPServer.upsertTools(seeded);
         actorsMCPServer.registerToolsChangedHandler(onToolsChanged);
 

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -6,18 +6,21 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 
 import { ApifyClient } from '../../src/apify_client.js';
 import { CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG, defaults, HelperTools, RAG_WEB_BROWSER, SKYFIRE_ENABLED_TOOLS } from '../../src/const.js';
-// Import tools from toolCategories instead of directly to avoid circular dependency during module initialization
-import { defaultTools, toolCategories } from '../../src/tools/index.js';
+// Import tools from getCategoryTools instead of directly to avoid circular dependency during module initialization
+import { getCategoryTools, getDefaultTools } from '../../src/tools/index.js';
 import { callActorOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import { actorNameToToolName } from '../../src/tools/utils.js';
-import type { ToolCategory, ToolEntry } from '../../src/types.js';
+import type { ServerMode, ToolCategory, ToolEntry } from '../../src/types.js';
 import { getExpectedToolNamesByCategories } from '../../src/utils/tool_categories_helpers.js';
 import { ACTOR_MCP_SERVER_ACTOR_NAME, ACTOR_PYTHON_EXAMPLE, DEFAULT_ACTOR_NAMES, getDefaultToolNames } from '../const.js';
 import { addActor, type McpClientOptions } from '../helpers.js';
 
-// Helper to find tool by name from toolCategories (avoids circular dependency)
-function findToolByName(name: string): ToolEntry | undefined {
-    for (const tools of Object.values(toolCategories)) {
+// Helper to find tool by name, resolving categories for the given mode on each call.
+// This ensures we always validate against the correct mode-specific tool definition
+// (e.g. outputSchema may diverge between modes in the future).
+function findToolByName(name: string, mode: ServerMode): ToolEntry | undefined {
+    const resolved = getCategoryTools(mode);
+    for (const tools of Object.values(resolved)) {
         const tool = tools.find((t) => t.name === name);
         if (tool) return tool;
     }
@@ -132,8 +135,8 @@ function expectReadmeInStructuredContent(
     expect(r.structuredContent?.inputSchema).toBeDefined();
 }
 
-function validateStructuredOutputForTool(result: unknown, toolName: string): void {
-    validateStructuredOutput(result, findToolByName(toolName)?.outputSchema, toolName);
+function validateStructuredOutputForTool(result: unknown, toolName: string, mode: ServerMode): void {
+    validateStructuredOutput(result, findToolByName(toolName, mode)?.outputSchema, toolName);
 }
 
 /** Validates that the listed tools have OpenAI metadata (_meta) with outputTemplate and widgetAccessible. */
@@ -231,7 +234,7 @@ export function createIntegrationTestsSuite(
         it('should list all default tools and Actors', async () => {
             client = await createClientFn();
             const tools = await client.listTools();
-            expect(tools.tools.length).toEqual(defaultTools.length + defaults.actors.length + 2);
+            expect(tools.tools.length).toEqual(getDefaultTools('default').length + defaults.actors.length + 2);
 
             const names = getToolNames(tools);
             expectToolNamesToContain(names, getDefaultToolNames());
@@ -298,7 +301,7 @@ export function createIntegrationTestsSuite(
         it('should list all default tools and Actors when enableAddingActors is false', async () => {
             client = await createClientFn({ enableAddingActors: false });
             const names = getToolNames(await client.listTools());
-            expect(names.length).toEqual(defaultTools.length + defaults.actors.length + 2);
+            expect(names.length).toEqual(getDefaultTools('default').length + defaults.actors.length + 2);
 
             expectToolNamesToContain(names, getDefaultToolNames());
             expectToolNamesToContain(names, DEFAULT_ACTOR_NAMES);
@@ -509,7 +512,7 @@ export function createIntegrationTestsSuite(
             client = await createClientFn({ enableAddingActors: true, tools: ['actors'] });
             const names = getToolNames(await client.listTools());
             // Only the actors category, get-actor-output, get-actor-run, and add-actor should be loaded
-            const numberOfTools = toolCategories.actors.length + 3;
+            const numberOfTools = getCategoryTools('default').actors.length + 3;
             expect(names).toHaveLength(numberOfTools);
             // get-actor-run should be automatically included when call-actor is present
             expect(names).toContain(HelperTools.ACTOR_RUNS_GET);
@@ -585,7 +588,7 @@ export function createIntegrationTestsSuite(
             expect(content.some((item) => item.text.includes('Dataset ID'))).toBe(true);
 
             // Validate structured output matches schema
-            validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL);
+            validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL, 'default');
 
             // Validate structured content has actual actor results
             expectPythonExampleStructuredContent(callResult, 1, 2);
@@ -616,7 +619,7 @@ export function createIntegrationTestsSuite(
             expect(typeof resultWithStructured.structuredContent?.runId).toBe('string');
 
             // Validate structured output matches schema
-            validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL);
+            validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL, 'default');
         });
 
         it('should support sync mode in call-actor with step call (default behavior)', async () => {
@@ -687,7 +690,7 @@ export function createIntegrationTestsSuite(
             expect(content.some((item) => item.text.includes('"sum": 3') || item.text.includes('"sum":3'))).toBe(false);
 
             // Validate structured output matches schema
-            validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL);
+            validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL, 'default');
 
             // Validate structured content has empty items (preview disabled)
             const resultWithStructured = callResult as { structuredContent?: { items?: unknown[] } };
@@ -713,7 +716,7 @@ export function createIntegrationTestsSuite(
             expect(content.some((item) => item.text.includes('"sum": 3') || item.text.includes('"sum":3'))).toBe(true);
 
             // Validate structured output matches schema
-            validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL);
+            validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL, 'default');
 
             // Validate structured content has actual actor results
             expectPythonExampleStructuredContent(callResult, 1, 2);
@@ -962,7 +965,7 @@ export function createIntegrationTestsSuite(
             const content = result.content as { text: string; isError?: boolean }[];
             expect(content.length).toBeGreaterThan(0);
 
-            validateStructuredOutputForTool(result, HelperTools.DOCS_SEARCH);
+            validateStructuredOutputForTool(result, HelperTools.DOCS_SEARCH, 'default');
         });
 
         it('should return structured output for fetch-actor-details matching outputSchema', async () => {
@@ -981,7 +984,7 @@ export function createIntegrationTestsSuite(
             const content = result.content as { text: string; isError?: boolean }[];
             expect(content.length).toBeGreaterThan(0);
 
-            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS);
+            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
         });
 
         it('should return only input schema when output={ inputSchema: true }', async () => {
@@ -1121,7 +1124,7 @@ export function createIntegrationTestsSuite(
             expect(content.length).toBeGreaterThan(0);
 
             // This should validate successfully - structured output must match schema
-            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS);
+            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
         });
 
         it('should return structured output for fetch-actor-details with output={ description: true, readme: true } matching outputSchema', async () => {
@@ -1152,7 +1155,7 @@ export function createIntegrationTestsSuite(
             expect(content.length).toBeGreaterThan(0);
 
             // This should validate successfully - structured output must match schema
-            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS);
+            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
         });
 
         it('should return only pricing when output={ pricing: true }', async () => {
@@ -1184,7 +1187,7 @@ export function createIntegrationTestsSuite(
             expect(content.some((item) => item.text.includes('Input schema'))).toBe(false);
 
             // Validate structured output
-            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS);
+            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
         });
 
         it('should return only readme when output={ readme: true }', async () => {
@@ -1216,7 +1219,7 @@ export function createIntegrationTestsSuite(
             expect(content.some((item) => item.text.includes('Input schema'))).toBe(false);
 
             // Validate structured output
-            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS);
+            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
         });
 
         it('should return README content (summary or full) in text and structured response for fetch-actor-details', async () => {
@@ -1247,7 +1250,7 @@ export function createIntegrationTestsSuite(
 
             expectReadmeInStructuredContent(result, RAG_WEB_BROWSER);
 
-            validateStructuredOutput(result, findToolByName(HelperTools.ACTOR_GET_DETAILS)?.outputSchema, 'fetch-actor-details');
+            validateStructuredOutput(result, findToolByName(HelperTools.ACTOR_GET_DETAILS, 'default')?.outputSchema, 'fetch-actor-details');
         });
 
         it('should return README content via fetch-actor-details-internal in openai mode', async () => {
@@ -1331,7 +1334,7 @@ export function createIntegrationTestsSuite(
             expect(resultWithStructured.structuredContent?.inputSchema).toBeDefined();
 
             // Validate against schema
-            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS);
+            validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
         });
 
         it('should support granular output controls for rating and metadata', async () => {
@@ -1468,10 +1471,10 @@ export function createIntegrationTestsSuite(
             expect(combinationText).not.toContain('Input schema');
 
             // Validate structured output for all test cases
-            validateStructuredOutputForTool(pricingOnlyResult, HelperTools.ACTOR_GET_DETAILS);
-            validateStructuredOutputForTool(ratingOnlyResult, HelperTools.ACTOR_GET_DETAILS);
-            validateStructuredOutputForTool(metadataOnlyResult, HelperTools.ACTOR_GET_DETAILS);
-            validateStructuredOutputForTool(combinationResult, HelperTools.ACTOR_GET_DETAILS);
+            validateStructuredOutputForTool(pricingOnlyResult, HelperTools.ACTOR_GET_DETAILS, 'default');
+            validateStructuredOutputForTool(ratingOnlyResult, HelperTools.ACTOR_GET_DETAILS, 'default');
+            validateStructuredOutputForTool(metadataOnlyResult, HelperTools.ACTOR_GET_DETAILS, 'default');
+            validateStructuredOutputForTool(combinationResult, HelperTools.ACTOR_GET_DETAILS, 'default');
         });
 
         it('should dynamically test all output options and verify section presence/absence', async () => {
@@ -1561,7 +1564,7 @@ export function createIntegrationTestsSuite(
                 }
 
                 // Validate structured output
-                validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS);
+                validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
             }
 
             // Test a combination: all actor card sections (description, stats, pricing, rating, metadata)
@@ -1598,7 +1601,7 @@ export function createIntegrationTestsSuite(
             expect(allCardText).not.toContain('README');
             expect(allCardText).not.toContain('Input schema');
 
-            validateStructuredOutputForTool(allCardSectionsResult, HelperTools.ACTOR_GET_DETAILS);
+            validateStructuredOutputForTool(allCardSectionsResult, HelperTools.ACTOR_GET_DETAILS, 'default');
         });
 
         it('should return structured output for search-actors matching outputSchema', async () => {
@@ -1619,7 +1622,7 @@ export function createIntegrationTestsSuite(
             const content = result.content as { text: string; isError?: boolean }[];
             expect(content.length).toBeGreaterThan(0);
 
-            validateStructuredOutputForTool(result, HelperTools.STORE_SEARCH);
+            validateStructuredOutputForTool(result, HelperTools.STORE_SEARCH, 'default');
         });
 
         it('should return structured output for fetch-apify-docs matching outputSchema', async () => {
@@ -1638,10 +1641,10 @@ export function createIntegrationTestsSuite(
             const content = result.content as { text: string; isError?: boolean }[];
             expect(content.length).toBeGreaterThan(0);
 
-            validateStructuredOutputForTool(result, HelperTools.DOCS_FETCH);
+            validateStructuredOutputForTool(result, HelperTools.DOCS_FETCH, 'default');
         });
 
-        it.for(Object.keys(toolCategories))('should load correct tools for %s category', async (category) => {
+        it.for(Object.keys(getCategoryTools('default')))('should load correct tools for %s category', async (category) => {
             client = await createClientFn({
                 tools: [category as ToolCategory],
             });
@@ -1836,7 +1839,7 @@ export function createIntegrationTestsSuite(
             // Test with enableAddingActors = false via env var
             client = await createClientFn({ enableAddingActors: false, useEnv: true });
             const names = getToolNames(await client.listTools());
-            expect(names.length).toEqual(defaultTools.length + defaults.actors.length + 2);
+            expect(names.length).toEqual(getDefaultTools('default').length + defaults.actors.length + 2);
 
             expectToolNamesToContain(names, getDefaultToolNames());
             expectToolNamesToContain(names, DEFAULT_ACTOR_NAMES);
@@ -1857,15 +1860,16 @@ export function createIntegrationTestsSuite(
         });
 
         it.runIf(options.transport === 'stdio')('should load tool categories from TOOLS environment variable', async () => {
-            const categories = ['docs', 'runs'] as ToolCategory[];
-            client = await createClientFn({ tools: categories, useEnv: true });
+            const selectedCategories = ['docs', 'runs'] as ToolCategory[];
+            client = await createClientFn({ tools: selectedCategories, useEnv: true });
 
             const loadedTools = await client.listTools();
             const toolNames = getToolNames(loadedTools);
 
+            const resolvedCategories = getCategoryTools('default');
             const expectedTools = [
-                ...toolCategories.docs,
-                ...toolCategories.runs,
+                ...resolvedCategories.docs,
+                ...resolvedCategories.runs,
             ];
             const expectedToolNames = expectedTools.map((tool) => tool.name);
 
@@ -1978,7 +1982,7 @@ export function createIntegrationTestsSuite(
             expect(resultWithStructured.structuredContent?.items?.[0]).toHaveProperty('crawl');
 
             // Validate structured output for get-actor-output
-            validateStructuredOutputForTool(outputResult, HelperTools.ACTOR_OUTPUT_GET);
+            validateStructuredOutputForTool(outputResult, HelperTools.ACTOR_OUTPUT_GET, 'default');
 
             await client.close();
         });
@@ -2031,7 +2035,7 @@ export function createIntegrationTestsSuite(
             expectUsageCostMeta(result);
 
             // Validate structured output for get-actor-output
-            validateStructuredOutputForTool(outputResult, HelperTools.ACTOR_OUTPUT_GET);
+            validateStructuredOutputForTool(outputResult, HelperTools.ACTOR_OUTPUT_GET, 'default');
         });
 
         it('should return structured output for get-actor-run matching outputSchema', async () => {
@@ -2059,7 +2063,7 @@ export function createIntegrationTestsSuite(
 
             expect(runResult.content).toBeDefined();
             // Validate structured output for get-actor-run
-            validateStructuredOutputForTool(runResult, HelperTools.ACTOR_RUNS_GET);
+            validateStructuredOutputForTool(runResult, HelperTools.ACTOR_RUNS_GET, 'default');
         });
 
         it('should return Actor details both for full Actor name and ID', async () => {
@@ -2115,7 +2119,7 @@ export function createIntegrationTestsSuite(
 
             expect(datasetResult.content).toBeDefined();
             // Validate structured output for get-dataset-items
-            validateStructuredOutputForTool(datasetResult, HelperTools.DATASET_GET_ITEMS);
+            validateStructuredOutputForTool(datasetResult, HelperTools.DATASET_GET_ITEMS, 'default');
 
             // Validate structured content has items with actual results
             const datasetWithStructured = datasetResult as { structuredContent?: {

--- a/tests/unit/mcp.utils.test.ts
+++ b/tests/unit/mcp.utils.test.ts
@@ -69,10 +69,12 @@ describe('MCP resources', () => {
 
     it('lists the Skyfire readme only when enabled', async () => {
         const skyfireService = createResourceService({
+            mode: 'default',
             skyfireMode: true,
             getAvailableWidgets: () => new Map(),
         });
         const defaultService = createResourceService({
+            mode: 'default',
             skyfireMode: false,
             getAvailableWidgets: () => new Map(),
         });
@@ -90,7 +92,7 @@ describe('MCP resources', () => {
             [WIDGET_URIS.ACTOR_RUN, buildAvailableWidget(WIDGET_URIS.ACTOR_RUN, false)],
         ]);
         const service = createResourceService({
-            uiMode: 'openai',
+            mode: 'openai',
             getAvailableWidgets: () => widgets,
         });
 
@@ -101,6 +103,7 @@ describe('MCP resources', () => {
 
     it('returns a plain-text message for missing resources', async () => {
         const service = createResourceService({
+            mode: 'default',
             getAvailableWidgets: () => new Map(),
         });
 
@@ -112,6 +115,7 @@ describe('MCP resources', () => {
 
     it('returns the Skyfire readme content when requested', async () => {
         const service = createResourceService({
+            mode: 'default',
             skyfireMode: true,
             getAvailableWidgets: () => new Map(),
         });
@@ -124,7 +128,7 @@ describe('MCP resources', () => {
 
     it('returns a plain-text message for unknown widgets', async () => {
         const service = createResourceService({
-            uiMode: 'openai',
+            mode: 'openai',
             getAvailableWidgets: () => new Map(),
         });
 
@@ -143,7 +147,7 @@ describe('MCP resources', () => {
             [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, true)],
         ]);
         const service = createResourceService({
-            uiMode: 'openai',
+            mode: 'openai',
             getAvailableWidgets: () => widgets,
         });
 
@@ -156,6 +160,7 @@ describe('MCP resources', () => {
 
     it('returns an empty resource templates list', async () => {
         const service = createResourceService({
+            mode: 'default',
             getAvailableWidgets: () => new Map(),
         });
 

--- a/tests/unit/tools.categories.test.ts
+++ b/tests/unit/tools.categories.test.ts
@@ -1,22 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
-import { buildCategories, CATEGORY_NAMES, toolCategories } from '../../src/tools/index.js';
+import { CATEGORY_NAMES, getCategoryTools, toolCategories } from '../../src/tools/index.js';
 import type { ToolCategory, ToolEntry } from '../../src/types.js';
 
 describe('CATEGORY_NAMES', () => {
-    it('should be derived from toolCategories keys', () => {
-        // CATEGORY_NAMES is derived from toolCategories via Object.keys(),
-        // so they are guaranteed to match. This test verifies the derivation is correct.
+    it('should match the keys of toolCategories', () => {
         const staticKeys = Object.keys(toolCategories);
-        expect(CATEGORY_NAMES).toEqual(staticKeys);
+        expect([...CATEGORY_NAMES]).toEqual(staticKeys);
     });
 });
 
-describe('buildCategories', () => {
+describe('getCategoryTools', () => {
     it('should return all category keys matching CATEGORY_NAMES', () => {
-        const defaultResult = buildCategories();
-        const openaiResult = buildCategories('openai');
+        const defaultResult = getCategoryTools('default');
+        const openaiResult = getCategoryTools('openai');
 
         for (const name of CATEGORY_NAMES) {
             expect(defaultResult).toHaveProperty(name);
@@ -25,8 +23,8 @@ describe('buildCategories', () => {
     });
 
     it('should return no undefined entries in any category (circular-init safety)', () => {
-        const defaultResult = buildCategories();
-        const openaiResult = buildCategories('openai');
+        const defaultResult = getCategoryTools('default');
+        const openaiResult = getCategoryTools('openai');
 
         for (const name of CATEGORY_NAMES) {
             for (const tool of defaultResult[name]) {
@@ -41,18 +39,18 @@ describe('buildCategories', () => {
     });
 
     it('should return empty ui category in default mode', () => {
-        const result = buildCategories();
+        const result = getCategoryTools('default');
         expect(result.ui).toEqual([]);
     });
 
     it('should return non-empty ui category in openai mode', () => {
-        const result = buildCategories('openai');
+        const result = getCategoryTools('openai');
         expect(result.ui.length).toBeGreaterThan(0);
     });
 
     it('should return different tool variants for actors category based on mode', () => {
-        const defaultResult = buildCategories();
-        const openaiResult = buildCategories('openai');
+        const defaultResult = getCategoryTools('default');
+        const openaiResult = getCategoryTools('openai');
 
         // Both modes should have the same tool names in actors category
         const defaultNames = defaultResult.actors.map((t: ToolEntry) => t.name);
@@ -64,8 +62,8 @@ describe('buildCategories', () => {
     });
 
     it('should return different get-actor-run variants based on mode', () => {
-        const defaultResult = buildCategories();
-        const openaiResult = buildCategories('openai');
+        const defaultResult = getCategoryTools('default');
+        const openaiResult = getCategoryTools('openai');
 
         const defaultGetRun = defaultResult.runs.find((t: ToolEntry) => t.name === HelperTools.ACTOR_RUNS_GET);
         const openaiGetRun = openaiResult.runs.find((t: ToolEntry) => t.name === HelperTools.ACTOR_RUNS_GET);
@@ -77,8 +75,8 @@ describe('buildCategories', () => {
     });
 
     it('should share identical tools for mode-independent categories', () => {
-        const defaultResult = buildCategories();
-        const openaiResult = buildCategories('openai');
+        const defaultResult = getCategoryTools('default');
+        const openaiResult = getCategoryTools('openai');
 
         const modeIndependentCategories: ToolCategory[] = ['experimental', 'docs', 'storage', 'dev'];
         for (const cat of modeIndependentCategories) {
@@ -87,7 +85,7 @@ describe('buildCategories', () => {
     });
 
     it('should preserve tool ordering within categories', () => {
-        const result = buildCategories();
+        const result = getCategoryTools('default');
         const actorNames = result.actors.map((t: ToolEntry) => t.name);
 
         // Verify workflow order: search → details → call

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -10,8 +10,9 @@
 import { describe, expect, it } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
-import { buildCategories, CATEGORY_NAMES } from '../../src/tools/index.js';
-import type { ToolEntry, UiMode } from '../../src/types.js';
+import { CATEGORY_NAMES, getCategoryTools } from '../../src/tools/index.js';
+import type { ToolEntry } from '../../src/types.js';
+import { SERVER_MODES } from '../../src/types.js';
 import { getToolPublicFieldOnly } from '../../src/utils/tools.js';
 
 /** Helper to extract tool names from a category. */
@@ -19,9 +20,9 @@ function toolNames(tools: ToolEntry[]): string[] {
     return tools.map((t) => t.name);
 }
 
-describe('buildCategories mode contract', () => {
-    const defaultCategories = buildCategories();
-    const openaiCategories = buildCategories('openai');
+describe('getCategoryTools mode contract (tool-mode separation)', () => {
+    const defaultCategories = getCategoryTools('default');
+    const openaiCategories = getCategoryTools('openai');
 
     describe('per-mode tool lists', () => {
         it('should have correct tools in experimental category (both modes)', () => {
@@ -85,14 +86,21 @@ describe('buildCategories mode contract', () => {
         });
     });
 
-    describe('mode-variant tool name parity', () => {
-        it('should have identical tool names in actors category across modes', () => {
-            expect(toolNames(defaultCategories.actors)).toEqual(toolNames(openaiCategories.actors));
-        });
+    describe('tool name invariance across modes', () => {
+        // Tool names MUST be identical across all modes for every category that has tools in both modes.
+        // This invariant is relied upon by getExpectedToolNamesByCategories, getUnauthEnabledToolCategories,
+        // and isApiTokenRequired — which all hardcode 'default' mode internally.
+        for (const categoryName of CATEGORY_NAMES) {
+            const defaultNames = toolNames(defaultCategories[categoryName]);
+            const openaiNames = toolNames(openaiCategories[categoryName]);
 
-        it('should have identical tool names in runs category across modes', () => {
-            expect(toolNames(defaultCategories.runs)).toEqual(toolNames(openaiCategories.runs));
-        });
+            // Only check categories that exist in both modes (ui category is openai-only)
+            if (defaultNames.length > 0 && openaiNames.length > 0) {
+                it(`should have identical tool names in ${categoryName} category across modes`, () => {
+                    expect(defaultNames).toEqual(openaiNames);
+                });
+            }
+        }
     });
 
     describe('inputSchema parity for mode-variant tools', () => {
@@ -118,13 +126,12 @@ describe('buildCategories mode contract', () => {
     });
 
     describe('tool definitions are frozen', () => {
-        for (const mode of [undefined, 'openai' as UiMode]) {
-            const label = mode ?? 'default';
-            const categories = buildCategories(mode);
+        for (const mode of SERVER_MODES) {
+            const categories = getCategoryTools(mode);
 
             for (const categoryName of CATEGORY_NAMES) {
                 for (const tool of categories[categoryName]) {
-                    it(`${tool.name} (${label} mode) should be frozen`, () => {
+                    it(`${tool.name} (${mode} mode) should be frozen`, () => {
                         expect(Object.isFrozen(tool)).toBe(true);
                     });
                 }
@@ -135,13 +142,12 @@ describe('buildCategories mode contract', () => {
     describe('all tool names match HelperTools enum values', () => {
         const allHelperToolNames = new Set(Object.values(HelperTools));
 
-        for (const mode of [undefined, 'openai' as UiMode]) {
-            const label = mode ?? 'default';
-            const categories = buildCategories(mode);
+        for (const mode of SERVER_MODES) {
+            const categories = getCategoryTools(mode);
 
             for (const categoryName of CATEGORY_NAMES) {
                 for (const tool of categories[categoryName]) {
-                    it(`${tool.name} (${label} mode) should be a known HelperTools value`, () => {
+                    it(`${tool.name} (${mode} mode) should be a known HelperTools value`, () => {
                         expect(allHelperToolNames.has(tool.name as HelperTools)).toBe(true);
                     });
                 }
@@ -166,7 +172,7 @@ describe('getToolPublicFieldOnly _meta filtering', () => {
     it('should strip openai/ _meta keys when filterOpenAiMeta is true and not in openai mode', () => {
         const result = getToolPublicFieldOnly(toolWithOpenAiMeta, {
             filterOpenAiMeta: true,
-            uiMode: undefined,
+            mode: 'default',
         });
         expect(result._meta).toBeDefined();
         expect(result._meta).toEqual({ 'regular-key': { data: 123 } });
@@ -177,7 +183,7 @@ describe('getToolPublicFieldOnly _meta filtering', () => {
     it('should preserve all _meta keys in openai mode', () => {
         const result = getToolPublicFieldOnly(toolWithOpenAiMeta, {
             filterOpenAiMeta: true,
-            uiMode: 'openai',
+            mode: 'openai',
         });
         expect(result._meta).toEqual(toolWithOpenAiMeta._meta);
     });
@@ -198,7 +204,7 @@ describe('getToolPublicFieldOnly _meta filtering', () => {
         };
         const result = getToolPublicFieldOnly(toolWithOnlyOpenAiMeta, {
             filterOpenAiMeta: true,
-            uiMode: undefined,
+            mode: 'default',
         });
         expect(result._meta).toBeUndefined();
     });

--- a/tests/unit/tools.skyfire.test.ts
+++ b/tests/unit/tools.skyfire.test.ts
@@ -308,7 +308,7 @@ describe('applySkyfireAugmentation', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Matrix: mode × eligibility (using buildCategories tools)
+// Matrix: mode × eligibility (using getCategoryTools)
 // ---------------------------------------------------------------------------
 
 describe('Skyfire eligibility matrix', () => {


### PR DESCRIPTION
## Summary

Replaces the duplicated `toolCategories` static map + `buildCategories()` function with a unified category definition using mode-aware entries and a generic `getCategoryTools(mode)` resolver. Introduces `ServerMode` type as the explicit mode contract, normalized once at server construction.

**Stacked on #491** (`refactor/one-file-per-tool`)

## Key changes

- **Unified category definitions**: Each tool entry in `toolCategories` is either a plain `ToolEntry` (mode-independent) or a `ModeMap` (`{ default: ..., openai: ... }`) — single source of truth, no duplication
- **`ServerMode` type** (`'default' | 'openai'`): string union (not enum), with `SERVER_MODES` const for iteration and `UiMode` derived as `Exclude<ServerMode, 'default'>`
- **Generic dispatch**: `Record<ServerMode, ...>` map lookups (`actorExecutorsByMode`, `instructionsByMode`) replace boolean/ternary branching
- **Normalize once**: `serverMode` computed once at construction from `options.uiMode ?? 'default'`, threaded only where behavior differs
- **Required mode parameter**: All tool-resolving functions require explicit `ServerMode` — prevents accidentally serving wrong-mode tools
- **Boundary validation**: `parseUiMode()` validates untrusted strings (URL params, env vars) replacing unsafe `as UiMode` casts in `actor/server.ts`
- **Invariant functions untouched**: `getExpectedToolNamesByCategories`, `getUnauthEnabledToolCategories`, `isApiTokenRequired` don't take mode (tool names are identical across modes)
- **Contract test**: New test enforces tool name invariance across all modes for every category

## Breaking changes for `apify-mcp-server-internal`

3 compile-time fixes needed (all mechanical):
1. `debug.ts`: `processParamsGetTools()` now requires 3rd arg `mode: ServerMode`
2. `server-suite.ts`: `defaultTools` static export → `getDefaultTools('default')` function call
3. `server-suite.ts`: `toolCategories.actors.length` → `getCategoryTools('default').actors.length`

Optional hardening: `extractUiModeConfig()` can adopt `parseUiMode()` to replace unsafe `as UiMode` casts.

## Stats

20 files changed, +299 / -223 (net +76)

## Verification

- ✅ `npm run type-check` — clean
- ✅ `npm run lint` — clean
- ✅ `npm run test:unit` — 398/398 passed