### PR TITLE
ci: Fix workflow concurrency settings

### DIFF
--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -32,10 +32,6 @@ permissions:
     id-token: write
     contents: write
 
-concurrency:
-    group: release
-    cancel-in-progress: false
-
 jobs:
     release_metadata:
         name: Prepare release metadata


### PR DESCRIPTION
- The concurrency settings in the reusable workflow caused issues - see https://github.com/apify/apify-mcp-server/actions/runs/22437268870/job/64970240194
