### PR TITLE
feat: Simplify tiered pricing to show user's plan tier price

### DIFF
--- a/src/tools/default/fetch_actor_details.ts
+++ b/src/tools/default/fetch_actor_details.ts
@@ -8,6 +8,7 @@ import {
     resolveOutputOptions,
 } from '../../utils/actor_details.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { getUserPlanTierCached } from '../../utils/userid_cache.js';
 import {
     fetchActorDetailsMetadata,
     fetchActorDetailsToolArgsSchema,
@@ -27,7 +28,8 @@ export const defaultFetchActorDetails: ToolEntry = Object.freeze({
         const resolvedOutput = resolveOutputOptions(parsed.output);
         const cardOptions = buildCardOptions(resolvedOutput);
 
-        const details = await fetchActorDetails(apifyClient, parsed.actor, cardOptions);
+        const userTier = await getUserPlanTierCached(apifyToken, apifyClient);
+        const details = await fetchActorDetails(apifyClient, parsed.actor, cardOptions, userTier);
         if (!details) {
             return buildActorNotFoundResponse(parsed.actor);
         }

--- a/src/tools/default/search_actors.ts
+++ b/src/tools/default/search_actors.ts
@@ -1,8 +1,10 @@
+import { ApifyClient } from '../../apify_client.js';
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
 import { formatActorToActorCard, formatActorToStructuredCard } from '../../utils/actor_card.js';
 import { searchAndFilterActors } from '../../utils/actor_search.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { getUserPlanTierCached } from '../../utils/userid_cache.js';
 import {
     searchActorsArgsSchema,
     searchActorsMetadata,
@@ -38,7 +40,9 @@ You MUST retry with broader, more generic keywords - use just the platform name 
             return buildMCPResponse({ texts: [instructions], structuredContent });
         }
 
-        const structuredActorCards = actors.map((actor) => formatActorToStructuredCard(actor));
+        const userTier = await getUserPlanTierCached(apifyToken, new ApifyClient({ token: apifyToken ?? undefined }));
+
+        const structuredActorCards = actors.map((actor) => formatActorToStructuredCard(actor, undefined, userTier));
         const structuredContent = {
             actors: structuredActorCards,
             query: parsed.keywords,
@@ -47,7 +51,7 @@ You MUST retry with broader, more generic keywords - use just the platform name 
 IMPORTANT: You MUST always do a second search with broader, more generic keywords (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure you haven't missed a better Actor.`,
         };
 
-        const actorCards = actors.map((actor) => formatActorToActorCard(actor));
+        const actorCards = actors.map((actor) => formatActorToActorCard(actor, undefined, userTier));
         const actorsText = actorCards.join('\n\n');
         const instructions = `
  # Search results:

--- a/src/tools/openai/fetch_actor_details.ts
+++ b/src/tools/openai/fetch_actor_details.ts
@@ -9,6 +9,7 @@ import {
     resolveOutputOptions,
 } from '../../utils/actor_details.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { getUserPlanTierCached } from '../../utils/userid_cache.js';
 import {
     fetchActorDetailsMetadata,
     fetchActorDetailsToolArgsSchema,
@@ -28,12 +29,13 @@ export const openaiFetchActorDetails: ToolEntry = Object.freeze({
         const resolvedOutput = resolveOutputOptions(parsed.output);
         const cardOptions = buildCardOptions(resolvedOutput);
 
-        const details = await fetchActorDetails(apifyClient, parsed.actor, cardOptions);
+        const userTier = await getUserPlanTierCached(apifyToken, apifyClient);
+        const details = await fetchActorDetails(apifyClient, parsed.actor, cardOptions, userTier);
         if (!details) {
             return buildActorNotFoundResponse(parsed.actor);
         }
 
-        const { structuredContent: processedStructuredContent, actorUrl } = processActorDetailsForResponse(details);
+        const { structuredContent: processedStructuredContent, actorUrl } = processActorDetailsForResponse(details, userTier);
         const structuredContent = {
             actorInfo: details.actorCardStructured,
             inputSchema: details.inputSchema,

--- a/src/tools/openai/fetch_actor_details_internal.ts
+++ b/src/tools/openai/fetch_actor_details_internal.ts
@@ -13,6 +13,7 @@ import {
 } from '../../utils/actor_details.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { getUserPlanTierCached } from '../../utils/userid_cache.js';
 import { actorDetailsOutputSchema } from '../structured_output_schemas.js';
 
 const fetchActorDetailsInternalArgsSchema = z.object({
@@ -56,7 +57,8 @@ but the user did NOT explicitly ask for Actor details presentation.`,
         const resolvedOutput = resolveOutputOptions(parsed.output);
         const cardOptions = buildCardOptions(resolvedOutput);
 
-        const details = await fetchActorDetails(apifyClient, parsed.actor, cardOptions);
+        const userTier = await getUserPlanTierCached(apifyToken, apifyClient);
+        const details = await fetchActorDetails(apifyClient, parsed.actor, cardOptions, userTier);
         if (!details) {
             return buildActorNotFoundResponse(parsed.actor);
         }

--- a/src/tools/openai/search_actors.ts
+++ b/src/tools/openai/search_actors.ts
@@ -1,9 +1,11 @@
+import { ApifyClient } from '../../apify_client.js';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
 import { formatActorForWidget, formatActorToActorCard, formatActorToStructuredCard, type WidgetActor } from '../../utils/actor_card.js';
 import { searchAndFilterActors } from '../../utils/actor_search.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { getUserPlanTierCached } from '../../utils/userid_cache.js';
 import {
     searchActorsArgsSchema,
     searchActorsMetadata,
@@ -39,7 +41,9 @@ You MUST retry with broader, more generic keywords - use just the platform name 
             return buildMCPResponse({ texts: [instructions], structuredContent });
         }
 
-        const structuredActorCards = actors.map((actor) => formatActorToStructuredCard(actor));
+        const userTier = await getUserPlanTierCached(apifyToken, new ApifyClient({ token: apifyToken ?? undefined }));
+
+        const structuredActorCards = actors.map((actor) => formatActorToStructuredCard(actor, undefined, userTier));
         const structuredContent: {
             actors: typeof structuredActorCards;
             query: string;
@@ -55,9 +59,9 @@ IMPORTANT: You MUST always do a second search with broader, more generic keyword
         };
 
         // Add widget-formatted actors for the interactive UI
-        structuredContent.widgetActors = actors.map(formatActorForWidget);
+        structuredContent.widgetActors = actors.map((actor) => formatActorForWidget(actor, userTier));
 
-        const actorCards = actors.map((actor) => formatActorToActorCard(actor));
+        const actorCards = actors.map((actor) => formatActorToActorCard(actor, undefined, userTier));
         const actorsText = actorCards.join('\n\n');
         const texts = [`
  # Search results:

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -17,20 +17,6 @@ const developerSchema = {
 };
 
 /**
- * Schema for tiered pricing within an event
- */
-const eventTieredPricingSchema = {
-    type: 'array' as const, // Literal type required for MCP SDK type compatibility
-    items: {
-        type: 'object' as const, // Literal type required for MCP SDK type compatibility
-        properties: {
-            tier: { type: 'string' },
-            priceUsd: { type: 'number' },
-        },
-    },
-};
-
-/**
  * Schema for pricing events (PAY_PER_EVENT model)
  */
 const pricingEventsSchema = {
@@ -40,40 +26,25 @@ const pricingEventsSchema = {
         properties: {
             title: { type: 'string', description: 'Event title' },
             description: { type: 'string', description: 'Event description' },
-            priceUsd: { type: 'number', description: 'Price in USD' },
-            tieredPricing: eventTieredPricingSchema,
+            priceUsd: { type: 'number', description: 'Resolved price in USD for the user\'s plan tier' },
         },
     },
     description: 'Event-based pricing information',
 };
 
 /**
- * Schema for tiered pricing (general)
- */
-const tieredPricingSchema = {
-    type: 'array' as const, // Literal type required for MCP SDK type compatibility
-    items: {
-        type: 'object' as const, // Literal type required for MCP SDK type compatibility
-        properties: {
-            tier: { type: 'string', description: 'Tier name' },
-            pricePerUnit: { type: 'number', description: 'Price per unit for this tier' },
-        },
-    },
-    description: 'Tiered pricing information',
-};
-
-/**
- * Schema for pricing information
+ * Schema for pricing information.
+ * Prices are resolved to the user's plan tier — no tiered arrays in output.
  */
 export const pricingSchema = {
     type: 'object' as const, // Literal type required for MCP SDK type compatibility
     properties: {
         model: { type: 'string', description: 'Pricing model (FREE, PRICE_PER_DATASET_ITEM, FLAT_PRICE_PER_MONTH, PAY_PER_EVENT)' },
         isFree: { type: 'boolean', description: 'Whether the Actor is free to use' },
-        pricePerUnit: { type: 'number', description: 'Price per unit (for non-free models)' },
+        pricePerUnit: { type: 'number', description: 'Price per unit resolved to the user\'s plan tier' },
         unitName: { type: 'string', description: 'Unit name for pricing' },
         trialMinutes: { type: 'number', description: 'Trial period in minutes' },
-        tieredPricing: tieredPricingSchema,
+        resolvedForTier: { type: 'string', description: 'Plan tier this price was resolved for, or "base" as fallback' },
         events: pricingEventsSchema,
     },
     required: ['model', 'isFree'],

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -1,5 +1,5 @@
 import { APIFY_STORE_URL } from '../const.js';
-import type { Actor, ActorCardOptions, ActorStoreList, PricingInfo, StructuredActorCard } from '../types.js';
+import type { Actor, ActorCardOptions, ActorStoreList, PricingInfo, PricingTier, StructuredActorCard } from '../types.js';
 import { getCurrentPricingInfo, pricingInfoToString, pricingInfoToStructured, type StructuredPricingInfo } from './pricing_info.js';
 
 // Helper function to format categories from uppercase with underscores to proper case
@@ -32,6 +32,7 @@ export function formatActorToActorCard(
         includeRating: true,
         includeMetadata: true,
     },
+    userTier?: PricingTier | null,
 ): string {
     const actorFullName = `${actor.username}/${actor.name}`;
     const actorUrl = `${APIFY_STORE_URL}/${actorFullName}`;
@@ -52,11 +53,11 @@ export function formatActorToActorCard(
         let pricingInfo: string;
         if ('currentPricingInfo' in actor) {
             // ActorStoreList has currentPricingInfo
-            pricingInfo = pricingInfoToString(actor.currentPricingInfo);
+            pricingInfo = pricingInfoToString(actor.currentPricingInfo, userTier);
         } else {
             // Actor has pricingInfos array
             const currentPricingInfo = getCurrentPricingInfo(actor.pricingInfos || [], new Date());
-            pricingInfo = pricingInfoToString(currentPricingInfo);
+            pricingInfo = pricingInfoToString(currentPricingInfo, userTier);
         }
         markdownLines.push(`- **[Pricing](${actorUrl}/pricing):** ${pricingInfo}`);
     }
@@ -142,6 +143,7 @@ export function formatActorToStructuredCard(
         includeRating: true,
         includeMetadata: true,
     },
+    userTier?: PricingTier | null,
 ): StructuredActorCard {
     const actorFullName = `${actor.username}/${actor.name}`;
     const actorUrl = `${APIFY_STORE_URL}/${actorFullName}`;
@@ -181,7 +183,7 @@ export function formatActorToStructuredCard(
             pricingInfo = getCurrentPricingInfo(actor.pricingInfos, new Date());
         }
         // If pricingInfo is still null, it means the actor is free (no pricing info means free)
-        structuredData.pricing = pricingInfoToStructured(pricingInfo);
+        structuredData.pricing = pricingInfoToStructured(pricingInfo, userTier);
     }
 
     // Add metadata (deprecation warning)
@@ -285,6 +287,7 @@ export type WidgetActor = {
  */
 export function formatActorForWidget(
     actor: ActorStoreList,
+    userTier?: PricingTier | null,
 ): WidgetActor {
     return {
         id: actor.id,
@@ -300,7 +303,7 @@ export function formatActorForWidget(
             totalUsers: actor.stats?.totalUsers || 0,
         },
         url: `${APIFY_STORE_URL}/${actor.username}/${actor.name}`,
-        currentPricingInfo: pricingInfoToStructured(actor.currentPricingInfo),
+        currentPricingInfo: pricingInfoToStructured(actor.currentPricingInfo, userTier),
     };
 }
 
@@ -314,6 +317,7 @@ export function formatActorForWidget(
 export function formatActorDetailsForWidget(
     actor: Actor,
     actorUrl: string,
+    userTier?: PricingTier | null,
 ): WidgetActor {
     const currentPricingInfo = getCurrentPricingInfo(actor.pricingInfos || [], new Date());
 
@@ -331,6 +335,6 @@ export function formatActorDetailsForWidget(
             actorReviewRating: actor.stats?.actorReviewRating || 0,
             actorReviewCount: actor.stats?.actorReviewCount || 0,
         },
-        currentPricingInfo: pricingInfoToStructured(currentPricingInfo),
+        currentPricingInfo: pricingInfoToStructured(currentPricingInfo, userTier),
     };
 }

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -5,7 +5,7 @@ import type { ApifyClient } from '../apify_client.js';
 import { HelperTools, TOOL_STATUS } from '../const.js';
 import { connectMCPClient } from '../mcp/client.js';
 import { filterSchemaProperties, shortenProperties } from '../tools/utils.js';
-import type { Actor, ActorCardOptions, ActorInputSchema, ActorStoreList, StructuredActorCard } from '../types.js';
+import type { Actor, ActorCardOptions, ActorInputSchema, ActorStoreList, PricingTier, StructuredActorCard } from '../types.js';
 import { getActorMcpUrlCached } from './actor.js';
 import { formatActorDetailsForWidget, formatActorToActorCard, formatActorToStructuredCard } from './actor_card.js';
 import { searchActorsByKeywords } from './actor_search.js';
@@ -87,6 +87,7 @@ export async function fetchActorDetails(
     apifyClient: ApifyClient,
     actorName: string,
     cardOptions?: ActorCardOptions,
+    userTier?: PricingTier | null,
 ): Promise<ActorDetailsResult | null> {
     try {
         const [actorInfo, buildInfo, storeActors]: [Actor | undefined, Build | undefined, ActorStoreList[]] = await Promise.all([
@@ -109,8 +110,8 @@ export async function fetchActorDetails(
         }) as ActorInputSchema;
         inputSchema.properties = filterSchemaProperties(inputSchema.properties);
         inputSchema.properties = shortenProperties(inputSchema.properties);
-        const actorCard = formatActorToActorCard(actorInfoWithPicture, cardOptions);
-        const actorCardStructured = formatActorToStructuredCard(actorInfoWithPicture, cardOptions);
+        const actorCard = formatActorToActorCard(actorInfoWithPicture, cardOptions, userTier);
+        const actorCardStructured = formatActorToStructuredCard(actorInfoWithPicture, cardOptions, userTier);
         return {
             actorInfo: actorInfoWithPicture,
             buildInfo,
@@ -132,7 +133,7 @@ export async function fetchActorDetails(
  * @param details - Raw actor details from fetchActorDetails
  * @returns Processed actor details with formatted content
  */
-export function processActorDetailsForResponse(details: ActorDetailsResult) {
+export function processActorDetailsForResponse(details: ActorDetailsResult, userTier?: PricingTier | null) {
     const actorUrl = `https://apify.com/${details.actorInfo.username}/${details.actorInfo.name}`;
     // Add link to README title
     const formattedReadme = details.readme.replace(/^# /, `# [README](${actorUrl}/readme): `);
@@ -150,7 +151,7 @@ export function processActorDetailsForResponse(details: ActorDetailsResult) {
 
     const structuredContent = {
         actorDetails: {
-            actorInfo: formatActorDetailsForWidget(details.actorInfo, actorUrl),
+            actorInfo: formatActorDetailsForWidget(details.actorInfo, actorUrl, userTier),
             actorCard: details.actorCard,
             readme: formattedReadme,
             inputSchema: details.inputSchema,

--- a/src/utils/pricing_info.ts
+++ b/src/utils/pricing_info.ts
@@ -1,5 +1,5 @@
 import { ACTOR_PRICING_MODEL } from '../const.js';
-import type { ActorChargeEvent, PricingInfo } from '../types.js';
+import type { ActorChargeEvent, PricingInfo, PricingTier } from '../types.js';
 
 /**
  * Custom type to transform raw API pricing data into a clean, client-friendly format
@@ -11,18 +11,12 @@ export type StructuredPricingInfo = {
     pricePerUnit?: number;
     unitName?: string;
     trialMinutes?: number;
-    tieredPricing?: {
-        tier: string;
-        pricePerUnit: number;
-    }[];
+    /** The tier this price was resolved for (e.g. "BRONZE"), or "base" when falling back */
+    resolvedForTier?: string;
     events?: {
         title: string;
         description: string;
         priceUsd?: number;
-        tieredPricing?: {
-            tier: string;
-            priceUsd: number;
-        }[];
     }[];
 }
 
@@ -64,6 +58,41 @@ function convertMinutesToGreatestUnit(minutes: number): { value: number; unit: s
     return { value: Math.floor(minutes / (60 * 24)), unit: 'days' };
 }
 
+/** Resolve a single price from tiered pricing for the user's tier, with fallback to base price. */
+function resolveTieredUnitPrice(
+    tieredPricing: Record<string, { tieredPricePerUnitUsd: number }>,
+    userTier: PricingTier | null | undefined,
+    basePrice: number | undefined,
+): { price: number | undefined; label: string } {
+    if (userTier && tieredPricing[userTier]) {
+        return { price: tieredPricing[userTier].tieredPricePerUnitUsd, label: userTier };
+    }
+    return { price: basePrice, label: 'base' };
+}
+
+/** Resolve a single event price for the user's tier. */
+function resolveEventPrice(
+    event: ActorChargeEvent,
+    userTier: PricingTier | null | undefined,
+): { price: number | undefined; label: string } {
+    if (typeof event.eventPriceUsd === 'number') return { price: event.eventPriceUsd, label: '' };
+    if (event.eventTieredPricingUsd) {
+        if (userTier && event.eventTieredPricingUsd[userTier]) {
+            return { price: event.eventTieredPricingUsd[userTier]!.tieredEventPriceUsd, label: userTier };
+        }
+        const first = Object.values(event.eventTieredPricingUsd)[0];
+        return { price: first?.tieredEventPriceUsd, label: 'base' };
+    }
+    return { price: undefined, label: '' };
+}
+
+/** Short note appended to pricing strings when tier was resolved. */
+function tierNote(label: string): string {
+    if (!label) return '';
+    if (label === 'base') return ' (base price; see Actor pricing page for all tiers)';
+    return ` (your ${label} plan price)`;
+}
+
 /**
  * Formats the pay-per-event pricing information into a human-readable string.
  *
@@ -77,18 +106,17 @@ function convertMinutesToGreatestUnit(minutes: number): { value: number; unit: s
  * @param pricingPerEvent
  */
 
-function payPerEventPricingToString(pricingPerEvent: { actorChargeEvents: Record<string, ActorChargeEvent> } | undefined): string {
+function payPerEventPricingToString(
+    pricingPerEvent: { actorChargeEvents: Record<string, ActorChargeEvent> } | undefined,
+    userTier?: PricingTier | null,
+): string {
     if (!pricingPerEvent || !pricingPerEvent.actorChargeEvents) return 'Pricing information for events is not available.';
     const eventStrings: string[] = [];
     for (const event of Object.values(pricingPerEvent.actorChargeEvents)) {
+        const { price, label } = resolveEventPrice(event, userTier);
         let eventStr = `\t- **${event.eventTitle}**: ${event.eventDescription} `;
-        if (typeof event.eventPriceUsd === 'number') {
-            eventStr += `(Flat price: $${event.eventPriceUsd} per event)`;
-        } else if (event.eventTieredPricingUsd) {
-            const tiers = Object.entries(event.eventTieredPricingUsd)
-                .map(([tier, price]) => `${tier}: $${price.tieredEventPriceUsd}`)
-                .join(', ');
-            eventStr += `(Tiered pricing: ${tiers} per event)`;
+        if (price !== undefined) {
+            eventStr += `(Flat price: $${price} per event)${tierNote(label)}`;
         } else {
             eventStr += '(No price info)';
         }
@@ -97,7 +125,7 @@ function payPerEventPricingToString(pricingPerEvent: { actorChargeEvents: Record
     return `This Actor is paid per event. You are not charged for the Apify platform usage, but only a fixed price for the following events:\n${eventStrings.join('\n')}`;
 }
 
-export function pricingInfoToString(pricingInfo: PricingInfo | null): string {
+export function pricingInfoToString(pricingInfo: PricingInfo | null, userTier?: PricingTier | null): string {
     // If there is no pricing infos entries the Actor is free to use
     // based on https://github.com/apify/apify-core/blob/058044945f242387dde2422b8f1bef395110a1bf/src/packages/actor/src/paid_actors/paid_actors_common.ts#L691
     if (pricingInfo === null || pricingInfo.pricingModel === ACTOR_PRICING_MODEL.FREE) {
@@ -105,28 +133,23 @@ export function pricingInfoToString(pricingInfo: PricingInfo | null): string {
     }
     if (pricingInfo.pricingModel === ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM) {
         const customUnitName = pricingInfo.unitName !== 'result' ? pricingInfo.unitName : '';
-        // Handle tiered pricing if present
         if (pricingInfo.tieredPricing && Object.keys(pricingInfo.tieredPricing).length > 0) {
-            const tiers = Object.entries(pricingInfo.tieredPricing)
-                .map(([tier, obj]) => `${tier}: $${obj.tieredPricePerUnitUsd * 1000} per 1000 ${customUnitName || 'results'}`)
-                .join(', ');
-            return `This Actor charges per results${customUnitName ? ` (in this case named ${customUnitName})` : ''}; tiered pricing per 1000 ${customUnitName || 'results'}: ${tiers}.`;
+            const { price, label } = resolveTieredUnitPrice(pricingInfo.tieredPricing, userTier, pricingInfo.pricePerUnitUsd);
+            const per1000 = price !== undefined ? price * 1000 : 'N/A';
+            return `This Actor charges per results${customUnitName ? ` (in this case named ${customUnitName})` : ''}; the price per 1000 ${customUnitName || 'results'} is ${per1000} USD.${tierNote(label)}`;
         }
         return `This Actor charges per results${customUnitName ? ` (in this case named ${customUnitName})` : ''}; the price per 1000 ${customUnitName || 'results'} is ${pricingInfo.pricePerUnitUsd as number * 1000} USD.`;
     }
     if (pricingInfo.pricingModel === ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH) {
         const { value, unit } = convertMinutesToGreatestUnit(pricingInfo.trialMinutes || 0);
-        // Handle tiered pricing if present
         if (pricingInfo.tieredPricing && Object.keys(pricingInfo.tieredPricing).length > 0) {
-            const tiers = Object.entries(pricingInfo.tieredPricing)
-                .map(([tier, obj]) => `${tier}: $${obj.tieredPricePerUnitUsd} per month`)
-                .join(', ');
-            return `This Actor is rental and has tiered pricing per month: ${tiers}, with a trial period of ${value} ${unit}.`;
+            const { price, label } = resolveTieredUnitPrice(pricingInfo.tieredPricing, userTier, pricingInfo.pricePerUnitUsd);
+            return `This Actor is rental and has a flat price of ${price ?? 'N/A'} USD per month, with a trial period of ${value} ${unit}.${tierNote(label)}`;
         }
         return `This Actor is rental and has a flat price of ${pricingInfo.pricePerUnitUsd} USD per month, with a trial period of ${value} ${unit}.`;
     }
     if (pricingInfo.pricingModel === ACTOR_PRICING_MODEL.PAY_PER_EVENT) {
-        return payPerEventPricingToString(pricingInfo.pricingPerEvent);
+        return payPerEventPricingToString(pricingInfo.pricingPerEvent, userTier);
     }
     return 'Pricing information is not available.';
 }
@@ -135,7 +158,7 @@ export function pricingInfoToString(pricingInfo: PricingInfo | null): string {
  * Transform and normalize API response to match unstructured text output format
  * instead of just dumping raw API data - ensures consistency across structured & unstructured modes.
  */
-export function pricingInfoToStructured(pricingInfo: PricingInfo | null): StructuredPricingInfo {
+export function pricingInfoToStructured(pricingInfo: PricingInfo | null, userTier?: PricingTier | null): StructuredPricingInfo {
     const structuredPricing: StructuredPricingInfo = {
         model: pricingInfo?.pricingModel || ACTOR_PRICING_MODEL.FREE,
         isFree: !pricingInfo || pricingInfo.pricingModel === ACTOR_PRICING_MODEL.FREE,
@@ -146,43 +169,40 @@ export function pricingInfoToStructured(pricingInfo: PricingInfo | null): Struct
     }
 
     if (pricingInfo.pricingModel === ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM) {
-        structuredPricing.pricePerUnit = pricingInfo.pricePerUnitUsd || 0;
         structuredPricing.unitName = pricingInfo.unitName || 'result';
 
         if (pricingInfo.tieredPricing && Object.keys(pricingInfo.tieredPricing).length > 0) {
-            structuredPricing.tieredPricing = Object.entries(pricingInfo.tieredPricing).map(([tier, obj]) => ({
-                tier,
-                pricePerUnit: obj.tieredPricePerUnitUsd,
-            }));
+            const { price, label } = resolveTieredUnitPrice(pricingInfo.tieredPricing, userTier, pricingInfo.pricePerUnitUsd);
+            structuredPricing.pricePerUnit = price;
+            structuredPricing.resolvedForTier = label;
+        } else {
+            structuredPricing.pricePerUnit = pricingInfo.pricePerUnitUsd || 0;
         }
     } else if (pricingInfo.pricingModel === ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH) {
-        structuredPricing.pricePerUnit = pricingInfo.pricePerUnitUsd;
         structuredPricing.trialMinutes = pricingInfo.trialMinutes;
 
         if (pricingInfo.tieredPricing && Object.keys(pricingInfo.tieredPricing).length > 0) {
-            structuredPricing.tieredPricing = Object.entries(pricingInfo.tieredPricing).map(([tier, obj]) => ({
-                tier,
-                pricePerUnit: obj.tieredPricePerUnitUsd,
-            }));
+            const { price, label } = resolveTieredUnitPrice(pricingInfo.tieredPricing, userTier, pricingInfo.pricePerUnitUsd);
+            structuredPricing.pricePerUnit = price;
+            structuredPricing.resolvedForTier = label;
+        } else {
+            structuredPricing.pricePerUnit = pricingInfo.pricePerUnitUsd;
         }
     } else if (pricingInfo.pricingModel === ACTOR_PRICING_MODEL.PAY_PER_EVENT) {
         if (pricingInfo.pricingPerEvent?.actorChargeEvents) {
             const { actorChargeEvents } = pricingInfo.pricingPerEvent;
-            structuredPricing.events = Object.entries(actorChargeEvents).map(([, event]) => {
+            let resolvedLabel = '';
+            structuredPricing.events = Object.values(actorChargeEvents).map((event) => {
                 const actorEvent = event as ActorChargeEvent;
+                const { price, label } = resolveEventPrice(actorEvent, userTier);
+                if (label) resolvedLabel = label;
                 return {
                     title: actorEvent.eventTitle,
                     description: actorEvent.eventDescription || '',
-                    priceUsd: typeof actorEvent.eventPriceUsd === 'number' ? actorEvent.eventPriceUsd : undefined,
-                    tieredPricing: actorEvent.eventTieredPricingUsd
-                        ? Object.entries(actorEvent.eventTieredPricingUsd)
-                            .map(([tier, price]) => ({
-                                tier,
-                                priceUsd: price.tieredEventPriceUsd,
-                            }))
-                        : undefined,
+                    priceUsd: price,
                 };
             });
+            if (resolvedLabel) structuredPricing.resolvedForTier = resolvedLabel;
         }
     }
 

--- a/src/utils/userid_cache.ts
+++ b/src/utils/userid_cache.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 
 import type { ApifyClient } from '../apify_client.js';
 import { USER_CACHE_MAX_SIZE, USER_CACHE_TTL_SECS } from '../const.js';
+import type { PricingTier } from '../types.js';
 import { TTLLRUCache } from './ttl_lru.js';
 
 // LRU cache with TTL for user info - stores the raw User object from API
@@ -27,6 +28,34 @@ export async function getUserIdFromTokenCached(
         }
         userIdCache.set(tokenHash, user.id);
         return user.id;
+    } catch {
+        return null;
+    }
+}
+
+// Separate cache for plan tier to avoid refactoring the userId cache
+const planTierCache = new TTLLRUCache<PricingTier>(USER_CACHE_MAX_SIZE, USER_CACHE_TTL_SECS);
+
+/**
+ * Gets user plan tier from token, using cache to avoid repeated API calls.
+ * Returns the tier string (e.g. "BRONZE") or null if unauthenticated / not found.
+ */
+export async function getUserPlanTierCached(
+    token: string | null | undefined,
+    apifyClient: ApifyClient,
+): Promise<PricingTier | null> {
+    if (!token) return null;
+    const tokenHash = createHash('sha256').update(token).digest('hex');
+    const cached = planTierCache.get(tokenHash);
+    if (cached) return cached;
+
+    try {
+        const user = await apifyClient.user('me').get();
+        const tier = (user as { plan?: { tier?: string } })?.plan?.tier as PricingTier | undefined;
+        if (tier) {
+            planTierCache.set(tokenHash, tier);
+        }
+        return tier ?? null;
     } catch {
         return null;
     }

--- a/tests/unit/utils.pricing_info.test.ts
+++ b/tests/unit/utils.pricing_info.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+
+import { ACTOR_PRICING_MODEL } from '../../src/const.js';
+import type { PricingInfo } from '../../src/types.js';
+import { pricingInfoToString, pricingInfoToStructured } from '../../src/utils/pricing_info.js';
+
+// Helper factory functions
+function makePricePerDatasetItem(opts: {
+    pricePerUnitUsd?: number;
+    unitName?: string;
+    tieredPricing?: Record<string, { tieredPricePerUnitUsd: number }>;
+}): PricingInfo {
+    return {
+        pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
+        pricePerUnitUsd: opts.pricePerUnitUsd,
+        unitName: opts.unitName ?? 'result',
+        tieredPricing: opts.tieredPricing,
+        startedAt: new Date('2024-01-01'),
+    } as unknown as PricingInfo;
+}
+
+function makeFlatPricePerMonth(opts: {
+    pricePerUnitUsd?: number;
+    trialMinutes?: number;
+    tieredPricing?: Record<string, { tieredPricePerUnitUsd: number }>;
+}): PricingInfo {
+    return {
+        pricingModel: ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH,
+        pricePerUnitUsd: opts.pricePerUnitUsd,
+        trialMinutes: opts.trialMinutes ?? 60,
+        tieredPricing: opts.tieredPricing,
+        startedAt: new Date('2024-01-01'),
+    } as unknown as PricingInfo;
+}
+
+function makePayPerEvent(opts: {
+    events: Record<string, {
+        eventTitle: string;
+        eventDescription?: string;
+        eventPriceUsd?: number;
+        eventTieredPricingUsd?: Record<string, { tieredEventPriceUsd: number }>;
+    }>;
+}): PricingInfo {
+    return {
+        pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
+        pricingPerEvent: { actorChargeEvents: opts.events },
+        startedAt: new Date('2024-01-01'),
+    } as unknown as PricingInfo;
+}
+
+const TIERS = {
+    BRONZE: { tieredPricePerUnitUsd: 0.002 },
+    SILVER: { tieredPricePerUnitUsd: 0.0015 },
+    GOLD: { tieredPricePerUnitUsd: 0.001 },
+};
+
+describe('pricingInfoToStructured', () => {
+    describe('FREE model', () => {
+        it('returns free pricing for null', () => {
+            const result = pricingInfoToStructured(null);
+            expect(result.model).toBe(ACTOR_PRICING_MODEL.FREE);
+            expect(result.isFree).toBe(true);
+            expect(result.resolvedForTier).toBeUndefined();
+        });
+    });
+
+    describe('PRICE_PER_DATASET_ITEM', () => {
+        it('resolves tiered price for matching user tier', () => {
+            const info = makePricePerDatasetItem({ pricePerUnitUsd: 0.003, tieredPricing: TIERS });
+            const result = pricingInfoToStructured(info, 'SILVER');
+            expect(result.pricePerUnit).toBe(0.0015);
+            expect(result.resolvedForTier).toBe('SILVER');
+        });
+
+        it('falls back to base price when user tier not in tiers', () => {
+            const info = makePricePerDatasetItem({ pricePerUnitUsd: 0.003, tieredPricing: TIERS });
+            const result = pricingInfoToStructured(info, 'DIAMOND');
+            expect(result.pricePerUnit).toBe(0.003);
+            expect(result.resolvedForTier).toBe('base');
+        });
+
+        it('falls back to base price when userTier is null', () => {
+            const info = makePricePerDatasetItem({ pricePerUnitUsd: 0.003, tieredPricing: TIERS });
+            const result = pricingInfoToStructured(info, null);
+            expect(result.pricePerUnit).toBe(0.003);
+            expect(result.resolvedForTier).toBe('base');
+        });
+
+        it('uses pricePerUnitUsd when no tieredPricing', () => {
+            const info = makePricePerDatasetItem({ pricePerUnitUsd: 0.005 });
+            const result = pricingInfoToStructured(info, 'BRONZE');
+            expect(result.pricePerUnit).toBe(0.005);
+            expect(result.resolvedForTier).toBeUndefined();
+        });
+
+        it('falls back to first tier when userTier is null and no base price', () => {
+            const info = makePricePerDatasetItem({ tieredPricing: TIERS });
+            const result = pricingInfoToStructured(info, null);
+            expect(result.pricePerUnit).toBeUndefined();
+            expect(result.resolvedForTier).toBe('base');
+        });
+    });
+
+    describe('FLAT_PRICE_PER_MONTH', () => {
+        it('resolves tiered price for matching user tier', () => {
+            const info = makeFlatPricePerMonth({ pricePerUnitUsd: 50, trialMinutes: 120, tieredPricing: TIERS });
+            const result = pricingInfoToStructured(info, 'GOLD');
+            expect(result.pricePerUnit).toBe(0.001);
+            expect(result.resolvedForTier).toBe('GOLD');
+            expect(result.trialMinutes).toBe(120);
+        });
+
+        it('falls back to base when no matching tier', () => {
+            const info = makeFlatPricePerMonth({ pricePerUnitUsd: 50, tieredPricing: TIERS });
+            const result = pricingInfoToStructured(info, null);
+            expect(result.pricePerUnit).toBe(50);
+            expect(result.resolvedForTier).toBe('base');
+        });
+    });
+
+    describe('PAY_PER_EVENT', () => {
+        it('resolves flat event price (no tiering)', () => {
+            const info = makePayPerEvent({
+                events: {
+                    search: { eventTitle: 'Search', eventDescription: 'A search', eventPriceUsd: 0.01 },
+                },
+            });
+            const result = pricingInfoToStructured(info, 'BRONZE');
+            expect(result.events).toHaveLength(1);
+            expect(result.events![0].priceUsd).toBe(0.01);
+            expect(result.resolvedForTier).toBeUndefined();
+        });
+
+        it('resolves tiered event price for matching tier', () => {
+            const info = makePayPerEvent({
+                events: {
+                    search: {
+                        eventTitle: 'Search',
+                        eventTieredPricingUsd: {
+                            BRONZE: { tieredEventPriceUsd: 0.005 },
+                            SILVER: { tieredEventPriceUsd: 0.003 },
+                        },
+                    },
+                },
+            });
+            const result = pricingInfoToStructured(info, 'BRONZE');
+            expect(result.events![0].priceUsd).toBe(0.005);
+            expect(result.resolvedForTier).toBe('BRONZE');
+        });
+
+        it('falls back to first tier for tiered events when user tier unknown', () => {
+            const info = makePayPerEvent({
+                events: {
+                    search: {
+                        eventTitle: 'Search',
+                        eventTieredPricingUsd: {
+                            BRONZE: { tieredEventPriceUsd: 0.005 },
+                        },
+                    },
+                },
+            });
+            const result = pricingInfoToStructured(info, null);
+            expect(result.events![0].priceUsd).toBe(0.005);
+            expect(result.resolvedForTier).toBe('base');
+        });
+    });
+});
+
+describe('pricingInfoToString', () => {
+    it('returns free text for null', () => {
+        expect(pricingInfoToString(null)).toContain('free to use');
+    });
+
+    describe('PRICE_PER_DATASET_ITEM with tiered pricing', () => {
+        it('includes tier note for matched tier', () => {
+            const info = makePricePerDatasetItem({ pricePerUnitUsd: 0.003, tieredPricing: TIERS });
+            const result = pricingInfoToString(info, 'BRONZE');
+            expect(result).toContain('(your BRONZE plan price)');
+            expect(result).toContain('2'); // 0.002 * 1000 = 2
+        });
+
+        it('includes base note when tier not found', () => {
+            const info = makePricePerDatasetItem({ pricePerUnitUsd: 0.003, tieredPricing: TIERS });
+            const result = pricingInfoToString(info, 'DIAMOND');
+            expect(result).toContain('(base price; see Actor pricing page for all tiers)');
+        });
+
+        it('no tier note without tiered pricing', () => {
+            const info = makePricePerDatasetItem({ pricePerUnitUsd: 0.003 });
+            const result = pricingInfoToString(info, 'BRONZE');
+            expect(result).not.toContain('plan price');
+            expect(result).not.toContain('base price');
+        });
+    });
+
+    describe('PAY_PER_EVENT with tiered pricing', () => {
+        it('includes tier note for tiered events', () => {
+            const info = makePayPerEvent({
+                events: {
+                    search: {
+                        eventTitle: 'Search',
+                        eventDescription: 'Do search',
+                        eventTieredPricingUsd: {
+                            BRONZE: { tieredEventPriceUsd: 0.01 },
+                            SILVER: { tieredEventPriceUsd: 0.008 },
+                        },
+                    },
+                },
+            });
+            const result = pricingInfoToString(info, 'BRONZE');
+            expect(result).toContain('$0.01 per event');
+            expect(result).toContain('(your BRONZE plan price)');
+        });
+
+        it('includes base note for tiered events when tier not matched', () => {
+            const info = makePayPerEvent({
+                events: {
+                    search: {
+                        eventTitle: 'Search',
+                        eventDescription: 'Do search',
+                        eventTieredPricingUsd: {
+                            BRONZE: { tieredEventPriceUsd: 0.01 },
+                        },
+                    },
+                },
+            });
+            const result = pricingInfoToString(info, 'DIAMOND');
+            expect(result).toContain('(base price; see Actor pricing page for all tiers)');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Closes #578
Closes https://github.com/apify/apify-mcp-server/issues/547

- **Resolves tiered pricing to a single price** based on the user's actual plan tier instead of outputting verbose breakdowns for all tiers (BRONZE, SILVER, GOLD, PLATINUM, DIAMOND)
- **Adds tier hint** in text output like `(your BRONZE plan price)` or `(base price; see Actor pricing page for all tiers)` when tier is unknown
- **Adds `resolvedForTier` field** in structured output replacing the removed `tieredPricing` arrays

### Changes
- `userid_cache.ts`: Add `getUserPlanTierCached()` with separate TTL cache
- `pricing_info.ts`: Add `resolveTieredUnitPrice()`, `resolveEventPrice()`, `tierNote()` helpers; update `pricingInfoToString` and `pricingInfoToStructured` to accept `userTier` param
- `actor_card.ts`: Thread `userTier` through 4 format functions
- `actor_details.ts`: Thread `userTier` through `fetchActorDetails` and `processActorDetailsForResponse`
- `structured_output_schemas.ts`: Remove `tieredPricing` arrays, add `resolvedForTier`
- All 5 tool handlers: Fetch user tier via `getUserPlanTierCached` and pass it through

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (410 tests, 17 new pricing tests)
- [ ] Manual testing with different user plan tiers
- [ ] Verify widget output shows simplified pricing

https://claude.ai/code/session_01RNnzsiNrtM3qJX9i1Kqfqy