### PR TITLE
fix(web): Add widget metadata to Actor tools

### DIFF
--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -12,6 +12,7 @@ import {
 import { getActorMCPServerPath, getActorMCPServerURL } from '../../mcp/actors.js';
 import { connectMCPClient } from '../../mcp/client.js';
 import { getMCPServerTools } from '../../mcp/proxy.js';
+import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import { actorDefinitionPrunedCache } from '../../state.js';
 import type {
     ActorInfo,
@@ -122,6 +123,10 @@ Actor description: ${definition.description}`;
             ajvValidate,
             requiresSkyfirePayId: true,
             memoryMbytes,
+            // openai/* keys are stripped in non-openai mode by stripOpenAiMeta() in src/utils/tools.ts
+            _meta: {
+                ...getWidgetConfig(WIDGET_URIS.ACTOR_RUN)?.meta,
+            },
             icons: definition.pictureUrl
                 ? [{ src: definition.pictureUrl, mimeType: 'image/png' }]
                 : undefined,


### PR DESCRIPTION
Attach widget config from `ACTOR_RUN` widget URI to Actor tool `_meta`, enabling proper widget rendering for Actor run results

This was the issue. I had to add `_meta` to the Actor tools.
Now it works the same way as `call-actor`

<img width="1348" height="379" alt="image" src="https://github.com/user-attachments/assets/d9d03528-768d-4817-98a8-b7c30a645eba" />

