### PR TITLE
fix(web): capitalize Actor in loading text per style guide

### DIFF
--- a/src/web/src/pages/ActorRun/ActorRun.tsx
+++ b/src/web/src/pages/ActorRun/ActorRun.tsx
@@ -435,7 +435,7 @@ export const ActorRun: React.FC = () => {
                 <Container>
                     <EmptyStateContainer>
                         <Text type="body" size="small" style={{ color: theme.color.neutral.textMuted }}>
-                            Loading actor run data...
+                            Loading Actor run data ...
                         </Text>
                     </EmptyStateContainer>
                 </Container>


### PR DESCRIPTION
- Capitalizes "actor" → "Actor" in the loading state text of `ActorRun.tsx` to align with the Apify writing style guide (Actor is a proper noun)

Before:
<img width="1290" height="393" alt="image" src="https://github.com/user-attachments/assets/d4ccba54-4705-446a-a1eb-167efc684545" />


After:
I'm not able to reproduce it in MCP Jam