### PR TITLE
fix: strip Zod-defaulted fields from required in tools/list response

### DIFF
--- a/src/utils/ajv.ts
+++ b/src/utils/ajv.ts
@@ -10,8 +10,9 @@ export const ajv = new Ajv({ coerceTypes: 'array', strict: false });
  * 2. Incorrectly marks fields with default values as required
  *
  * This function fixes both issues to ensure proper schema validation.
+ * Exported so MCP tool listings can apply the same fix via `fixZodInputSchemaRequired` (see `getToolPublicFieldOnly`).
  */
-function cleanJsonSchema(schema: Record<string, unknown>): Record<string, unknown> {
+export function fixZodSchemaRequired(schema: Record<string, unknown>): Record<string, unknown> {
     const cleaned = { ...schema };
     delete cleaned.$schema;
 
@@ -36,5 +37,5 @@ function cleanJsonSchema(schema: Record<string, unknown>): Record<string, unknow
  * This wrapper ensures compatibility with z.toJSONSchema() output.
  */
 export function compileSchema(schema: Record<string, unknown>): ValidateFunction {
-    return ajv.compile(cleanJsonSchema(schema));
+    return ajv.compile(fixZodSchemaRequired(schema));
 }

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -4,7 +4,8 @@ import {
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../const.js';
-import type { HelperTool, ServerMode, ToolBase, ToolEntry } from '../types.js';
+import type { HelperTool, ServerMode, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
+import { fixZodSchemaRequired } from './ajv.js';
 
 type ToolPublicFieldOptions = {
     mode?: ServerMode;
@@ -27,6 +28,15 @@ function stripWidgetMeta(meta?: ToolBase['_meta']) {
 }
 
 /**
+ * Zod 4's z.toJSONSchema() lists properties with `.default()` in `required`.
+ * Clients treat that as mandatory arguments; strip them before tools/list.
+ */
+function fixZodInputSchemaRequired(inputSchema: ToolBase['inputSchema']): ToolBase['inputSchema'] {
+    if (!inputSchema || typeof inputSchema !== 'object') return inputSchema;
+    return fixZodSchemaRequired({ ...inputSchema } as Record<string, unknown>) as ToolInputSchema;
+}
+
+/**
  * Returns a public version of the tool containing only fields that should be exposed publicly.
  * Used for the tools list request.
  */
@@ -40,7 +50,7 @@ export function getToolPublicFieldOnly(tool: ToolBase, options: ToolPublicFieldO
         name: tool.name,
         title: tool.title,
         description: tool.description,
-        inputSchema: tool.inputSchema,
+        inputSchema: fixZodInputSchemaRequired(tool.inputSchema),
         outputSchema: tool.outputSchema,
         annotations: tool.annotations,
         icons: tool.icons,

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
+import { searchApifyDocsTool } from '../../src/tools/common/search_apify_docs.js';
 import { CATEGORY_NAMES, getCategoryTools } from '../../src/tools/index.js';
 import type { ToolEntry } from '../../src/types.js';
 import { SERVER_MODES } from '../../src/types.js';
@@ -227,5 +228,17 @@ describe('getToolPublicFieldOnly _meta filtering', () => {
             mode: 'default',
         });
         expect(result._meta).toBeUndefined();
+    });
+});
+
+describe('getToolPublicFieldOnly inputSchema normalization', () => {
+    it('should not expose Zod-defaulted fields as JSON Schema required (search-apify-docs)', () => {
+        const { inputSchema } = getToolPublicFieldOnly(searchApifyDocsTool, { filterWidgetMeta: false });
+        const schema = inputSchema as { required?: string[]; properties?: Record<string, { default?: unknown }> };
+
+        expect(schema.required).toEqual(['query']);
+        expect(schema.properties?.docSource).toMatchObject({ default: 'apify' });
+        expect(schema.properties?.limit).toMatchObject({ default: 5 });
+        expect(schema.properties?.offset).toMatchObject({ default: 0 });
     });
 });


### PR DESCRIPTION
## Summary

- Zod 4's `z.toJSONSchema()` incorrectly marks fields with `.default()` as `required`, causing MCP clients to show optional parameters (e.g. `docSource`, `limit`, `offset` on `search-apify-docs`) as mandatory
- Reuses the existing `fixZodSchemaRequired` function (already applied during AJV validation) at the `getToolPublicFieldOnly` boundary so all `tools/list` responses are normalized

Before 
<img width="2768" height="1986" alt="image" src="https://github.com/user-attachments/assets/e9fb1217-5828-4525-bd01-d47d525cca6f" />


After
<img width="1910" height="708" alt="image" src="https://github.com/user-attachments/assets/46e0b549-7837-4202-bb74-7cd5fb59cd73" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)