### PR TITLE
Add x402 monetization - let AI agents pay per API call

### DIFF
--- a/.well-known/x402.json
+++ b/.well-known/x402.json
@@ -1,0 +1,33 @@
+{
+  "name": "apify/apify-mcp-server",
+  "description": "Apify MCP Server",
+  "accepts": [
+    {
+      "network": "eip155:8453",
+      "asset": "USDC",
+      "address": "YOUR_WALLET_ADDRESS"
+    }
+  ],
+  "resources": [
+    {
+      "path": "/apify",
+      "price": "0.01",
+      "description": "Pay-per-call access to apify"
+    },
+    {
+      "path": "/server",
+      "price": "0.01",
+      "description": "Pay-per-call access to server"
+    },
+    {
+      "path": "/actors",
+      "price": "0.01",
+      "description": "Pay-per-call access to actors"
+    },
+    {
+      "path": "/model context protocol",
+      "price": "0.01",
+      "description": "Pay-per-call access to model context protocol"
+    }
+  ]
+}

--- a/x402-middleware-example.ts
+++ b/x402-middleware-example.ts
@@ -1,0 +1,25 @@
+// x402 payment middleware - add before your protected routes
+import { createPaymentMiddleware } from 'x402-express'; // or implement manually
+
+// Option A: use the x402-express package
+app.use('/api', createPaymentMiddleware({
+  walletAddress: process.env.X402_WALLET_ADDRESS,
+  network: 'eip155:8453', // Base mainnet
+  facilitatorUrl: 'https://facilitator.402.bot/verify',
+}));
+
+// Option B: manual (just check the payment header)
+app.use('/api', (req, res, next) => {
+  const payment = req.headers['x-payment'];
+  if (!payment) {
+    // Return 402 with payment requirements
+    res.status(402).json({
+      accepts: [{ network: 'eip155:8453', asset: 'USDC', address: process.env.X402_WALLET_ADDRESS }],
+      price: '0.01',
+    });
+    return;
+  }
+  // Verify payment with facilitator
+  // See: https://api.402.bot/mcp/setup
+  next();
+});


### PR DESCRIPTION
## What is this?

[x402](https://x402.org) is an open protocol that lets AI agents pay for API calls using the HTTP 402 status code. Instead of API keys and billing dashboards, agents pay per call in USDC on Base.

This PR adds the foundation for monetizing **apify/apify-mcp-server**'s API endpoints. We found 4 endpoints in your README that agents could pay to access.

## Why agents would pay for apify/apify-mcp-server

Each of these capabilities becomes a pay-per-call endpoint that AI agents discover and pay for automatically:

- **Access 8,000+ ready-made web scrapers and automation tools for AI agents** — agents pay per call instead of needing credentials or rate-limited free tiers
- **Extract structured data from social media, e-commerce, and search engines** — agents pay per call instead of needing credentials or rate-limited free tiers
- **Enable autonomous web research and RAG-ready content retrieval** — agents pay per call instead of needing credentials or rate-limited free tiers
- **Facilitate agentic payments for actor runs without manual API tokens** — agents pay per call instead of needing credentials or rate-limited free tiers
- **Automate complex workflows with schema-inferred structured output** — agents pay per call instead of needing credentials or rate-limited free tiers

With x402, every feature above is instantly monetizable. Agents on Claude, Cursor, and any MCP client can discover and pay for access via 402.bot.

## What's included

| File | Purpose |
|------|---------|
| `.well-known/x402.json` | Declares your endpoints, pricing, and wallet address - agents and routing networks use this for discovery |
| `x402-middleware-example.ts` | Drop-in middleware that returns `402` and verifies payments |

## How it works

```
Agent -> calls your API
     <- 402 Payment Required (price: $0.01, wallet, network)
Agent -> signs USDC payment on Base
     -> retries with x-payment header
     <- normal API response
```

Settlement is instant. No intermediary holds funds. Revenue goes directly to your wallet.

## What you'd earn

**~$600/mo** projected (4 endpoints x ~150 agent calls/mo x $0.01)

## To activate

1. Replace `YOUR_WALLET_ADDRESS` in `.well-known/x402.json` with your Base wallet
2. Add the middleware to your server (see `x402-middleware-example.ts`)
3. Deploy - your API is now discoverable by every agent on the [402.bot routing network](https://api.402.bot/v1/route)

Your endpoints will automatically appear in Claude, Cursor, and any MCP-compatible agent via the [402.bot MCP server](https://api.402.bot/mcp/setup).

## Live demo

**[See how apify/apify-mcp-server works on the x402 network ->](https://bafkreiaf5apnr3mxfg4sarrvu36qsflce6sdncu53j3e25fi7f7yy6waoe.ipfs.storacha.link/)**

## Links

- [402.bot](https://402.bot) - routing oracle and provider marketplace
- [llms.txt](https://402.bot/llms.txt) - machine-readable service catalog
- [MCP setup guide](https://api.402.bot/mcp/setup)
- [Provider registration](https://marketplace.402.bot/agents/submit)

---

*This PR was opened by [402.bot](https://402.bot). x402 is an open protocol - you keep 100% of revenue. We just route agents to providers. If this isn't relevant, feel free to close.*