### PR TITLE
fix: Review feedback for PR #556

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1024,34 +1024,36 @@ Please verify the tool name and ensure the tool is properly registered.`;
             if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === 'internal') {
                 const progressTracker = createProgressTracker(progressToken, extra.sendNotification, taskId, onStatusMessage);
 
-                log.info('Calling internal tool for task', { taskId, name: tool.name, mcpSessionId, input: redactSkyfirePayId(args) });
-                const res = await tool.call({
-                    args,
-                    extra,
-                    apifyMcpServer: this,
-                    mcpServer: this.server,
-                    apifyToken,
-                    userRentedActorIds,
-                    progressTracker,
-                    mcpSessionId,
-                }) as object;
+                try {
+                    log.info('Calling internal tool for task', { taskId, name: tool.name, mcpSessionId, input: redactSkyfirePayId(args) });
+                    const res = await tool.call({
+                        args,
+                        extra,
+                        apifyMcpServer: this,
+                        mcpServer: this.server,
+                        apifyToken,
+                        userRentedActorIds,
+                        progressTracker,
+                        mcpSessionId,
+                    }) as object;
 
-                if (progressTracker) {
-                    progressTracker.stop();
+                    // If the tool returned internalToolStatus, use it; otherwise infer from isError flag
+                    const { internalToolStatus, ...rest } = res as { internalToolStatus?: ToolStatus; isError?: boolean };
+                    if (internalToolStatus !== undefined) {
+                        toolStatus = internalToolStatus;
+                    } else if ('isError' in rest && rest.isError) {
+                        toolStatus = TOOL_STATUS.FAILED;
+                    } else {
+                        toolStatus = TOOL_STATUS.SUCCEEDED;
+                    }
+
+                    // Never expose internalToolStatus to MCP clients
+                    result = rest;
+                } finally {
+                    if (progressTracker) {
+                        progressTracker.stop();
+                    }
                 }
-
-                // If tool returned internalToolStatus, use it; otherwise infer from isError flag
-                const { internalToolStatus, ...rest } = res as { internalToolStatus?: ToolStatus; isError?: boolean };
-                if (internalToolStatus !== undefined) {
-                    toolStatus = internalToolStatus;
-                } else if ('isError' in rest && rest.isError) {
-                    toolStatus = TOOL_STATUS.FAILED;
-                } else {
-                    toolStatus = TOOL_STATUS.SUCCEEDED;
-                }
-
-                // Never expose internalToolStatus to MCP clients
-                result = rest;
             }
 
             // Handle actor tool execution in task mode

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2411,7 +2411,45 @@ export function createIntegrationTestsSuite(
             expect(resultReceived).toBe(true);
         });
 
-        // WARNING: This test can be flaky on streamable HTTP transport due to timing —
+        // Helper to verify statusMessage propagation in task mode.
+        // Reads the callToolStream, checks that tasks/get (via taskStatus events) and
+        // tasks/list both return statusMessage for the running task.
+        async function assertStatusMessagePropagated(
+            taskClient: Client,
+            stream: AsyncIterable<{ type: string; task?: { taskId: string; statusMessage?: string }; error?: Error }>,
+        ) {
+            let taskId: string | null = null;
+            let getTaskSawStatusMessage = false;
+            let listTasksSawStatusMessage = false;
+            for await (const message of stream) {
+                if (message.type === 'taskCreated') {
+                    taskId = message.task!.taskId;
+                } else if (message.type === 'taskStatus') {
+                    if (message.task?.statusMessage) {
+                        getTaskSawStatusMessage = true;
+
+                        // Verify tasks/list also includes statusMessage (one-time check)
+                        if (!listTasksSawStatusMessage && taskId) {
+                            const currentTaskId = taskId;
+                            const tasksList = await taskClient.experimental.tasks.listTasks();
+                            const ourTask = tasksList.tasks.find((t) => t.taskId === currentTaskId);
+                            if (ourTask?.statusMessage) {
+                                listTasksSawStatusMessage = true;
+                            }
+                        }
+                    }
+                } else if (message.type === 'error') {
+                    throw message.error;
+                }
+            }
+
+            // Stream taskStatus events (backed by tasks/get) must have included statusMessage
+            expect(getTaskSawStatusMessage).toBe(true);
+            // tasks/list must have also returned statusMessage
+            expect(listTasksSawStatusMessage).toBe(true);
+        }
+
+        // WARNING: These tests can be flaky on streamable HTTP transport due to timing —
         // the Actor may complete before the 5s progress polling interval fires a statusMessage.
         // See: https://github.com/apify/apify-mcp-server/issues/558
         it('should propagate statusMessage to tasks/get and tasks/list for internal tools in task mode', async () => {
@@ -2435,44 +2473,9 @@ export function createIntegrationTestsSuite(
                 },
             );
 
-            // The SDK's callToolStream internally polls tasks/get and yields taskStatus events.
-            // Each taskStatus event IS the result of a tasks/get call, so if statusMessage appears
-            // in the stream, it proves tasks/get returns it correctly.
-            // We separately verify tasks/list once we know statusMessage exists.
-            let taskId: string | null = null;
-            let getTaskSawStatusMessage = false;
-            let listTasksSawStatusMessage = false;
-            for await (const message of stream) {
-                if (message.type === 'taskCreated') {
-                    taskId = message.task.taskId;
-                } else if (message.type === 'taskStatus') {
-                    if (message.task.statusMessage) {
-                        getTaskSawStatusMessage = true;
-
-                        // Verify tasks/list also includes statusMessage (one-time check)
-                        if (!listTasksSawStatusMessage && taskId) {
-                            const currentTaskId = taskId;
-                            const tasksList = await client.experimental.tasks.listTasks();
-                            const ourTask = tasksList.tasks.find((t) => t.taskId === currentTaskId);
-                            if (ourTask?.statusMessage) {
-                                listTasksSawStatusMessage = true;
-                            }
-                        }
-                    }
-                } else if (message.type === 'error') {
-                    throw message.error;
-                }
-            }
-
-            // Stream taskStatus events (backed by tasks/get) must have included statusMessage
-            expect(getTaskSawStatusMessage).toBe(true);
-            // tasks/list must have also returned statusMessage
-            expect(listTasksSawStatusMessage).toBe(true);
+            await assertStatusMessagePropagated(client, stream);
         });
 
-        // WARNING: This test can be flaky on streamable HTTP transport due to timing —
-        // the Actor may complete before the 5s progress polling interval fires a statusMessage.
-        // See: https://github.com/apify/apify-mcp-server/issues/558
         it('should propagate statusMessage to tasks/get and tasks/list for actor tools in task mode', async () => {
             client = await createClientFn({ tools: [RAG_WEB_BROWSER] });
 
@@ -2491,32 +2494,7 @@ export function createIntegrationTestsSuite(
                 },
             );
 
-            let taskId: string | null = null;
-            let getTaskSawStatusMessage = false;
-            let listTasksSawStatusMessage = false;
-            for await (const message of stream) {
-                if (message.type === 'taskCreated') {
-                    taskId = message.task.taskId;
-                } else if (message.type === 'taskStatus') {
-                    if (message.task.statusMessage) {
-                        getTaskSawStatusMessage = true;
-
-                        if (!listTasksSawStatusMessage && taskId) {
-                            const currentTaskId = taskId;
-                            const tasksList = await client.experimental.tasks.listTasks();
-                            const ourTask = tasksList.tasks.find((t) => t.taskId === currentTaskId);
-                            if (ourTask?.statusMessage) {
-                                listTasksSawStatusMessage = true;
-                            }
-                        }
-                    }
-                } else if (message.type === 'error') {
-                    throw message.error;
-                }
-            }
-
-            expect(getTaskSawStatusMessage).toBe(true);
-            expect(listTasksSawStatusMessage).toBe(true);
+            await assertStatusMessagePropagated(client, stream);
         });
 
         it.runIf(options.transport === 'stdio')('should use UI_MODE env var when CLI arg is not provided', async () => {

--- a/tests/unit/utils.progress.test.ts
+++ b/tests/unit/utils.progress.test.ts
@@ -56,4 +56,31 @@ describe('ProgressTracker', () => {
         await expect(tracker.updateProgress('Test')).resolves.toBeUndefined();
         expect(mockSendNotification).toHaveBeenCalled();
     });
+
+    it('should call onStatusMessage with the progress message', async () => {
+        const mockOnStatusMessage = vi.fn();
+        const tracker = new ProgressTracker({ onStatusMessage: mockOnStatusMessage });
+
+        await tracker.updateProgress('Actor running');
+
+        expect(mockOnStatusMessage).toHaveBeenCalledWith('Actor running');
+    });
+
+    it('should not call onStatusMessage when message is undefined', async () => {
+        const mockOnStatusMessage = vi.fn();
+        const tracker = new ProgressTracker({ onStatusMessage: mockOnStatusMessage });
+
+        await tracker.updateProgress();
+
+        expect(mockOnStatusMessage).not.toHaveBeenCalled();
+    });
+
+    it('should handle onStatusMessage errors gracefully', async () => {
+        const mockOnStatusMessage = vi.fn().mockRejectedValue(new Error('Store error'));
+        const tracker = new ProgressTracker({ onStatusMessage: mockOnStatusMessage });
+
+        // Should not throw
+        await expect(tracker.updateProgress('Test')).resolves.toBeUndefined();
+        expect(mockOnStatusMessage).toHaveBeenCalledWith('Test');
+    });
 });


### PR DESCRIPTION
## Summary
Review feedback fixes for #556 (propagate task statusMessage):

- **Fix interval leak in internal tool branch**: Wrap `tool.call()` in `try/finally` to ensure `progressTracker.stop()` is always called, matching the actor tool branch. Without this, if `tool.call()` throws after `startActorRunUpdates`, the polling interval leaks and may set a failed task back to "working".
- **Deduplicate integration tests**: Extract `assertStatusMessagePropagated()` helper to share the stream-reading + tasks/list verification logic between the two statusMessage tests.
- **Add unit tests for `onStatusMessage`**: Verify the callback is called with the message, not called when message is undefined, and errors are handled gracefully.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (406 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)