### PR TITLE
feat: Async call-actor with uniform response + waitSecs on get-actor-run

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -7,6 +7,18 @@ export const ACTOR_MAX_DESCRIPTION_LENGTH = 500;
 // Actor run const
 export const ACTOR_MAX_MEMORY_MBYTES = 4_096; // If the Actor requires 8GB of memory, free users can't run actors-mcp-server and requested Actor
 
+/** Apify Actor run status values, mirroring ACTOR_JOB_STATUSES from @apify/consts. */
+export const ACTOR_RUN_STATUS = {
+    READY: 'READY',
+    RUNNING: 'RUNNING',
+    SUCCEEDED: 'SUCCEEDED',
+    FAILED: 'FAILED',
+    TIMING_OUT: 'TIMING-OUT',
+    TIMED_OUT: 'TIMED-OUT',
+    ABORTING: 'ABORTING',
+    ABORTED: 'ABORTED',
+} as const;
+
 // Tool output
 /**
  * Usual tool output limit is 25k tokens where 1 token =~ 4 characters

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1035,6 +1035,7 @@ Please verify the tool name and ensure the tool is properly registered.`;
                         userRentedActorIds,
                         progressTracker,
                         mcpSessionId,
+                        mcpTaskExecution: true,
                     }) as object;
 
                     // If the tool returned internalToolStatus, use it; otherwise infer from isError flag

--- a/src/tools/core/actor_execution.ts
+++ b/src/tools/core/actor_execution.ts
@@ -6,10 +6,11 @@ import type { ApifyClient } from '../../apify_client.js';
 import { TOOL_MAX_OUTPUT_CHARS } from '../../const.js';
 import type { ActorDefinitionStorage, DatasetItem } from '../../types.js';
 import { ensureOutputWithinCharLimit, getActorDefinitionStorageFieldNames } from '../../utils/actor.js';
-import { logHttpError, redactSkyfirePayId } from '../../utils/logging.js';
+import { redactSkyfirePayId } from '../../utils/logging.js';
 import type { ProgressTracker } from '../../utils/progress.js';
 import type { JsonSchemaProperty } from '../../utils/schema_generation.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
+import { waitForRunWithAbort } from './call_actor_common.js';
 
 // Define a named return type for callActorGetDataset
 export type CallActorGetDatasetResult = {
@@ -56,7 +57,6 @@ export async function callActorGetDataset(options: {
         previewOutput = true,
         mcpSessionId,
     } = options;
-    const CLIENT_ABORT = Symbol('CLIENT_ABORT'); // Just an internal symbol to identify client abort
     const actorClient = apifyClient.actor(actorName);
 
     // Start the actor run
@@ -67,31 +67,17 @@ export async function callActorGetDataset(options: {
         progressTracker.startActorRunUpdates(actorRun.id, apifyClient, actorName);
     }
 
-    // Create abort promise that handles both API abort and race rejection
-    const abortPromise = async () => new Promise<typeof CLIENT_ABORT>((resolve) => {
-        abortSignal?.addEventListener('abort', async () => {
-            // Abort the actor run via API
-            try {
-                await apifyClient.run(actorRun.id).abort({ gracefully: false });
-            } catch (e) {
-                logHttpError(e, 'Error aborting Actor run', { runId: actorRun.id });
-            }
-            // Reject to stop waiting
-            resolve(CLIENT_ABORT);
-        }, { once: true });
+    // Wait for completion or cancellation
+    const completedRun = await waitForRunWithAbort({
+        runId: actorRun.id,
+        apifyClient,
+        abortSignal,
     });
 
-    // Wait for completion or cancellation
-    const potentialAbortedRun = await Promise.race([
-        apifyClient.run(actorRun.id).waitForFinish(),
-        ...(abortSignal ? [abortPromise()] : []),
-    ]);
-
-    if (potentialAbortedRun === CLIENT_ABORT) {
+    if (!completedRun) {
         log.info('Actor run aborted by client', { actorName, mcpSessionId, input: redactSkyfirePayId(input) });
         return null;
     }
-    const completedRun = potentialAbortedRun as ActorRun;
 
     // Process the completed run
     const dataset = apifyClient.dataset(completedRun.defaultDatasetId);

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -1,8 +1,10 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { ActorRun } from 'apify-client';
 import { z } from 'zod';
 
 import { ApifyClient, createApifyClientWithSkyfireSupport } from '../../apify_client.js';
 import {
+    ACTOR_RUN_STATUS,
     CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG,
     HelperTools,
     TOOL_STATUS,
@@ -50,12 +52,6 @@ export const callActorArgs = z.object({
 For MCP server Actors, use format "actorName:toolName" to call a specific tool (e.g., "apify/actors-mcp-server:fetch-apify-docs").`),
     input: z.object({}).passthrough()
         .describe('The input JSON to pass to the Actor. Required.'),
-    async: z.boolean()
-        .optional()
-        .describe(`When true, starts the run and returns immediately with runId. When false or omitted, behavior depends on the active server mode/tool variant. IMPORTANT: use async=true only when the user explicitly asks to run in the background or does not need immediate results.`),
-    previewOutput: z.boolean()
-        .optional()
-        .describe('When true (default): includes preview items. When false: metadata only (reduces context). Use when fetching fields via get-actor-output.'),
     callOptions: z.object({
         memory: z.number()
             .min(128, 'Memory must be at least 128 MB')
@@ -295,4 +291,55 @@ export async function callActorPreExecute(toolArgs: InternalToolArgs): Promise<
     }
 
     return { parsed, baseActorName, mcpToolName };
+}
+
+/**
+ * Returns a contextual hint string for the LLM based on the Actor run status.
+ */
+export function getRunStatusHint(status: string): string {
+    switch (status) {
+        case ACTOR_RUN_STATUS.READY:
+        case ACTOR_RUN_STATUS.RUNNING:
+            return `Use \`${HelperTools.ACTOR_RUNS_GET}\` to wait for the Actor run to finish.`;
+        case ACTOR_RUN_STATUS.SUCCEEDED:
+            return `Use \`${HelperTools.ACTOR_OUTPUT_GET}\` with the \`datasetId\` from storages to retrieve results.`;
+        case ACTOR_RUN_STATUS.FAILED:
+        case ACTOR_RUN_STATUS.ABORTED:
+        case ACTOR_RUN_STATUS.TIMED_OUT:
+            return `Actor run failed. Use \`${HelperTools.ACTOR_RUNS_LOG}\` to inspect errors.`;
+        default:
+            return `Use \`${HelperTools.ACTOR_RUNS_GET}\` to check the Actor run status.`;
+    }
+}
+
+/**
+ * Builds the uniform structured content returned by both call-actor and get-actor-run.
+ */
+export function buildActorRunStructuredContent(params: {
+    run: ActorRun;
+    actorName: string;
+}): {
+    runId: string;
+    actorName: string;
+    status: string;
+    startedAt: string;
+    finishedAt?: string;
+    stats?: unknown;
+    storages: { defaultDatasetId: string; defaultKeyValueStoreId: string };
+    hint: string;
+} {
+    const { run, actorName } = params;
+    return {
+        runId: run.id,
+        actorName,
+        status: run.status,
+        startedAt: run.startedAt?.toISOString() || '',
+        ...(run.finishedAt ? { finishedAt: run.finishedAt.toISOString() } : {}),
+        ...(run.stats ? { stats: run.stats } : {}),
+        storages: {
+            defaultDatasetId: run.defaultDatasetId,
+            defaultKeyValueStoreId: run.defaultKeyValueStoreId,
+        },
+        hint: getRunStatusHint(run.status),
+    };
 }

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -2,6 +2,7 @@ import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { ActorRun } from 'apify-client';
 import { z } from 'zod';
 
+import type { ApifyClient as ApifyClientType } from '../../apify_client.js';
 import { ApifyClient, createApifyClientWithSkyfireSupport } from '../../apify_client.js';
 import {
     ACTOR_RUN_STATUS,
@@ -291,6 +292,39 @@ export async function callActorPreExecute(toolArgs: InternalToolArgs): Promise<
     }
 
     return { parsed, baseActorName, mcpToolName };
+}
+
+/**
+ * Waits for an Actor run to finish, racing against an optional abort signal.
+ * On abort, the Actor run is aborted via the API.
+ * Returns the completed ActorRun, or `null` if the run was aborted by the client.
+ */
+export async function waitForRunWithAbort(params: {
+    runId: string;
+    apifyClient: ApifyClientType;
+    abortSignal?: AbortSignal;
+}): Promise<ActorRun | null> {
+    const { runId, apifyClient, abortSignal } = params;
+    const CLIENT_ABORT = Symbol('CLIENT_ABORT');
+
+    const abortPromise = new Promise<typeof CLIENT_ABORT>((resolve) => {
+        abortSignal?.addEventListener('abort', () => {
+            apifyClient.run(runId).abort({ gracefully: false }).catch((e) => {
+                logHttpError(e, 'Error aborting Actor run', { runId });
+            });
+            resolve(CLIENT_ABORT);
+        }, { once: true });
+    });
+
+    const result = await Promise.race([
+        apifyClient.run(runId).waitForFinish(),
+        ...(abortSignal ? [abortPromise] : []),
+    ]);
+
+    if (result === CLIENT_ABORT) {
+        return null;
+    }
+    return result as ActorRun;
 }
 
 /**

--- a/src/tools/core/get_actor_run_common.ts
+++ b/src/tools/core/get_actor_run_common.ts
@@ -8,8 +8,8 @@ import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { HelperTool, ToolInputSchema } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
-import { generateSchemaFromItems } from '../../utils/schema_generation.js';
-import { getActorRunOutputSchema } from '../structured_output_schemas.js';
+import { actorRunOutputSchema } from '../structured_output_schemas.js';
+import { getRunStatusHint } from './call_actor_common.js';
 
 /**
  * Zod schema for get-actor-run arguments — shared between default and openai variants.
@@ -18,17 +18,28 @@ export const getActorRunArgs = z.object({
     runId: z.string()
         .min(1)
         .describe('The ID of the Actor run.'),
+    waitSecs: z.number()
+        .int()
+        .min(0)
+        .max(60)
+        .default(10)
+        .describe(
+            'Maximum seconds to wait for the Actor run to finish (default 10, max 60).'
+            + ' The server polls the run at short intervals and returns immediately when a terminal state is reached.',
+        ),
 });
 
 const GET_ACTOR_RUN_DESCRIPTION = `Get detailed information about a specific Actor run by runId.
-The results will include run metadata (status, timestamps), performance stats, and resource IDs (datasetId, keyValueStoreId, requestQueueId).
+The results will include run metadata (status, timestamps), performance stats, and storage IDs (datasetId, keyValueStoreId).
+
+Supports bounded waiting via the \`waitSecs\` parameter (default: 10s, max: 60s). The server polls the run and returns as soon as a terminal state is reached or the wait time expires.
 
 CRITICAL WARNING: NEVER call this tool immediately after call-actor in UI mode. The call-actor response includes a widget that automatically polls for updates. Calling this tool after call-actor is FORBIDDEN and unnecessary.
 
 USAGE:
-- Use ONLY when user explicitly asks about a specific run's status or details.
-- Use ONLY for runs that were started outside the current conversation.
-- DO NOT use this tool as part of the call-actor workflow in UI mode.
+- Use to wait for an Actor run to finish after calling call-actor.
+- Use when user explicitly asks about a specific run's status or details.
+- Pass \`waitSecs: 0\` for an instant status check without waiting.
 
 USAGE EXAMPLES:
 - user_input: Show details of run y2h7sK3Wc (where y2h7sK3Wc is an existing run)
@@ -43,7 +54,7 @@ export const getActorRunMetadata: Omit<HelperTool, 'call'> = {
     name: HelperTools.ACTOR_RUNS_GET,
     description: GET_ACTOR_RUN_DESCRIPTION,
     inputSchema: z.toJSONSchema(getActorRunArgs) as ToolInputSchema,
-    outputSchema: getActorRunOutputSchema,
+    outputSchema: actorRunOutputSchema,
     ajvValidate: compileSchema({ ...z.toJSONSchema(getActorRunArgs), additionalProperties: true }),
     requiresSkyfirePayId: true,
     // openai/* and ui keys are stripped in non-openai mode by stripWidgetMeta() in src/utils/tools.ts
@@ -69,13 +80,11 @@ export type ActorRunStructuredContent = {
     startedAt: string;
     finishedAt?: string;
     stats?: unknown;
-    dataset?: {
-        datasetId: string;
-        totalItemCount: number;
-        previewItemCount: number;
-        schema: unknown;
-        previewItems: unknown[];
+    storages: {
+        defaultDatasetId: string;
+        defaultKeyValueStoreId: string;
     };
+    hint: string;
 };
 
 /**
@@ -87,19 +96,21 @@ export type FetchActorRunResult = {
 };
 
 /**
- * Fetches actor run data, resolves actor name, and fetches dataset results if completed.
- * Shared data-fetching logic used by both default and openai variants.
- *
+ * Fetches actor run data with optional bounded waiting, resolves actor name.
  * Returns the run data and structured content, or an early error response.
  */
 export async function fetchActorRunData(params: {
     runId: string;
     client: ApifyClient;
+    waitSecs?: number;
     mcpSessionId?: string;
 }): Promise<{ error: object } | { result: FetchActorRunResult }> {
-    const { runId, client, mcpSessionId } = params;
+    const { runId, client, waitSecs = 10, mcpSessionId } = params;
 
-    const run = await client.run(runId).get();
+    // waitSecs: 0 means instant check; otherwise use waitForFinish with bounded wait
+    const run = waitSecs === 0
+        ? await client.run(runId).get()
+        : await client.run(runId).waitForFinish({ waitSecs });
 
     if (!run) {
         return {
@@ -130,28 +141,14 @@ export async function fetchActorRunData(params: {
         actorName,
         status: run.status,
         startedAt: run.startedAt?.toISOString() || '',
-        finishedAt: run.finishedAt?.toISOString(),
-        stats: run.stats,
+        ...(run.finishedAt ? { finishedAt: run.finishedAt.toISOString() } : {}),
+        ...(run.stats ? { stats: run.stats } : {}),
+        storages: {
+            defaultDatasetId: run.defaultDatasetId,
+            defaultKeyValueStoreId: run.defaultKeyValueStoreId,
+        },
+        hint: getRunStatusHint(run.status),
     };
-
-    // If completed, fetch dataset results
-    if (run.status === 'SUCCEEDED' && run.defaultDatasetId) {
-        const dataset = client.dataset(run.defaultDatasetId);
-        const datasetItems = await dataset.listItems({ limit: 5 });
-
-        const generatedSchema = generateSchemaFromItems(datasetItems.items, {
-            clean: true,
-            arrayMode: 'all',
-        });
-
-        structuredContent.dataset = {
-            datasetId: run.defaultDatasetId,
-            totalItemCount: datasetItems.total,
-            previewItemCount: datasetItems.items.length,
-            schema: generatedSchema || { type: 'object', properties: {} },
-            previewItems: datasetItems.items,
-        };
-    }
 
     return { result: { run: run as unknown as Record<string, unknown>, structuredContent } };
 }

--- a/src/tools/default/call_actor.ts
+++ b/src/tools/default/call_actor.ts
@@ -6,9 +6,8 @@ import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse, buildUsageMeta } from '../../utils/mcp.js';
-import { callActorGetDataset } from '../core/actor_execution.js';
-import { buildActorResponseContent } from '../core/actor_response.js';
 import {
+    buildActorRunStructuredContent,
     CALL_ACTOR_EXAMPLES_SECTION,
     CALL_ACTOR_MCP_SERVER_SECTION,
     CALL_ACTOR_USAGE_SECTION,
@@ -16,8 +15,9 @@ import {
     callActorInputSchema,
     callActorPreExecute,
     resolveAndValidateActor,
+    waitForRunWithAbort,
 } from '../core/call_actor_common.js';
-import { callActorOutputSchema } from '../structured_output_schemas.js';
+import { actorRunOutputSchema } from '../structured_output_schemas.js';
 
 const CALL_ACTOR_DEFAULT_DESCRIPTION = [
     `Call any Actor from the Apify Store.`,
@@ -31,30 +31,27 @@ If the actor name is not in "username/name" format, use ${HelperTools.STORE_SEAR
     CALL_ACTOR_MCP_SERVER_SECTION,
 
     `IMPORTANT:
-- Typically returns a datasetId and preview of output items
-- Use ${HelperTools.ACTOR_OUTPUT_GET} tool with the datasetId to fetch full results
+- This tool starts the Actor and returns immediately with run metadata (runId, status, storages).
+- Use ${HelperTools.ACTOR_RUNS_GET} to wait for the Actor run to finish (supports waitSecs for bounded waiting).
+- Once completed, use ${HelperTools.ACTOR_OUTPUT_GET} tool with the datasetId from storages to fetch full results.
 - Use dedicated Actor tools when available for better experience`,
 
     CALL_ACTOR_USAGE_SECTION,
-
-    `- This tool supports async execution via the \`async\` parameter:
-  - **When \`async: false\` or not provided** (default): Waits for completion and returns results immediately with dataset preview. Use this whenever the user asks for data or results.
-  - **When \`async: true\`**: Starts the run and returns immediately with runId. Only use this when the user explicitly asks to run the Actor in the background or does not need immediate results.`,
 
     CALL_ACTOR_EXAMPLES_SECTION,
 ].join('\n\n');
 
 /**
  * Default mode call-actor tool.
- * Supports both sync (default) and async execution.
- * Does not include widget metadata in responses.
+ * Always starts the Actor and returns immediately with run metadata.
+ * In MCP task mode (mcpTaskExecution), waits for completion before returning.
  */
 export const defaultCallActor: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.ACTOR_CALL,
     description: CALL_ACTOR_DEFAULT_DESCRIPTION,
     inputSchema: callActorInputSchema,
-    outputSchema: callActorOutputSchema,
+    outputSchema: actorRunOutputSchema,
     ajvValidate: callActorAjvValidate,
     requiresSkyfirePayId: true,
     // openai/* and ui keys are stripped in non-openai mode by stripWidgetMeta() in src/utils/tools.ts
@@ -79,7 +76,7 @@ export const defaultCallActor: ToolEntry = Object.freeze({
         }
 
         const { parsed, baseActorName } = preResult;
-        const { input, async: isAsync = false, previewOutput = true, callOptions } = parsed;
+        const { input, callOptions } = parsed;
 
         try {
             const resolution = await resolveAndValidateActor({
@@ -93,58 +90,52 @@ export const defaultCallActor: ToolEntry = Object.freeze({
 
             const apifyClient = createApifyClientWithSkyfireSupport(toolArgs.apifyMcpServer, toolArgs.args, toolArgs.apifyToken);
 
-            // Async mode: start run and return immediately with runId
-            if (isAsync) {
-                const actorClient = apifyClient.actor(baseActorName);
-                const actorRun = await actorClient.start(input, callOptions);
+            // Start the Actor run
+            const actorRun = await apifyClient.actor(baseActorName).start(input, callOptions);
 
-                log.debug('Started Actor run (async)', { actorName: baseActorName, runId: actorRun.id, mcpSessionId: toolArgs.mcpSessionId });
+            log.debug('Started Actor run', { actorName: baseActorName, runId: actorRun.id, mcpSessionId: toolArgs.mcpSessionId });
 
-                const structuredContent = {
+            // In task mode, wait for the run to finish before returning.
+            // The MCP task framework keeps the task "working" while this promise is pending.
+            if (toolArgs.mcpTaskExecution) {
+                if (toolArgs.progressTracker) {
+                    toolArgs.progressTracker.startActorRunUpdates(actorRun.id, apifyClient, baseActorName);
+                }
+
+                const completedRun = await waitForRunWithAbort({
                     runId: actorRun.id,
-                    actorName: baseActorName,
-                    status: actorRun.status,
-                    startedAt: actorRun.startedAt?.toISOString() || '',
-                    input,
-                };
+                    apifyClient,
+                    abortSignal: toolArgs.extra.signal,
+                });
 
+                if (!completedRun) {
+                    log.info('Actor run aborted by client', { actorName: baseActorName, mcpSessionId: toolArgs.mcpSessionId });
+                    return {};
+                }
+
+                const structuredContent = buildActorRunStructuredContent({ run: completedRun, actorName: baseActorName });
+                const _meta = buildUsageMeta(completedRun);
                 return {
                     content: [{
                         type: 'text',
-                        text: `Started Actor "${baseActorName}" (Run ID: ${actorRun.id}).`,
+                        text: `Actor "${baseActorName}" run ${completedRun.id} finished with status: ${completedRun.status}. ${structuredContent.hint}`,
                     }],
                     structuredContent,
+                    ...(_meta && { _meta }),
                 };
             }
 
-            // Sync mode: wait for completion and return results
-            const callResult = await callActorGetDataset({
-                actorName: baseActorName,
-                input,
-                apifyClient,
-                callOptions,
-                progressTracker: toolArgs.progressTracker,
-                abortSignal: toolArgs.extra.signal,
-                previewOutput,
-                mcpSessionId: toolArgs.mcpSessionId,
-            });
-
-            if (!callResult) {
-                // Receivers of cancellation notifications SHOULD NOT send a response for the cancelled request
-                // https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/cancellation#behavior-requirements
-                return {};
-            }
-
-            const { content, structuredContent } = buildActorResponseContent(baseActorName, callResult, previewOutput);
-            const _meta = buildUsageMeta(callResult);
+            // Non-task mode: return immediately with run metadata
+            const structuredContent = buildActorRunStructuredContent({ run: actorRun, actorName: baseActorName });
             return {
-                content,
+                content: [{
+                    type: 'text',
+                    text: `Started Actor "${baseActorName}" (Run ID: ${actorRun.id}). ${structuredContent.hint}`,
+                }],
                 structuredContent,
-                ...(_meta && { _meta }),
             };
         } catch (error) {
-            logHttpError(error, 'Failed to call Actor', { actorName: baseActorName, async: isAsync });
-            // Let the server classify the error; we only mark it as an MCP error response
+            logHttpError(error, 'Failed to call Actor', { actorName: baseActorName });
             return buildMCPResponse({
                 texts: [`Failed to call Actor '${baseActorName}': ${error instanceof Error ? error.message : String(error)}.
 Please verify the Actor name, input parameters, and ensure the Actor exists.

--- a/src/tools/default/get_actor_run.ts
+++ b/src/tools/default/get_actor_run.ts
@@ -12,6 +12,7 @@ import {
 /**
  * Default mode get-actor-run tool.
  * Returns full JSON dump of the run without widget metadata.
+ * Supports bounded waiting via waitSecs parameter.
  */
 export const defaultGetActorRun: ToolEntry = Object.freeze({
     ...getActorRunMetadata,
@@ -25,6 +26,7 @@ export const defaultGetActorRun: ToolEntry = Object.freeze({
             const fetchResult = await fetchActorRunData({
                 runId: parsed.runId,
                 client,
+                waitSecs: parsed.waitSecs,
                 mcpSessionId,
             });
 

--- a/src/tools/openai/call_actor.ts
+++ b/src/tools/openai/call_actor.ts
@@ -7,6 +7,7 @@ import type { InternalToolArgs, ToolEntry } from '../../types.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import {
+    buildActorRunStructuredContent,
     CALL_ACTOR_EXAMPLES_SECTION,
     CALL_ACTOR_MCP_SERVER_SECTION,
     CALL_ACTOR_USAGE_SECTION,
@@ -15,7 +16,7 @@ import {
     callActorPreExecute,
     resolveAndValidateActor,
 } from '../core/call_actor_common.js';
-import { callActorOutputSchema } from '../structured_output_schemas.js';
+import { actorRunOutputSchema } from '../structured_output_schemas.js';
 
 const CALL_ACTOR_OPENAI_DESCRIPTION = [
     `Call any Actor from the Apify Store.`,
@@ -32,7 +33,7 @@ Do NOT use ${HelperTools.STORE_SEARCH} for name resolution when the next step is
     `IMPORTANT:
 - This tool always runs asynchronously — it starts the Actor and returns immediately with a runId. A live widget automatically tracks the run progress.
 - After calling this tool, do NOT poll or call any other tool. Wait for the user to respond — the widget will update them when the run completes.
-- Once the run completes, use ${HelperTools.ACTOR_OUTPUT_GET} tool with the datasetId to fetch full results.
+- Once the run completes, use ${HelperTools.ACTOR_OUTPUT_GET} tool with the datasetId from storages to fetch full results.
 - Use dedicated Actor tools when available for better experience`,
 
     CALL_ACTOR_USAGE_SECTION,
@@ -50,7 +51,7 @@ export const openaiCallActor: ToolEntry = Object.freeze({
     name: HelperTools.ACTOR_CALL,
     description: CALL_ACTOR_OPENAI_DESCRIPTION,
     inputSchema: callActorInputSchema,
-    outputSchema: callActorOutputSchema,
+    outputSchema: actorRunOutputSchema,
     ajvValidate: callActorAjvValidate,
     requiresSkyfirePayId: true,
     // openai-only tool; openai/* and ui keys also stripped in non-openai mode by stripWidgetMeta() in src/utils/tools.ts
@@ -86,33 +87,23 @@ export const openaiCallActor: ToolEntry = Object.freeze({
             const apifyClient = createApifyClientWithSkyfireSupport(toolArgs.apifyMcpServer, toolArgs.args, toolArgs.apifyToken);
 
             // OpenAI mode always runs asynchronously
-            const actorClient = apifyClient.actor(baseActorName);
-            const actorRun = await actorClient.start(input, callOptions);
+            const actorRun = await apifyClient.actor(baseActorName).start(input, callOptions);
 
             log.debug('Started Actor run (async)', { actorName: baseActorName, runId: actorRun.id, mcpSessionId: toolArgs.mcpSessionId });
 
-            const structuredContent = {
-                runId: actorRun.id,
-                actorName: baseActorName,
-                status: actorRun.status,
-                startedAt: actorRun.startedAt?.toISOString() || '',
-                input,
-            };
+            const structuredContent = buildActorRunStructuredContent({ run: actorRun, actorName: baseActorName });
 
             const responseText = `Started Actor "${baseActorName}" (Run ID: ${actorRun.id}).
 
 A live progress widget has been rendered that automatically tracks this run and refreshes status every few seconds until completion.
 
-The widget will update the context with run status and datasetId when the run completes. Once complete (or if the user requests results), use ${HelperTools.ACTOR_OUTPUT_GET} with the datasetId to retrieve the output.
+The widget will update the context with run status and datasetId when the run completes. Once complete (or if the user requests results), use ${HelperTools.ACTOR_OUTPUT_GET} with the datasetId from storages to retrieve the output.
 
 Do NOT proactively poll using ${HelperTools.ACTOR_RUNS_GET}. Wait for the widget state update or user instructions. Ask the user what they would like to do next.`;
 
             const widgetConfig = getWidgetConfig(WIDGET_URIS.ACTOR_RUN);
             return {
-                content: [{
-                    type: 'text',
-                    text: responseText,
-                }],
+                content: [{ type: 'text', text: responseText }],
                 structuredContent,
                 // Response-level meta; only returned in openai mode (this handler is openai-only)
                 _meta: {

--- a/src/tools/openai/get_actor_run.ts
+++ b/src/tools/openai/get_actor_run.ts
@@ -13,6 +13,7 @@ import {
 /**
  * OpenAI mode get-actor-run tool.
  * Returns abbreviated text with widget metadata for interactive progress display.
+ * Supports bounded waiting via waitSecs parameter.
  */
 export const openaiGetActorRun: ToolEntry = Object.freeze({
     ...getActorRunMetadata,
@@ -26,6 +27,7 @@ export const openaiGetActorRun: ToolEntry = Object.freeze({
             const fetchResult = await fetchActorRunData({
                 runId: parsed.runId,
                 client,
+                waitSecs: parsed.waitSecs,
                 mcpSessionId,
             });
 
@@ -35,9 +37,9 @@ export const openaiGetActorRun: ToolEntry = Object.freeze({
 
             const { run, structuredContent } = fetchResult.result;
 
-            const statusText = run.status === 'SUCCEEDED' && structuredContent.dataset
-                ? `Actor run ${parsed.runId} completed successfully with ${structuredContent.dataset.totalItemCount} items. A widget has been rendered with the details.`
-                : `Actor run ${parsed.runId} status: ${run.status as string}. A progress widget has been rendered.`;
+            const statusText = run.status === 'SUCCEEDED'
+                ? `Actor run ${parsed.runId} completed successfully. ${structuredContent.hint} A widget has been rendered with the details.`
+                : `Actor run ${parsed.runId} status: ${run.status as string}. ${structuredContent.hint} A progress widget has been rendered.`;
 
             const widgetConfig = getWidgetConfig(WIDGET_URIS.ACTOR_RUN);
             const usageMeta = buildUsageMeta(run);

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -239,39 +239,34 @@ export const callActorOutputSchema = {
 };
 
 /**
- * Schema for get-actor-run tool output.
- * Contains full run information including status, timestamps, stats, and dataset preview.
+ * Shared schema for call-actor (non-blocking) and get-actor-run responses.
+ * Contains Actor run metadata, storage IDs, and a contextual hint.
+ * Used as outputSchema for both tools.
  */
-export const getActorRunOutputSchema = {
+export const actorRunOutputSchema = {
     type: 'object' as const,
     properties: {
         runId: { type: 'string', description: 'Actor run ID' },
         actorName: { type: 'string', description: 'Name of the Actor' },
-        status: { type: 'string', description: 'Run status (READY, RUNNING, SUCCEEDED, FAILED, ABORTING, ABORTED, TIMED-OUT)' },
+        status: { type: 'string', description: 'Run status (READY, RUNNING, SUCCEEDED, FAILED, ABORTING, ABORTED, TIMING-OUT, TIMED-OUT)' },
         startedAt: { type: 'string', description: 'ISO timestamp when the run started' },
         finishedAt: { type: 'string', description: 'ISO timestamp when the run finished (only for completed runs)' },
         stats: {
             type: 'object' as const,
             description: 'Run statistics (compute units, memory, duration, etc.)',
         },
-        dataset: {
+        storages: {
             type: 'object' as const,
-            description: 'Dataset information (only for completed runs with results)',
+            description: 'Storage IDs associated with the Actor run',
             properties: {
-                datasetId: { type: 'string', description: 'Default dataset ID' },
-                totalItemCount: { type: 'number', description: 'Total number of items in dataset' },
-                previewItemCount: { type: 'number', description: 'Number of preview items returned' },
-                schema: { type: 'object' as const, description: 'Auto-generated JSON schema from dataset items' },
-                previewItems: {
-                    type: 'array' as const,
-                    items: { type: 'object' as const },
-                    description: 'Preview of first 5 dataset items',
-                },
+                defaultDatasetId: { type: 'string', description: 'Default dataset ID for the run' },
+                defaultKeyValueStoreId: { type: 'string', description: 'Default key-value store ID for the run' },
             },
-            required: ['datasetId', 'totalItemCount', 'previewItemCount', 'schema', 'previewItems'],
+            required: ['defaultDatasetId', 'defaultKeyValueStoreId'],
         },
+        hint: { type: 'string', description: 'Contextual hint for next steps based on run status' },
     },
-    required: ['runId', 'status', 'startedAt'],
+    required: ['runId', 'actorName', 'status', 'startedAt', 'storages', 'hint'],
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,9 @@ export type InternalToolArgs = {
     progressTracker?: ProgressTracker | null;
     /** MCP session ID for logging context */
     mcpSessionId?: string;
+    /** When true, indicates the tool is executing inside an MCP task (long-running).
+     *  call-actor uses this to wait for the Actor run to finish before returning. */
+    mcpTaskExecution?: boolean;
 };
 
 /**

--- a/src/utils/server-instructions/common.ts
+++ b/src/utils/server-instructions/common.ts
@@ -51,9 +51,9 @@ ${input.workflowRules}## Tool dependencies and disambiguation
   - ${input.schemaToolHint}
   - Then call with proper input to execute the Actor
   - For MCP server Actors, use format "actorName:toolName" to call specific tools
-  - Supports async execution via the \`async\` parameter:
-  - When \`async: false\` or not provided (default when UI mode is disabled): Waits for completion and returns results immediately.
-  - When \`async: true\` (enforced when UI mode is enabled): Starts the run and returns immediately with runId. The widget automatically displays and polls for updates - no further action needed.
+  - Always starts the Actor and returns immediately with run metadata (runId, status, storages).
+  - Use \`${HelperTools.ACTOR_RUNS_GET}\` with \`waitSecs\` to wait for the run to finish.
+  - Once completed, use \`${HelperTools.ACTOR_OUTPUT_GET}\` with the datasetId from storages to retrieve results.
 
 ### Tool disambiguation
 - **${HelperTools.ACTOR_OUTPUT_GET} vs ${HelperTools.DATASET_GET_ITEMS}:**

--- a/src/web/src/pages/ActorRun/ActorRun.tsx
+++ b/src/web/src/pages/ActorRun/ActorRun.tsx
@@ -9,6 +9,16 @@ import { formatDuration, formatTimestamp, humanizeActorName } from "../../utils/
 import { extractActorRunErrorMessage } from "../../utils/actor-run";
 import { TableSkeleton } from "./ActorRun.skeleton";
 
+// TODO: Define shared types for the tool response shape (text mode vs UI mode).
+// Text mode returns `actorRunOutputSchema` (storages, hint); UI mode may include widget-specific fields.
+// Both modes should share a single source of truth for the structured content shape.
+
+interface DatasetOutput {
+    datasetId: string;
+    totalItemCount: number;
+    items: Record<string, any>[];
+}
+
 interface ActorRunData {
     runId: string;
     actorName: string;
@@ -20,26 +30,30 @@ interface ActorRunData {
     duration: string;
     startedAt: string;
     finishedAt?: string;
+    datasetId?: string;
     stats?: {
         computeUnits?: number;
         memoryAvgBytes?: number;
         memoryMaxBytes?: number;
     };
-    dataset?: {
-        datasetId: string;
-        totalItemCount: number;
-        previewItems: Record<string, any>[];
-    };
 }
 
+/**
+ * Shape of the structured content returned by call-actor and get-actor-run tools.
+ * Matches `actorRunOutputSchema` from the server.
+ */
 interface ToolOutput extends Record<string, unknown> {
     runId?: string;
-    actorName?: string; // Full actor name with username (e.g., "apify/rag-web-browser")
+    actorName?: string;
     status?: string;
     startedAt?: string;
     finishedAt?: string;
     stats?: any;
-    dataset?: any;
+    storages?: {
+        defaultDatasetId?: string;
+        defaultKeyValueStoreId?: string;
+    };
+    hint?: string;
 }
 
 
@@ -297,8 +311,8 @@ function toolOutputToRunData(
         timestamp: formatTimestamp(startedAt),
         duration,
         cost: usageTotalUsd,
+        datasetId: toolOutput.storages?.defaultDatasetId,
         stats: toolOutput.stats,
-        dataset: toolOutput.dataset,
     };
 }
 
@@ -311,6 +325,7 @@ export const ActorRun: React.FC = () => {
 
     const [runData, setRunData] = useState<ActorRunData | null>(null);
     const [pictureUrl, setPictureUrl] = useState<string | undefined>(undefined);
+    const [datasetOutput, setDatasetOutput] = useState<DatasetOutput | null>(null);
 
     // Initialize runData from toolOutput (call-actor result) or by fetching run when we have a stable runId.
     // When the host overwrites toolResult with another tool (e.g. search-actors), toolOutput has no runId;
@@ -328,7 +343,7 @@ export const ActorRun: React.FC = () => {
         let cancelled = false;
         const fetchRunByRunId = async () => {
             try {
-                const response = await app.callServerTool({ name: "get-actor-run", arguments: { runId: stableRunId } });
+                const response = await app.callServerTool({ name: "get-actor-run", arguments: { runId: stableRunId, waitSecs: 0 } });
                 if (cancelled) return;
                 const data = response?.structuredContent as ToolOutput | undefined;
                 if (data?.runId) {
@@ -368,6 +383,35 @@ export const ActorRun: React.FC = () => {
         fetchActorDetails();
     }, [runData?.actorFullName, pictureUrl, app]);
 
+    // Fetch dataset preview items once the run succeeds
+    useEffect(() => {
+        if (!app || !runData?.datasetId || datasetOutput) return;
+        if (runData.status.toUpperCase() !== 'SUCCEEDED') return;
+
+        let cancelled = false;
+        const fetchDataset = async () => {
+            try {
+                const response = await app.callServerTool({
+                    name: "get-actor-output",
+                    arguments: { datasetId: runData.datasetId, limit: 5 },
+                });
+                if (cancelled) return;
+                const content = response?.structuredContent as { items?: Record<string, any>[]; totalItemCount?: number } | undefined;
+                if (content?.items) {
+                    setDatasetOutput({
+                        datasetId: runData.datasetId!,
+                        totalItemCount: content.totalItemCount ?? content.items.length,
+                        items: content.items,
+                    });
+                }
+            } catch (err) {
+                console.error('[ActorRun] Failed to fetch dataset items:', err);
+            }
+        };
+        void fetchDataset();
+        return () => { cancelled = true; };
+    }, [app, runData?.datasetId, runData?.status, datasetOutput]);
+
     // Auto-polling: Fetch status updates automatically with gradual escalation
     useEffect(() => {
         if (!app || !runData?.runId) return;
@@ -391,7 +435,7 @@ export const ActorRun: React.FC = () => {
                 if (isCancelled) break;
 
                 try {
-                    const response = await app.callServerTool({ name: "get-actor-run", arguments: { runId: runData.runId } });
+                    const response = await app.callServerTool({ name: "get-actor-run", arguments: { runId: runData.runId, waitSecs: 0 } });
 
                     if (response.structuredContent) {
                         const newData = response.structuredContent as unknown as ToolOutput;
@@ -419,8 +463,8 @@ export const ActorRun: React.FC = () => {
                             timestamp: formatTimestamp(startedAt),
                             duration,
                             cost: pollUsageTotalUsd,
+                            datasetId: newData.storages?.defaultDatasetId,
                             stats: newData.stats,
-                            dataset: newData.dataset,
                         };
 
                         setRunData(updatedRunData);
@@ -428,10 +472,11 @@ export const ActorRun: React.FC = () => {
                         const newStatus = (newData.status || '').toUpperCase();
                         if (TERMINAL_STATUSES.has(newStatus)) {
                             // Notify the model that the run completed so it can follow up.
+                            const datasetId = newData.storages?.defaultDatasetId;
                             const ctx = [
                                 `Actor run ${runData.runId} finished with status: ${newStatus}.`,
-                                newData.dataset?.datasetId ? `Dataset ID: ${newData.dataset.datasetId}` : null,
-                                newData.dataset?.totalItemCount != null ? `Items scraped: ${newData.dataset.totalItemCount}` : null,
+                                datasetId ? `Dataset ID: ${datasetId}` : null,
+                                newData.hint || null,
                             ].filter(Boolean).join(' ');
                             await app.updateModelContext({ content: [{ type: 'text', text: ctx }] }).catch(() => {});
                             break;
@@ -487,12 +532,6 @@ export const ActorRun: React.FC = () => {
         );
     }
 
-    // Extract table columns from first item
-    const columns = runData.dataset?.previewItems.length
-        ? Object.keys(runData.dataset.previewItems[0])
-        : [];
-
-
     const handleOpenRun = () => {
         if (runData && app) {
             app.openLink({ url: `https://console.apify.com/actors/runs/${runData.runId}` });
@@ -545,13 +584,13 @@ export const ActorRun: React.FC = () => {
                 {/* <IconButton Icon={ExpandIcon} onClick={() => setIsExpanded(!isExpanded)} /> */}
                 </ActorHeader>
 
-                {runData.dataset && runData.dataset.previewItems.length > 0 ? (
+                {datasetOutput && datasetOutput.items.length > 0 ? (
                     <>
                         <TableContainer>
                             <Table>
                                 <TableHeader>
                                     <tr>
-                                        {columns.map((column) => (
+                                        {Object.keys(datasetOutput.items[0]).map((column) => (
                                             <TableHeaderCell key={column}>
                                                 {column.charAt(0).toUpperCase() + column.slice(1)}
                                             </TableHeaderCell>
@@ -559,13 +598,12 @@ export const ActorRun: React.FC = () => {
                                     </tr>
                                 </TableHeader>
                                 <TableBody>
-                                    {runData.dataset.previewItems.map((item, index) => (
+                                    {datasetOutput.items.map((item, index) => (
                                         <TableRow key={index}>
-                                            {columns.map((column) => (
+                                            {Object.keys(datasetOutput.items[0]).map((column) => (
                                                 <TableCell key={column}>
                                                     {item[column] == null
                                                         ? "—"
-                                                        // If the value is an object, show number of fields instead of [object Object]
                                                         : typeof item[column] === 'object'
                                                             ? `${Object.keys(item[column]).length} fields`
                                                             : String(item[column]) || "—"}
@@ -575,33 +613,27 @@ export const ActorRun: React.FC = () => {
                                     ))}
                                 </TableBody>
                             </Table>
-                            {runData.dataset.previewItems.length > 3 && <TableGradientOverlay />}
+                            {datasetOutput.items.length > 3 && <TableGradientOverlay />}
                         </TableContainer>
                     </>
                 ) : runData.status.toUpperCase() === 'RUNNING' ? (
                     <TableSkeleton />
-                ) : (
+                ) : runData.status.toUpperCase() === 'READY' ? (
                     <EmptyStateContainer>
-                        {runData.status.toUpperCase() === 'READY' ? (
-                            <Text type="body" size="small" style={{ color: theme.color.neutral.textMuted }}>
-                                The Actor is ready to run.
-                            </Text>
-                        ) : (
-                            <Text type="body" size="small" style={{ color: theme.color.neutral.textMuted }}>
-                                No results available.
-                            </Text>
-                        )}
+                        <Text type="body" size="small" style={{ color: theme.color.neutral.textMuted }}>
+                            The Actor is ready to run.
+                        </Text>
                     </EmptyStateContainer>
-                )}
+                ) : null}
                 <Footer>
                     <Button onClick={handleOpenRun} variant="secondary" size="small">
                         View on Apify
                     </Button>
                 </Footer>
             </Container>
-            {runData.status.toUpperCase() === 'SUCCEEDED' && runData && runData.dataset && runData.dataset.totalItemCount > 0 && (
+            {runData.status.toUpperCase() === 'SUCCEEDED' && datasetOutput && datasetOutput.totalItemCount > 0 && (
                 <SuccessMessage>
-                    The {runData.actorName} found {runData.dataset.totalItemCount} result{runData.dataset.totalItemCount !== 1 ? 's' : ''}. You can visit results via the provided link.
+                    The {runData.actorName} found {datasetOutput.totalItemCount} result{datasetOutput.totalItemCount !== 1 ? 's' : ''}. You can visit results via the provided link.
                 </SuccessMessage>
             )}
         </WidgetLayout>


### PR DESCRIPTION
## Summary

Closes #582

- **`call-actor` always returns immediately** with uniform run metadata (`runId`, `status`, `storages`, `hint`). In MCP task mode (`mcpTaskExecution`), it waits for completion internally with abort signal support.
- **`get-actor-run` gains `waitSecs`** parameter (default 10s, max 60s) for bounded server-side waiting. `waitSecs: 0` gives instant status checks (used by the widget).
- **Removed `async` and `previewOutput` parameters** from `call-actor` — replaced by the MCP task protocol and the start → wait → get-data workflow.
- **Shared `actorRunOutputSchema`** used by both `call-actor` and `get-actor-run` with `storages` and contextual `hint`.
- **Extracted `waitForRunWithAbort` helper** — deduplicates the abort-race pattern between `call-actor` (task mode) and `actor_execution.ts` (direct actor tools).
- **Widget fetches dataset items separately** via `get-actor-output` on run completion instead of relying on inline dataset previews from `get-actor-run`.
- **Added `ACTOR_RUN_STATUS` constants** in `src/const.ts` for type-safe status handling.

### Client flows

**Task client:** `call-actor` (task stays "working" with progress) → `get-actor-output`
**Non-task client:** `call-actor` → `get-actor-run(waitSecs:10)` (repeat) → `get-actor-output`
**OpenAI/widget:** `call-actor` → widget polls `get-actor-run(waitSecs:0)` → fetches `get-actor-output` on completion

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (393 tests)
- [ ] Integration tests (requires `APIFY_TOKEN`)
- [ ] Manual test: call-actor in non-task mode returns immediately
- [ ] Manual test: call-actor in task mode waits for completion
- [ ] Manual test: widget polls with `waitSecs: 0` and fetches dataset on success
- [ ] Manual test: cancellation aborts the Actor run

🤖 Generated with [Claude Code](https://claude.com/claude-code)