### PR TITLE
fix: Actor run show number of fields for nested objects

### DIFF
--- a/src/web/src/pages/ActorRun/ActorRun.tsx
+++ b/src/web/src/pages/ActorRun/ActorRun.tsx
@@ -533,7 +533,12 @@ export const ActorRun: React.FC = () => {
                                         <TableRow key={index}>
                                             {columns.map((column) => (
                                                 <TableCell key={column}>
-                                                    {item[column]?.toString() || "—"}
+                                                    {item[column] == null
+                                                        ? "—"
+                                                        // If the value is an object, show number of fields instead of [object Object]
+                                                        : typeof item[column] === 'object'
+                                                            ? `${Object.keys(item[column]).length} fields`
+                                                            : String(item[column]) || "—"}
                                                 </TableCell>
                                             ))}
                                         </TableRow>

--- a/src/web/src/widgets/actor-run-widget.tsx
+++ b/src/web/src/widgets/actor-run-widget.tsx
@@ -60,6 +60,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 1",
                                       url: "https://example.com/page-1",
+                                      crawl: { loadedUrl: "https://example.com/page-1", httpStatusCode: 200, depth: 0, contentType: "text/html" },
                                       description: "This is a long description that should test text overflow and ellipsis in table cells",
                                       category: "Technology",
                                       price: "$29.99",
@@ -69,6 +70,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 2",
                                       url: "https://example.com/page-2",
+                                      crawl: { loadedUrl: "https://example.com/page-2", httpStatusCode: 200, depth: 1, contentType: "text/html" },
                                       description: "Another lengthy description to ensure we can test horizontal scrolling properly",
                                       category: "Business",
                                       price: "$49.99",
@@ -78,6 +80,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 3",
                                       url: "https://example.com/page-3",
+                                      crawl: { loadedUrl: "https://example.com/page-3", httpStatusCode: 404, depth: 2, contentType: "text/html" },
                                       description: "Third item with even more text content for testing purposes",
                                       category: "Science",
                                       price: "$39.99",
@@ -87,6 +90,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 4",
                                       url: "https://example.com/page-4",
+                                      crawl: { loadedUrl: "https://example.com/page-4", httpStatusCode: 200, depth: 0, contentType: "text/html" },
                                       description: "Fourth item in the dataset to test vertical scrolling",
                                       category: "Health",
                                       price: "$19.99",
@@ -96,6 +100,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 5",
                                       url: "https://example.com/page-5",
+                                      crawl: { loadedUrl: "https://example.com/page-5", httpStatusCode: 200, depth: 1, contentType: "text/html" },
                                       description: "Fifth item with more content to fill the table",
                                       category: "Education",
                                       price: "$59.99",
@@ -105,6 +110,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 6",
                                       url: "https://example.com/page-6",
+                                      crawl: { loadedUrl: "https://example.com/page-6", httpStatusCode: 200, depth: 0, contentType: "text/html" },
                                       description: "Sixth item continuing the test data pattern",
                                       category: "Entertainment",
                                       price: "$24.99",
@@ -114,6 +120,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 7",
                                       url: "https://example.com/page-7",
+                                      crawl: { loadedUrl: "https://example.com/page-7", httpStatusCode: 200, depth: 2, contentType: "text/html" },
                                       description: "Seventh item with varied content for testing",
                                       category: "Sports",
                                       price: "$34.99",
@@ -123,6 +130,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 8",
                                       url: "https://example.com/page-8",
+                                      crawl: { loadedUrl: "https://example.com/page-8", httpStatusCode: 200, depth: 1, contentType: "text/html" },
                                       description: "Eighth item to ensure we have enough rows for scrolling",
                                       category: "Travel",
                                       price: "$44.99",
@@ -132,6 +140,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 9",
                                       url: "https://example.com/page-9",
+                                      crawl: { loadedUrl: "https://example.com/page-9", httpStatusCode: 200, depth: 0, contentType: "text/html" },
                                       description: "Ninth item with additional test data",
                                       category: "Food",
                                       price: "$14.99",
@@ -141,6 +150,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 10",
                                       url: "https://example.com/page-10",
+                                      crawl: { loadedUrl: "https://example.com/page-10", httpStatusCode: 200, depth: 3, contentType: "text/html" },
                                       description: "Tenth item for comprehensive testing",
                                       category: "Fashion",
                                       price: "$54.99",
@@ -150,6 +160,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 11",
                                       url: "https://example.com/page-11",
+                                      crawl: { loadedUrl: "https://example.com/page-11", httpStatusCode: 200, depth: 0, contentType: "text/html" },
                                       description: "Eleventh item to ensure shadow appears correctly",
                                       category: "Music",
                                       price: "$29.99",
@@ -159,6 +170,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 12",
                                       url: "https://example.com/page-12",
+                                      crawl: { loadedUrl: "https://example.com/page-12", httpStatusCode: 200, depth: 1, contentType: "text/html" },
                                       description: "Twelfth item for extended testing scenarios",
                                       category: "Art",
                                       price: "$69.99",
@@ -168,6 +180,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 13",
                                       url: "https://example.com/page-13",
+                                      crawl: { loadedUrl: "https://example.com/page-13", httpStatusCode: 200, depth: 2, contentType: "text/html" },
                                       description: "Thirteenth item with more varied content",
                                       category: "Finance",
                                       price: "$39.99",
@@ -177,6 +190,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 14",
                                       url: "https://example.com/page-14",
+                                      crawl: { loadedUrl: "https://example.com/page-14", httpStatusCode: 200, depth: 0, contentType: "text/html" },
                                       description: "Fourteenth item to test pagination and scrolling limits",
                                       category: "Automotive",
                                       price: "$79.99",
@@ -186,6 +200,7 @@ setupMockOpenAi({
                                   {
                                       title: "Example Page 15",
                                       url: "https://example.com/page-15",
+                                      crawl: { loadedUrl: "https://example.com/page-15", httpStatusCode: 200, depth: 1, contentType: "text/html" },
                                       description: "Fifteenth and final item in the test dataset",
                                       category: "Real Estate",
                                       price: "$99.99",
@@ -218,6 +233,7 @@ if (isMockEnvironment) {
                         {
                             title: "Example Page 1",
                             url: "https://example.com/page-1",
+                            crawl: { loadedUrl: "https://example.com/page-1", httpStatusCode: 200, depth: 0, contentType: "text/html" },
                             description: "This is a long description that should test text overflow and ellipsis in table cells",
                             category: "Technology",
                             price: "$29.99",
@@ -227,6 +243,7 @@ if (isMockEnvironment) {
                         {
                             title: "Example Page 2",
                             url: "https://example.com/page-2",
+                            crawl: { loadedUrl: "https://example.com/page-2", httpStatusCode: 200, depth: 1, contentType: "text/html" },
                             description: "Another lengthy description to ensure we can test horizontal scrolling properly",
                             category: "Business",
                             price: "$49.99",
@@ -236,6 +253,7 @@ if (isMockEnvironment) {
                         {
                             title: "Example Page 3",
                             url: "https://example.com/page-3",
+                            crawl: { loadedUrl: "https://example.com/page-3", httpStatusCode: 404, depth: 2, contentType: "text/html" },
                             description: "Third item with even more text content for testing purposes",
                             category: "Science",
                             price: "$39.99",
@@ -245,6 +263,7 @@ if (isMockEnvironment) {
                         {
                             title: "Example Page 4",
                             url: "https://example.com/page-4",
+                            crawl: { loadedUrl: "https://example.com/page-4", httpStatusCode: 200, depth: 0, contentType: "text/html" },
                             description: "Fourth item in the dataset to test vertical scrolling",
                             category: "Health",
                             price: "$19.99",
@@ -254,6 +273,7 @@ if (isMockEnvironment) {
                         {
                             title: "Example Page 5",
                             url: "https://example.com/page-5",
+                            crawl: { loadedUrl: "https://example.com/page-5", httpStatusCode: 200, depth: 1, contentType: "text/html" },
                             description: "Fifth item with more content to fill the table",
                             category: "Education",
                             price: "$59.99",


### PR DESCRIPTION
solving issue with nested object in actor run response -> reported [here](https://www.notion.so/apify/ChatGPT-apps-311f39950a2280f4970de7a49c579630?source=copy_link#311f39950a228067acd1c0cd7d9c7b7a)

-> after the fix, insted of [object object] we show `XZ fields` (number of keys in the object) the same way as in console, the detail can be viewed after clicking on `View on Apify` (it would be overkill implementing the whole views logic to the widget)
-> for empty columns, we show '-' : I believe it is better solution than hiding the column entirely

<img width="871" height="439" alt="Screenshot 2026-03-02 at 14 39 30" src="https://github.com/user-attachments/assets/26f3bc28-6617-4119-8052-3034bc744cf0" />
