### PR TITLE
fix: expose Mcp-Session-Id header to browser clients via CORS

### DIFF
--- a/src/actor/server.ts
+++ b/src/actor/server.ts
@@ -51,11 +51,15 @@ export function createExpressApp(
     }
 
     // CORS middleware: expose Mcp-Session-Id to browser clients
-    app.use((_req: Request, res: Response, next: NextFunction) => {
+    app.use((req: Request, res: Response, next: NextFunction) => {
         res.setHeader('Access-Control-Allow-Origin', '*');
         res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
         res.setHeader('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id');
         res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+        if (req.method === 'OPTIONS') {
+            res.sendStatus(204);
+            return;
+        }
         next();
     });
 


### PR DESCRIPTION
### Problem  
                                                                                                                                       
Browser-based MCP clients could not read the Mcp-Session-Id response header returned by the server during session initialization. Even though the header was present in the HTTP response, browsers block JavaScript access to any response header not explicitly listed in [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Expose-Headers) — this is a CORS security restriction enforced by all modern browsers.

**We need this available so we can initiate a client on console.apify.com and forward the tools from mcp.apify.com to the internal browser LLM chat (for WebMCP use).**

### Fix

Added a CORS middleware in src/actor/server.ts that runs before all route handlers and sets the following headers on every response:
```
  Access-Control-Allow-Origin: *
  Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS
  Access-Control-Allow-Headers: Content-Type, mcp-session-id
  Access-Control-Expose-Headers: Mcp-Session-Id
```