### PR TITLE
fix: Return only 5 results instead of 10, clamLines in search-actor

### DIFF
--- a/src/tools/search-actors-internal.ts
+++ b/src/tools/search-actors-internal.ts
@@ -12,8 +12,8 @@ const searchActorsInternalArgsSchema = z.object({
         .int()
         .min(1)
         .max(100)
-        .default(10)
-        .describe('The maximum number of Actors to return (default = 10)'),
+        .default(5)
+        .describe('The maximum number of Actors to return (default = 5)'),
     offset: z.number()
         .int()
         .min(0)

--- a/src/tools/store_collection.ts
+++ b/src/tools/store_collection.ts
@@ -15,8 +15,8 @@ export const searchActorsArgsSchema = z.object({
         .int()
         .min(1)
         .max(100)
-        .default(10)
-        .describe('The maximum number of Actors to return (default = 10)'),
+        .default(5)
+        .describe('The maximum number of Actors to return (default = 5)'),
     offset: z.number()
         .int()
         .min(0)

--- a/src/web/src/components/actor/ActorCard.tsx
+++ b/src/web/src/components/actor/ActorCard.tsx
@@ -58,7 +58,7 @@ const StyledSeparator = styled(Box)`
 
 const DescriptionText = styled(Text)<{ isDetail: boolean }>`
     white-space: pre-wrap;
-    ${({ isDetail }) => !isDetail && clampLines(2)};
+    ${({ isDetail }) => !isDetail && clampLines(1)};
 `;
 
 const ActorHeader = styled.div`


### PR DESCRIPTION
Return only 5 results instead of 10 to make the widget smaller 10 is probably too large even for text.
In the search-actor clamp lines to a single line.

@jmikitova @baldasseva I'm not really sure about that clamp, please advise :) . 
The line looks pretty packed now (but the previous version was a bit distracting too me)

After:
<img width="1168" height="764" alt="image" src="https://github.com/user-attachments/assets/d7cd83c5-4a0a-47cd-847b-924e92b7def2" />


Before:
<img width="1195" height="1599" alt="image" src="https://github.com/user-attachments/assets/3fa5c316-40d0-408a-8b93-7ac7a4ed6143" />
