### PR TITLE
fix: remove stale Skyfire-specific code, address PR #590 review comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -583,7 +583,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1581,7 +1580,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
       "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
@@ -1875,7 +1873,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4072,7 +4069,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
       "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -5211,7 +5207,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.0.tgz",
       "integrity": "sha512-uOXpVX0ZjO7heSVjhheW2XEPrhQAWr2BScDPoZ9UDycl5iuHG+Usyc3AIfG6kZeC1GyLpMInpQ6X5+9n69yOFw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -5224,7 +5219,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
       "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -5240,7 +5234,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.211.0.tgz",
       "integrity": "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.211.0",
         "import-in-the-middle": "^2.0.0",
@@ -5258,7 +5251,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.0.tgz",
       "integrity": "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0",
@@ -5276,7 +5268,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
       "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5704,7 +5695,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -6057,7 +6047,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6631,7 +6620,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7639,7 +7627,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7780,7 +7767,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8097,7 +8083,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -10559,7 +10544,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11974,7 +11958,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -12111,7 +12094,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12126,7 +12108,6 @@
       "integrity": "sha512-FbOKN1fqNoXp1hIl5KYpObVrp0mCn+CLgn479nmu2IsRMrx2vyv74MmsBLVlhg8qVwNFGbXSp8fh1zp8pEoC2A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.48.1",
         "@typescript-eslint/parser": "8.48.1",
@@ -12273,7 +12254,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -13197,7 +13177,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/index_internals.ts
+++ b/src/index_internals.ts
@@ -15,7 +15,6 @@ import { actorNameToToolName } from './tools/utils.js';
 import type { ActorStore, ServerCard, ServerMode, ToolCategory, UiMode } from './types.js';
 import { parseUiMode, SERVER_MODES } from './types.js';
 import { parseCommaSeparatedList, parseQueryParamList, readJsonFile } from './utils/generic.js';
-import { redactSkyfirePayId } from './utils/logging.js';
 import { getExpectedToolNamesByCategories } from './utils/tool_categories_helpers.js';
 import { getToolPublicFieldOnly } from './utils/tools.js';
 import { TTLLRUCache } from './utils/ttl_lru.js';
@@ -52,8 +51,4 @@ export {
     parseQueryParamList,
     resolvePaymentProvider,
     type PaymentProvider,
-    /**
-     * @deprecated Use the server's paymentProvider.redactForLogging instead. This will be removed in a future release.
-     */
-    redactSkyfirePayId,
 };

--- a/src/tools/core/actor_execution.ts
+++ b/src/tools/core/actor_execution.ts
@@ -6,7 +6,7 @@ import type { ApifyClient } from '../../apify_client.js';
 import { TOOL_MAX_OUTPUT_CHARS } from '../../const.js';
 import type { ActorDefinitionStorage, DatasetItem } from '../../types.js';
 import { ensureOutputWithinCharLimit, getActorDefinitionStorageFieldNames } from '../../utils/actor.js';
-import { logHttpError, redactSkyfirePayId } from '../../utils/logging.js';
+import { logHttpError } from '../../utils/logging.js';
 import type { ProgressTracker } from '../../utils/progress.js';
 import type { JsonSchemaProperty } from '../../utils/schema_generation.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
@@ -88,7 +88,7 @@ export async function callActorGetDataset(options: {
     ]);
 
     if (potentialAbortedRun === CLIENT_ABORT) {
-        log.info('Actor run aborted by client', { actorName, mcpSessionId, input: redactSkyfirePayId(input) });
+        log.info('Actor run aborted by client', { actorName, mcpSessionId, input });
         return null;
     }
     const completedRun = potentialAbortedRun as ActorRun;

--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -158,8 +158,8 @@ export async function getMCPServersAsTools(
     mcpSessionId?: string,
 ): Promise<ToolEntry[]> {
     /**
-     * This is case for the Skyfire request without any Apify token, we do not support
-     * standby Actors in this case, so we can skip MCP servers since they would fail anyway (they are standby Actors).
+     * Payment providers that replace the Apify token have no token available.
+     * MCP servers (standby Actors) require a token, so skip them in this case.
     */
     if (apifyToken === null || apifyToken === undefined) {
         return [];

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -226,7 +226,7 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
  * Performs the pre-execution checks common to both modes:
  * - Parses args
  * - Resolves actor/MCP context
- * - Handles Skyfire restrictions
+ * - Handles payment provider restrictions
  * - Handles MCP tool calls
  *
  * Returns either an early response (error or MCP tool result) or the parsed context for mode-specific execution.
@@ -244,16 +244,16 @@ export async function callActorPreExecute(toolArgs: InternalToolArgs): Promise<
 
     const { baseActorName, mcpToolName } = resolveActorContext(parsed.actor);
 
-    // For definition resolution we always use token-based client; Skyfire is only for actual Actor runs
+    // For definition resolution we always use token-based client; payment headers are only for actual Actor runs
     const apifyClientForDefinition = new ApifyClient({ token: apifyToken });
     const mcpServerUrlOrFalse = await getActorMcpUrlCached(baseActorName, apifyClientForDefinition);
     const isActorMcpServer = mcpServerUrlOrFalse && typeof mcpServerUrlOrFalse === 'string';
 
-    // Standby Actors (MCPs) are not supported in Skyfire mode
+    // Standby Actors (MCPs) are not supported in payment provider mode
     if (isActorMcpServer && apifyMcpServer.options.paymentProvider) {
         return {
             earlyResponse: buildMCPResponse({
-                texts: [`This Actor (${parsed.actor}) is an MCP server and cannot be accessed using a Skyfire token. To use this Actor, please provide a valid Apify token instead of a Skyfire token.`],
+                texts: [`This Actor (${parsed.actor}) is an MCP server and cannot be accessed using a payment token. To use this Actor, please provide a valid Apify token instead.`],
                 isError: true,
                 // Internal status used by server telemetry; not part of the MCP client contract.
                 toolStatus: TOOL_STATUS.SOFT_FAIL,

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -243,9 +243,9 @@ export async function getMcpToolsMessage(
         return `Note: This Actor is not an MCP server and does not expose MCP tools.`;
     }
 
-    // Early return: Skyfire mode restriction
+    // Early return: payment provider mode restriction
     if (paymentProvider) {
-        return `This Actor is an MCP server and cannot be accessed in Skyfire mode.`;
+        return `This Actor is an MCP server and cannot be accessed in payment provider mode.`;
     }
 
     // Connect and list tools

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -52,29 +52,3 @@ export function logHttpError<T extends object>(error: unknown, message: string, 
         log.error(message, { error, ...data });
     }
 }
-
-const SKYFIRE_PAY_ID_KEY = 'skyfire-pay-id';
-const REDACTED_VALUE = '[REDACTED]';
-
-const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
-};
-
-/**
- * Sanitizes tool call parameters by redacting the skyfire-pay-id.
- * Used for logging to avoid exposing the Skyfire payment token.
- *
- * @param params - The parameters object to sanitize
- * @returns A new object with skyfire-pay-id replaced with '[REDACTED]'
- */
-export function redactSkyfirePayId(params: unknown): unknown {
-    if (!isPlainRecord(params) || !(SKYFIRE_PAY_ID_KEY in params)) {
-        return params;
-    }
-
-    if (params[SKYFIRE_PAY_ID_KEY] === REDACTED_VALUE) {
-        return params;
-    }
-
-    return { ...params, [SKYFIRE_PAY_ID_KEY]: REDACTED_VALUE };
-}

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,9 +1,3 @@
-import {
-    type HelperTools,
-    SKYFIRE_ENABLED_TOOLS,
-    SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
-    SKYFIRE_TOOL_INSTRUCTIONS,
-} from '../const.js';
 import type { HelperTool, ServerMode, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
 import { fixZodSchemaRequired } from './ajv.js';
 
@@ -81,43 +75,4 @@ export function cloneToolEntry(toolEntry: ToolEntry): ToolEntry {
     }
 
     return cloned;
-}
-
-/** Returns true if the tool is eligible for Skyfire augmentation. */
-function isSkyfireEligible(tool: ToolEntry): boolean {
-    return tool.type === 'actor'
-        || (tool.type === 'internal' && SKYFIRE_ENABLED_TOOLS.has(tool.name as HelperTools));
-}
-
-/**
- * Applies Skyfire augmentation to a tool entry.
- * Clones the tool and, if eligible, appends Skyfire instructions to the description
- * and adds a `skyfire-pay-id` property to the input schema.
- *
- * Returns the (possibly augmented) clone if the tool is eligible,
- * or the original tool reference if it is not eligible.
- * Augmentation is idempotent — calling this on an already-augmented clone is safe.
- */
-export function applySkyfireAugmentation(tool: ToolEntry): ToolEntry {
-    if (!isSkyfireEligible(tool)) return tool;
-
-    const cloned = cloneToolEntry(tool);
-
-    // Append Skyfire instructions to description (idempotent)
-    if (cloned.description && !cloned.description.includes(SKYFIRE_TOOL_INSTRUCTIONS)) {
-        cloned.description += `\n\n${SKYFIRE_TOOL_INSTRUCTIONS}`;
-    }
-
-    // Add skyfire-pay-id property to inputSchema (idempotent)
-    if (cloned.inputSchema && 'properties' in cloned.inputSchema) {
-        const props = cloned.inputSchema.properties as Record<string, unknown>;
-        if (!props['skyfire-pay-id']) {
-            props['skyfire-pay-id'] = {
-                type: 'string',
-                description: SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
-            };
-        }
-    }
-
-    return Object.freeze(cloned);
 }

--- a/tests/unit/tools.skyfire.test.ts
+++ b/tests/unit/tools.skyfire.test.ts
@@ -1,8 +1,8 @@
 /**
- * Tests for Skyfire augmentation logic: `applySkyfireAugmentation` and `cloneToolEntry`.
+ * Tests for Skyfire tool decoration logic: `SkyfirePaymentProvider.decorateToolSchema` and `cloneToolEntry`.
  *
  * Covers:
- * - Eligible vs non-eligible tools
+ * - paymentRequired tools are decorated; others are returned unchanged
  * - Idempotency (double-apply does not duplicate)
  * - Frozen originals are not mutated
  * - `cloneToolEntry` preserves functions (ajvValidate, call)
@@ -11,13 +11,14 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-    HelperTools,
-    SKYFIRE_ENABLED_TOOLS,
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../../src/const.js';
+import { SkyfirePaymentProvider } from '../../src/payments/skyfire.js';
 import type { ActorMcpTool, ActorTool, HelperTool, ToolEntry } from '../../src/types.js';
-import { applySkyfireAugmentation, cloneToolEntry } from '../../src/utils/tools.js';
+import { cloneToolEntry } from '../../src/utils/tools.js';
+
+const provider = new SkyfirePaymentProvider();
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -27,7 +28,7 @@ const MOCK_AJV_VALIDATE = vi.fn(() => true);
 
 function makeInternalTool(overrides: Partial<HelperTool> = {}): HelperTool {
     return {
-        name: HelperTools.ACTOR_CALL,
+        name: 'call-actor',
         description: 'Call an Actor',
         type: 'internal',
         inputSchema: {
@@ -71,14 +72,6 @@ function makeActorMcpTool(overrides: Partial<ActorMcpTool> = {}): ActorMcpTool {
         ajvValidate: MOCK_AJV_VALIDATE as never,
         ...overrides,
     };
-}
-
-function makeNonEligibleInternalTool(): HelperTool {
-    // search-apify-docs is NOT in SKYFIRE_ENABLED_TOOLS
-    return makeInternalTool({
-        name: HelperTools.DOCS_SEARCH,
-        description: 'Search documentation',
-    });
 }
 
 // ---------------------------------------------------------------------------
@@ -139,16 +132,15 @@ describe('cloneToolEntry', () => {
 });
 
 // ---------------------------------------------------------------------------
-// applySkyfireAugmentation — eligible tools
+// SkyfirePaymentProvider.decorateToolSchema — paymentRequired tools
 // ---------------------------------------------------------------------------
 
-describe('applySkyfireAugmentation', () => {
-    describe('eligible internal tools', () => {
-        it('should augment an eligible internal tool', () => {
-            const original = makeInternalTool({ name: HelperTools.ACTOR_CALL });
-            const result = applySkyfireAugmentation(original);
+describe('SkyfirePaymentProvider.decorateToolSchema', () => {
+    describe('paymentRequired tools', () => {
+        it('should decorate an internal tool with paymentRequired: true', () => {
+            const original = makeInternalTool({ paymentRequired: true });
+            const result = provider.decorateToolSchema(original);
 
-            // Returns a different object (cloned)
             expect(result).not.toBe(original);
             expect(result.description).toContain(SKYFIRE_TOOL_INSTRUCTIONS);
 
@@ -160,22 +152,9 @@ describe('applySkyfireAugmentation', () => {
             expect(Object.isFrozen(result)).toBe(true);
         });
 
-        // Test each SKYFIRE_ENABLED_TOOLS member
-        for (const toolName of SKYFIRE_ENABLED_TOOLS) {
-            it(`should augment ${toolName}`, () => {
-                const tool = makeInternalTool({ name: toolName });
-                const result = applySkyfireAugmentation(tool);
-
-                expect(result).not.toBe(tool);
-                expect(result.description).toContain(SKYFIRE_TOOL_INSTRUCTIONS);
-            });
-        }
-    });
-
-    describe('actor tools', () => {
-        it('should augment any actor tool (type: actor)', () => {
-            const original = makeActorTool();
-            const result = applySkyfireAugmentation(original);
+        it('should decorate an actor tool with paymentRequired: true', () => {
+            const original = makeActorTool({ paymentRequired: true });
+            const result = provider.decorateToolSchema(original);
 
             expect(result).not.toBe(original);
             expect(result.description).toContain(SKYFIRE_TOOL_INSTRUCTIONS);
@@ -186,40 +165,44 @@ describe('applySkyfireAugmentation', () => {
         });
     });
 
-    describe('non-eligible tools', () => {
-        it('should return the original reference for non-eligible internal tool', () => {
-            const original = makeNonEligibleInternalTool();
-            const result = applySkyfireAugmentation(original);
+    describe('non-paymentRequired tools', () => {
+        it('should return the original reference when paymentRequired is false', () => {
+            const original = makeInternalTool({ paymentRequired: false });
+            const result = provider.decorateToolSchema(original);
 
-            // Returns the exact same object (not cloned)
             expect(result).toBe(original);
             expect(result.description).not.toContain(SKYFIRE_TOOL_INSTRUCTIONS);
         });
 
-        it('should return the original reference for actor-mcp tool', () => {
-            const original = makeActorMcpTool();
-            const result = applySkyfireAugmentation(original);
+        it('should return the original reference when paymentRequired is undefined', () => {
+            const original = makeActorTool();
+            const result = provider.decorateToolSchema(original);
 
             expect(result).toBe(original);
-            expect(result.description).not.toContain(SKYFIRE_TOOL_INSTRUCTIONS);
+        });
+
+        it('should return the original reference for actor-mcp tool without paymentRequired', () => {
+            const original = makeActorMcpTool();
+            const result = provider.decorateToolSchema(original);
+
+            expect(result).toBe(original);
         });
     });
 
     describe('idempotency', () => {
         it('should not double-append description when called twice', () => {
-            const original = makeInternalTool({ name: HelperTools.ACTOR_CALL });
-            const firstPass = applySkyfireAugmentation(original);
-            const secondPass = applySkyfireAugmentation(firstPass);
+            const original = makeInternalTool({ paymentRequired: true });
+            const firstPass = provider.decorateToolSchema(original);
+            const secondPass = provider.decorateToolSchema(firstPass);
 
-            // Description should contain SKYFIRE_TOOL_INSTRUCTIONS exactly once
             const occurrences = secondPass.description!.split(SKYFIRE_TOOL_INSTRUCTIONS).length - 1;
             expect(occurrences).toBe(1);
         });
 
         it('should not duplicate skyfire-pay-id property when called twice', () => {
-            const original = makeActorTool();
-            const firstPass = applySkyfireAugmentation(original);
-            const secondPass = applySkyfireAugmentation(firstPass);
+            const original = makeActorTool({ paymentRequired: true });
+            const firstPass = provider.decorateToolSchema(original);
+            const secondPass = provider.decorateToolSchema(firstPass);
 
             const props = secondPass.inputSchema.properties as Record<string, unknown>;
             expect(props['skyfire-pay-id']).toEqual({
@@ -230,29 +213,18 @@ describe('applySkyfireAugmentation', () => {
     });
 
     describe('frozen originals', () => {
-        it('should not mutate a frozen internal tool', () => {
-            const original = Object.freeze(makeInternalTool({ name: HelperTools.ACTOR_CALL }));
-            const result = applySkyfireAugmentation(original);
+        it('should not mutate a frozen tool with paymentRequired: true', () => {
+            const original = Object.freeze(makeInternalTool({ paymentRequired: true }));
+            const result = provider.decorateToolSchema(original);
 
-            // Result is augmented
             expect(result.description).toContain(SKYFIRE_TOOL_INSTRUCTIONS);
-
-            // Original is unchanged
             expect(original.description).not.toContain(SKYFIRE_TOOL_INSTRUCTIONS);
             expect(Object.isFrozen(original)).toBe(true);
         });
 
-        it('should not mutate a frozen actor tool', () => {
-            const original = Object.freeze(makeActorTool());
-            const result = applySkyfireAugmentation(original);
-
-            expect(result.description).toContain(SKYFIRE_TOOL_INSTRUCTIONS);
-            expect(original.description).not.toContain(SKYFIRE_TOOL_INSTRUCTIONS);
-        });
-
-        it('should return frozen non-eligible tool as-is', () => {
-            const original = Object.freeze(makeNonEligibleInternalTool());
-            const result = applySkyfireAugmentation(original);
+        it('should return frozen non-paymentRequired tool as-is', () => {
+            const original = Object.freeze(makeInternalTool());
+            const result = provider.decorateToolSchema(original);
 
             expect(result).toBe(original);
             expect(Object.isFrozen(result)).toBe(true);
@@ -260,25 +232,25 @@ describe('applySkyfireAugmentation', () => {
     });
 
     describe('function preservation', () => {
-        it('should preserve ajvValidate on augmented internal tool', () => {
-            const original = makeInternalTool({ name: HelperTools.ACTOR_CALL });
-            const result = applySkyfireAugmentation(original) as HelperTool;
+        it('should preserve ajvValidate on decorated internal tool', () => {
+            const original = makeInternalTool({ paymentRequired: true });
+            const result = provider.decorateToolSchema(original) as HelperTool;
 
             expect(result.ajvValidate).toBe(original.ajvValidate);
             expect(typeof result.ajvValidate).toBe('function');
         });
 
-        it('should preserve call function on augmented internal tool', () => {
-            const original = makeInternalTool({ name: HelperTools.ACTOR_CALL });
-            const result = applySkyfireAugmentation(original) as HelperTool;
+        it('should preserve call function on decorated internal tool', () => {
+            const original = makeInternalTool({ paymentRequired: true });
+            const result = provider.decorateToolSchema(original) as HelperTool;
 
             expect(result.call).toBe(original.call);
             expect(typeof result.call).toBe('function');
         });
 
-        it('should preserve ajvValidate on augmented actor tool', () => {
-            const original = makeActorTool();
-            const result = applySkyfireAugmentation(original);
+        it('should preserve ajvValidate on decorated actor tool', () => {
+            const original = makeActorTool({ paymentRequired: true });
+            const result = provider.decorateToolSchema(original);
 
             expect(result.ajvValidate).toBe(original.ajvValidate);
         });
@@ -287,21 +259,20 @@ describe('applySkyfireAugmentation', () => {
     describe('edge cases', () => {
         it('should handle tool with no description gracefully', () => {
             const original = makeInternalTool({
-                name: HelperTools.ACTOR_CALL,
+                paymentRequired: true,
                 description: undefined as unknown as string,
             });
-            const result = applySkyfireAugmentation(original);
+            const result = provider.decorateToolSchema(original);
 
-            // Should not throw, description stays undefined
             expect(result.description).toBeUndefined();
         });
 
         it('should handle tool with empty inputSchema properties', () => {
             const original = makeInternalTool({
-                name: HelperTools.ACTOR_CALL,
+                paymentRequired: true,
                 inputSchema: { type: 'object' as const, properties: {} },
             });
-            const result = applySkyfireAugmentation(original);
+            const result = provider.decorateToolSchema(original);
 
             const props = result.inputSchema.properties as Record<string, unknown>;
             expect(props['skyfire-pay-id']).toBeDefined();
@@ -310,23 +281,23 @@ describe('applySkyfireAugmentation', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Matrix: mode × eligibility (using getCategoryTools)
+// Matrix: paymentRequired × tool type
 // ---------------------------------------------------------------------------
 
-describe('Skyfire eligibility matrix', () => {
-    const testCases: { tool: ToolEntry; eligible: boolean; label: string }[] = [
-        { tool: makeInternalTool({ name: HelperTools.ACTOR_CALL }), eligible: true, label: 'internal/eligible (call-actor)' },
-        { tool: makeInternalTool({ name: HelperTools.ACTOR_OUTPUT_GET }), eligible: true, label: 'internal/eligible (get-actor-output)' },
-        { tool: makeNonEligibleInternalTool(), eligible: false, label: 'internal/non-eligible (search-apify-docs)' },
-        { tool: makeActorTool(), eligible: true, label: 'actor tool' },
-        { tool: makeActorMcpTool(), eligible: false, label: 'actor-mcp tool' },
+describe('decorateToolSchema eligibility matrix', () => {
+    const testCases: { tool: ToolEntry; decorated: boolean; label: string }[] = [
+        { tool: makeInternalTool({ paymentRequired: true }), decorated: true, label: 'internal/paymentRequired' },
+        { tool: makeActorTool({ paymentRequired: true }), decorated: true, label: 'actor/paymentRequired' },
+        { tool: makeInternalTool({ paymentRequired: false }), decorated: false, label: 'internal/not-paymentRequired' },
+        { tool: makeActorTool(), decorated: false, label: 'actor/no-paymentRequired' },
+        { tool: makeActorMcpTool(), decorated: false, label: 'actor-mcp/no-paymentRequired' },
     ];
 
-    for (const { tool, eligible, label } of testCases) {
-        it(`${label}: eligible=${eligible}`, () => {
-            const result = applySkyfireAugmentation(tool);
+    for (const { tool, decorated, label } of testCases) {
+        it(`${label}: decorated=${decorated}`, () => {
+            const result = provider.decorateToolSchema(tool);
 
-            if (eligible) {
+            if (decorated) {
                 expect(result).not.toBe(tool);
                 expect(result.description).toContain(SKYFIRE_TOOL_INSTRUCTIONS);
                 const props = result.inputSchema.properties as Record<string, unknown>;

--- a/tests/unit/utils.logging.test.ts
+++ b/tests/unit/utils.logging.test.ts
@@ -1,59 +1,61 @@
 import { describe, expect, it } from 'vitest';
 
-import { redactSkyfirePayId } from '../../src/utils/logging.js';
+import { SkyfirePaymentProvider } from '../../src/payments/skyfire.js';
 
-describe('redactSkyfirePayId', () => {
+const provider = new SkyfirePaymentProvider();
+
+describe('SkyfirePaymentProvider.redactForLogging', () => {
     it('should redact skyfire-pay-id when present', () => {
         const params = { 'skyfire-pay-id': 'secret-token-123', actor: 'apify/web-scraper', url: 'https://example.com' };
-        const result = redactSkyfirePayId(params);
+        const result = provider.redactForLogging(params);
         expect(result).toEqual({ 'skyfire-pay-id': '[REDACTED]', actor: 'apify/web-scraper', url: 'https://example.com' });
     });
 
     it('should return params unchanged when skyfire-pay-id is not present', () => {
         const params = { actor: 'apify/web-scraper', url: 'https://example.com' };
-        const result = redactSkyfirePayId(params);
+        const result = provider.redactForLogging(params);
         expect(result).toBe(params); // same reference, no copy
     });
 
     it('should return null as-is', () => {
-        expect(redactSkyfirePayId(null)).toBeNull();
+        expect(provider.redactForLogging(null)).toBeNull();
     });
 
     it('should return undefined as-is', () => {
-        expect(redactSkyfirePayId(undefined)).toBeUndefined();
+        expect(provider.redactForLogging(undefined)).toBeUndefined();
     });
 
     it('should return primitives as-is', () => {
-        expect(redactSkyfirePayId('string')).toBe('string');
-        expect(redactSkyfirePayId(42)).toBe(42);
-        expect(redactSkyfirePayId(true)).toBe(true);
+        expect(provider.redactForLogging('string')).toBe('string');
+        expect(provider.redactForLogging(42)).toBe(42);
+        expect(provider.redactForLogging(true)).toBe(true);
     });
 
     it('should return arrays as-is', () => {
         const arr = [1, 2, 3];
-        expect(redactSkyfirePayId(arr)).toBe(arr);
+        expect(provider.redactForLogging(arr)).toBe(arr);
     });
 
     it('should return empty object as-is', () => {
         const params = {};
-        expect(redactSkyfirePayId(params)).toBe(params);
+        expect(provider.redactForLogging(params)).toBe(params);
     });
 
     it('should not mutate the original object', () => {
         const params = { 'skyfire-pay-id': 'secret', foo: 'bar' };
-        redactSkyfirePayId(params);
+        provider.redactForLogging(params);
         expect(params['skyfire-pay-id']).toBe('secret');
     });
 
     it('should handle skyfire-pay-id with empty string value', () => {
         const params = { 'skyfire-pay-id': '', other: 'value' };
-        const result = redactSkyfirePayId(params);
+        const result = provider.redactForLogging(params);
         expect(result).toEqual({ 'skyfire-pay-id': '[REDACTED]', other: 'value' });
     });
 
     it('should not redact if already redacted', () => {
         const params = { 'skyfire-pay-id': '[REDACTED]', other: 'value' };
-        const result = redactSkyfirePayId(params);
+        const result = provider.redactForLogging(params);
         expect(result).toBe(params); // same reference, already redacted
     });
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Addresses review points 1 and 6 from PR #590 that were reported as unfixed.

### Changes

- **Remove `redactSkyfirePayId`** from `utils/logging.ts` — superseded by `SkyfirePaymentProvider.redactForLogging()` on the provider interface; remove deprecated re-export from `index_internals.ts`
- **Remove dead `applySkyfireAugmentation` / `isSkyfireEligible`** from `utils/tools.ts` — superseded by `SkyfirePaymentProvider.decorateToolSchema()`
- **Replace Skyfire-specific comments/messages** with provider-agnostic wording in `call_actor_common.ts`, `actor_execution.ts`, `actor_tools_factory.ts`, and `actor_details.ts`
- **Update unit tests** to target `SkyfirePaymentProvider.redactForLogging()` and `decorateToolSchema()` instead of the removed standalone functions

### Note on reviewer point 1 (`PaymentProvider` as `interface`)

The project's `@typescript-eslint/consistent-type-definitions` ESLint rule enforces `type` over `interface`. Changing `PaymentProvider` to `interface` would fail lint. `PaymentProvider` stays as `type`.

### Verification

- ✅ `npm run type-check` — zero errors
- ✅ `npm run lint` — zero errors
- ✅ `npm run test:unit` — 382 tests pass

https://claude.ai/code/session_014w5Sku1kPe6Qxck3Vdsovv
EOF
)