### PR TITLE
feat(web): change web dev server port [internal]

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -84,7 +84,7 @@ What happens:
 Notes:
 - You can get your `APIFY_TOKEN` from [Apify Console](https://console.apify.com/settings/integrations)
 - Widget discovery happens when the server connects. Changing widget code is hot-reloaded; adding brand-new widget filenames typically requires reconnecting the MCP client (or restarting the server) to expose the new resource.
-- You can preview widgets quickly via the local esbuild dev server at `http://localhost:3000/index.html`.
+- You can preview widgets quickly via the local esbuild dev server at `http://localhost:3226/index.html`.
 
 The MCP server listens on port `3001`. The HTTP server implementation used here is the standby Actor server in `src/actor/server.ts` (used by `src/main.ts` in STANDBY mode). The hosted production server behind [mcp.apify.com](https://mcp.apify.com) is located in the internal Apify repository.
 

--- a/src/web/build.js
+++ b/src/web/build.js
@@ -118,7 +118,7 @@ async function buildAll() {
 
         const { host, port } = await ctx.serve({
             servedir: dirName,
-            port: 3000,
+            port: 3226,
         });
 
         console.log(`\n✓ Dev server running at http://${host}:${port}/`);


### PR DESCRIPTION
Hello, AI team

I am wiring my local apify-core repo to the local dev mcp server. Apify console frontend and the widgets in dev mode are both served by port 3000 and this is creating me problems. Since in the near future I will want to use the widgets in the console, I would like to start them both locally and this is the smallest change I can make to fix this problem