### PR TITLE
fix: Read server version from package.json instead of hardcoded constant

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -19,8 +19,6 @@ export const TOOL_MAX_OUTPUT_CHARS = 50000;
 // MCP Server
 export const SERVER_NAME = 'apify-mcp-server';
 export const SERVER_TITLE = 'Apify MCP Server';
-export const SERVER_VERSION = '1.0.0';
-
 // User agent headers
 export const USER_AGENT_ORIGIN = 'Origin/mcp-server';
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -42,7 +42,6 @@ import {
     DEFAULT_TELEMETRY_ENV,
     HelperTools,
     SERVER_NAME,
-    SERVER_VERSION,
     TOOL_STATUS,
 } from '../const.js';
 import { prompts } from '../prompts/index.js';
@@ -138,7 +137,7 @@ export class ActorsMcpServer {
         this.server = new Server(
             {
                 name: SERVER_NAME,
-                version: SERVER_VERSION,
+                version: getPackageVersion()!,
                 websiteUrl: APIFY_MCP_URL,
             },
             {

--- a/src/server_card.ts
+++ b/src/server_card.ts
@@ -1,8 +1,9 @@
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 
-import { APIFY_DOCS_MCP_URL, APIFY_FAVICON_URL, SERVER_NAME, SERVER_TITLE, SERVER_VERSION } from './const.js';
+import { APIFY_DOCS_MCP_URL, APIFY_FAVICON_URL, SERVER_NAME, SERVER_TITLE } from './const.js';
 import type { ServerCard } from './types.js';
 import { readJsonFile } from './utils/generic.js';
+import { getPackageVersion } from './utils/version.js';
 
 const serverJson = readJsonFile<{ description: string }>(import.meta.url, '../server.json');
 
@@ -15,7 +16,7 @@ export function getServerCard(): ServerCard {
         serverInfo: {
             name: SERVER_NAME,
             title: SERVER_TITLE,
-            version: SERVER_VERSION,
+            version: getPackageVersion()!,
         },
         description: serverJson.description,
         iconUrl: APIFY_FAVICON_URL,

--- a/tests/unit/server_card.test.ts
+++ b/tests/unit/server_card.test.ts
@@ -1,9 +1,10 @@
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it } from 'vitest';
 
-import { SERVER_NAME, SERVER_TITLE, SERVER_VERSION } from '../../src/const.js';
+import { SERVER_NAME, SERVER_TITLE } from '../../src/const.js';
 import { getServerCard } from '../../src/server_card.js';
 import { readJsonFile } from '../../src/utils/generic.js';
+import { getPackageVersion } from '../../src/utils/version.js';
 
 const serverJson = readJsonFile<{ description: string }>(import.meta.url, '../../server.json');
 
@@ -21,7 +22,7 @@ describe('getServerCard', () => {
 
         expect(card.serverInfo.name).toBe(SERVER_NAME);
         expect(card.serverInfo.title).toBe(SERVER_TITLE);
-        expect(card.serverInfo.version).toBe(SERVER_VERSION);
+        expect(card.serverInfo.version).toBe(getPackageVersion());
     });
 
     it('should declare streamable-http transport at root endpoint', () => {


### PR DESCRIPTION
## Summary
- Removed hardcoded `SERVER_VERSION = '1.0.0'` from `src/const.ts` that was never updated during releases
- Server now uses the existing `getPackageVersion()` utility to read the version from `package.json` at startup
- Updated test to assert against the dynamic version

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (393 tests)
- [x] Verify server card endpoint reports the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)