### PR TITLE
Fix type assertions and add missing dependency to useEffect

### DIFF
--- a/src/web/src/pages/ActorRun/ActorRun.tsx
+++ b/src/web/src/pages/ActorRun/ActorRun.tsx
@@ -299,7 +299,7 @@ export const ActorRun: React.FC = () => {
             const developerUsername = extractDeveloperUsername(fullActorName);
 
             const usageTotalUsd = typeof toolResponseMetadata?.usageTotalUsd === 'number'
-                ? toolResponseMetadata.usageTotalUsd as number
+                ? toolResponseMetadata.usageTotalUsd
                 : undefined;
 
             setRunData({
@@ -317,7 +317,7 @@ export const ActorRun: React.FC = () => {
                 dataset: toolOutput.dataset,
             });
         }
-    }, [toolOutput, runData]);
+    }, [toolOutput, runData, toolResponseMetadata]);
 
     // Fetch actor details to get pictureUrl
     useEffect(() => {
@@ -380,7 +380,7 @@ export const ActorRun: React.FC = () => {
                         const developerUsername = extractDeveloperUsername(fullActorName);
 
                         const pollUsageTotalUsd = typeof response._meta?.usageTotalUsd === 'number'
-                            ? response._meta.usageTotalUsd as number
+                            ? response._meta.usageTotalUsd
                             : undefined;
 
                         const updatedRunData: ActorRunData = {


### PR DESCRIPTION
## Summary
This PR fixes type safety issues and improves the dependency array in the ActorRun component by removing unnecessary type assertions and adding a missing dependency to a useEffect hook.

## Key Changes
- Removed redundant `as number` type assertions for `usageTotalUsd` values (2 instances)
  - The ternary operator already ensures the value is of type `number` when the condition is true, making the explicit cast unnecessary
- Added `toolResponseMetadata` to the dependency array of the useEffect hook
  - This ensures the effect properly re-runs when `toolResponseMetadata` changes, preventing stale closures and potential bugs

## Implementation Details
The type assertions were removed because TypeScript's type narrowing already handles the type correctly. When checking `typeof toolResponseMetadata?.usageTotalUsd === 'number'`, the subsequent assignment already has the correct type without an explicit cast.

The missing dependency was identified as a potential issue where the effect uses `toolResponseMetadata` but didn't include it in the dependency array, which could lead to the effect using stale values.

https://claude.ai/code/session_013epLuei9qoP5V2nyM1BYc4