### PR TITLE
feat: Add failure diagnostics to tool-call telemetry

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ export default [
         ignores: [
             '**/dist', // Build output directory
             '**/.venv', // Python virtual environment (if present)
+            '.claude/worktrees/**', // Local Codex/Claude worktrees are outside this repo's TS project
             'evals/*.ts', // Top-level evaluation scripts
             'evals/*.md', // Documentation files
             'evals/*.json', // Test case data files

--- a/src/const.ts
+++ b/src/const.ts
@@ -190,7 +190,7 @@ export const SEGMENT_FLUSH_INTERVAL_MS = 5_000;
 
 // Tool status
 /**
- * Unified status constants for tool execution lifecycle.
+ * Unified status constants for the tool execution lifecycle.
  * Single source of truth for all tool status values.
  */
 export const TOOL_STATUS = {
@@ -198,6 +198,12 @@ export const TOOL_STATUS = {
     FAILED: 'FAILED',
     ABORTED: 'ABORTED',
     SOFT_FAIL: 'SOFT_FAIL',
+} as const;
+
+export const FAILURE_CATEGORY = {
+    INVALID_INPUT: 'INVALID_INPUT',
+    AUTH: 'AUTH',
+    INTERNAL_ERROR: 'INTERNAL_ERROR',
 } as const;
 
 // HTTP status codes

--- a/src/const.ts
+++ b/src/const.ts
@@ -207,7 +207,10 @@ export const FAILURE_CATEGORY = {
 } as const;
 
 // HTTP status codes
+export const HTTP_UNAUTHORIZED = 401;
 export const HTTP_PAYMENT_REQUIRED = 402;
+export const HTTP_FORBIDDEN = 403;
+export const HTTP_NOT_FOUND = 404;
 
 // Modes that allow long running task tool executions
 export const ALLOWED_TASK_TOOL_EXECUTION_MODES = ['optional', 'required'] as const;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -62,7 +62,7 @@ import type {
     ActorsMcpServerOptions,
     ActorStore,
     ApifyRequestParams,
-    FailureDiagnostics,
+    FailureDetails,
     ServerMode,
     TelemetryEnv,
     ToolCallTelemetryProperties,
@@ -74,8 +74,8 @@ import { buildMCPResponse } from '../utils/mcp.js';
 import { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
-import { classifyFailureCategory, extractToolResponseDiagnostics, extractValidationDiagnostics, getToolStatusFromError } from '../utils/tool_status.js';
-import { extractActorName, getToolFullName, getToolPublicFieldOnly } from '../utils/tools.js';
+import { classifyFailureCategory, extractAjvErrorDetails, extractToolTelemetry, getToolStatusFromError } from '../utils/tool_status.js';
+import { buildActorFields, extractActorId, extractActorName, getToolFullName, getToolPublicFieldOnly } from '../utils/tools.js';
 import { getUserIdFromTokenCached } from '../utils/userid_cache.js';
 import { getPackageVersion } from '../utils/version.js';
 import { connectMCPClient } from './client.js';
@@ -642,23 +642,23 @@ export class ActorsMcpServer {
             let telemetryData: ToolCallTelemetryProperties | null;
             let userId: string | null;
             let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
-            let failureDiagnostics: FailureDiagnostics = {};
+            let failureDetails: FailureDetails = {};
             let shouldTrackTelemetry = true;
             const failInvalidParams = async (
                 message: string,
-                diagnostics: FailureDiagnostics,
+                details: FailureDetails,
                 logFields?: Record<string, unknown>,
             ): Promise<never> => {
                 toolStatus = TOOL_STATUS.SOFT_FAIL;
-                failureDiagnostics = diagnostics;
+                failureDetails = details;
                 log.softFail(message, {
                     mcpSessionId,
-                    failureCategory: diagnostics.failure_category,
-                    actorName: diagnostics.actor_name,
-                    validationKeyword: diagnostics.validation_keyword,
-                    validationPath: diagnostics.validation_path,
-                    validationMissingProperty: diagnostics.validation_missing_property,
-                    validationAdditionalProperty: diagnostics.validation_additional_property,
+                    failureCategory: details.failure_category,
+                    actorName: details.actor_name,
+                    validationKeyword: details.validation_keyword,
+                    validationPath: details.validation_path,
+                    validationMissingProperty: details.validation_missing_property,
+                    validationAdditionalProperty: details.validation_additional_property,
                     ...logFields,
                 });
                 await this.server.sendLoggingMessage({ level: 'error', data: message });
@@ -669,9 +669,10 @@ export class ActorsMcpServer {
             // This ensures telemetry is available even for early failures (missing token, tool not found).
             ({ telemetryData, userId } = await this.prepareTelemetryData(name, mcpSessionId, apifyToken));
 
-            // actorName is declared here so it's available in the catch block for diagnostics.
-            // It's set after tool resolution (inside the try block).
+            // actorName/actorId are declared here so they're available in the catch block for telemetry.
+            // Set after tool resolution (inside the try block).
             let actorName: string | undefined;
+            let actorId: string | undefined;
 
             try {
                 // Validate token
@@ -706,9 +707,9 @@ export class ActorsMcpServer {
                 // Re-initialize telemetry with the resolved tool (uses actorFullName for actor tools).
                 ({ telemetryData, userId } = await this.prepareTelemetryData(getToolFullName(tool), mcpSessionId, apifyToken));
 
-                // Extract actor name for telemetry — available even when validation fails later.
-                // For call-actor, the actor name is in `args.actor` (before validation / decoding).
+                // Extract actor name/id for telemetry — available even when validation fails later.
                 actorName = extractActorName(tool, args as Record<string, unknown>);
+                actorId = extractActorId(tool);
 
                 if (!args) {
                     await failInvalidParams(dedent`
@@ -716,7 +717,7 @@ export class ActorsMcpServer {
                     Please provide the required arguments for this tool. Check the tool's input schema using ${HelperTools.ACTOR_GET_DETAILS} tool to see what parameters are required.
                 `, {
                         failure_category: FAILURE_CATEGORY.INVALID_INPUT,
-                        ...(actorName ? { actor_name: actorName } : {}),
+                        ...buildActorFields(actorName, actorId),
                     });
                 }
 
@@ -738,7 +739,7 @@ export class ActorsMcpServer {
                 log.debug('Validate arguments for tool', { toolName: tool.name, mcpSessionId, input: logSafeArgs });
                 if (!tool.ajvValidate(toolArgs)) {
                     const errors = tool.ajvValidate.errors || [];
-                    const validationDiagnostics = extractValidationDiagnostics(errors);
+                    const ajvErrorDetails = extractAjvErrorDetails(errors);
                     const errorMessages = errors.map((e: { message?: string; instancePath?: string }) => `${e.instancePath || 'root'}: ${e.message || 'validation error'}`).join('; ');
                     await failInvalidParams(dedent`
                     Invalid arguments for tool "${tool.name}".
@@ -746,8 +747,8 @@ export class ActorsMcpServer {
                     Please check the tool's input schema using ${HelperTools.ACTOR_GET_DETAILS} tool and ensure all required parameters are provided with correct types and values.
                 `, {
                         failure_category: FAILURE_CATEGORY.INVALID_INPUT,
-                        ...validationDiagnostics,
-                        ...(actorName ? { actor_name: actorName } : {}),
+                        ...ajvErrorDetails,
+                        ...buildActorFields(actorName, actorId),
                     });
                 }
 
@@ -760,7 +761,7 @@ export class ActorsMcpServer {
                     Please remove the "task" parameter from the tool call request or use a different tool that supports long running tasks.
                 `, {
                         failure_category: FAILURE_CATEGORY.INVALID_INPUT,
-                        ...(actorName ? { actor_name: actorName } : {}),
+                        ...buildActorFields(actorName, actorId),
                     });
                 }
 
@@ -790,6 +791,7 @@ export class ActorsMcpServer {
                             extra,
                             mcpSessionId,
                             actorName,
+                            actorId,
                             userRentedActorIds,
                         });
                     });
@@ -802,10 +804,10 @@ export class ActorsMcpServer {
                 // Check payment validation (already computed by prepareToolCallContext)
                 if (paymentRequiredResult) {
                     toolStatus = TOOL_STATUS.SOFT_FAIL;
-                    failureDiagnostics = {
+                    failureDetails = {
                         failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                         failure_http_status: 402,
-                        ...(actorName ? { actor_name: actorName } : {}),
+                        ...buildActorFields(actorName, actorId),
                     };
                     return paymentRequiredResult;
                 }
@@ -832,9 +834,9 @@ export class ActorsMcpServer {
                         }) as Record<string, unknown>;
 
                         // Extract diagnostics and strip internal fields from res before returning to client.
-                        const diag = extractToolResponseDiagnostics(res, actorName);
+                        const diag = extractToolTelemetry(res, actorName, actorId);
                         toolStatus = diag.toolStatus;
-                        failureDiagnostics = diag.failureDiagnostics;
+                        failureDetails = diag.failureDetails;
                         return res;
                     } finally {
                         progressTracker?.stop();
@@ -853,7 +855,7 @@ export class ActorsMcpServer {
                             log.softFail(msg, { mcpSessionId, failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR });
                             await this.server.sendLoggingMessage({ level: 'error', data: msg });
                             toolStatus = TOOL_STATUS.SOFT_FAIL;
-                            failureDiagnostics = { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR };
+                            failureDetails = { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR };
                             return buildMCPResponse({ texts: [msg], isError: true });
                         }
 
@@ -894,23 +896,21 @@ export class ActorsMcpServer {
                         // actor-mcp gets deeper telemetry treatment.
                         if ('isError' in res && res.isError) {
                             toolStatus = TOOL_STATUS.SOFT_FAIL;
-                            failureDiagnostics = {
-                                failure_category: FAILURE_CATEGORY.INTERNAL_ERROR,
-                            };
+                            failureDetails = { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR };
                         }
 
                         return { ...res };
                     } catch (error) {
                         toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
                         const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
-                        failureDiagnostics = {
+                        failureDetails = {
                             failure_category: classifyFailureCategory(error),
                             failure_detail: failureDetail,
                         };
                         logHttpError(error, `Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}'`, {
                             actorId: tool.actorId,
                             toolName: tool.originToolName,
-                            failureCategory: failureDiagnostics.failure_category,
+                            failureCategory: failureDetails.failure_category,
                         });
                         return buildMCPResponse({
                             texts: [`Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}': ${error instanceof Error ? error.message : String(error)}. The MCP server may be temporarily unavailable.`],
@@ -960,16 +960,16 @@ export class ActorsMcpServer {
                 // content[0].text (JSON) + isError: true
                 if (httpStatus === HTTP_PAYMENT_REQUIRED) {
                     toolStatus = TOOL_STATUS.SOFT_FAIL;
-                    failureDiagnostics = {
+                    failureDetails = {
                         failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                         failure_http_status: 402,
-                        ...(actorName ? { actor_name: actorName } : {}),
+                        ...buildActorFields(actorName, actorId),
                     };
                     return buildPaymentRequiredResponse(error);
                 }
 
                 // Re-throw MCP protocol errors (e.g. from failInvalidParams) so the SDK
-                // returns them as JSON-RPC errors. failInvalidParams already set failureDiagnostics
+                // returns them as JSON-RPC errors. failInvalidParams already set failureDetails
                 // with the correct semantic category (e.g. AUTH), so we must not overwrite it.
                 if (error instanceof McpError) {
                     throw error;
@@ -977,37 +977,37 @@ export class ActorsMcpServer {
 
                 toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
                 const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
-                failureDiagnostics = {
+                failureDetails = {
                     // Spread existing diagnostics first (e.g. validation_keyword from failInvalidParams),
                     // then overwrite with freshly computed fields so they take precedence.
-                    ...failureDiagnostics,
+                    ...failureDetails,
                     failure_category: classifyFailureCategory(error),
                     ...(httpStatus !== undefined ? { failure_http_status: httpStatus } : {}),
                     failure_detail: failureDetail,
-                    ...(actorName ? { actor_name: actorName } : {}),
+                    ...buildActorFields(actorName, actorId),
                 };
 
                 logHttpError(error, 'Error occurred while calling tool', {
                     toolName: name,
                     toolStatus,
                     mcpSessionId,
-                    failureCategory: failureDiagnostics.failure_category,
-                    failureHttpStatus: failureDiagnostics.failure_http_status,
-                    actorName: failureDiagnostics.actor_name,
-                    validationKeyword: failureDiagnostics.validation_keyword,
-                    validationPath: failureDiagnostics.validation_path,
-                    validationMissingProperty: failureDiagnostics.validation_missing_property,
-                    validationAdditionalProperty: failureDiagnostics.validation_additional_property,
+                    failureCategory: failureDetails.failure_category,
+                    failureHttpStatus: failureDetails.failure_http_status,
+                    actorName: failureDetails.actor_name,
+                    validationKeyword: failureDetails.validation_keyword,
+                    validationPath: failureDetails.validation_path,
+                    validationMissingProperty: failureDetails.validation_missing_property,
+                    validationAdditionalProperty: failureDetails.validation_additional_property,
                 });
                 const errorMessage = (error instanceof Error) ? error.message : 'Unknown error';
                 return buildMCPResponse({
                     texts: [`Error calling tool "${name}": ${errorMessage}.  Please verify the tool name, input parameters, and ensure all required resources are available.`],
                     isError: true,
-                    toolStatus,
+                    telemetry: { toolStatus },
                 });
             } finally {
                 if (shouldTrackTelemetry) {
-                    this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDiagnostics);
+                    this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDetails);
                 }
             }
 
@@ -1037,14 +1037,14 @@ export class ActorsMcpServer {
      * @param userId - Apify user ID (string or null if not available)
      * @param startTime - Timestamp when the tool call started
      * @param toolStatus - Final status of the tool call
-     * @param diagnostics
+     * @param failureDetails - Failure details to include when toolStatus is not SUCCEEDED
      */
     private finalizeAndTrackTelemetry(
         telemetryData: ToolCallTelemetryProperties | null,
         userId: string | null,
         startTime: number,
         toolStatus: ToolStatus,
-        diagnostics?: FailureDiagnostics,
+        failureDetails?: FailureDetails,
     ): void {
         if (!telemetryData) {
             return;
@@ -1055,7 +1055,7 @@ export class ActorsMcpServer {
             ...telemetryData,
             tool_status: toolStatus,
             tool_exec_time_ms: execTime,
-            ...(toolStatus !== TOOL_STATUS.SUCCEEDED ? diagnostics : {}),
+            ...(toolStatus !== TOOL_STATUS.SUCCEEDED ? failureDetails : {}),
         };
         trackToolCall(userId, this.telemetryEnv, finalizedTelemetryData);
     }
@@ -1086,14 +1086,15 @@ export class ActorsMcpServer {
         extra: RequestHandlerExtra<Request, Notification>;
         mcpSessionId: string | undefined;
         actorName?: string;
+        actorId?: string;
         userRentedActorIds?: string[];
     }): Promise<void> {
         const {
             taskId, tool, toolArgs, logSafeArgs, paymentRequiredResult,
-            apifyClient, apifyToken, progressToken, extra, mcpSessionId, actorName, userRentedActorIds,
+            apifyClient, apifyToken, progressToken, extra, mcpSessionId, actorName, actorId, userRentedActorIds,
         } = params;
         let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
-        let failureDiagnostics: FailureDiagnostics = {};
+        let failureDetails: FailureDetails = {};
         const startTime = Date.now();
 
         log.debug('[executeToolAndUpdateTask] Starting task execution', {
@@ -1117,7 +1118,7 @@ export class ActorsMcpServer {
                     mcpSessionId,
                 });
                 this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, TOOL_STATUS.ABORTED, {
-                    ...(actorName ? { actor_name: actorName } : {}),
+                    ...buildActorFields(actorName, actorId),
                 });
                 return;
             }
@@ -1134,10 +1135,10 @@ export class ActorsMcpServer {
             // Check payment validation (already computed by prepareToolCallContext in the caller)
             if (paymentRequiredResult) {
                 toolStatus = TOOL_STATUS.SOFT_FAIL;
-                failureDiagnostics = {
+                failureDetails = {
                     failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                     failure_http_status: 402,
-                    ...(actorName ? { actor_name: actorName } : {}),
+                    ...buildActorFields(actorName, actorId),
                 };
                 result = paymentRequiredResult;
             }
@@ -1167,9 +1168,9 @@ export class ActorsMcpServer {
                         mcpSessionId,
                     }) as Record<string, unknown>;
 
-                    const diag = extractToolResponseDiagnostics(res, actorName);
+                    const diag = extractToolTelemetry(res, actorName, actorId);
                     toolStatus = diag.toolStatus;
-                    failureDiagnostics = diag.failureDiagnostics;
+                    failureDetails = diag.failureDetails;
                     result = res;
                 } finally {
                     if (progressTracker) {
@@ -1227,7 +1228,7 @@ export class ActorsMcpServer {
             await this.taskStore.storeTaskResult(taskId, 'completed', result, mcpSessionId);
             log.debug('Task completed successfully', { taskId, toolName: tool.name, mcpSessionId });
 
-            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDiagnostics);
+            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDetails);
         } catch (error) {
             // Handle 402 Payment Required — return structured x402 result so clients can auto-pay
             const httpStatus = getHttpStatusCode(error);
@@ -1237,27 +1238,27 @@ export class ActorsMcpServer {
                 this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, TOOL_STATUS.SOFT_FAIL, {
                     failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                     failure_http_status: 402,
-                    ...(actorName ? { actor_name: actorName } : {}),
+                    ...buildActorFields(actorName, actorId),
                 });
                 return;
             }
 
             toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
             const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
-            failureDiagnostics = {
+            failureDetails = {
                 failure_category: classifyFailureCategory(error),
                 ...(httpStatus !== undefined ? { failure_http_status: httpStatus } : {}),
                 failure_detail: failureDetail,
-                ...(actorName ? { actor_name: actorName } : {}),
+                ...buildActorFields(actorName, actorId),
             };
             log.error('Error executing tool for task', {
                 taskId,
                 toolName: tool.name,
                 toolStatus,
                 mcpSessionId,
-                failureCategory: failureDiagnostics.failure_category,
-                failureHttpStatus: failureDiagnostics.failure_http_status,
-                actorName: failureDiagnostics.actor_name,
+                failureCategory: failureDetails.failure_category,
+                failureHttpStatus: failureDetails.failure_http_status,
+                actorName: failureDetails.actor_name,
                 error,
             });
             const errorMessage = (error instanceof Error) ? error.message : 'Unknown error';
@@ -1270,7 +1271,7 @@ export class ActorsMcpServer {
                     taskId,
                     mcpSessionId,
                 });
-                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDiagnostics);
+                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDetails);
                 return;
             }
 
@@ -1288,7 +1289,7 @@ export class ActorsMcpServer {
                 internalToolStatus: toolStatus,
             }, mcpSessionId);
 
-            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDiagnostics);
+            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDetails);
         }
     }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -100,6 +100,7 @@ type ToolsChangedHandler = (toolNames: string[]) => void;
  */
 function extractActorName(tool: ToolEntry, args?: Record<string, unknown>): string | undefined {
     if (tool.type === 'actor') return tool.actorFullName;
+    if (tool.type === 'actor-mcp') return tool.actorId;
 
     // For call-actor, the actor name is in `args.actor`.
     // The format can be "username/name" or "username/name:toolName" (MCP server Actors).

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -667,8 +667,8 @@ export class ActorsMcpServer {
                 throw new Error('MCP Session ID is required for tool calls');
             }
             const startTime = Date.now();
-            let telemetryData: ToolCallTelemetryProperties | null = null;
-            let userId: string | null = null;
+            let telemetryData: ToolCallTelemetryProperties | null;
+            let userId: string | null;
             let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
             let failureDiagnostics: FailureDiagnostics = {};
             let shouldTrackTelemetry = true;
@@ -830,6 +830,11 @@ export class ActorsMcpServer {
                 // Check payment validation (already computed by prepareToolCallContext)
                 if (paymentRequiredResult) {
                     toolStatus = TOOL_STATUS.SOFT_FAIL;
+                    failureDiagnostics = {
+                        failure_category: FAILURE_CATEGORY.INVALID_INPUT,
+                        failure_http_status: 402,
+                        ...(actorName ? { actor_name: actorName } : {}),
+                    };
                     return paymentRequiredResult;
                 }
 
@@ -1023,6 +1028,13 @@ export class ActorsMcpServer {
                     return buildPaymentRequiredResponse(error);
                 }
 
+                // Re-throw MCP protocol errors (e.g. from failInvalidParams) so the SDK
+                // returns them as JSON-RPC errors. failInvalidParams already set failureDiagnostics
+                // with the correct semantic category (e.g. AUTH), so we must not overwrite it.
+                if (error instanceof McpError) {
+                    throw error;
+                }
+
                 toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
                 const httpStatus = getHttpStatusCode(error);
                 const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
@@ -1035,12 +1047,6 @@ export class ActorsMcpServer {
                     failure_detail: failureDetail,
                     ...(actorName ? { actor_name: actorName } : {}),
                 };
-
-                // Re-throw MCP protocol errors (e.g. from failInvalidParams) so the SDK
-                // returns them as JSON-RPC errors. failInvalidParams already logged the error.
-                if (error instanceof McpError) {
-                    throw error;
-                }
 
                 logHttpError(error, 'Error occurred while calling tool', {
                     toolName: name,
@@ -1189,6 +1195,11 @@ export class ActorsMcpServer {
             // Check payment validation (already computed by preparePayment in the caller)
             if (paymentRequiredResult) {
                 toolStatus = TOOL_STATUS.SOFT_FAIL;
+                failureDiagnostics = {
+                    failure_category: FAILURE_CATEGORY.INVALID_INPUT,
+                    failure_http_status: 402,
+                    ...(actorName ? { actor_name: actorName } : {}),
+                };
                 result = paymentRequiredResult;
             }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1016,9 +1016,11 @@ export class ActorsMcpServer {
                 // If we reached here without returning, it means the tool type was not recognized (user error)
                 toolStatus = TOOL_STATUS.SOFT_FAIL;
             } catch (error) {
+                const httpStatus = getHttpStatusCode(error);
+
                 // Propagate 402 Payment Required as a tool result per x402 MCP transport spec:
                 // content[0].text (JSON) + isError: true
-                if (getHttpStatusCode(error) === HTTP_PAYMENT_REQUIRED) {
+                if (httpStatus === HTTP_PAYMENT_REQUIRED) {
                     toolStatus = TOOL_STATUS.SOFT_FAIL;
                     failureDiagnostics = {
                         failure_category: FAILURE_CATEGORY.INVALID_INPUT,
@@ -1036,7 +1038,6 @@ export class ActorsMcpServer {
                 }
 
                 toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
-                const httpStatus = getHttpStatusCode(error);
                 const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
                 failureDiagnostics = {
                     // Spread existing diagnostics first (e.g. validation_keyword from failInvalidParams),
@@ -1192,7 +1193,7 @@ export class ActorsMcpServer {
             // Execute the tool and get the result
             let result: Record<string, unknown> = {};
 
-            // Check payment validation (already computed by preparePayment in the caller)
+            // Check payment validation (already computed by prepareToolCallContext in the caller)
             if (paymentRequiredResult) {
                 toolStatus = TOOL_STATUS.SOFT_FAIL;
                 failureDiagnostics = {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -896,7 +896,7 @@ export class ActorsMcpServer {
                         // actor-mcp gets deeper telemetry treatment.
                         if ('isError' in res && res.isError) {
                             toolStatus = TOOL_STATUS.SOFT_FAIL;
-                            failureDetails = { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR };
+                            failureDetails = { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR, ...buildActorFields(actorName, actorId) };
                         }
 
                         return { ...res };
@@ -906,6 +906,7 @@ export class ActorsMcpServer {
                         failureDetails = {
                             failure_category: classifyFailureCategory(error),
                             failure_detail: failureDetail,
+                            ...buildActorFields(actorName, actorId),
                         };
                         logHttpError(error, `Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}'`, {
                             actorId: tool.actorId,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -64,7 +64,7 @@ import type {
     ActorStore,
     ActorTool,
     ApifyRequestParams,
-    FailureCategory,
+    FailureDiagnostics,
     HelperTool,
     ServerMode,
     TelemetryEnv,
@@ -77,7 +77,7 @@ import { buildMCPResponse } from '../utils/mcp.js';
 import { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
-import { classifyFailureCategory, extractValidationDiagnostics, getToolStatusFromError } from '../utils/tool_status.js';
+import { classifyFailureCategory, extractToolResponseDiagnostics, extractValidationDiagnostics, getToolStatusFromError } from '../utils/tool_status.js';
 import { getToolPublicFieldOnly } from '../utils/tools.js';
 import { getUserIdFromTokenCached } from '../utils/userid_cache.js';
 import { getPackageVersion } from '../utils/version.js';
@@ -92,15 +92,6 @@ const actorExecutorsByMode: Record<ServerMode, ActorExecutor> = {
 };
 
 type ToolsChangedHandler = (toolNames: string[]) => void;
-type FailureDiagnostics = Pick<ToolCallTelemetryProperties,
-    | 'failure_category'
-    | 'failure_http_status'
-    | 'failure_detail'
-    | 'actor_name'
-    | 'validation_keyword'
-    | 'validation_path'
-    | 'validation_missing_property'
-    | 'validation_additional_property'>;
 
 /**
  * Extract actor name for telemetry from the tool entry or call-actor args.
@@ -857,47 +848,13 @@ export class ActorsMcpServer {
                             userRentedActorIds,
                             progressTracker,
                             mcpSessionId,
-                        }) as object;
+                        }) as Record<string, unknown>;
 
-                        // Extract internal diagnostic fields from the tool response.
-                        // These transient fields are set by buildMCPResponse() in tool helpers
-                        // and stripped before the response reaches the MCP client (see `...rest` below).
-                        //
-                        // Three cases:
-                        // 1. internalToolStatus is set → the tool explicitly classified itself (e.g. SOFT_FAIL).
-                        //    Trust it and use any accompanying diagnostics as-is.
-                        // 2. isError is true but no internalToolStatus → the tool returned an error
-                        //    without classifying it. Default to SOFT_FAIL because tools that return
-                        //    isError as a normal response do so for user/input problems (not-found,
-                        //    validation). Real server failures throw exceptions (caught by outer catch).
-                        // 3. Neither → success.
-                        const { internalToolStatus, internalFailureCategory, internalFailureHttpStatus, internalValidationDiagnostics, ...rest } = res as {
-                            internalToolStatus?: ToolStatus;
-                            internalFailureCategory?: FailureCategory;
-                            internalFailureHttpStatus?: number;
-                            internalValidationDiagnostics?: FailureDiagnostics;
-                            isError?: boolean;
-                        };
-                        if (internalToolStatus !== undefined) {
-                            toolStatus = internalToolStatus;
-                            failureDiagnostics = {
-                                ...(internalFailureCategory ? { failure_category: internalFailureCategory } : {}),
-                                ...(internalFailureHttpStatus !== undefined ? { failure_http_status: internalFailureHttpStatus } : {}),
-                                ...(actorName ? { actor_name: actorName } : {}),
-                                ...internalValidationDiagnostics,
-                            };
-                        } else if ('isError' in rest && rest.isError) {
-                            toolStatus = TOOL_STATUS.SOFT_FAIL;
-                            failureDiagnostics = {
-                                failure_category: internalFailureCategory ?? FAILURE_CATEGORY.INTERNAL_ERROR,
-                                ...(internalFailureHttpStatus !== undefined ? { failure_http_status: internalFailureHttpStatus } : {}),
-                                ...(actorName ? { actor_name: actorName } : {}),
-                                ...internalValidationDiagnostics,
-                            };
-                        }
-
-                        // Never expose internal diagnostic fields to MCP clients
-                        return { ...rest };
+                        // Extract diagnostics and strip internal fields from res before returning to client.
+                        const diag = extractToolResponseDiagnostics(res, actorName);
+                        toolStatus = diag.toolStatus;
+                        failureDiagnostics = diag.failureDiagnostics;
+                        return res;
                     } finally {
                         progressTracker?.stop();
                     }
@@ -1227,39 +1184,12 @@ export class ActorsMcpServer {
                         userRentedActorIds,
                         progressTracker,
                         mcpSessionId,
-                    }) as object;
+                    }) as Record<string, unknown>;
 
-                    // Extract internal diagnostic fields — same three-case logic as
-                    // the main callTool handler (see comment there for rationale).
-                    const { internalToolStatus, internalFailureCategory, internalFailureHttpStatus, internalValidationDiagnostics, ...rest } = res as {
-                        internalToolStatus?: ToolStatus;
-                        internalFailureCategory?: FailureCategory;
-                        internalFailureHttpStatus?: number;
-                        internalValidationDiagnostics?: FailureDiagnostics;
-                        isError?: boolean;
-                    };
-                    if (internalToolStatus !== undefined) {
-                        toolStatus = internalToolStatus;
-                        failureDiagnostics = {
-                            ...(internalFailureCategory ? { failure_category: internalFailureCategory } : {}),
-                            ...(internalFailureHttpStatus !== undefined ? { failure_http_status: internalFailureHttpStatus } : {}),
-                            ...(actorName ? { actor_name: actorName } : {}),
-                            ...internalValidationDiagnostics,
-                        };
-                    } else if ('isError' in rest && rest.isError) {
-                        toolStatus = TOOL_STATUS.SOFT_FAIL;
-                        failureDiagnostics = {
-                            failure_category: internalFailureCategory ?? FAILURE_CATEGORY.INTERNAL_ERROR,
-                            ...(internalFailureHttpStatus !== undefined ? { failure_http_status: internalFailureHttpStatus } : {}),
-                            ...(actorName ? { actor_name: actorName } : {}),
-                            ...internalValidationDiagnostics,
-                        };
-                    } else {
-                        toolStatus = TOOL_STATUS.SUCCEEDED;
-                    }
-
-                    // Never expose internal diagnostic fields to MCP clients
-                    result = rest;
+                    const diag = extractToolResponseDiagnostics(res, actorName);
+                    toolStatus = diag.toolStatus;
+                    failureDiagnostics = diag.failureDiagnostics;
+                    result = res;
                 } finally {
                     if (progressTracker) {
                         progressTracker.stop();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -59,13 +59,10 @@ import { openaiActorExecutor } from '../tools/openai/actor_executor.js';
 import { decodeDotPropertyNames, legacyToolNameToNew } from '../tools/utils.js';
 import type {
     ActorExecutor,
-    ActorMcpTool,
     ActorsMcpServerOptions,
     ActorStore,
-    ActorTool,
     ApifyRequestParams,
     FailureDiagnostics,
-    HelperTool,
     ServerMode,
     TelemetryEnv,
     ToolCallTelemetryProperties,
@@ -78,7 +75,7 @@ import { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
 import { classifyFailureCategory, extractToolResponseDiagnostics, extractValidationDiagnostics, getToolStatusFromError } from '../utils/tool_status.js';
-import { getToolPublicFieldOnly } from '../utils/tools.js';
+import { extractActorName, getToolFullName, getToolPublicFieldOnly } from '../utils/tools.js';
 import { getUserIdFromTokenCached } from '../utils/userid_cache.js';
 import { getPackageVersion } from '../utils/version.js';
 import { connectMCPClient } from './client.js';
@@ -92,23 +89,6 @@ const actorExecutorsByMode: Record<ServerMode, ActorExecutor> = {
 };
 
 type ToolsChangedHandler = (toolNames: string[]) => void;
-
-/**
- * Extract actor name for telemetry from the tool entry or call-actor args.
- * For actor tools, read from the tool entry. For call-actor, parse from the `actor` arg.
- * Returns undefined for other internal tools or when the arg is missing/invalid.
- */
-function extractActorName(tool: ToolEntry, args?: Record<string, unknown>): string | undefined {
-    if (tool.type === 'actor') return tool.actorFullName;
-    if (tool.type === 'actor-mcp') return tool.actorId;
-
-    // For call-actor, the actor name is in `args.actor`.
-    // The format can be "username/name" or "username/name:toolName" (MCP server Actors).
-    // Strip the optional `:toolName` suffix to get the base actor name.
-    const actorArg = args?.actor;
-    if (typeof actorArg !== 'string') return undefined;
-    return actorArg.split(':')[0]?.trim() || undefined;
-}
 
 /**
  * Create Apify MCP server
@@ -709,7 +689,7 @@ export class ActorsMcpServer {
                 // Find tool by name, actor full name, or legacy tool name (e.g. apify-slash-rag-web-browser → apify--rag-web-browser)
                 const newName = legacyToolNameToNew(name) ?? name;
                 const toolEntry = Array.from(this.tools.values())
-                    .find((t) => t.name === newName || (t.type === 'actor' && t.actorFullName === newName));
+                    .find((t) => t.name === newName || getToolFullName(t) === newName);
 
                 if (!toolEntry) {
                     const availableTools = this.listToolNames();
@@ -724,7 +704,7 @@ export class ActorsMcpServer {
 
                 const tool = toolEntry!;
                 // Re-initialize telemetry with the resolved tool (uses actorFullName for actor tools).
-                ({ telemetryData, userId } = await this.prepareTelemetryData(tool, mcpSessionId, apifyToken));
+                ({ telemetryData, userId } = await this.prepareTelemetryData(getToolFullName(tool), mcpSessionId, apifyToken));
 
                 // Extract actor name for telemetry — available even when validation fails later.
                 // For call-actor, the actor name is in `args.actor` (before validation / decoding).
@@ -1124,7 +1104,7 @@ export class ActorsMcpServer {
 
         // Prepare telemetry before try-catch so it's accessible to both paths.
         // This avoids re-fetching user data in the error handler.
-        const { telemetryData, userId } = await this.prepareTelemetryData(tool, mcpSessionId, apifyToken);
+        const { telemetryData, userId } = await this.prepareTelemetryData(getToolFullName(tool), mcpSessionId, apifyToken);
 
         try {
             // Check if task was already cancelled before we start execution.
@@ -1316,19 +1296,10 @@ export class ActorsMcpServer {
      * Creates telemetry data for a tool call.
     */
     private async prepareTelemetryData(
-        tool: HelperTool | ActorTool | ActorMcpTool | string, mcpSessionId: string | undefined, apifyToken: string,
+        toolName: string, mcpSessionId: string | undefined, apifyToken: string,
     ): Promise<{ telemetryData: ToolCallTelemetryProperties | null; userId: string | null }> {
         if (!this.telemetryEnabled) {
             return { telemetryData: null, userId: null };
-        }
-
-        let toolFullName: string;
-        if (typeof tool === 'string') {
-            toolFullName = tool;
-        } else if (tool.type === 'actor') {
-            toolFullName = tool.actorFullName;
-        } else {
-            toolFullName = tool.name;
         }
 
         // Get userId from cache or fetch from API
@@ -1349,7 +1320,7 @@ export class ActorsMcpServer {
             mcp_client_capabilities: capabilities || null,
             mcp_session_id: mcpSessionId || '',
             transport_type: this.options.transportType || '',
-            tool_name: toolFullName,
+            tool_name: toolName,
             tool_status: TOOL_STATUS.SUCCEEDED, // Will be updated in finally
             tool_exec_time_ms: 0, // Will be calculated in finally
         };

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -30,6 +30,7 @@ import {
     SetLevelRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { ValidateFunction } from 'ajv';
+import dedent from 'dedent';
 
 import log from '@apify/log';
 import { parseBooleanOrNull } from '@apify/utilities';
@@ -40,12 +41,13 @@ import {
     APIFY_MCP_URL,
     DEFAULT_TELEMETRY_ENABLED,
     DEFAULT_TELEMETRY_ENV,
+    FAILURE_CATEGORY,
     HelperTools,
     HTTP_PAYMENT_REQUIRED,
     SERVER_NAME,
     TOOL_STATUS,
 } from '../const.js';
-import { preparePayment } from '../payments/helpers.js';
+import { prepareToolCallContext } from '../payments/helpers.js';
 import { prompts } from '../prompts/index.js';
 import { createResourceService } from '../resources/resource_service.js';
 import type { AvailableWidget } from '../resources/widgets.js';
@@ -62,6 +64,7 @@ import type {
     ActorStore,
     ActorTool,
     ApifyRequestParams,
+    FailureCategory,
     HelperTool,
     ServerMode,
     TelemetryEnv,
@@ -74,7 +77,7 @@ import { buildMCPResponse } from '../utils/mcp.js';
 import { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
-import { getToolStatusFromError } from '../utils/tool_status.js';
+import { classifyFailureCategory, extractValidationDiagnostics, getToolStatusFromError } from '../utils/tool_status.js';
 import { getToolPublicFieldOnly } from '../utils/tools.js';
 import { getUserIdFromTokenCached } from '../utils/userid_cache.js';
 import { getPackageVersion } from '../utils/version.js';
@@ -89,6 +92,31 @@ const actorExecutorsByMode: Record<ServerMode, ActorExecutor> = {
 };
 
 type ToolsChangedHandler = (toolNames: string[]) => void;
+type FailureDiagnostics = Pick<ToolCallTelemetryProperties,
+    | 'failure_category'
+    | 'failure_http_status'
+    | 'failure_detail'
+    | 'actor_name'
+    | 'validation_keyword'
+    | 'validation_path'
+    | 'validation_missing_property'
+    | 'validation_additional_property'>;
+
+/**
+ * Extract actor name for telemetry from the tool entry or call-actor args.
+ * For actor tools, read from the tool entry. For call-actor, parse from the `actor` arg.
+ * Returns undefined for other internal tools or when the arg is missing/invalid.
+ */
+function extractActorName(tool: ToolEntry, args?: Record<string, unknown>): string | undefined {
+    if (tool.type === 'actor') return tool.actorFullName;
+
+    // For call-actor, the actor name is in `args.actor`.
+    // The format can be "username/name" or "username/name:toolName" (MCP server Actors).
+    // Strip the optional `:toolName` suffix to get the base actor name.
+    const actorArg = args?.actor;
+    if (typeof actorArg !== 'string') return undefined;
+    return actorArg.split(':')[0]?.trim() || undefined;
+}
 
 /**
  * Create Apify MCP server
@@ -638,133 +666,171 @@ export class ActorsMcpServer {
                 log.error('MCP Session ID is missing in tool call request. This should never happen.');
                 throw new Error('MCP Session ID is required for tool calls');
             }
-
-            // Validate token
-            if (!apifyToken && !this.options.paymentProvider?.allowsUnauthenticated && !this.options.allowUnauthMode) {
-                const msg = `Apify API token is required but was not provided.
-Please set the APIFY_TOKEN environment variable or pass it as a parameter in the request header as Authorization Bearer <token>.
-You can obtain your Apify token from https://console.apify.com/account/integrations.`;
-                log.softFail(msg, { mcpSessionId, statusCode: 400 });
-                await this.server.sendLoggingMessage({ level: 'error', data: msg });
-                throw new McpError(
-                    ErrorCode.InvalidParams,
-                    msg,
-                );
-            }
-
-            // TODO - if connection is /mcp client will not receive notification on tool change
-            // Find tool by name, actor full name, or legacy tool name (e.g. apify-slash-rag-web-browser → apify--rag-web-browser)
-            const newName = legacyToolNameToNew(name) ?? name;
-            const tool = Array.from(this.tools.values())
-                .find((t) => t.name === newName || (t.type === 'actor' && t.actorFullName === newName));
-            if (!tool) {
-                const availableTools = this.listToolNames();
-                const msg = `Tool "${name}" was not found.
-Available tools: ${availableTools.length > 0 ? availableTools.join(', ') : 'none'}.
-Please verify the tool name is correct. You can list all available tools using the tools/list request.`;
-                log.softFail(msg, { mcpSessionId, statusCode: 404 });
-                await this.server.sendLoggingMessage({ level: 'error', data: msg });
-                throw new McpError(
-                    ErrorCode.InvalidParams,
-                    msg,
-                );
-            }
-            if (!args) {
-                const msg = `Missing arguments for tool "${name}".
-Please provide the required arguments for this tool. Check the tool's input schema using ${HelperTools.ACTOR_GET_DETAILS} tool to see what parameters are required.`;
-                log.softFail(msg, { mcpSessionId, statusCode: 400 });
-                await this.server.sendLoggingMessage({ level: 'error', data: msg });
-                throw new McpError(
-                    ErrorCode.InvalidParams,
-                    msg,
-                );
-            }
-            // Decode dot property names in arguments before validation,
-            // since validation expects the original, non-encoded property names.
-            args = decodeDotPropertyNames(args as Record<string, unknown>) as Record<string, unknown>;
-
-            // Centralize all payment processing: validate, strip payment fields, create client.
-            // Must run before ajv validation so cleanArgs doesn't contain provider-specific fields.
-            const payment = preparePayment({
-                provider: this.options.paymentProvider,
-                tool,
-                args: args as Record<string, unknown>,
-                apifyToken,
-                meta,
-                requestHeaders: extra.requestInfo?.headers,
-            });
-
-            log.debug('Validate arguments for tool', { toolName: tool.name, mcpSessionId, input: payment.logArgs });
-            if (!tool.ajvValidate(payment.cleanArgs)) {
-                const errors = tool?.ajvValidate.errors || [];
-                const errorMessages = errors.map((e: { message?: string; instancePath?: string }) => `${e.instancePath || 'root'}: ${e.message || 'validation error'}`).join('; ');
-                const msg = `Invalid arguments for tool "${tool.name}".
-Validation errors: ${errorMessages}.
-Please check the tool's input schema using ${HelperTools.ACTOR_GET_DETAILS} tool and ensure all required parameters are provided with correct types and values.`;
-                log.softFail(msg, { mcpSessionId, statusCode: 400 });
-                await this.server.sendLoggingMessage({ level: 'error', data: msg });
-                throw new McpError(
-                    ErrorCode.InvalidParams,
-                    msg,
-                );
-            }
-            // TODO: we should split this huge method into smaller parts as it is slowly getting out of hand
-            // Check if tool call is a long running task and the tool supports that
-            // Cast to allowed task mode types ('optional' | 'required') for type-safe includes() check
-            const taskSupport = tool.execution?.taskSupport as typeof ALLOWED_TASK_TOOL_EXECUTION_MODES[number];
-            if (request.params.task && !ALLOWED_TASK_TOOL_EXECUTION_MODES.includes(taskSupport)) {
-                const msg = `Tool "${tool.name}" does not support long running task calls.
-Please remove the "task" parameter from the tool call request or use a different tool that supports long running tasks.`;
-                log.softFail(msg, { mcpSessionId, statusCode: 400 });
-                await this.server.sendLoggingMessage({ level: 'error', data: msg });
-                throw new McpError(
-                    ErrorCode.InvalidParams,
-                    msg,
-                );
-            }
-
-            // Handle long-running task request
-            if (request.params.task) {
-                const task = await this.taskStore.createTask(
-                    {
-                        ttl: request.params.task.ttl,
-                    },
-                    `call-tool-${name}-${randomUUID()}`,
-                    request,
-                );
-                log.debug('Created task for tool execution', { taskId: task.taskId, toolName: tool.name, mcpSessionId });
-
-                // Execute the tool asynchronously and update task status
-                setImmediate(async () => {
-                    await this.executeToolAndUpdateTask({
-                        taskId: task.taskId,
-                        tool,
-                        cleanArgs: payment.cleanArgs,
-                        logArgs: payment.logArgs,
-                        paymentErrorResult: payment.errorResult,
-                        apifyClient: payment.client,
-                        apifyToken,
-                        progressToken,
-                        extra,
-                        mcpSessionId,
-                        userRentedActorIds,
-                    });
-                });
-
-                // Return the task immediately; execution continues asynchronously
-                return { task };
-            }
-
-            const { telemetryData, userId } = await this.prepareTelemetryData(tool, mcpSessionId, apifyToken);
-
             const startTime = Date.now();
+            let telemetryData: ToolCallTelemetryProperties | null = null;
+            let userId: string | null = null;
             let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
+            let failureDiagnostics: FailureDiagnostics = {};
+            let shouldTrackTelemetry = true;
+            const failInvalidParams = async (
+                message: string,
+                diagnostics: FailureDiagnostics,
+                logFields?: Record<string, unknown>,
+            ): Promise<never> => {
+                toolStatus = TOOL_STATUS.SOFT_FAIL;
+                failureDiagnostics = diagnostics;
+                log.softFail(message, {
+                    mcpSessionId,
+                    failureCategory: diagnostics.failure_category,
+                    actorName: diagnostics.actor_name,
+                    validationKeyword: diagnostics.validation_keyword,
+                    validationPath: diagnostics.validation_path,
+                    validationMissingProperty: diagnostics.validation_missing_property,
+                    validationAdditionalProperty: diagnostics.validation_additional_property,
+                    ...logFields,
+                });
+                await this.server.sendLoggingMessage({ level: 'error', data: message });
+                throw new McpError(ErrorCode.InvalidParams, message);
+            };
+
+            // Initialize telemetry with raw tool name — may be overwritten below once the tool is resolved.
+            // This ensures telemetry is available even for early failures (missing token, tool not found).
+            ({ telemetryData, userId } = await this.prepareTelemetryData(name, mcpSessionId, apifyToken));
+
+            // actorName is declared here so it's available in the catch block for diagnostics.
+            // It's set after tool resolution (inside the try block).
+            let actorName: string | undefined;
 
             try {
-                // Check payment validation (already computed by preparePayment)
-                if (payment.errorResult) {
+                // Validate token
+                if (!apifyToken && !this.options.paymentProvider?.allowsUnauthenticated && !this.options.allowUnauthMode) {
+                    await failInvalidParams(dedent`
+                    Apify API token is required but was not provided.
+                    Please set the APIFY_TOKEN environment variable or pass it as a parameter in the request header as Authorization Bearer <token>.
+                    You can get your Apify token from https://console.apify.com/account/integrations.
+                `, {
+                        failure_category: FAILURE_CATEGORY.AUTH,
+                    });
+                }
+
+                // TODO - if connection is /mcp client will not receive notification on tool change
+                // Find tool by name, actor full name, or legacy tool name (e.g. apify-slash-rag-web-browser → apify--rag-web-browser)
+                const newName = legacyToolNameToNew(name) ?? name;
+                const toolEntry = Array.from(this.tools.values())
+                    .find((t) => t.name === newName || (t.type === 'actor' && t.actorFullName === newName));
+
+                if (!toolEntry) {
+                    const availableTools = this.listToolNames();
+                    await failInvalidParams(dedent`
+                    Tool "${name}" was not found.
+                    Available tools: ${availableTools.length > 0 ? availableTools.join(', ') : 'none'}.
+                    Please verify the tool name is correct. You can list all available tools using the tools/list request.
+                `, {
+                        failure_category: FAILURE_CATEGORY.INVALID_INPUT,
+                    });
+                }
+
+                const tool = toolEntry!;
+                // Re-initialize telemetry with the resolved tool (uses actorFullName for actor tools).
+                ({ telemetryData, userId } = await this.prepareTelemetryData(tool, mcpSessionId, apifyToken));
+
+                // Extract actor name for telemetry — available even when validation fails later.
+                // For call-actor, the actor name is in `args.actor` (before validation / decoding).
+                actorName = extractActorName(tool, args as Record<string, unknown>);
+
+                if (!args) {
+                    await failInvalidParams(dedent`
+                    Missing arguments for tool "${name}".
+                    Please provide the required arguments for this tool. Check the tool's input schema using ${HelperTools.ACTOR_GET_DETAILS} tool to see what parameters are required.
+                `, {
+                        failure_category: FAILURE_CATEGORY.INVALID_INPUT,
+                        ...(actorName ? { actor_name: actorName } : {}),
+                    });
+                }
+
+                // Decode dot property names in arguments before validation,
+                // since validation expects the original, non-encoded property names.
+                args = decodeDotPropertyNames(args as Record<string, unknown>) as Record<string, unknown>;
+
+                // Centralize all payment processing: validate, strip payment fields, create client.
+                // Must run before ajv validation so toolArgs doesn't contain provider-specific fields.
+                const { toolArgs, logSafeArgs, apifyClient, paymentRequiredResult } = prepareToolCallContext({
+                    provider: this.options.paymentProvider,
+                    tool,
+                    args: args as Record<string, unknown>,
+                    apifyToken,
+                    meta,
+                    requestHeaders: extra.requestInfo?.headers,
+                });
+
+                log.debug('Validate arguments for tool', { toolName: tool.name, mcpSessionId, input: logSafeArgs });
+                if (!tool.ajvValidate(toolArgs)) {
+                    const errors = tool.ajvValidate.errors || [];
+                    const validationDiagnostics = extractValidationDiagnostics(errors);
+                    const errorMessages = errors.map((e: { message?: string; instancePath?: string }) => `${e.instancePath || 'root'}: ${e.message || 'validation error'}`).join('; ');
+                    await failInvalidParams(dedent`
+                    Invalid arguments for tool "${tool.name}".
+                    Validation errors: ${errorMessages}.
+                    Please check the tool's input schema using ${HelperTools.ACTOR_GET_DETAILS} tool and ensure all required parameters are provided with correct types and values.
+                `, {
+                        failure_category: FAILURE_CATEGORY.INVALID_INPUT,
+                        ...validationDiagnostics,
+                        ...(actorName ? { actor_name: actorName } : {}),
+                    });
+                }
+
+                // Check if tool call is a long running task and the tool supports that
+                // Cast to allowed task mode types ('optional' | 'required') for type-safe includes() check
+                const taskSupport = tool.execution?.taskSupport as typeof ALLOWED_TASK_TOOL_EXECUTION_MODES[number];
+                if (request.params.task && !ALLOWED_TASK_TOOL_EXECUTION_MODES.includes(taskSupport)) {
+                    await failInvalidParams(dedent`
+                    Tool "${tool.name}" does not support long running task calls.
+                    Please remove the "task" parameter from the tool call request or use a different tool that supports long running tasks.
+                `, {
+                        failure_category: FAILURE_CATEGORY.INVALID_INPUT,
+                        ...(actorName ? { actor_name: actorName } : {}),
+                    });
+                }
+
+                // TODO: we should split this huge method into smaller parts as it is slowly getting out of hand
+                // Handle long-running task request
+                if (request.params.task) {
+                    const task = await this.taskStore.createTask(
+                        {
+                            ttl: request.params.task.ttl,
+                        },
+                        `call-tool-${name}-${randomUUID()}`,
+                        request,
+                    );
+                    log.debug('Created task for tool execution', { taskId: task.taskId, toolName: tool.name, mcpSessionId });
+
+                    // Execute the tool asynchronously and update task status
+                    setImmediate(async () => {
+                        await this.executeToolAndUpdateTask({
+                            taskId: task.taskId,
+                            tool,
+                            toolArgs: toolArgs!,
+                            logSafeArgs,
+                            paymentRequiredResult,
+                            apifyClient: apifyClient!,
+                            apifyToken,
+                            progressToken,
+                            extra,
+                            mcpSessionId,
+                            actorName,
+                            userRentedActorIds,
+                        });
+                    });
+
+                    // Return the task immediately; execution continues asynchronously
+                    shouldTrackTelemetry = false;
+                    return { task };
+                }
+
+                // Check payment validation (already computed by prepareToolCallContext)
+                if (paymentRequiredResult) {
                     toolStatus = TOOL_STATUS.SOFT_FAIL;
-                    return payment.errorResult;
+                    return paymentRequiredResult;
                 }
 
                 // Handle internal tool
@@ -774,35 +840,62 @@ Please remove the "task" parameter from the tool call request or use a different
                         ? createProgressTracker(progressToken, extra.sendNotification)
                         : null;
 
-                    log.info('Calling internal tool', { name: tool.name, mcpSessionId, input: payment.logArgs });
-                    const res = await tool.call({
-                        args: payment.cleanArgs,
-                        extra,
-                        apifyMcpServer: this,
-                        mcpServer: this.server,
-                        apifyToken,
-                        apifyClient: payment.client,
-                        userRentedActorIds,
-                        progressTracker,
-                        mcpSessionId,
-                    }) as object;
+                    try {
+                        log.info('Calling internal tool', { name: tool.name, mcpSessionId, input: logSafeArgs });
+                        const res = await tool.call({
+                            args: toolArgs!,
+                            extra,
+                            apifyMcpServer: this,
+                            mcpServer: this.server,
+                            apifyToken,
+                            apifyClient: apifyClient!,
+                            userRentedActorIds,
+                            progressTracker,
+                            mcpSessionId,
+                        }) as object;
 
-                    if (progressTracker) {
-                        progressTracker.stop();
+                        // Extract internal diagnostic fields from the tool response.
+                        // These transient fields are set by buildMCPResponse() in tool helpers
+                        // and stripped before the response reaches the MCP client (see `...rest` below).
+                        //
+                        // Three cases:
+                        // 1. internalToolStatus is set → the tool explicitly classified itself (e.g. SOFT_FAIL).
+                        //    Trust it and use any accompanying diagnostics as-is.
+                        // 2. isError is true but no internalToolStatus → the tool returned an error
+                        //    without classifying it. Default to SOFT_FAIL because tools that return
+                        //    isError as a normal response do so for user/input problems (not-found,
+                        //    validation). Real server failures throw exceptions (caught by outer catch).
+                        // 3. Neither → success.
+                        const { internalToolStatus, internalFailureCategory, internalFailureHttpStatus, internalValidationDiagnostics, ...rest } = res as {
+                            internalToolStatus?: ToolStatus;
+                            internalFailureCategory?: FailureCategory;
+                            internalFailureHttpStatus?: number;
+                            internalValidationDiagnostics?: FailureDiagnostics;
+                            isError?: boolean;
+                        };
+                        if (internalToolStatus !== undefined) {
+                            toolStatus = internalToolStatus;
+                            failureDiagnostics = {
+                                ...(internalFailureCategory ? { failure_category: internalFailureCategory } : {}),
+                                ...(internalFailureHttpStatus !== undefined ? { failure_http_status: internalFailureHttpStatus } : {}),
+                                ...(actorName ? { actor_name: actorName } : {}),
+                                ...internalValidationDiagnostics,
+                            };
+                        } else if ('isError' in rest && rest.isError) {
+                            toolStatus = TOOL_STATUS.SOFT_FAIL;
+                            failureDiagnostics = {
+                                failure_category: internalFailureCategory ?? FAILURE_CATEGORY.INTERNAL_ERROR,
+                                ...(internalFailureHttpStatus !== undefined ? { failure_http_status: internalFailureHttpStatus } : {}),
+                                ...(actorName ? { actor_name: actorName } : {}),
+                                ...internalValidationDiagnostics,
+                            };
+                        }
+
+                        // Never expose internal diagnostic fields to MCP clients
+                        return { ...rest };
+                    } finally {
+                        progressTracker?.stop();
                     }
-
-                    // If tool returned internalToolStatus, use it; otherwise infer from isError flag
-                    const { internalToolStatus, ...rest } = res as { internalToolStatus?: ToolStatus; isError?: boolean };
-                    if (internalToolStatus !== undefined) {
-                        toolStatus = internalToolStatus;
-                    } else if ('isError' in rest && rest.isError) {
-                        toolStatus = TOOL_STATUS.FAILED;
-                    } else {
-                        toolStatus = TOOL_STATUS.SUCCEEDED;
-                    }
-
-                    // Never expose internalToolStatus to MCP clients
-                    return { ...rest };
                 }
 
                 if (tool.type === 'actor-mcp') {
@@ -810,11 +903,14 @@ Please remove the "task" parameter from the tool call request or use a different
                     try {
                         client = await connectMCPClient(tool.serverUrl, apifyToken, mcpSessionId);
                         if (!client) {
-                            const msg = `Failed to connect to MCP server at "${tool.serverUrl}".
-Please verify the server URL is correct and accessible, and ensure you have a valid Apify token with appropriate permissions.`;
-                            log.softFail(msg, { mcpSessionId, statusCode: 408 }); // 408 Request Timeout
+                            const msg = dedent`
+                                Failed to connect to MCP server at "${tool.serverUrl}".
+                                Please verify the server URL is correct and accessible, and ensure you have a valid Apify token with appropriate permissions.
+                            `;
+                            log.softFail(msg, { mcpSessionId, failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR });
                             await this.server.sendLoggingMessage({ level: 'error', data: msg });
                             toolStatus = TOOL_STATUS.SOFT_FAIL;
+                            failureDiagnostics = { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR };
                             return buildMCPResponse({ texts: [msg], isError: true });
                         }
 
@@ -839,27 +935,40 @@ Please verify the server URL is correct and accessible, and ensure you have a va
                             actorId: tool.actorId,
                             toolName: tool.originToolName,
                             mcpSessionId,
-                            input: payment.logArgs,
+                            input: logSafeArgs,
                         });
                         const res = await client.callTool({
                             name: tool.originToolName,
-                            arguments: payment.cleanArgs,
-                            _meta: {
-                                progressToken,
-                            },
+                            arguments: toolArgs!,
+                            _meta: { progressToken },
                         }, CallToolResultSchema, {
                             timeout: EXTERNAL_TOOL_CALL_TIMEOUT_MSEC,
                         });
 
-                        // For external MCP servers we do not try to infer soft_fail vs failed from isError.
-                        // We treat the call as succeeded at the telemetry layer unless an actual error is thrown.
+                        // TODO: actor-mcp responses are opaque — isError could be a user input problem
+                        // (e.g. invalid query) or a genuine server failure. We can't distinguish without
+                        // parsing the error text. Defaulting to INTERNAL_ERROR for now; revisit when
+                        // actor-mcp gets deeper telemetry treatment.
+                        if ('isError' in res && res.isError) {
+                            toolStatus = TOOL_STATUS.SOFT_FAIL;
+                            failureDiagnostics = {
+                                failure_category: FAILURE_CATEGORY.INTERNAL_ERROR,
+                            };
+                        }
+
                         return { ...res };
                     } catch (error) {
+                        toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
+                        const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
+                        failureDiagnostics = {
+                            failure_category: classifyFailureCategory(error),
+                            failure_detail: failureDetail,
+                        };
                         logHttpError(error, `Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}'`, {
                             actorId: tool.actorId,
                             toolName: tool.originToolName,
+                            failureCategory: failureDiagnostics.failure_category,
                         });
-                        toolStatus = TOOL_STATUS.FAILED;
                         return buildMCPResponse({
                             texts: [`Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}': ${error instanceof Error ? error.message : String(error)}. The MCP server may be temporarily unavailable.`],
                             isError: true,
@@ -874,11 +983,11 @@ Please verify the server URL is correct and accessible, and ensure you have a va
                     const progressTracker = createProgressTracker(progressToken, extra.sendNotification);
 
                     try {
-                        log.info('Calling Actor', { actorName: tool.actorFullName, mcpSessionId, input: payment.logArgs });
+                        log.info('Calling Actor', { actorName: tool.actorFullName, mcpSessionId, input: logSafeArgs });
                         const executorResult = await this.actorExecutor.executeActorTool({
                             actorFullName: tool.actorFullName,
-                            input: payment.cleanArgs,
-                            apifyClient: payment.client,
+                            input: toolArgs!,
+                            apifyClient: apifyClient!,
                             callOptions: { memory: tool.memoryMbytes },
                             progressTracker,
                             abortSignal: extra.signal,
@@ -904,15 +1013,47 @@ Please verify the server URL is correct and accessible, and ensure you have a va
             } catch (error) {
                 // Propagate 402 Payment Required as a tool result per x402 MCP transport spec:
                 // content[0].text (JSON) + isError: true
-                const httpStatus = getHttpStatusCode(error);
-                if (httpStatus === HTTP_PAYMENT_REQUIRED) {
-                    logHttpError(error, 'Payment required while calling tool', { toolName: name });
+                if (getHttpStatusCode(error) === HTTP_PAYMENT_REQUIRED) {
                     toolStatus = TOOL_STATUS.SOFT_FAIL;
+                    failureDiagnostics = {
+                        failure_category: FAILURE_CATEGORY.INVALID_INPUT,
+                        failure_http_status: 402,
+                        ...(actorName ? { actor_name: actorName } : {}),
+                    };
                     return buildPaymentRequiredResponse(error);
                 }
 
                 toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
-                logHttpError(error, 'Error occurred while calling tool', { toolName: name });
+                const httpStatus = getHttpStatusCode(error);
+                const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
+                failureDiagnostics = {
+                    // Spread existing diagnostics first (e.g. validation_keyword from failInvalidParams),
+                    // then overwrite with freshly computed fields so they take precedence.
+                    ...failureDiagnostics,
+                    failure_category: classifyFailureCategory(error),
+                    ...(httpStatus !== undefined ? { failure_http_status: httpStatus } : {}),
+                    failure_detail: failureDetail,
+                    ...(actorName ? { actor_name: actorName } : {}),
+                };
+
+                // Re-throw MCP protocol errors (e.g. from failInvalidParams) so the SDK
+                // returns them as JSON-RPC errors. failInvalidParams already logged the error.
+                if (error instanceof McpError) {
+                    throw error;
+                }
+
+                logHttpError(error, 'Error occurred while calling tool', {
+                    toolName: name,
+                    toolStatus,
+                    mcpSessionId,
+                    failureCategory: failureDiagnostics.failure_category,
+                    failureHttpStatus: failureDiagnostics.failure_http_status,
+                    actorName: failureDiagnostics.actor_name,
+                    validationKeyword: failureDiagnostics.validation_keyword,
+                    validationPath: failureDiagnostics.validation_path,
+                    validationMissingProperty: failureDiagnostics.validation_missing_property,
+                    validationAdditionalProperty: failureDiagnostics.validation_additional_property,
+                });
                 const errorMessage = (error instanceof Error) ? error.message : 'Unknown error';
                 return buildMCPResponse({
                     texts: [`Error calling tool "${name}": ${errorMessage}.  Please verify the tool name, input parameters, and ensure all required resources are available.`],
@@ -920,13 +1061,17 @@ Please verify the server URL is correct and accessible, and ensure you have a va
                     toolStatus,
                 });
             } finally {
-                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus);
+                if (shouldTrackTelemetry) {
+                    this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDiagnostics);
+                }
             }
 
             const availableTools = this.listToolNames();
-            const msg = `Unknown tool type for "${name}".
-Available tools: ${availableTools.length > 0 ? availableTools.join(', ') : 'none'}.
-Please verify the tool name and ensure the tool is properly registered.`;
+            const msg = dedent`
+                Unknown tool type for "${name}".
+                Available tools: ${availableTools.length > 0 ? availableTools.join(', ') : 'none'}.
+                Please verify the tool name and ensure the tool is properly registered.
+            `;
             log.softFail(msg, { mcpSessionId, statusCode: 404 });
             await this.server.sendLoggingMessage({
                 level: 'error',
@@ -947,12 +1092,14 @@ Please verify the tool name and ensure the tool is properly registered.`;
      * @param userId - Apify user ID (string or null if not available)
      * @param startTime - Timestamp when the tool call started
      * @param toolStatus - Final status of the tool call
+     * @param diagnostics
      */
     private finalizeAndTrackTelemetry(
         telemetryData: ToolCallTelemetryProperties | null,
         userId: string | null,
         startTime: number,
         toolStatus: ToolStatus,
+        diagnostics?: FailureDiagnostics,
     ): void {
         if (!telemetryData) {
             return;
@@ -963,6 +1110,7 @@ Please verify the tool name and ensure the tool is properly registered.`;
             ...telemetryData,
             tool_status: toolStatus,
             tool_exec_time_ms: execTime,
+            ...(toolStatus !== TOOL_STATUS.SUCCEEDED ? diagnostics : {}),
         };
         trackToolCall(userId, this.telemetryEnv, finalizedTelemetryData);
     }
@@ -984,21 +1132,23 @@ Please verify the tool name and ensure the tool is properly registered.`;
     private async executeToolAndUpdateTask(params: {
         taskId: string;
         tool: ToolEntry;
-        cleanArgs: Record<string, unknown>;
-        logArgs: unknown;
-        paymentErrorResult?: Record<string, unknown>;
+        toolArgs: Record<string, unknown>;
+        logSafeArgs: unknown;
+        paymentRequiredResult?: Record<string, unknown>;
         apifyClient: ApifyClient;
         apifyToken: string;
         progressToken: string | number | undefined;
         extra: RequestHandlerExtra<Request, Notification>;
         mcpSessionId: string | undefined;
+        actorName?: string;
         userRentedActorIds?: string[];
     }): Promise<void> {
         const {
-            taskId, tool, cleanArgs, logArgs, paymentErrorResult,
-            apifyClient, apifyToken, progressToken, extra, mcpSessionId, userRentedActorIds,
+            taskId, tool, toolArgs, logSafeArgs, paymentRequiredResult,
+            apifyClient, apifyToken, progressToken, extra, mcpSessionId, actorName, userRentedActorIds,
         } = params;
         let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
+        let failureDiagnostics: FailureDiagnostics = {};
         const startTime = Date.now();
 
         log.debug('[executeToolAndUpdateTask] Starting task execution', {
@@ -1021,7 +1171,9 @@ Please verify the tool name and ensure the tool is properly registered.`;
                     taskId,
                     mcpSessionId,
                 });
-                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, TOOL_STATUS.ABORTED);
+                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, TOOL_STATUS.ABORTED, {
+                    ...(actorName ? { actor_name: actorName } : {}),
+                });
                 return;
             }
 
@@ -1035,9 +1187,9 @@ Please verify the tool name and ensure the tool is properly registered.`;
             let result: Record<string, unknown> = {};
 
             // Check payment validation (already computed by preparePayment in the caller)
-            if (paymentErrorResult) {
+            if (paymentRequiredResult) {
                 toolStatus = TOOL_STATUS.SOFT_FAIL;
-                result = paymentErrorResult;
+                result = paymentRequiredResult;
             }
 
             // Callback to propagate Actor run statusMessage into the task store.
@@ -1052,9 +1204,9 @@ Please verify the tool name and ensure the tool is properly registered.`;
                 const progressTracker = createProgressTracker(progressToken, extra.sendNotification, taskId, onStatusMessage);
 
                 try {
-                    log.info('Calling internal tool for task', { taskId, name: tool.name, mcpSessionId, input: logArgs });
+                    log.info('Calling internal tool for task', { taskId, name: tool.name, mcpSessionId, input: logSafeArgs });
                     const res = await tool.call({
-                        args: cleanArgs,
+                        args: toolArgs,
                         extra,
                         apifyMcpServer: this,
                         mcpServer: this.server,
@@ -1065,17 +1217,36 @@ Please verify the tool name and ensure the tool is properly registered.`;
                         mcpSessionId,
                     }) as object;
 
-                    // If the tool returned internalToolStatus, use it; otherwise infer from isError flag
-                    const { internalToolStatus, ...rest } = res as { internalToolStatus?: ToolStatus; isError?: boolean };
+                    // Extract internal diagnostic fields — same three-case logic as
+                    // the main callTool handler (see comment there for rationale).
+                    const { internalToolStatus, internalFailureCategory, internalFailureHttpStatus, internalValidationDiagnostics, ...rest } = res as {
+                        internalToolStatus?: ToolStatus;
+                        internalFailureCategory?: FailureCategory;
+                        internalFailureHttpStatus?: number;
+                        internalValidationDiagnostics?: FailureDiagnostics;
+                        isError?: boolean;
+                    };
                     if (internalToolStatus !== undefined) {
                         toolStatus = internalToolStatus;
+                        failureDiagnostics = {
+                            ...(internalFailureCategory ? { failure_category: internalFailureCategory } : {}),
+                            ...(internalFailureHttpStatus !== undefined ? { failure_http_status: internalFailureHttpStatus } : {}),
+                            ...(actorName ? { actor_name: actorName } : {}),
+                            ...internalValidationDiagnostics,
+                        };
                     } else if ('isError' in rest && rest.isError) {
-                        toolStatus = TOOL_STATUS.FAILED;
+                        toolStatus = TOOL_STATUS.SOFT_FAIL;
+                        failureDiagnostics = {
+                            failure_category: internalFailureCategory ?? FAILURE_CATEGORY.INTERNAL_ERROR,
+                            ...(internalFailureHttpStatus !== undefined ? { failure_http_status: internalFailureHttpStatus } : {}),
+                            ...(actorName ? { actor_name: actorName } : {}),
+                            ...internalValidationDiagnostics,
+                        };
                     } else {
                         toolStatus = TOOL_STATUS.SUCCEEDED;
                     }
 
-                    // Never expose internalToolStatus to MCP clients
+                    // Never expose internal diagnostic fields to MCP clients
                     result = rest;
                 } finally {
                     if (progressTracker) {
@@ -1089,10 +1260,10 @@ Please verify the tool name and ensure the tool is properly registered.`;
                 const progressTracker = createProgressTracker(progressToken, extra.sendNotification, taskId, onStatusMessage);
 
                 try {
-                    log.info('Calling Actor for task', { taskId, actorName: tool.actorFullName, mcpSessionId, input: logArgs });
+                    log.info('Calling Actor for task', { taskId, actorName: tool.actorFullName, mcpSessionId, input: logSafeArgs });
                     const executorResult = await this.actorExecutor.executeActorTool({
                         actorFullName: tool.actorFullName,
-                        input: cleanArgs,
+                        input: toolArgs,
                         apifyClient,
                         callOptions: { memory: tool.memoryMbytes },
                         progressTracker,
@@ -1133,20 +1304,39 @@ Please verify the tool name and ensure the tool is properly registered.`;
             await this.taskStore.storeTaskResult(taskId, 'completed', result, mcpSessionId);
             log.debug('Task completed successfully', { taskId, toolName: tool.name, mcpSessionId });
 
-            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus);
+            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDiagnostics);
         } catch (error) {
-            log.error('Error executing tool for task', { taskId, mcpSessionId, error });
-
             // Handle 402 Payment Required — return structured x402 result so clients can auto-pay
             const httpStatus = getHttpStatusCode(error);
             if (httpStatus === HTTP_PAYMENT_REQUIRED) {
                 logHttpError(error, 'Payment required while calling tool (task mode)', { toolName: tool.name });
                 await this.taskStore.storeTaskResult(taskId, 'completed', buildPaymentRequiredResponse(error), mcpSessionId);
-                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, TOOL_STATUS.SOFT_FAIL);
+                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, TOOL_STATUS.SOFT_FAIL, {
+                    failure_category: FAILURE_CATEGORY.INVALID_INPUT,
+                    failure_http_status: 402,
+                    ...(actorName ? { actor_name: actorName } : {}),
+                });
                 return;
             }
 
             toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
+            const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
+            failureDiagnostics = {
+                failure_category: classifyFailureCategory(error),
+                ...(httpStatus !== undefined ? { failure_http_status: httpStatus } : {}),
+                failure_detail: failureDetail,
+                ...(actorName ? { actor_name: actorName } : {}),
+            };
+            log.error('Error executing tool for task', {
+                taskId,
+                toolName: tool.name,
+                toolStatus,
+                mcpSessionId,
+                failureCategory: failureDiagnostics.failure_category,
+                failureHttpStatus: failureDiagnostics.failure_http_status,
+                actorName: failureDiagnostics.actor_name,
+                error,
+            });
             const errorMessage = (error instanceof Error) ? error.message : 'Unknown error';
 
             // Check if task was cancelled before storing result
@@ -1157,7 +1347,7 @@ Please verify the tool name and ensure the tool is properly registered.`;
                     taskId,
                     mcpSessionId,
                 });
-                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus);
+                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDiagnostics);
                 return;
             }
 
@@ -1175,7 +1365,7 @@ Please verify the tool name and ensure the tool is properly registered.`;
                 internalToolStatus: toolStatus,
             }, mcpSessionId);
 
-            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus);
+            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDiagnostics);
         }
     }
 
@@ -1183,13 +1373,20 @@ Please verify the tool name and ensure the tool is properly registered.`;
      * Creates telemetry data for a tool call.
     */
     private async prepareTelemetryData(
-        tool: HelperTool | ActorTool | ActorMcpTool, mcpSessionId: string | undefined, apifyToken: string,
+        tool: HelperTool | ActorTool | ActorMcpTool | string, mcpSessionId: string | undefined, apifyToken: string,
     ): Promise<{ telemetryData: ToolCallTelemetryProperties | null; userId: string | null }> {
         if (!this.telemetryEnabled) {
             return { telemetryData: null, userId: null };
         }
 
-        const toolFullName = tool.type === 'actor' ? tool.actorFullName : tool.name;
+        let toolFullName: string;
+        if (typeof tool === 'string') {
+            toolFullName = tool;
+        } else if (tool.type === 'actor') {
+            toolFullName = tool.actorFullName;
+        } else {
+            toolFullName = tool.name;
+        }
 
         // Get userId from cache or fetch from API
         let userId: string | null = null;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -62,7 +62,7 @@ import type {
     ActorsMcpServerOptions,
     ActorStore,
     ApifyRequestParams,
-    FailureDetails,
+    CallDiagnostics,
     ServerMode,
     TelemetryEnv,
     ToolCallTelemetryProperties,
@@ -642,15 +642,15 @@ export class ActorsMcpServer {
             let telemetryData: ToolCallTelemetryProperties | null;
             let userId: string | null;
             let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
-            let failureDetails: FailureDetails = {};
+            let callDiagnostics: CallDiagnostics = {};
             let shouldTrackTelemetry = true;
             const failInvalidParams = async (
                 message: string,
-                details: FailureDetails,
+                details: CallDiagnostics,
                 logFields?: Record<string, unknown>,
             ): Promise<never> => {
                 toolStatus = TOOL_STATUS.SOFT_FAIL;
-                failureDetails = details;
+                callDiagnostics = details;
                 log.softFail(message, {
                     mcpSessionId,
                     failureCategory: details.failure_category,
@@ -710,6 +710,9 @@ export class ActorsMcpServer {
                 // Extract actor name/id for telemetry — available even when validation fails later.
                 actorName = extractActorName(tool, args as Record<string, unknown>);
                 actorId = extractActorId(tool);
+
+                // Always populate actor fields so they're tracked on both success and failure paths.
+                callDiagnostics = { ...callDiagnostics, ...buildActorFields(actorName, actorId) };
 
                 if (!args) {
                     await failInvalidParams(dedent`
@@ -804,7 +807,7 @@ export class ActorsMcpServer {
                 // Check payment validation (already computed by prepareToolCallContext)
                 if (paymentRequiredResult) {
                     toolStatus = TOOL_STATUS.SOFT_FAIL;
-                    failureDetails = {
+                    callDiagnostics = {
                         failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                         failure_http_status: 402,
                         ...buildActorFields(actorName, actorId),
@@ -836,7 +839,7 @@ export class ActorsMcpServer {
                         // Extract diagnostics and strip internal fields from res before returning to client.
                         const diag = extractToolTelemetry(res, actorName, actorId);
                         toolStatus = diag.toolStatus;
-                        failureDetails = diag.failureDetails;
+                        callDiagnostics = { ...callDiagnostics, ...diag.callDiagnostics };
                         return res;
                     } finally {
                         progressTracker?.stop();
@@ -855,7 +858,7 @@ export class ActorsMcpServer {
                             log.softFail(msg, { mcpSessionId, failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR });
                             await this.server.sendLoggingMessage({ level: 'error', data: msg });
                             toolStatus = TOOL_STATUS.SOFT_FAIL;
-                            failureDetails = { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR };
+                            callDiagnostics = { ...callDiagnostics, failure_category: FAILURE_CATEGORY.INTERNAL_ERROR };
                             return buildMCPResponse({ texts: [msg], isError: true });
                         }
 
@@ -896,14 +899,14 @@ export class ActorsMcpServer {
                         // actor-mcp gets deeper telemetry treatment.
                         if ('isError' in res && res.isError) {
                             toolStatus = TOOL_STATUS.SOFT_FAIL;
-                            failureDetails = { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR, ...buildActorFields(actorName, actorId) };
+                            callDiagnostics = { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR, ...buildActorFields(actorName, actorId) };
                         }
 
                         return { ...res };
                     } catch (error) {
                         toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
                         const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
-                        failureDetails = {
+                        callDiagnostics = {
                             failure_category: classifyFailureCategory(error),
                             failure_detail: failureDetail,
                             ...buildActorFields(actorName, actorId),
@@ -911,7 +914,7 @@ export class ActorsMcpServer {
                         logHttpError(error, `Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}'`, {
                             actorId: tool.actorId,
                             toolName: tool.originToolName,
-                            failureCategory: failureDetails.failure_category,
+                            failureCategory: callDiagnostics.failure_category,
                         });
                         return buildMCPResponse({
                             texts: [`Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}': ${error instanceof Error ? error.message : String(error)}. The MCP server may be temporarily unavailable.`],
@@ -961,7 +964,7 @@ export class ActorsMcpServer {
                 // content[0].text (JSON) + isError: true
                 if (httpStatus === HTTP_PAYMENT_REQUIRED) {
                     toolStatus = TOOL_STATUS.SOFT_FAIL;
-                    failureDetails = {
+                    callDiagnostics = {
                         failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                         failure_http_status: 402,
                         ...buildActorFields(actorName, actorId),
@@ -970,7 +973,7 @@ export class ActorsMcpServer {
                 }
 
                 // Re-throw MCP protocol errors (e.g. from failInvalidParams) so the SDK
-                // returns them as JSON-RPC errors. failInvalidParams already set failureDetails
+                // returns them as JSON-RPC errors. failInvalidParams already set callDiagnostics
                 // with the correct semantic category (e.g. AUTH), so we must not overwrite it.
                 if (error instanceof McpError) {
                     throw error;
@@ -978,10 +981,10 @@ export class ActorsMcpServer {
 
                 toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
                 const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
-                failureDetails = {
+                callDiagnostics = {
                     // Spread existing diagnostics first (e.g. validation_keyword from failInvalidParams),
                     // then overwrite with freshly computed fields so they take precedence.
-                    ...failureDetails,
+                    ...callDiagnostics,
                     failure_category: classifyFailureCategory(error),
                     ...(httpStatus !== undefined ? { failure_http_status: httpStatus } : {}),
                     failure_detail: failureDetail,
@@ -992,13 +995,13 @@ export class ActorsMcpServer {
                     toolName: name,
                     toolStatus,
                     mcpSessionId,
-                    failureCategory: failureDetails.failure_category,
-                    failureHttpStatus: failureDetails.failure_http_status,
-                    actorName: failureDetails.actor_name,
-                    validationKeyword: failureDetails.validation_keyword,
-                    validationPath: failureDetails.validation_path,
-                    validationMissingProperty: failureDetails.validation_missing_property,
-                    validationAdditionalProperty: failureDetails.validation_additional_property,
+                    failureCategory: callDiagnostics.failure_category,
+                    failureHttpStatus: callDiagnostics.failure_http_status,
+                    actorName: callDiagnostics.actor_name,
+                    validationKeyword: callDiagnostics.validation_keyword,
+                    validationPath: callDiagnostics.validation_path,
+                    validationMissingProperty: callDiagnostics.validation_missing_property,
+                    validationAdditionalProperty: callDiagnostics.validation_additional_property,
                 });
                 const errorMessage = (error instanceof Error) ? error.message : 'Unknown error';
                 return buildMCPResponse({
@@ -1008,7 +1011,7 @@ export class ActorsMcpServer {
                 });
             } finally {
                 if (shouldTrackTelemetry) {
-                    this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDetails);
+                    this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, callDiagnostics);
                 }
             }
 
@@ -1038,14 +1041,14 @@ export class ActorsMcpServer {
      * @param userId - Apify user ID (string or null if not available)
      * @param startTime - Timestamp when the tool call started
      * @param toolStatus - Final status of the tool call
-     * @param failureDetails - Failure details to include when toolStatus is not SUCCEEDED
+     * @param callDiagnostics - Telemetry fields: always includes actor_name/actor_id when available; failure-specific fields only on non-success
      */
     private finalizeAndTrackTelemetry(
         telemetryData: ToolCallTelemetryProperties | null,
         userId: string | null,
         startTime: number,
         toolStatus: ToolStatus,
-        failureDetails?: FailureDetails,
+        callDiagnostics?: CallDiagnostics,
     ): void {
         if (!telemetryData) {
             return;
@@ -1056,7 +1059,8 @@ export class ActorsMcpServer {
             ...telemetryData,
             tool_status: toolStatus,
             tool_exec_time_ms: execTime,
-            ...(toolStatus !== TOOL_STATUS.SUCCEEDED ? failureDetails : {}),
+            // Always include actor_name/actor_id; failure-specific fields are only present when callDiagnostics has them.
+            ...callDiagnostics,
         };
         trackToolCall(userId, this.telemetryEnv, finalizedTelemetryData);
     }
@@ -1095,7 +1099,8 @@ export class ActorsMcpServer {
             apifyClient, apifyToken, progressToken, extra, mcpSessionId, actorName, actorId, userRentedActorIds,
         } = params;
         let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
-        let failureDetails: FailureDetails = {};
+        // Always populate actor fields so they're tracked on both success and failure paths.
+        let callDiagnostics: CallDiagnostics = { ...buildActorFields(actorName, actorId) };
         const startTime = Date.now();
 
         log.debug('[executeToolAndUpdateTask] Starting task execution', {
@@ -1136,7 +1141,7 @@ export class ActorsMcpServer {
             // Check payment validation (already computed by prepareToolCallContext in the caller)
             if (paymentRequiredResult) {
                 toolStatus = TOOL_STATUS.SOFT_FAIL;
-                failureDetails = {
+                callDiagnostics = {
                     failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                     failure_http_status: 402,
                     ...buildActorFields(actorName, actorId),
@@ -1171,7 +1176,7 @@ export class ActorsMcpServer {
 
                     const diag = extractToolTelemetry(res, actorName, actorId);
                     toolStatus = diag.toolStatus;
-                    failureDetails = diag.failureDetails;
+                    callDiagnostics = { ...callDiagnostics, ...diag.callDiagnostics };
                     result = res;
                 } finally {
                     if (progressTracker) {
@@ -1229,7 +1234,7 @@ export class ActorsMcpServer {
             await this.taskStore.storeTaskResult(taskId, 'completed', result, mcpSessionId);
             log.debug('Task completed successfully', { taskId, toolName: tool.name, mcpSessionId });
 
-            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDetails);
+            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, callDiagnostics);
         } catch (error) {
             // Handle 402 Payment Required — return structured x402 result so clients can auto-pay
             const httpStatus = getHttpStatusCode(error);
@@ -1246,7 +1251,7 @@ export class ActorsMcpServer {
 
             toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
             const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
-            failureDetails = {
+            callDiagnostics = {
                 failure_category: classifyFailureCategory(error),
                 ...(httpStatus !== undefined ? { failure_http_status: httpStatus } : {}),
                 failure_detail: failureDetail,
@@ -1257,9 +1262,9 @@ export class ActorsMcpServer {
                 toolName: tool.name,
                 toolStatus,
                 mcpSessionId,
-                failureCategory: failureDetails.failure_category,
-                failureHttpStatus: failureDetails.failure_http_status,
-                actorName: failureDetails.actor_name,
+                failureCategory: callDiagnostics.failure_category,
+                failureHttpStatus: callDiagnostics.failure_http_status,
+                actorName: callDiagnostics.actor_name,
                 error,
             });
             const errorMessage = (error instanceof Error) ? error.message : 'Unknown error';
@@ -1272,7 +1277,7 @@ export class ActorsMcpServer {
                     taskId,
                     mcpSessionId,
                 });
-                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDetails);
+                this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, callDiagnostics);
                 return;
             }
 
@@ -1290,7 +1295,7 @@ export class ActorsMcpServer {
                 internalToolStatus: toolStatus,
             }, mcpSessionId);
 
-            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, failureDetails);
+            this.finalizeAndTrackTelemetry(telemetryData, userId, startTime, toolStatus, callDiagnostics);
         }
     }
 

--- a/src/payments/helpers.ts
+++ b/src/payments/helpers.ts
@@ -4,22 +4,22 @@ import { buildPaymentRequiredResponse, registerPaymentRequiredInterceptor } from
 import type { PaymentMeta, PaymentProvider, RequestHeaders } from './types.js';
 
 /**
- * Result of preparing payment context for a tool call.
- * Centralizes all payment-related processing into a single step.
+ * Result of preparing tool-call context.
+ * Centralizes payment-aware argument sanitization, logging data, and client creation.
  */
-export type PreparePaymentResult = {
+export type PrepareToolCallContextResult = {
     /** Structured error result for a 402 PaymentRequired response. Undefined if no error. */
-    errorResult?: ReturnType<typeof buildPaymentRequiredResponse>;
-    /** Args with payment-specific fields removed — safe for ajv validation and Actor input. */
-    cleanArgs: Record<string, unknown>;
-    /** Args with sensitive payment fields redacted — safe for logging. */
-    logArgs: unknown;
+    paymentRequiredResult?: ReturnType<typeof buildPaymentRequiredResponse>;
+    /** Tool args with payment-specific fields removed — safe for ajv validation and Actor input. */
+    toolArgs: Record<string, unknown>;
+    /** Tool args with sensitive payment fields redacted — safe for logging. */
+    logSafeArgs: unknown;
     /** ApifyClient configured with payment headers (if applicable) or standard token. */
-    client: ApifyClient;
+    apifyClient: ApifyClient;
 };
 
 /**
- * Prepares payment context for a tool call.
+ * Prepares tool-call context before validation and execution.
  *
  * This helper centralizes all payment processing:
  * 1. Validates payment credentials (for tools with `paymentRequired: true`)
@@ -27,44 +27,49 @@ export type PreparePaymentResult = {
  * 3. Redacts sensitive fields for logging
  * 4. Creates an ApifyClient with payment headers or standard token
  *
- * Call this BEFORE ajv validation so `cleanArgs` can be validated without
+ * Call this BEFORE ajv validation so `toolArgs` can be validated without
  * the `additionalProperties: true` hack.
+ *
+ * TODO: This function has mixed responsibilities. It should be split into separate concerns:
+ * - validatePaymentCredentials (returns error or void)
+ * - sanitizeToolArgs (returns toolArgs and logSafeArgs)
+ * - createApifyClient (returns apifyClient)
  */
-export function preparePayment(input: {
+export function prepareToolCallContext(input: {
     provider: PaymentProvider | undefined;
     tool: ToolEntry;
     args: Record<string, unknown>;
     apifyToken: ApifyToken;
     meta?: PaymentMeta;
     requestHeaders?: RequestHeaders;
-}): PreparePaymentResult {
+}): PrepareToolCallContextResult {
     const { provider, tool, args, apifyToken, meta, requestHeaders } = input;
 
     if (!provider) {
-        const client = new ApifyClient({ token: apifyToken });
-        registerPaymentRequiredInterceptor(client);
+        const apifyClient = new ApifyClient({ token: apifyToken });
+        registerPaymentRequiredInterceptor(apifyClient);
         return {
-            cleanArgs: args,
-            logArgs: args,
-            client,
+            toolArgs: args,
+            logSafeArgs: args,
+            apifyClient,
         };
     }
 
     const error = tool.paymentRequired ? provider.validatePayment(args, meta, requestHeaders) : null;
     const errorData = error && provider.getPaymentRequiredData ? provider.getPaymentRequiredData() : undefined;
-    const cleanArgs = provider.removePaymentFields(args);
-    const logArgs = provider.redactForLogging(args);
+    const toolArgs = provider.removePaymentFields(args);
+    const logSafeArgs = provider.redactForLogging(args);
 
     const paymentHeaders = provider.getPaymentHeaders(args, meta, requestHeaders);
-    const client = Object.keys(paymentHeaders).length > 0
+    const apifyClient = Object.keys(paymentHeaders).length > 0
         ? new ApifyClient({ paymentHeaders })
         : new ApifyClient({ token: apifyToken });
-    registerPaymentRequiredInterceptor(client);
+    registerPaymentRequiredInterceptor(apifyClient);
 
     return {
-        errorResult: error ? buildPaymentRequiredResponse(error, errorData) : undefined,
-        cleanArgs,
-        logArgs,
-        client,
+        paymentRequiredResult: error ? buildPaymentRequiredResponse(error, errorData) : undefined,
+        toolArgs,
+        logSafeArgs,
+        apifyClient,
     };
 }

--- a/src/payments/index.ts
+++ b/src/payments/index.ts
@@ -2,5 +2,5 @@ export type { PaymentHeaders, PaymentMeta, PaymentProvider, PaymentProviderId, R
 export { SkyfirePaymentProvider } from './skyfire.js';
 export { X402PaymentProvider } from './x402.js';
 export { resolvePaymentProvider } from './resolve.js';
-export { preparePayment } from './helpers.js';
-export type { PreparePaymentResult } from './helpers.js';
+export { prepareToolCallContext } from './helpers.js';
+export type { PrepareToolCallContextResult } from './helpers.js';

--- a/src/tools/common/fetch_apify_docs.ts
+++ b/src/tools/common/fetch_apify_docs.ts
@@ -66,8 +66,7 @@ Only documentation URLs from Apify and Crawlee are allowed \
 Please provide a valid documentation URL. \
 You can find documentation URLs using the ${HelperTools.DOCS_SEARCH} tool.`],
                 isError: true,
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
-                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
             });
         }
 
@@ -89,9 +88,11 @@ You can find documentation URLs using the ${HelperTools.DOCS_SEARCH} tool.`],
                     return buildMCPResponse({
                         texts: [buildFetchErrorMessage(url, `HTTP Status: ${response.status} ${response.statusText}.`)],
                         isError: true,
-                        toolStatus: isUserError ? TOOL_STATUS.SOFT_FAIL : TOOL_STATUS.FAILED,
-                        failureCategory: classifyFailureCategory(error),
-                        failureHttpStatus: response.status,
+                        telemetry: {
+                            toolStatus: isUserError ? TOOL_STATUS.SOFT_FAIL : TOOL_STATUS.FAILED,
+                            failureCategory: classifyFailureCategory(error),
+                            failureHttpStatus: response.status,
+                        },
                     });
                 }
                 markdown = await response.text();
@@ -101,8 +102,7 @@ You can find documentation URLs using the ${HelperTools.DOCS_SEARCH} tool.`],
                 return buildMCPResponse({
                     texts: [buildFetchErrorMessage(url, `Error: ${error instanceof Error ? error.message : String(error)}.`)],
                     isError: true,
-                    toolStatus: TOOL_STATUS.SOFT_FAIL,
-                    failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR,
+                    telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR },
                 });
             }
         }

--- a/src/tools/common/fetch_apify_docs.ts
+++ b/src/tools/common/fetch_apify_docs.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import log from '@apify/log';
 
-import { ALLOWED_DOC_DOMAINS, HelperTools, TOOL_STATUS } from '../../const.js';
+import { ALLOWED_DOC_DOMAINS, FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import { fetchApifyDocsCache } from '../../state.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -66,6 +66,7 @@ Please provide a valid documentation URL. \
 You can find documentation URLs using the ${HelperTools.DOCS_SEARCH} tool.`],
                 isError: true,
                 toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
             });
         }
 
@@ -88,6 +89,8 @@ You can find documentation URLs using the ${HelperTools.DOCS_SEARCH} tool.`],
                         texts: [buildFetchErrorMessage(url, `HTTP Status: ${response.status} ${response.statusText}.`)],
                         isError: true,
                         toolStatus: isUserError ? TOOL_STATUS.SOFT_FAIL : TOOL_STATUS.FAILED,
+                        failureCategory: isUserError ? FAILURE_CATEGORY.INVALID_INPUT : FAILURE_CATEGORY.INTERNAL_ERROR,
+                        failureHttpStatus: response.status,
                     });
                 }
                 markdown = await response.text();
@@ -98,6 +101,7 @@ You can find documentation URLs using the ${HelperTools.DOCS_SEARCH} tool.`],
                     texts: [buildFetchErrorMessage(url, `Error: ${error instanceof Error ? error.message : String(error)}.`)],
                     isError: true,
                     toolStatus: TOOL_STATUS.SOFT_FAIL,
+                    failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR,
                 });
             }
         }

--- a/src/tools/common/fetch_apify_docs.ts
+++ b/src/tools/common/fetch_apify_docs.ts
@@ -8,6 +8,7 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { classifyFailureCategory } from '../../utils/tool_status.js';
 import { fetchApifyDocsToolOutputSchema } from '../structured_output_schemas.js';
 
 const fetchApifyDocsToolArgsSchema = z.object({
@@ -89,7 +90,7 @@ You can find documentation URLs using the ${HelperTools.DOCS_SEARCH} tool.`],
                         texts: [buildFetchErrorMessage(url, `HTTP Status: ${response.status} ${response.statusText}.`)],
                         isError: true,
                         toolStatus: isUserError ? TOOL_STATUS.SOFT_FAIL : TOOL_STATUS.FAILED,
-                        failureCategory: isUserError ? FAILURE_CATEGORY.INVALID_INPUT : FAILURE_CATEGORY.INTERNAL_ERROR,
+                        failureCategory: classifyFailureCategory(error),
                         failureHttpStatus: response.status,
                     });
                 }

--- a/src/tools/common/get_actor_output.ts
+++ b/src/tools/common/get_actor_output.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, TOOL_MAX_OUTPUT_CHARS, TOOL_STATUS } from '../../const.js';
+import { FAILURE_CATEGORY, HelperTools, TOOL_MAX_OUTPUT_CHARS, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { getValuesByDotKeys, parseCommaSeparatedList } from '../../utils/generic.js';
@@ -121,6 +121,7 @@ export const getActorOutput: ToolEntry = Object.freeze({
                 texts: [`Dataset '${parsed.datasetId}' not found.`],
                 isError: true,
                 toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
             });
         }
 

--- a/src/tools/common/get_actor_output.ts
+++ b/src/tools/common/get_actor_output.ts
@@ -120,8 +120,7 @@ export const getActorOutput: ToolEntry = Object.freeze({
             return buildMCPResponse({
                 texts: [`Dataset '${parsed.datasetId}' not found.`],
                 isError: true,
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
-                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
             });
         }
 

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { HelperTools, TOOL_STATUS } from '../../const.js';
+import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -47,6 +47,7 @@ USAGE EXAMPLES:
                 texts: [`Dataset '${parsed.datasetId}' not found.`],
                 isError: true,
                 toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
             });
         }
         return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(v)}\n\`\`\`` }] };

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -46,8 +46,7 @@ USAGE EXAMPLES:
             return buildMCPResponse({
                 texts: [`Dataset '${parsed.datasetId}' not found.`],
                 isError: true,
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
-                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
             });
         }
         return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(v)}\n\`\`\`` }] };

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -84,7 +84,7 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             return buildMCPResponse({
                 texts: [`Dataset '${parsed.datasetId}' not found.`],
                 isError: true,
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL },
             });
         }
 

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -61,7 +61,7 @@ USAGE EXAMPLES:
             return buildMCPResponse({
                 texts: [`Dataset '${parsed.datasetId}' not found.`],
                 isError: true,
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL },
             });
         }
 
@@ -83,7 +83,7 @@ USAGE EXAMPLES:
             return buildMCPResponse({
                 texts: [`Failed to generate schema for dataset '${parsed.datasetId}'.`],
                 isError: true,
-                toolStatus: TOOL_STATUS.FAILED,
+                telemetry: { toolStatus: TOOL_STATUS.FAILED },
             });
         }
 

--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -71,6 +71,7 @@ export async function enrichActorToolOutputSchemas(tools: ToolEntry[], actorStor
  * 5. Enums are added to descriptions with examples using addEnumsToDescriptionsWithExamples()
  *
  * @param {ActorInfo[]} actorsInfo - An array of ActorInfo objects with webServerMcpPath, definition, and Actor.
+ * @param options - Optional settings: mcpSessionId for telemetry correlation, actorStore for caching.
  * @returns {Promise<ToolEntry[]>} - A promise that resolves to an array of MCP tools.
  */
 export async function getNormalActorsAsTools(
@@ -237,7 +238,9 @@ export async function getActorsAsTools(
             try {
                 const actorDefinitionWithInfo = await getActorDefinition(actorIdOrName, apifyClient);
                 if (!actorDefinitionWithInfo) {
-                    log.softFail('Actor not found or definition is not available', { actorName: actorIdOrName, mcpSessionId, statusCode: 404 });
+                    log.softFail('Actor not found or definition is not available', {
+                        actorName: actorIdOrName, mcpSessionId, statusCode: 404, failureCategory: 'INVALID_INPUT',
+                    });
                     return null;
                 }
                 // Cache the Actor definition with info

--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -116,6 +116,7 @@ Actor description: ${definition.description}`;
         tools.push({
             type: 'actor',
             name: actorNameToToolName(definition.actorFullName),
+            actorId: definition.id,
             actorFullName: definition.actorFullName,
             description,
             inputSchema: inputSchema as ToolInputSchema,

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -15,6 +15,7 @@ import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { extractAjvErrorDetails } from '../../utils/tool_status.js';
+import { extractActorId } from '../../utils/tools.js';
 import { actorNameToToolName } from '../utils.js';
 import { getActorsAsTools } from './actor_tools_factory.js';
 
@@ -199,6 +200,8 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
         };
     }
 
+    const actorId = extractActorId(actor);
+
     if (!input) {
         return {
             error: buildMCPResponse({
@@ -208,7 +211,7 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
                     `\`\`\`json\n${JSON.stringify(actor.inputSchema)}\n\`\`\``,
                 ],
                 isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT, actorId },
             }),
         };
     }
@@ -229,6 +232,7 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
                 telemetry: {
                     toolStatus: TOOL_STATUS.SOFT_FAIL,
                     failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                    actorId,
                     ajvErrorDetails: extractAjvErrorDetails(errors ?? null),
                 },
             }),

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -1,6 +1,8 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { z } from 'zod';
 
+import log from '@apify/log';
+
 import { ApifyClient } from '../../apify_client.js';
 import {
     CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG,
@@ -195,7 +197,12 @@ export async function resolveAndValidateActor(params: {
 Please verify Actor ID or name format (e.g., "username/name" like "apify/rag-web-browser") and ensure that the Actor exists.
 You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.`],
                 isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT, failureHttpStatus: 404 },
+                telemetry: {
+                    toolStatus: TOOL_STATUS.SOFT_FAIL,
+                    failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                    failureHttpStatus: 404,
+                    failureDetail: `Actor '${actorName}' was not found`,
+                },
             }),
         };
     }
@@ -203,6 +210,11 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
     const actorId = extractActorId(actor);
 
     if (!input) {
+        log.softFail('Input is required for Actor', {
+            actorName,
+            mcpSessionId: toolArgs.mcpSessionId,
+            failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+        });
         return {
             error: buildMCPResponse({
                 texts: [
@@ -211,19 +223,36 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
                     `\`\`\`json\n${JSON.stringify(actor.inputSchema)}\n\`\`\``,
                 ],
                 isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT, actorId },
+                telemetry: {
+                    toolStatus: TOOL_STATUS.SOFT_FAIL,
+                    failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                    actorId,
+                    failureDetail: 'input is required',
+                },
             }),
         };
     }
 
     if (!actor.ajvValidate(input)) {
         const { errors } = actor.ajvValidate;
+        const ajvDetails = extractAjvErrorDetails(errors ?? null);
+        const validationSummary = errors?.map((e) => (e as { message?: string; }).message).join(', ') ?? '';
+
+        log.softFail('Input validation failed for Actor', {
+            actorName,
+            mcpSessionId: toolArgs.mcpSessionId,
+            failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+            validationKeyword: ajvDetails.validation_keyword,
+            validationPath: ajvDetails.validation_path,
+            validationMissingProperty: ajvDetails.validation_missing_property,
+        });
+
         const content = [
             `Input validation failed for Actor '${actorName}'. Please ensure your input matches the Actor's input schema.`,
             `Input schema:\n\`\`\`json\n${JSON.stringify(actor.inputSchema)}\n\`\`\``,
         ];
-        if (errors && errors.length > 0) {
-            content.push(`Validation errors: ${errors.map((e) => (e as { message?: string; }).message).join(', ')}`);
+        if (validationSummary) {
+            content.push(`Validation errors: ${validationSummary}`);
         }
         return {
             error: buildMCPResponse({
@@ -233,7 +262,8 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
                     toolStatus: TOOL_STATUS.SOFT_FAIL,
                     failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
                     actorId,
-                    ajvErrorDetails: extractAjvErrorDetails(errors ?? null),
+                    failureDetail: validationSummary.slice(0, 200) || 'input validation failed',
+                    ajvErrorDetails: ajvDetails,
                 },
             }),
         };
@@ -267,7 +297,7 @@ export async function callActorPreExecute(toolArgs: InternalToolArgs): Promise<
     // For definition resolution we always use token-based client; payment provider is only for actual Actor runs
     const apifyClientForDefinition = new ApifyClient({ token: apifyToken });
     const mcpServerUrlOrFalse = await getActorMcpUrlCached(baseActorName, apifyClientForDefinition);
-    const isActorMcpServer = mcpServerUrlOrFalse && typeof mcpServerUrlOrFalse === 'string';
+    const isActorMcpServer = !!mcpServerUrlOrFalse;
 
     // Standby Actors (MCPs) are not supported with external payment providers (like Skyfire or x402)
     if (isActorMcpServer && apifyMcpServer.options.paymentProvider) {

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -317,7 +317,7 @@ export async function callActorPreExecute(toolArgs: InternalToolArgs): Promise<
             baseActorName,
             mcpToolName,
             input: parsed.input as Record<string, unknown>,
-            isActorMcpServer: !!isActorMcpServer,
+            isActorMcpServer,
             mcpServerUrl: mcpServerUrlOrFalse,
             apifyToken,
             mcpSessionId,

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { ApifyClient } from '../../apify_client.js';
 import {
     CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG,
+    FAILURE_CATEGORY,
     HelperTools,
     TOOL_STATUS,
 } from '../../const.js';
@@ -13,6 +14,7 @@ import { getActorMcpUrlCached } from '../../utils/actor.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { extractValidationDiagnostics } from '../../utils/tool_status.js';
 import { actorNameToToolName } from '../utils.js';
 import { getActorsAsTools } from './actor_tools_factory.js';
 
@@ -194,6 +196,7 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
                 isError: true,
                 // `toolStatus` is internal-only (telemetry/server logic); clients should rely on `isError`.
                 toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
             }),
         };
     }
@@ -204,7 +207,11 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
             `The input schema for this Actor was retrieved and is shown below:`,
             `\`\`\`json\n${JSON.stringify(actor.inputSchema)}\n\`\`\``,
         ];
-        return { error: buildMCPResponse({ texts: content, isError: true }) };
+        return {
+            error: buildMCPResponse({
+                texts: content, isError: true, toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+            }),
+        };
     }
 
     if (!actor.ajvValidate(input)) {
@@ -216,7 +223,16 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
         if (errors && errors.length > 0) {
             content.push(`Validation errors: ${errors.map((e) => (e as { message?: string; }).message).join(', ')}`);
         }
-        return { error: buildMCPResponse({ texts: content, isError: true }) };
+        const validationDiagnostics = extractValidationDiagnostics(errors ?? null);
+        return {
+            error: buildMCPResponse({
+                texts: content,
+                isError: true,
+                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                validationDiagnostics,
+            }),
+        };
     }
 
     return { actor };
@@ -257,6 +273,7 @@ export async function callActorPreExecute(toolArgs: InternalToolArgs): Promise<
                 isError: true,
                 // Internal status used by server telemetry; not part of the MCP client contract.
                 toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
             }),
         };
     }

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -89,19 +89,8 @@ export const callActorAjvValidate = compileSchema({ ...z.toJSONSchema(callActorA
 export type CallActorParsedArgs = z.infer<typeof callActorArgs>;
 
 /**
- * Result of resolving actor and MCP URL before execution.
- * Contains everything needed for the mode-specific execution path.
- */
-export type CallActorResolvedContext = {
-    baseActorName: string;
-    mcpToolName: string | undefined;
-    isActorMcpServer: boolean;
-    mcpServerUrl: string | false;
-};
-
-/**
  * Resolves MCP URL and parses the "actor:tool" format.
- * Shared pre-processing step used by both default and openai variants.
+ * Shared pre-processing step used by both default and OpenAI variants.
  */
 export function resolveActorContext(actorName: string): {
     baseActorName: string;
@@ -294,7 +283,7 @@ export async function callActorPreExecute(toolArgs: InternalToolArgs): Promise<
 
     const { baseActorName, mcpToolName } = resolveActorContext(parsed.actor);
 
-    // For definition resolution we always use token-based client; payment provider is only for actual Actor runs
+    // For definition resolution we always use a token-based client; payment provider is only for actual Actor runs
     const apifyClientForDefinition = new ApifyClient({ token: apifyToken });
     const mcpServerUrlOrFalse = await getActorMcpUrlCached(baseActorName, apifyClientForDefinition);
     const isActorMcpServer = !!mcpServerUrlOrFalse;

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -14,7 +14,7 @@ import { getActorMcpUrlCached } from '../../utils/actor.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
-import { extractValidationDiagnostics } from '../../utils/tool_status.js';
+import { extractAjvErrorDetails } from '../../utils/tool_status.js';
 import { actorNameToToolName } from '../utils.js';
 import { getActorsAsTools } from './actor_tools_factory.js';
 
@@ -194,22 +194,21 @@ export async function resolveAndValidateActor(params: {
 Please verify Actor ID or name format (e.g., "username/name" like "apify/rag-web-browser") and ensure that the Actor exists.
 You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.`],
                 isError: true,
-                // `toolStatus` is internal-only (telemetry/server logic); clients should rely on `isError`.
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
-                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT, failureHttpStatus: 404 },
             }),
         };
     }
 
     if (!input) {
-        const content = [
-            `Input is required for Actor '${actorName}'. Please provide the input parameter based on the Actor's input schema.`,
-            `The input schema for this Actor was retrieved and is shown below:`,
-            `\`\`\`json\n${JSON.stringify(actor.inputSchema)}\n\`\`\``,
-        ];
         return {
             error: buildMCPResponse({
-                texts: content, isError: true, toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                texts: [
+                    `Input is required for Actor '${actorName}'. Please provide the input parameter based on the Actor's input schema.`,
+                    `The input schema for this Actor was retrieved and is shown below:`,
+                    `\`\`\`json\n${JSON.stringify(actor.inputSchema)}\n\`\`\``,
+                ],
+                isError: true,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
             }),
         };
     }
@@ -223,14 +222,15 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
         if (errors && errors.length > 0) {
             content.push(`Validation errors: ${errors.map((e) => (e as { message?: string; }).message).join(', ')}`);
         }
-        const validationDiagnostics = extractValidationDiagnostics(errors ?? null);
         return {
             error: buildMCPResponse({
                 texts: content,
                 isError: true,
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
-                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
-                validationDiagnostics,
+                telemetry: {
+                    toolStatus: TOOL_STATUS.SOFT_FAIL,
+                    failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                    ajvErrorDetails: extractAjvErrorDetails(errors ?? null),
+                },
             }),
         };
     }
@@ -271,9 +271,7 @@ export async function callActorPreExecute(toolArgs: InternalToolArgs): Promise<
             earlyResponse: buildMCPResponse({
                 texts: [`This Actor (${parsed.actor}) is an MCP server and cannot be accessed using a third-party payment provider. To use this Actor, please provide a valid Apify token instead.`],
                 isError: true,
-                // Internal status used by server telemetry; not part of the MCP client contract.
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
-                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
             }),
         };
     }

--- a/src/tools/core/get_actor_run_common.ts
+++ b/src/tools/core/get_actor_run_common.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import log from '@apify/log';
 
 import type { ApifyClient } from '../../apify_client.js';
-import { HelperTools, TOOL_STATUS } from '../../const.js';
+import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { HelperTool, ToolInputSchema } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -107,6 +107,7 @@ export async function fetchActorRunData(params: {
                 texts: [`Run with ID '${runId}' not found.`],
                 isError: true,
                 toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
             }),
         };
     }

--- a/src/tools/core/get_actor_run_common.ts
+++ b/src/tools/core/get_actor_run_common.ts
@@ -106,8 +106,7 @@ export async function fetchActorRunData(params: {
             error: buildMCPResponse({
                 texts: [`Run with ID '${runId}' not found.`],
                 isError: true,
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
-                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
             }),
         };
     }

--- a/src/tools/default/call_actor.ts
+++ b/src/tools/default/call_actor.ts
@@ -3,8 +3,10 @@ import log from '@apify/log';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
-import { logHttpError } from '../../utils/logging.js';
+import { getHttpStatusCode, logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse, buildUsageMeta } from '../../utils/mcp.js';
+import { classifyFailureCategory, getToolStatusFromError } from '../../utils/tool_status.js';
+import { extractActorId } from '../../utils/tools.js';
 import { callActorGetDataset } from '../core/actor_execution.js';
 import { buildActorResponseContent } from '../core/actor_response.js';
 import {
@@ -80,6 +82,7 @@ export const defaultCallActor: ToolEntry = Object.freeze({
         const { parsed, baseActorName } = preResult;
         const { input, async: isAsync = false, previewOutput = true, callOptions } = parsed;
 
+        let resolvedActorId: string | undefined;
         try {
             const resolution = await resolveAndValidateActor({
                 actorName: baseActorName,
@@ -90,6 +93,7 @@ export const defaultCallActor: ToolEntry = Object.freeze({
                 return resolution.error;
             }
 
+            resolvedActorId = extractActorId(resolution.actor);
             const { apifyClient } = toolArgs;
 
             // Async mode: start run and return immediately with runId
@@ -113,6 +117,7 @@ export const defaultCallActor: ToolEntry = Object.freeze({
                         text: `Started Actor "${baseActorName}" (Run ID: ${actorRun.id}).`,
                     }],
                     structuredContent,
+                    toolTelemetry: { actorId: resolvedActorId },
                 };
             }
 
@@ -140,15 +145,21 @@ export const defaultCallActor: ToolEntry = Object.freeze({
                 content,
                 structuredContent,
                 ...(_meta && { _meta }),
+                toolTelemetry: { actorId: resolvedActorId },
             };
         } catch (error) {
             logHttpError(error, 'Failed to call Actor', { actorName: baseActorName, async: isAsync });
-            // Let the server classify the error; we only mark it as an MCP error response
             return buildMCPResponse({
                 texts: [`Failed to call Actor '${baseActorName}': ${error instanceof Error ? error.message : String(error)}.
 Please verify the Actor name, input parameters, and ensure the Actor exists.
 You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}, or get Actor details using: ${HelperTools.ACTOR_GET_DETAILS}.`],
                 isError: true,
+                telemetry: {
+                    toolStatus: getToolStatusFromError(error, false),
+                    failureCategory: classifyFailureCategory(error),
+                    failureHttpStatus: getHttpStatusCode(error),
+                    actorId: resolvedActorId,
+                },
             });
         }
     },

--- a/src/tools/default/call_actor.ts
+++ b/src/tools/default/call_actor.ts
@@ -148,9 +148,15 @@ export const defaultCallActor: ToolEntry = Object.freeze({
                 toolTelemetry: { actorId: resolvedActorId },
             };
         } catch (error) {
-            logHttpError(error, 'Failed to call Actor', { actorName: baseActorName, async: isAsync });
+            const errMsg = error instanceof Error ? error.message : String(error);
+            logHttpError(error, 'Failed to call Actor', {
+                actorName: baseActorName,
+                async: isAsync,
+                mcpSessionId: toolArgs.mcpSessionId,
+                failureCategory: classifyFailureCategory(error),
+            });
             return buildMCPResponse({
-                texts: [`Failed to call Actor '${baseActorName}': ${error instanceof Error ? error.message : String(error)}.
+                texts: [`Failed to call Actor '${baseActorName}': ${errMsg}.
 Please verify the Actor name, input parameters, and ensure the Actor exists.
 You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}, or get Actor details using: ${HelperTools.ACTOR_GET_DETAILS}.`],
                 isError: true,
@@ -158,6 +164,7 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH},
                     toolStatus: getToolStatusFromError(error, false),
                     failureCategory: classifyFailureCategory(error),
                     failureHttpStatus: getHttpStatusCode(error),
+                    failureDetail: errMsg.slice(0, 200),
                     actorId: resolvedActorId,
                 },
             });

--- a/src/tools/default/get_actor_run.ts
+++ b/src/tools/default/get_actor_run.ts
@@ -46,7 +46,7 @@ export const defaultGetActorRun: ToolEntry = Object.freeze({
                 texts: [`Failed to get Actor run '${parsed.runId}': ${error instanceof Error ? error.message : String(error)}.
 Please verify the run ID and ensure that the run exists.`],
                 isError: true,
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL },
             });
         }
     },

--- a/src/tools/openai/call_actor.ts
+++ b/src/tools/openai/call_actor.ts
@@ -3,8 +3,10 @@ import log from '@apify/log';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
-import { logHttpError } from '../../utils/logging.js';
+import { getHttpStatusCode, logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { classifyFailureCategory, getToolStatusFromError } from '../../utils/tool_status.js';
+import { extractActorId } from '../../utils/tools.js';
 import {
     CALL_ACTOR_EXAMPLES_SECTION,
     CALL_ACTOR_MCP_SERVER_SECTION,
@@ -72,6 +74,7 @@ export const openaiCallActor: ToolEntry = Object.freeze({
         const { parsed, baseActorName } = preResult;
         const { input, callOptions } = parsed;
 
+        let resolvedActorId: string | undefined;
         try {
             const resolution = await resolveAndValidateActor({
                 actorName: baseActorName,
@@ -82,6 +85,7 @@ export const openaiCallActor: ToolEntry = Object.freeze({
                 return resolution.error;
             }
 
+            resolvedActorId = extractActorId(resolution.actor);
             const { apifyClient } = toolArgs;
 
             // OpenAI mode always runs asynchronously
@@ -118,15 +122,21 @@ Do NOT proactively poll using ${HelperTools.ACTOR_RUNS_GET}. Wait for the widget
                     ...widgetConfig?.meta,
                     'openai/widgetDescription': `Actor run progress for ${baseActorName}`,
                 },
+                toolTelemetry: { actorId: resolvedActorId },
             };
         } catch (error) {
             logHttpError(error, 'Failed to call Actor', { actorName: baseActorName, async: true });
-            // Let the server classify the error; we only mark it as an MCP error response
             return buildMCPResponse({
                 texts: [`Failed to call Actor '${baseActorName}': ${error instanceof Error ? error.message : String(error)}.
 Please verify the Actor name, input parameters, and ensure the Actor exists.
 You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH_INTERNAL}, or get Actor details using: ${HelperTools.ACTOR_GET_DETAILS_INTERNAL}.`],
                 isError: true,
+                telemetry: {
+                    toolStatus: getToolStatusFromError(error, false),
+                    failureCategory: classifyFailureCategory(error),
+                    failureHttpStatus: getHttpStatusCode(error),
+                    actorId: resolvedActorId,
+                },
             });
         }
     },

--- a/src/tools/openai/call_actor.ts
+++ b/src/tools/openai/call_actor.ts
@@ -125,9 +125,15 @@ Do NOT proactively poll using ${HelperTools.ACTOR_RUNS_GET}. Wait for the widget
                 toolTelemetry: { actorId: resolvedActorId },
             };
         } catch (error) {
-            logHttpError(error, 'Failed to call Actor', { actorName: baseActorName, async: true });
+            const errMsg = error instanceof Error ? error.message : String(error);
+            logHttpError(error, 'Failed to call Actor', {
+                actorName: baseActorName,
+                async: true,
+                mcpSessionId: toolArgs.mcpSessionId,
+                failureCategory: classifyFailureCategory(error),
+            });
             return buildMCPResponse({
-                texts: [`Failed to call Actor '${baseActorName}': ${error instanceof Error ? error.message : String(error)}.
+                texts: [`Failed to call Actor '${baseActorName}': ${errMsg}.
 Please verify the Actor name, input parameters, and ensure the Actor exists.
 You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH_INTERNAL}, or get Actor details using: ${HelperTools.ACTOR_GET_DETAILS_INTERNAL}.`],
                 isError: true,
@@ -135,6 +141,7 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH_I
                     toolStatus: getToolStatusFromError(error, false),
                     failureCategory: classifyFailureCategory(error),
                     failureHttpStatus: getHttpStatusCode(error),
+                    failureDetail: errMsg.slice(0, 200),
                     actorId: resolvedActorId,
                 },
             });

--- a/src/tools/openai/get_actor_run.ts
+++ b/src/tools/openai/get_actor_run.ts
@@ -53,7 +53,7 @@ export const openaiGetActorRun: ToolEntry = Object.freeze({
                 texts: [`Failed to get Actor run '${parsed.runId}': ${error instanceof Error ? error.message : String(error)}.
 Please verify the run ID and ensure that the run exists.`],
                 isError: true,
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL },
             });
         }
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ import type {
 import type z from 'zod';
 
 import type { ApifyClient } from './apify_client.js';
-import type { ACTOR_PRICING_MODEL, TELEMETRY_ENV, TOOL_STATUS } from './const.js';
+import type { ACTOR_PRICING_MODEL, FAILURE_CATEGORY, TELEMETRY_ENV, TOOL_STATUS } from './const.js';
 import type { ActorsMcpServer } from './mcp/server.js';
 import type { PaymentProvider } from './payments/types.js';
 import type { CATEGORY_NAMES } from './tools/categories.js';
@@ -369,6 +369,7 @@ export type ApifyToken = string | null | undefined;
  * Derived from TOOL_STATUS to ensure type safety and avoid duplication.
  */
 export type ToolStatus = (typeof TOOL_STATUS)[keyof typeof TOOL_STATUS];
+export type FailureCategory = (typeof FAILURE_CATEGORY)[keyof typeof FAILURE_CATEGORY];
 
 /**
  * Properties for tool call telemetry events sent to Segment.
@@ -385,6 +386,14 @@ export type ToolCallTelemetryProperties = {
     tool_name: string;
     tool_status: ToolStatus;
     tool_exec_time_ms: number;
+    failure_category?: FailureCategory;
+    failure_http_status?: number;
+    failure_detail?: string;
+    actor_name?: string;
+    validation_keyword?: string;
+    validation_path?: string;
+    validation_missing_property?: string;
+    validation_additional_property?: string;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -409,7 +409,7 @@ export type AjvErrorDetails = Pick<ToolCallTelemetryProperties,
 
 /**
  * Telemetry reported by tool handlers on the response object.
- * The server reads `toolTelemetry` from the response, strips it, and maps it to FailureDetails.
+ * The server reads `toolTelemetry` from the response, strips it, and maps it to CallDiagnostics.
  */
 export type ToolTelemetryContext = {
     toolStatus?: ToolStatus;
@@ -419,7 +419,7 @@ export type ToolTelemetryContext = {
     ajvErrorDetails?: AjvErrorDetails;
 };
 
-export type FailureDetails = Pick<ToolCallTelemetryProperties,
+export type CallDiagnostics = Pick<ToolCallTelemetryProperties,
     | 'failure_category'
     | 'failure_http_status'
     | 'failure_detail'

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,8 @@ export type ToolInputSchema = z.infer<typeof ToolSchema>['inputSchema'];
 export type ActorTool = ToolBase & {
     /** Type discriminator for actor tools */
     type: 'actor';
+    /** Stable Apify Actor ID (e.g. "JxcaGGqy7TwBdHxMz") — does not change on rename */
+    actorId: string;
     /** Full name of the Apify Actor (username/name) */
     actorFullName: string;
     /** Optional memory limit in MB for the Actor execution */
@@ -390,6 +392,7 @@ export type ToolCallTelemetryProperties = {
     failure_http_status?: number;
     failure_detail?: string;
     actor_name?: string;
+    actor_id?: string;
     validation_keyword?: string;
     validation_path?: string;
     validation_missing_property?: string;
@@ -397,18 +400,31 @@ export type ToolCallTelemetryProperties = {
     validation_error_count?: number;
 };
 
-export type ValidationDiagnostics = Pick<ToolCallTelemetryProperties,
+export type AjvErrorDetails = Pick<ToolCallTelemetryProperties,
     | 'validation_keyword'
     | 'validation_path'
     | 'validation_missing_property'
     | 'validation_additional_property'
     | 'validation_error_count'>;
 
-export type FailureDiagnostics = Pick<ToolCallTelemetryProperties,
+/**
+ * Telemetry reported by tool handlers on the response object.
+ * The server reads `toolTelemetry` from the response, strips it, and maps it to FailureDetails.
+ */
+export type ToolTelemetryContext = {
+    toolStatus?: ToolStatus;
+    failureCategory?: FailureCategory;
+    failureHttpStatus?: number;
+    actorId?: string;
+    ajvErrorDetails?: AjvErrorDetails;
+};
+
+export type FailureDetails = Pick<ToolCallTelemetryProperties,
     | 'failure_category'
     | 'failure_http_status'
     | 'failure_detail'
     | 'actor_name'
+    | 'actor_id'
     | 'validation_keyword'
     | 'validation_path'
     | 'validation_missing_property'

--- a/src/types.ts
+++ b/src/types.ts
@@ -402,6 +402,16 @@ export type ValidationDiagnostics = Pick<ToolCallTelemetryProperties,
     | 'validation_missing_property'
     | 'validation_additional_property'>;
 
+export type FailureDiagnostics = Pick<ToolCallTelemetryProperties,
+    | 'failure_category'
+    | 'failure_http_status'
+    | 'failure_detail'
+    | 'actor_name'
+    | 'validation_keyword'
+    | 'validation_path'
+    | 'validation_missing_property'
+    | 'validation_additional_property'>;
+
 /**
  * Internal server mode that controls which tool variants, descriptions, and response
  * formats are served. Every internal call site (tool loading, category resolution,

--- a/src/types.ts
+++ b/src/types.ts
@@ -394,13 +394,15 @@ export type ToolCallTelemetryProperties = {
     validation_path?: string;
     validation_missing_property?: string;
     validation_additional_property?: string;
+    validation_error_count?: number;
 };
 
 export type ValidationDiagnostics = Pick<ToolCallTelemetryProperties,
     | 'validation_keyword'
     | 'validation_path'
     | 'validation_missing_property'
-    | 'validation_additional_property'>;
+    | 'validation_additional_property'
+    | 'validation_error_count'>;
 
 export type FailureDiagnostics = Pick<ToolCallTelemetryProperties,
     | 'failure_category'
@@ -410,7 +412,8 @@ export type FailureDiagnostics = Pick<ToolCallTelemetryProperties,
     | 'validation_keyword'
     | 'validation_path'
     | 'validation_missing_property'
-    | 'validation_additional_property'>;
+    | 'validation_additional_property'
+    | 'validation_error_count'>;
 
 /**
  * Internal server mode that controls which tool variants, descriptions, and response

--- a/src/types.ts
+++ b/src/types.ts
@@ -396,6 +396,12 @@ export type ToolCallTelemetryProperties = {
     validation_additional_property?: string;
 };
 
+export type ValidationDiagnostics = Pick<ToolCallTelemetryProperties,
+    | 'validation_keyword'
+    | 'validation_path'
+    | 'validation_missing_property'
+    | 'validation_additional_property'>;
+
 /**
  * Internal server mode that controls which tool variants, descriptions, and response
  * formats are served. Every internal call site (tool loading, category resolution,

--- a/src/types.ts
+++ b/src/types.ts
@@ -415,6 +415,7 @@ export type ToolTelemetryContext = {
     toolStatus?: ToolStatus;
     failureCategory?: FailureCategory;
     failureHttpStatus?: number;
+    failureDetail?: string;
     actorId?: string;
     ajvErrorDetails?: AjvErrorDetails;
 };

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -2,7 +2,7 @@ import type { Build } from 'apify-client';
 import { z } from 'zod';
 
 import type { ApifyClient } from '../apify_client.js';
-import { HelperTools, TOOL_STATUS } from '../const.js';
+import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../const.js';
 import { connectMCPClient } from '../mcp/client.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { filterSchemaProperties, shortenProperties } from '../tools/utils.js';
@@ -299,6 +299,7 @@ Please verify Actor ID or name format and ensure that the Actor exists.
 You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.`],
         isError: true,
         toolStatus: TOOL_STATUS.SOFT_FAIL,
+        failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
     });
 }
 

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -298,8 +298,7 @@ export function buildActorNotFoundResponse(actorName: string): ReturnType<typeof
 Please verify Actor ID or name format and ensure that the Actor exists.
 You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.`],
         isError: true,
-        toolStatus: TOOL_STATUS.SOFT_FAIL,
-        failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+        telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
     });
 }
 

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -1,4 +1,4 @@
-import type { ToolStatus } from '../types.js';
+import type { FailureCategory, ToolCallTelemetryProperties, ToolStatus } from '../types.js';
 
 /**
  * Builds usage metadata for MCP response from a source object containing Apify run costs.
@@ -29,6 +29,10 @@ export function buildUsageMeta(source: {
  * - `toolStatus` is an internal helper input for server telemetry.
  * - `internalToolStatus` is the transient wire field carrying `toolStatus`
  *   from tool helpers back to the server, and is stripped before client response.
+ * - `internalFailureCategory` is the transient wire field carrying `failureCategory`
+ *   from tool helpers back to the server, and is stripped before client response.
+ * - `internalFailureHttpStatus` is the transient wire field carrying `failureHttpStatus`
+ *   from tool helpers back to the server, and is stripped before client response.
  *
  * @param options - Object containing response configuration
  * @param options.texts - Array of text strings to include in the response
@@ -36,6 +40,12 @@ export function buildUsageMeta(source: {
  *                          This must remain MCP compliant: true for any tool-level error.
  * @param options.toolStatus - Optional internal tool status used for telemetry. When provided,
  *                             it is attached as `internalToolStatus` for server-side processing only.
+ * @param options.failureCategory - Optional failure category for telemetry diagnostics. When provided,
+ *                                  it is attached as `internalFailureCategory` for server-side processing only.
+ * @param options.failureHttpStatus - Optional HTTP status code for telemetry diagnostics. When provided,
+ *                                    it is attached as `internalFailureHttpStatus` for server-side processing only.
+ * @param options.validationDiagnostics - Optional AJV validation diagnostics for telemetry. When provided,
+ *                                        it is attached as `internalValidationDiagnostics` for server-side processing only.
  * @param options.structuredContent - Optional structured content of unknown type
  * @param options._meta - Optional metadata for widget rendering (e.g., OpenAI widget metadata)
  */
@@ -43,6 +53,13 @@ export function buildMCPResponse(options: {
     texts: string[];
     isError?: boolean;
     toolStatus?: ToolStatus;
+    failureCategory?: FailureCategory;
+    failureHttpStatus?: number;
+    validationDiagnostics?: Pick<ToolCallTelemetryProperties,
+        | 'validation_keyword'
+        | 'validation_path'
+        | 'validation_missing_property'
+        | 'validation_additional_property'>;
     structuredContent?: unknown;
     _meta?: Record<string, unknown>;
 }) {
@@ -50,6 +67,9 @@ export function buildMCPResponse(options: {
         texts,
         isError = false,
         toolStatus,
+        failureCategory,
+        failureHttpStatus,
+        validationDiagnostics,
         structuredContent,
         _meta,
     } = options;
@@ -58,6 +78,9 @@ export function buildMCPResponse(options: {
         content: texts.map((text) => ({ type: 'text' as const, text })),
         isError,
         ...(toolStatus && { internalToolStatus: toolStatus }),
+        ...(failureCategory && { internalFailureCategory: failureCategory }),
+        ...(failureHttpStatus !== undefined && { internalFailureHttpStatus: failureHttpStatus }),
+        ...(validationDiagnostics !== undefined && { internalValidationDiagnostics: validationDiagnostics }),
         ...(structuredContent !== undefined && { structuredContent }),
         ...(_meta !== undefined && { _meta }),
     };

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -1,4 +1,4 @@
-import type { FailureCategory, ToolCallTelemetryProperties, ToolStatus } from '../types.js';
+import type { FailureCategory, ToolStatus, ValidationDiagnostics } from '../types.js';
 
 /**
  * Builds usage metadata for MCP response from a source object containing Apify run costs.
@@ -55,11 +55,7 @@ export function buildMCPResponse(options: {
     toolStatus?: ToolStatus;
     failureCategory?: FailureCategory;
     failureHttpStatus?: number;
-    validationDiagnostics?: Pick<ToolCallTelemetryProperties,
-        | 'validation_keyword'
-        | 'validation_path'
-        | 'validation_missing_property'
-        | 'validation_additional_property'>;
+    validationDiagnostics?: ValidationDiagnostics;
     structuredContent?: unknown;
     _meta?: Record<string, unknown>;
 }) {

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -1,4 +1,4 @@
-import type { FailureCategory, ToolStatus, ValidationDiagnostics } from '../types.js';
+import type { ToolTelemetryContext } from '../types.js';
 
 /**
  * Builds usage metadata for MCP response from a source object containing Apify run costs.
@@ -22,61 +22,27 @@ export function buildUsageMeta(source: {
 }
 
 /**
- * Helper to build a response for MCP from an array of text strings.
+ * Helper to build a content response for MCP from an array of text strings.
  *
- * Status model used by this project:
- * - `isError` is MCP-visible and returned to the client.
- * - `toolStatus` is an internal helper input for server telemetry.
- * - `internalToolStatus` is the transient wire field carrying `toolStatus`
- *   from tool helpers back to the server, and is stripped before client response.
- * - `internalFailureCategory` is the transient wire field carrying `failureCategory`
- *   from tool helpers back to the server, and is stripped before client response.
- * - `internalFailureHttpStatus` is the transient wire field carrying `failureHttpStatus`
- *   from tool helpers back to the server, and is stripped before client response.
- *
- * @param options - Object containing response configuration
- * @param options.texts - Array of text strings to include in the response
- * @param options.isError - Optional flag to mark the response as an error (default: false).
- *                          This must remain MCP compliant: true for any tool-level error.
- * @param options.toolStatus - Optional internal tool status used for telemetry. When provided,
- *                             it is attached as `internalToolStatus` for server-side processing only.
- * @param options.failureCategory - Optional failure category for telemetry diagnostics. When provided,
- *                                  it is attached as `internalFailureCategory` for server-side processing only.
- * @param options.failureHttpStatus - Optional HTTP status code for telemetry diagnostics. When provided,
- *                                    it is attached as `internalFailureHttpStatus` for server-side processing only.
- * @param options.validationDiagnostics - Optional AJV validation diagnostics for telemetry. When provided,
- *                                        it is attached as `internalValidationDiagnostics` for server-side processing only.
- * @param options.structuredContent - Optional structured content of unknown type
- * @param options._meta - Optional metadata for widget rendering (e.g., OpenAI widget metadata)
+ * Status model:
+ * - `isError` is MCP-visible — returned to the client.
+ * - `telemetry` is server-internal — attached as `toolTelemetry` on the response,
+ *   then stripped by `extractToolTelemetry()` before the response reaches the client.
+ *   Contains tool outcome (toolStatus, failureCategory, etc.) used for Segment telemetry.
  */
 export function buildMCPResponse(options: {
     texts: string[];
     isError?: boolean;
-    toolStatus?: ToolStatus;
-    failureCategory?: FailureCategory;
-    failureHttpStatus?: number;
-    validationDiagnostics?: ValidationDiagnostics;
+    telemetry?: ToolTelemetryContext;
     structuredContent?: unknown;
     _meta?: Record<string, unknown>;
 }) {
-    const {
-        texts,
-        isError = false,
-        toolStatus,
-        failureCategory,
-        failureHttpStatus,
-        validationDiagnostics,
-        structuredContent,
-        _meta,
-    } = options;
+    const { texts, isError = false, telemetry, structuredContent, _meta } = options;
 
     return {
         content: texts.map((text) => ({ type: 'text' as const, text })),
         isError,
-        ...(toolStatus && { internalToolStatus: toolStatus }),
-        ...(failureCategory && { internalFailureCategory: failureCategory }),
-        ...(failureHttpStatus !== undefined && { internalFailureHttpStatus: failureHttpStatus }),
-        ...(validationDiagnostics !== undefined && { internalValidationDiagnostics: validationDiagnostics }),
+        ...(telemetry && { toolTelemetry: telemetry }),
         ...(structuredContent !== undefined && { structuredContent }),
         ...(_meta !== undefined && { _meta }),
     };

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -129,6 +129,7 @@ export function extractToolTelemetry(
     const callDiagnostics: CallDiagnostics = {
         ...(telemetry.failureCategory && { failure_category: telemetry.failureCategory }),
         ...(telemetry.failureHttpStatus !== undefined && { failure_http_status: telemetry.failureHttpStatus }),
+        ...(telemetry.failureDetail && { failure_detail: telemetry.failureDetail }),
         ...actorFields,
         ...telemetry.ajvErrorDetails,
     };

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -2,8 +2,9 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { ErrorObject } from 'ajv';
 
 import { FAILURE_CATEGORY, HTTP_FORBIDDEN, HTTP_NOT_FOUND, HTTP_UNAUTHORIZED, TOOL_STATUS } from '../const.js';
-import type { FailureCategory, FailureDiagnostics, ToolStatus, ValidationDiagnostics } from '../types.js';
+import type { AjvErrorDetails, FailureCategory, FailureDetails, ToolStatus, ToolTelemetryContext } from '../types.js';
 import { getHttpStatusCode } from './logging.js';
+import { buildActorFields } from './tools.js';
 
 /**
  * Central helper to classify an error into a ToolStatus value.
@@ -54,9 +55,9 @@ function limitField(value: string | undefined): string | undefined {
     return value.length > MAX_VALIDATION_FIELD_LENGTH ? value.slice(0, MAX_VALIDATION_FIELD_LENGTH) : value;
 }
 
-export function extractValidationDiagnostics(
+export function extractAjvErrorDetails(
     errors: ErrorObject[] | null | undefined,
-): ValidationDiagnostics {
+): AjvErrorDetails {
     if (!errors?.length) return {};
 
     const firstError = errors[0];
@@ -67,7 +68,7 @@ export function extractValidationDiagnostics(
     // - validation_missing_property: required-property name such as "query"
     // - validation_additional_property: unexpected-property name such as "docSource"
     // - validation_error_count: total number of AJV errors (signals when there's more than one)
-    const diagnostics: ValidationDiagnostics = {
+    const diagnostics: AjvErrorDetails = {
         validation_keyword: limitField(firstError.keyword),
         validation_path: limitField(firstError.instancePath || undefined),
         validation_error_count: errors.length,
@@ -91,56 +92,46 @@ export function extractValidationDiagnostics(
 }
 
 /**
- * Strips internal diagnostic fields from a tool response in-place and derives toolStatus + failureDiagnostics.
+ * Reads `toolTelemetry` from a tool response, strips it, and returns toolStatus + failureDetails.
  *
- * Three cases:
- * 1. internalToolStatus present → use it directly.
- * 2. isError set without internalToolStatus → SOFT_FAIL (user/input problem).
+ * toolStatus resolution:
+ * 1. `toolTelemetry.toolStatus` present → use it directly.
+ * 2. `isError` set without toolStatus → SOFT_FAIL.
  * 3. Neither → SUCCEEDED.
  *
- * Internal fields (`internalToolStatus`, `internalFailureCategory`, etc.) are deleted
- * from `res` so they are never exposed to MCP clients.
+ * actorName/actorId are server-side context (from tool resolution).
+ * Tool-reported actorId (e.g. from call-actor after resolution) takes precedence.
  */
-export function extractToolResponseDiagnostics(
+export function extractToolTelemetry(
     res: Record<string, unknown>,
     actorName: string | undefined,
-): { toolStatus: ToolStatus; failureDiagnostics: FailureDiagnostics } {
-    const internalToolStatus = res.internalToolStatus as ToolStatus | undefined;
-    const internalFailureCategory = res.internalFailureCategory as FailureCategory | undefined;
-    const internalFailureHttpStatus = res.internalFailureHttpStatus as number | undefined;
-    const internalValidationDiagnostics = res.internalValidationDiagnostics as FailureDiagnostics | undefined;
+    actorId: string | undefined,
+): { toolStatus: ToolStatus; failureDetails: FailureDetails } {
+    const telemetry = res.toolTelemetry as ToolTelemetryContext | undefined;
+    delete res.toolTelemetry;
 
-    delete res.internalToolStatus;
-    delete res.internalFailureCategory;
-    delete res.internalFailureHttpStatus;
-    delete res.internalValidationDiagnostics;
+    // Tool-reported actorId (e.g. from call-actor) takes precedence over server-side actorId
+    const actorFields = buildActorFields(actorName, telemetry?.actorId ?? actorId);
 
-    const actorField = actorName ? { actor_name: actorName } : {};
-    const httpField = internalFailureHttpStatus !== undefined ? { failure_http_status: internalFailureHttpStatus } : {};
-
-    if (internalToolStatus !== undefined) {
-        return {
-            toolStatus: internalToolStatus,
-            failureDiagnostics: {
-                ...(internalFailureCategory ? { failure_category: internalFailureCategory } : {}),
-                ...httpField,
-                ...actorField,
-                ...internalValidationDiagnostics,
-            },
-        };
+    if (!telemetry) {
+        if (res.isError) {
+            return {
+                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureDetails: { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR, ...actorFields },
+            };
+        }
+        return { toolStatus: TOOL_STATUS.SUCCEEDED, failureDetails: {} };
     }
 
-    if (res.isError) {
-        return {
-            toolStatus: TOOL_STATUS.SOFT_FAIL,
-            failureDiagnostics: {
-                failure_category: internalFailureCategory ?? FAILURE_CATEGORY.INTERNAL_ERROR,
-                ...httpField,
-                ...actorField,
-                ...internalValidationDiagnostics,
-            },
-        };
-    }
+    const toolStatus = telemetry.toolStatus
+        ?? (res.isError ? TOOL_STATUS.SOFT_FAIL : TOOL_STATUS.SUCCEEDED);
 
-    return { toolStatus: TOOL_STATUS.SUCCEEDED, failureDiagnostics: {} };
+    const failureDetails: FailureDetails = {
+        ...(telemetry.failureCategory && { failure_category: telemetry.failureCategory }),
+        ...(telemetry.failureHttpStatus !== undefined && { failure_http_status: telemetry.failureHttpStatus }),
+        ...actorFields,
+        ...telemetry.ajvErrorDetails,
+    };
+
+    return { toolStatus, failureDetails };
 }

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -1,7 +1,7 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { ErrorObject } from 'ajv';
 
-import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
+import { FAILURE_CATEGORY, HTTP_FORBIDDEN, HTTP_NOT_FOUND, HTTP_UNAUTHORIZED, TOOL_STATUS } from '../const.js';
 import type { FailureCategory, FailureDiagnostics, ToolStatus, ValidationDiagnostics } from '../types.js';
 import { getHttpStatusCode } from './logging.js';
 
@@ -39,8 +39,8 @@ export function classifyFailureCategory(error: unknown): FailureCategory {
     }
 
     const statusCode = getHttpStatusCode(error);
-    if (statusCode === 401 || statusCode === 403) return FAILURE_CATEGORY.AUTH;
-    if (statusCode === 404) return FAILURE_CATEGORY.INVALID_INPUT;
+    if (statusCode === HTTP_UNAUTHORIZED || statusCode === HTTP_FORBIDDEN) return FAILURE_CATEGORY.AUTH;
+    if (statusCode === HTTP_NOT_FOUND) return FAILURE_CATEGORY.INVALID_INPUT;
     if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) return FAILURE_CATEGORY.INVALID_INPUT;
     if (statusCode !== undefined && statusCode >= 500) return FAILURE_CATEGORY.INTERNAL_ERROR;
 

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -2,7 +2,7 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { ErrorObject } from 'ajv';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
-import type { FailureCategory, ToolCallTelemetryProperties, ToolStatus } from '../types.js';
+import type { FailureCategory, ToolStatus, ValidationDiagnostics } from '../types.js';
 import { getHttpStatusCode } from './logging.js';
 
 /**
@@ -56,11 +56,7 @@ function limitField(value: string | undefined): string | undefined {
 
 export function extractValidationDiagnostics(
     errors: ErrorObject[] | null | undefined,
-): Pick<ToolCallTelemetryProperties,
-    | 'validation_keyword'
-    | 'validation_path'
-    | 'validation_missing_property'
-    | 'validation_additional_property'> {
+): ValidationDiagnostics {
     const firstError = errors?.[0];
     if (!firstError) return {};
 
@@ -69,14 +65,10 @@ export function extractValidationDiagnostics(
     // - validation_path: AJV instancePath such as "/input/query" or "/callOptions/memory"
     // - validation_missing_property: required-property name such as "query"
     // - validation_additional_property: unexpected-property name such as "docSource"
-    const diagnostics: Pick<ToolCallTelemetryProperties,
-        | 'validation_keyword'
-        | 'validation_path'
-        | 'validation_missing_property'
-        | 'validation_additional_property'> = {
-            validation_keyword: limitField(firstError.keyword),
-            validation_path: limitField(firstError.instancePath || undefined),
-        };
+    const diagnostics: ValidationDiagnostics = {
+        validation_keyword: limitField(firstError.keyword),
+        validation_path: limitField(firstError.instancePath || undefined),
+    };
 
     const hasParams = typeof firstError.params === 'object' && firstError.params !== null;
 

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -1,13 +1,14 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { ErrorObject } from 'ajv';
 
-import { TOOL_STATUS } from '../const.js';
-import type { ToolStatus } from '../types.js';
+import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
+import type { FailureCategory, ToolCallTelemetryProperties, ToolStatus } from '../types.js';
 import { getHttpStatusCode } from './logging.js';
 
 /**
  * Central helper to classify an error into a ToolStatus value.
  *
- * - TOOL_STATUS.ABORTED   → Request was explicitly aborted by the client.
+ * - TOOL_STATUS.ABORTED   → the client explicitly aborted Request.
  * - TOOL_STATUS.SOFT_FAIL → User/client errors (HTTP 4xx, InvalidParams, validation issues).
  * - TOOL_STATUS.FAILED    → Server errors (HTTP 5xx, unknown, or unexpected exceptions).
  */
@@ -30,4 +31,66 @@ export function getToolStatusFromError(error: unknown, isAborted: boolean): Tool
 
     // Everything else is considered a server / unexpected failure
     return TOOL_STATUS.FAILED;
+}
+
+export function classifyFailureCategory(error: unknown): FailureCategory {
+    if (error instanceof McpError && error.code === ErrorCode.InvalidParams) {
+        return FAILURE_CATEGORY.INVALID_INPUT;
+    }
+
+    const statusCode = getHttpStatusCode(error);
+    if (statusCode === 401 || statusCode === 403) return FAILURE_CATEGORY.AUTH;
+    if (statusCode === 404) return FAILURE_CATEGORY.INVALID_INPUT;
+    if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) return FAILURE_CATEGORY.INVALID_INPUT;
+    if (statusCode !== undefined && statusCode >= 500) return FAILURE_CATEGORY.INTERNAL_ERROR;
+
+    return FAILURE_CATEGORY.INTERNAL_ERROR;
+}
+
+const MAX_VALIDATION_FIELD_LENGTH = 120;
+
+function limitField(value: string | undefined): string | undefined {
+    if (!value) return undefined;
+    return value.length > MAX_VALIDATION_FIELD_LENGTH ? value.slice(0, MAX_VALIDATION_FIELD_LENGTH) : value;
+}
+
+export function extractValidationDiagnostics(
+    errors: ErrorObject[] | null | undefined,
+): Pick<ToolCallTelemetryProperties,
+    | 'validation_keyword'
+    | 'validation_path'
+    | 'validation_missing_property'
+    | 'validation_additional_property'> {
+    const firstError = errors?.[0];
+    if (!firstError) return {};
+
+    // Extracted fields use the first AJV error as the canonical summary:
+    // - validation_keyword: AJV keyword such as "required", "additionalProperties", "minimum", "type"
+    // - validation_path: AJV instancePath such as "/input/query" or "/callOptions/memory"
+    // - validation_missing_property: required-property name such as "query"
+    // - validation_additional_property: unexpected-property name such as "docSource"
+    const diagnostics: Pick<ToolCallTelemetryProperties,
+        | 'validation_keyword'
+        | 'validation_path'
+        | 'validation_missing_property'
+        | 'validation_additional_property'> = {
+            validation_keyword: limitField(firstError.keyword),
+            validation_path: limitField(firstError.instancePath || undefined),
+        };
+
+    const hasParams = typeof firstError.params === 'object' && firstError.params !== null;
+
+    if (firstError.keyword === 'required' && hasParams && 'missingProperty' in firstError.params) {
+        const { missingProperty } = firstError.params as { missingProperty?: unknown };
+        if (typeof missingProperty === 'string') {
+            diagnostics.validation_missing_property = limitField(missingProperty);
+        }
+    } else if (firstError.keyword === 'additionalProperties' && hasParams && 'additionalProperty' in firstError.params) {
+        const { additionalProperty } = firstError.params as { additionalProperty?: unknown };
+        if (typeof additionalProperty === 'string') {
+            diagnostics.validation_additional_property = limitField(additionalProperty);
+        }
+    }
+
+    return diagnostics;
 }

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -57,17 +57,20 @@ function limitField(value: string | undefined): string | undefined {
 export function extractValidationDiagnostics(
     errors: ErrorObject[] | null | undefined,
 ): ValidationDiagnostics {
-    const firstError = errors?.[0];
-    if (!firstError) return {};
+    if (!errors?.length) return {};
+
+    const firstError = errors[0];
 
     // Extracted fields use the first AJV error as the canonical summary:
     // - validation_keyword: AJV keyword such as "required", "additionalProperties", "minimum", "type"
     // - validation_path: AJV instancePath such as "/input/query" or "/callOptions/memory"
     // - validation_missing_property: required-property name such as "query"
     // - validation_additional_property: unexpected-property name such as "docSource"
+    // - validation_error_count: total number of AJV errors (signals when there's more than one)
     const diagnostics: ValidationDiagnostics = {
         validation_keyword: limitField(firstError.keyword),
         validation_path: limitField(firstError.instancePath || undefined),
+        validation_error_count: errors.length,
     };
 
     const hasParams = typeof firstError.params === 'object' && firstError.params !== null;

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -2,7 +2,7 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { ErrorObject } from 'ajv';
 
 import { FAILURE_CATEGORY, HTTP_FORBIDDEN, HTTP_NOT_FOUND, HTTP_UNAUTHORIZED, TOOL_STATUS } from '../const.js';
-import type { AjvErrorDetails, FailureCategory, FailureDetails, ToolStatus, ToolTelemetryContext } from '../types.js';
+import type { AjvErrorDetails, CallDiagnostics, FailureCategory, ToolStatus, ToolTelemetryContext } from '../types.js';
 import { getHttpStatusCode } from './logging.js';
 import { buildActorFields } from './tools.js';
 
@@ -92,7 +92,7 @@ export function extractAjvErrorDetails(
 }
 
 /**
- * Reads `toolTelemetry` from a tool response, strips it, and returns toolStatus + failureDetails.
+ * Reads `toolTelemetry` from a tool response, strips it, and returns toolStatus + callDiagnostics.
  *
  * toolStatus resolution:
  * 1. `toolTelemetry.toolStatus` present → use it directly.
@@ -106,7 +106,7 @@ export function extractToolTelemetry(
     res: Record<string, unknown>,
     actorName: string | undefined,
     actorId: string | undefined,
-): { toolStatus: ToolStatus; failureDetails: FailureDetails } {
+): { toolStatus: ToolStatus; callDiagnostics: CallDiagnostics } {
     const telemetry = res.toolTelemetry as ToolTelemetryContext | undefined;
     delete res.toolTelemetry;
 
@@ -117,21 +117,21 @@ export function extractToolTelemetry(
         if (res.isError) {
             return {
                 toolStatus: TOOL_STATUS.SOFT_FAIL,
-                failureDetails: { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR, ...actorFields },
+                callDiagnostics: { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR, ...actorFields },
             };
         }
-        return { toolStatus: TOOL_STATUS.SUCCEEDED, failureDetails: {} };
+        return { toolStatus: TOOL_STATUS.SUCCEEDED, callDiagnostics: {} };
     }
 
     const toolStatus = telemetry.toolStatus
         ?? (res.isError ? TOOL_STATUS.SOFT_FAIL : TOOL_STATUS.SUCCEEDED);
 
-    const failureDetails: FailureDetails = {
+    const callDiagnostics: CallDiagnostics = {
         ...(telemetry.failureCategory && { failure_category: telemetry.failureCategory }),
         ...(telemetry.failureHttpStatus !== undefined && { failure_http_status: telemetry.failureHttpStatus }),
         ...actorFields,
         ...telemetry.ajvErrorDetails,
     };
 
-    return { toolStatus, failureDetails };
+    return { toolStatus, callDiagnostics };
 }

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -2,7 +2,7 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { ErrorObject } from 'ajv';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
-import type { FailureCategory, ToolStatus, ValidationDiagnostics } from '../types.js';
+import type { FailureCategory, FailureDiagnostics, ToolStatus, ValidationDiagnostics } from '../types.js';
 import { getHttpStatusCode } from './logging.js';
 
 /**
@@ -85,4 +85,59 @@ export function extractValidationDiagnostics(
     }
 
     return diagnostics;
+}
+
+/**
+ * Strips internal diagnostic fields from a tool response in-place and derives toolStatus + failureDiagnostics.
+ *
+ * Three cases:
+ * 1. internalToolStatus present → use it directly.
+ * 2. isError set without internalToolStatus → SOFT_FAIL (user/input problem).
+ * 3. Neither → SUCCEEDED.
+ *
+ * Internal fields (`internalToolStatus`, `internalFailureCategory`, etc.) are deleted
+ * from `res` so they are never exposed to MCP clients.
+ */
+export function extractToolResponseDiagnostics(
+    res: Record<string, unknown>,
+    actorName: string | undefined,
+): { toolStatus: ToolStatus; failureDiagnostics: FailureDiagnostics } {
+    const internalToolStatus = res.internalToolStatus as ToolStatus | undefined;
+    const internalFailureCategory = res.internalFailureCategory as FailureCategory | undefined;
+    const internalFailureHttpStatus = res.internalFailureHttpStatus as number | undefined;
+    const internalValidationDiagnostics = res.internalValidationDiagnostics as FailureDiagnostics | undefined;
+
+    delete res.internalToolStatus;
+    delete res.internalFailureCategory;
+    delete res.internalFailureHttpStatus;
+    delete res.internalValidationDiagnostics;
+
+    const actorField = actorName ? { actor_name: actorName } : {};
+    const httpField = internalFailureHttpStatus !== undefined ? { failure_http_status: internalFailureHttpStatus } : {};
+
+    if (internalToolStatus !== undefined) {
+        return {
+            toolStatus: internalToolStatus,
+            failureDiagnostics: {
+                ...(internalFailureCategory ? { failure_category: internalFailureCategory } : {}),
+                ...httpField,
+                ...actorField,
+                ...internalValidationDiagnostics,
+            },
+        };
+    }
+
+    if (res.isError) {
+        return {
+            toolStatus: TOOL_STATUS.SOFT_FAIL,
+            failureDiagnostics: {
+                failure_category: internalFailureCategory ?? FAILURE_CATEGORY.INTERNAL_ERROR,
+                ...httpField,
+                ...actorField,
+                ...internalValidationDiagnostics,
+            },
+        };
+    }
+
+    return { toolStatus: TOOL_STATUS.SUCCEEDED, failureDiagnostics: {} };
 }

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -4,7 +4,7 @@ import {
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../const.js';
-import type { HelperTool, ServerMode, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
+import type { FailureDetails, HelperTool, ServerMode, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
 import { fixZodSchemaRequired } from './ajv.js';
 
 /**
@@ -19,6 +19,25 @@ export function getToolFullName(tool: ToolEntry): string {
         case 'actor-mcp': return tool.name;
         default: return (tool satisfies never as ToolEntry).name;
     }
+}
+
+/**
+ * Extract stable Actor ID for telemetry.
+ * Available for actor and actor-mcp tools; undefined for internal tools.
+ */
+export function extractActorId(tool: ToolEntry): string | undefined {
+    if (tool.type === 'actor' || tool.type === 'actor-mcp') return tool.actorId;
+    return undefined;
+}
+
+/**
+ * Build actor identification fields for failure telemetry.
+ */
+export function buildActorFields(actorName?: string, actorId?: string): Pick<FailureDetails, 'actor_name' | 'actor_id'> {
+    return {
+        ...(actorName ? { actor_name: actorName } : {}),
+        ...(actorId ? { actor_id: actorId } : {}),
+    };
 }
 
 /**

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -7,6 +7,37 @@ import {
 import type { HelperTool, ServerMode, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
 import { fixZodSchemaRequired } from './ajv.js';
 
+/**
+ * Returns the canonical full name for a tool.
+ * For actor tools this is actorFullName (e.g. "apify/rag-web-browser"),
+ * for all others it's the tool name.
+ */
+export function getToolFullName(tool: ToolEntry): string {
+    switch (tool.type) {
+        case 'actor': return tool.actorFullName;
+        case 'internal':
+        case 'actor-mcp': return tool.name;
+        default: return (tool satisfies never as ToolEntry).name;
+    }
+}
+
+/**
+ * Extract actor name for telemetry from the tool entry or call-actor args.
+ * For actor tools, read from the tool entry. For call-actor, parse from the `actor` arg.
+ * Returns undefined for other internal tools or when the arg is missing/invalid.
+ */
+export function extractActorName(tool: ToolEntry, args?: Record<string, unknown>): string | undefined {
+    if (tool.type === 'actor') return tool.actorFullName;
+    if (tool.type === 'actor-mcp') return tool.actorId;
+
+    // For call-actor, the actor name is in `args.actor`.
+    // The format can be "username/name" or "username/name:toolName" (MCP server Actors).
+    // Strip the optional `:toolName` suffix to get the base actor name.
+    const actorArg = args?.actor;
+    if (typeof actorArg !== 'string') return undefined;
+    return actorArg.split(':')[0]?.trim() || undefined;
+}
+
 type ToolPublicFieldOptions = {
     mode?: ServerMode;
     filterWidgetMeta?: boolean;

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -4,7 +4,7 @@ import {
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../const.js';
-import type { FailureDetails, HelperTool, ServerMode, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
+import type { CallDiagnostics, HelperTool, ServerMode, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
 import { fixZodSchemaRequired } from './ajv.js';
 
 /**
@@ -33,7 +33,7 @@ export function extractActorId(tool: ToolEntry): string | undefined {
 /**
  * Build actor identification fields for failure telemetry.
  */
-export function buildActorFields(actorName?: string, actorId?: string): Pick<FailureDetails, 'actor_name' | 'actor_id'> {
+export function buildActorFields(actorName?: string, actorId?: string): Pick<CallDiagnostics, 'actor_name' | 'actor_id'> {
     return {
         ...(actorName ? { actor_name: actorName } : {}),
         ...(actorId ? { actor_id: actorId } : {}),

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -81,4 +81,32 @@ describe('telemetry', () => {
         expect(callArgs.event).toBe('MCP Tool Call');
         expect(callArgs.properties).toEqual(properties);
     });
+
+    it('should preserve optional failure diagnostics in the payload', () => {
+        const properties = {
+            app: 'mcp' as const,
+            app_version: '0.5.6',
+            mcp_client_name: 'test-client',
+            mcp_client_version: '1.0.0',
+            mcp_protocol_version: '2024-11-05',
+            mcp_client_capabilities: {},
+            mcp_session_id: 'session-123',
+            transport_type: 'stdio',
+            tool_name: 'call-actor',
+            tool_status: 'SOFT_FAIL' as const,
+            tool_exec_time_ms: 100,
+            failure_category: 'INVALID_INPUT' as const,
+            actor_name: 'apify/rag-web-browser',
+            validation_keyword: 'required',
+            validation_missing_property: 'query',
+        };
+
+        trackToolCall('test-user-123', 'DEV', properties);
+
+        expect(mockTrack).toHaveBeenCalledWith({
+            userId: 'test-user-123',
+            event: 'MCP Tool Call',
+            properties,
+        });
+    });
 });

--- a/tests/unit/tools.skyfire.test.ts
+++ b/tests/unit/tools.skyfire.test.ts
@@ -45,6 +45,7 @@ function makeActorTool(overrides: Partial<ActorTool> = {}): ActorTool {
         name: 'apify--web-scraper',
         description: 'Web scraper tool',
         type: 'actor',
+        actorId: 'abc123',
         actorFullName: 'apify/web-scraper',
         inputSchema: {
             type: 'object' as const,

--- a/tests/unit/tools.utils.test.ts
+++ b/tests/unit/tools.utils.test.ts
@@ -4,7 +4,8 @@ import { ACTOR_ENUM_MAX_LENGTH, ACTOR_MAX_DESCRIPTION_LENGTH } from '../../src/c
 import { buildApifySpecificProperties, decodeDotPropertyNames, encodeDotPropertyNames,
     filterAndShortenEnum, inferArrayItemsTypeIfMissing, inferArrayItemType, markInputPropertiesAsRequired, shortenProperties,
     transformActorInputSchemaProperties } from '../../src/tools/utils.js';
-import type { ActorInputSchema, SchemaProperties } from '../../src/types.js';
+import type { ActorInputSchema, SchemaProperties, ToolEntry } from '../../src/types.js';
+import { extractActorName, getToolFullName } from '../../src/utils/tools.js';
 
 describe('buildApifySpecificProperties', () => {
     it('should add resource picker structure to array items with editor resourcePicker', () => {
@@ -901,5 +902,49 @@ describe('filterAndShortenEnum', () => {
         const shortenedList = filterAndShortenEnum(enumList);
 
         expect(shortenedList?.length || 0).toBe(ACTOR_ENUM_MAX_LENGTH / wordLength);
+    });
+});
+
+describe('getToolFullName', () => {
+    it('returns actorFullName for actor tools', () => {
+        const tool = { type: 'actor', name: 'actor-web-scraper-by-apify', actorFullName: 'apify/web-scraper' } as unknown as ToolEntry;
+        expect(getToolFullName(tool)).toBe('apify/web-scraper');
+    });
+
+    it('returns name for internal tools', () => {
+        const tool = { type: 'internal', name: 'store-search' } as unknown as ToolEntry;
+        expect(getToolFullName(tool)).toBe('store-search');
+    });
+
+    it('returns name for actor-mcp tools', () => {
+        const tool = { type: 'actor-mcp', name: 'mcp-tool-search', actorId: 'apify/actors-mcp-server' } as unknown as ToolEntry;
+        expect(getToolFullName(tool)).toBe('mcp-tool-search');
+    });
+});
+
+describe('extractActorName', () => {
+    it('returns actorFullName for actor tools', () => {
+        const tool = { type: 'actor', actorFullName: 'apify/web-scraper' } as unknown as ToolEntry;
+        expect(extractActorName(tool)).toBe('apify/web-scraper');
+    });
+
+    it('returns actorId for actor-mcp tools', () => {
+        const tool = { type: 'actor-mcp', actorId: 'apify/actors-mcp-server' } as unknown as ToolEntry;
+        expect(extractActorName(tool)).toBe('apify/actors-mcp-server');
+    });
+
+    it('parses actor name from call-actor args', () => {
+        const tool = { type: 'internal', name: 'call-actor' } as unknown as ToolEntry;
+        expect(extractActorName(tool, { actor: 'apify/web-scraper' })).toBe('apify/web-scraper');
+    });
+
+    it('strips :toolName suffix from call-actor args', () => {
+        const tool = { type: 'internal', name: 'call-actor' } as unknown as ToolEntry;
+        expect(extractActorName(tool, { actor: 'apify/actors-mcp-server:search' })).toBe('apify/actors-mcp-server');
+    });
+
+    it('returns undefined for internal tools without actor arg', () => {
+        const tool = { type: 'internal', name: 'store-search' } as unknown as ToolEntry;
+        expect(extractActorName(tool)).toBeUndefined();
     });
 });

--- a/tests/unit/utils.tool_status.test.ts
+++ b/tests/unit/utils.tool_status.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, it } from 'vitest';
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
 import {
     classifyFailureCategory,
-    extractToolResponseDiagnostics,
-    extractValidationDiagnostics,
+    extractAjvErrorDetails,
+    extractToolTelemetry,
     getToolStatusFromError,
 } from '../../src/utils/tool_status.js';
 
@@ -76,9 +76,9 @@ describe('classifyFailureCategory', () => {
     });
 });
 
-describe('extractValidationDiagnostics', () => {
+describe('extractAjvErrorDetails', () => {
     it('extracts required-property diagnostics', () => {
-        const diagnostics = extractValidationDiagnostics([
+        const diagnostics = extractAjvErrorDetails([
             {
                 keyword: 'required',
                 instancePath: '',
@@ -97,7 +97,7 @@ describe('extractValidationDiagnostics', () => {
     });
 
     it('extracts additional-property diagnostics', () => {
-        const diagnostics = extractValidationDiagnostics([
+        const diagnostics = extractAjvErrorDetails([
             {
                 keyword: 'additionalProperties',
                 instancePath: '/output',
@@ -113,7 +113,7 @@ describe('extractValidationDiagnostics', () => {
     });
 
     it('reports error count for multiple validation errors', () => {
-        const diagnostics = extractValidationDiagnostics([
+        const diagnostics = extractAjvErrorDetails([
             { keyword: 'required', instancePath: '', schemaPath: '#/required', params: { missingProperty: 'query' }, message: '' },
             { keyword: 'required', instancePath: '', schemaPath: '#/required', params: { missingProperty: 'url' }, message: '' },
             { keyword: 'type', instancePath: '/limit', schemaPath: '#/type', params: { type: 'number' }, message: '' },
@@ -127,40 +127,42 @@ describe('extractValidationDiagnostics', () => {
     });
 
     it('returns empty for null/undefined errors', () => {
-        expect(extractValidationDiagnostics(null)).toEqual({});
-        expect(extractValidationDiagnostics(undefined)).toEqual({});
-        expect(extractValidationDiagnostics([])).toEqual({});
+        expect(extractAjvErrorDetails(null)).toEqual({});
+        expect(extractAjvErrorDetails(undefined)).toEqual({});
+        expect(extractAjvErrorDetails([])).toEqual({});
     });
 });
 
-describe('extractToolResponseDiagnostics', () => {
-    it('uses internalToolStatus when present and strips internal fields', () => {
+describe('extractToolTelemetry', () => {
+    it('reads toolTelemetry, strips it, and maps to failureDetails', () => {
         const res: Record<string, unknown> = {
             content: 'ok',
-            internalToolStatus: TOOL_STATUS.SOFT_FAIL,
-            internalFailureCategory: FAILURE_CATEGORY.INVALID_INPUT,
-            internalFailureHttpStatus: 404,
+            toolTelemetry: {
+                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                failureHttpStatus: 404,
+            },
         };
 
-        const { toolStatus, failureDiagnostics } = extractToolResponseDiagnostics(res, 'apify/web-scraper');
+        const { toolStatus, failureDetails } = extractToolTelemetry(res, 'apify/web-scraper', 'abc123');
 
         expect(toolStatus).toBe(TOOL_STATUS.SOFT_FAIL);
-        expect(failureDiagnostics).toMatchObject(
-            { failure_category: FAILURE_CATEGORY.INVALID_INPUT, failure_http_status: 404, actor_name: 'apify/web-scraper' },
+        expect(failureDetails).toMatchObject(
+            { failure_category: FAILURE_CATEGORY.INVALID_INPUT, failure_http_status: 404, actor_name: 'apify/web-scraper', actor_id: 'abc123' },
         );
-        expect(res.internalToolStatus).toBeUndefined();
+        expect(res.toolTelemetry).toBeUndefined();
         expect(res.content).toBe('ok');
     });
 
-    it('defaults to SOFT_FAIL when isError without internalToolStatus', () => {
-        const { toolStatus, failureDiagnostics } = extractToolResponseDiagnostics({ isError: true }, undefined);
+    it('defaults to SOFT_FAIL when isError without toolTelemetry', () => {
+        const { toolStatus, failureDetails } = extractToolTelemetry({ isError: true }, undefined, undefined);
         expect(toolStatus).toBe(TOOL_STATUS.SOFT_FAIL);
-        expect(failureDiagnostics.failure_category).toBe(FAILURE_CATEGORY.INTERNAL_ERROR);
+        expect(failureDetails.failure_category).toBe(FAILURE_CATEGORY.INTERNAL_ERROR);
     });
 
     it('returns SUCCEEDED when no error signals', () => {
-        const { toolStatus, failureDiagnostics } = extractToolResponseDiagnostics({ content: 'ok' }, undefined);
+        const { toolStatus, failureDetails } = extractToolTelemetry({ content: 'ok' }, undefined, undefined);
         expect(toolStatus).toBe(TOOL_STATUS.SUCCEEDED);
-        expect(failureDiagnostics).toEqual({});
+        expect(failureDetails).toEqual({});
     });
 });

--- a/tests/unit/utils.tool_status.test.ts
+++ b/tests/unit/utils.tool_status.test.ts
@@ -134,7 +134,7 @@ describe('extractAjvErrorDetails', () => {
 });
 
 describe('extractToolTelemetry', () => {
-    it('reads toolTelemetry, strips it, and maps to failureDetails', () => {
+    it('reads toolTelemetry, strips it, and maps to callDiagnostics', () => {
         const res: Record<string, unknown> = {
             content: 'ok',
             toolTelemetry: {
@@ -144,10 +144,10 @@ describe('extractToolTelemetry', () => {
             },
         };
 
-        const { toolStatus, failureDetails } = extractToolTelemetry(res, 'apify/web-scraper', 'abc123');
+        const { toolStatus, callDiagnostics } = extractToolTelemetry(res, 'apify/web-scraper', 'abc123');
 
         expect(toolStatus).toBe(TOOL_STATUS.SOFT_FAIL);
-        expect(failureDetails).toMatchObject(
+        expect(callDiagnostics).toMatchObject(
             { failure_category: FAILURE_CATEGORY.INVALID_INPUT, failure_http_status: 404, actor_name: 'apify/web-scraper', actor_id: 'abc123' },
         );
         expect(res.toolTelemetry).toBeUndefined();
@@ -155,14 +155,14 @@ describe('extractToolTelemetry', () => {
     });
 
     it('defaults to SOFT_FAIL when isError without toolTelemetry', () => {
-        const { toolStatus, failureDetails } = extractToolTelemetry({ isError: true }, undefined, undefined);
+        const { toolStatus, callDiagnostics } = extractToolTelemetry({ isError: true }, undefined, undefined);
         expect(toolStatus).toBe(TOOL_STATUS.SOFT_FAIL);
-        expect(failureDetails.failure_category).toBe(FAILURE_CATEGORY.INTERNAL_ERROR);
+        expect(callDiagnostics.failure_category).toBe(FAILURE_CATEGORY.INTERNAL_ERROR);
     });
 
     it('returns SUCCEEDED when no error signals', () => {
-        const { toolStatus, failureDetails } = extractToolTelemetry({ content: 'ok' }, undefined, undefined);
+        const { toolStatus, callDiagnostics } = extractToolTelemetry({ content: 'ok' }, undefined, undefined);
         expect(toolStatus).toBe(TOOL_STATUS.SUCCEEDED);
-        expect(failureDetails).toEqual({});
+        expect(callDiagnostics).toEqual({});
     });
 });

--- a/tests/unit/utils.tool_status.test.ts
+++ b/tests/unit/utils.tool_status.test.ts
@@ -1,8 +1,8 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it } from 'vitest';
 
-import { TOOL_STATUS } from '../../src/const.js';
-import { getToolStatusFromError } from '../../src/utils/tool_status.js';
+import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
+import { classifyFailureCategory, extractValidationDiagnostics, getToolStatusFromError } from '../../src/utils/tool_status.js';
 
 describe('getToolStatusFromError', () => {
     it('returns aborted when isAborted is true', () => {
@@ -31,5 +31,62 @@ describe('getToolStatusFromError', () => {
     it('classifies unknown errors without status code as failed', () => {
         const status = getToolStatusFromError(new Error('unknown'), false);
         expect(status).toBe(TOOL_STATUS.FAILED);
+    });
+});
+
+describe('classifyFailureCategory', () => {
+    it('classifies invalid params as INVALID_INPUT', () => {
+        const category = classifyFailureCategory(new McpError(ErrorCode.InvalidParams, 'invalid', undefined));
+        expect(category).toBe(FAILURE_CATEGORY.INVALID_INPUT);
+    });
+
+    it('classifies 404 as INVALID_INPUT', () => {
+        const category = classifyFailureCategory(Object.assign(new Error('Not found'), { statusCode: 404 }));
+        expect(category).toBe(FAILURE_CATEGORY.INVALID_INPUT);
+    });
+
+    it('classifies generic 4xx as INVALID_INPUT', () => {
+        const category = classifyFailureCategory(Object.assign(new Error('Bad request'), { statusCode: 402 }));
+        expect(category).toBe(FAILURE_CATEGORY.INVALID_INPUT);
+    });
+
+    it('classifies unexpected errors as INTERNAL_ERROR', () => {
+        const category = classifyFailureCategory(new Error('connect ECONNREFUSED 127.0.0.1'));
+        expect(category).toBe(FAILURE_CATEGORY.INTERNAL_ERROR);
+    });
+});
+
+describe('extractValidationDiagnostics', () => {
+    it('extracts required-property diagnostics', () => {
+        const diagnostics = extractValidationDiagnostics([
+            {
+                keyword: 'required',
+                instancePath: '',
+                schemaPath: '#/required',
+                params: { missingProperty: 'query' },
+                message: 'must have required property',
+            },
+        ]);
+
+        expect(diagnostics).toEqual({
+            validation_keyword: 'required',
+            validation_path: undefined,
+            validation_missing_property: 'query',
+        });
+    });
+
+    it('extracts additional-property diagnostics', () => {
+        const diagnostics = extractValidationDiagnostics([
+            {
+                keyword: 'additionalProperties',
+                instancePath: '/output',
+                schemaPath: '#/additionalProperties',
+                params: { additionalProperty: 'docSource' },
+                message: 'must NOT have additional properties',
+            },
+        ]);
+
+        expect(diagnostics.validation_additional_property).toBe('docSource');
+        expect(diagnostics.validation_path).toBe('/output');
     });
 });

--- a/tests/unit/utils.tool_status.test.ts
+++ b/tests/unit/utils.tool_status.test.ts
@@ -2,7 +2,12 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it } from 'vitest';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
-import { classifyFailureCategory, extractValidationDiagnostics, getToolStatusFromError } from '../../src/utils/tool_status.js';
+import {
+    classifyFailureCategory,
+    extractToolResponseDiagnostics,
+    extractValidationDiagnostics,
+    getToolStatusFromError,
+} from '../../src/utils/tool_status.js';
 
 describe('getToolStatusFromError', () => {
     it('returns aborted when isAborted is true', () => {
@@ -40,6 +45,16 @@ describe('classifyFailureCategory', () => {
         expect(category).toBe(FAILURE_CATEGORY.INVALID_INPUT);
     });
 
+    it('classifies 401 as AUTH', () => {
+        const category = classifyFailureCategory(Object.assign(new Error('Unauthorized'), { statusCode: 401 }));
+        expect(category).toBe(FAILURE_CATEGORY.AUTH);
+    });
+
+    it('classifies 403 as AUTH', () => {
+        const category = classifyFailureCategory(Object.assign(new Error('Forbidden'), { statusCode: 403 }));
+        expect(category).toBe(FAILURE_CATEGORY.AUTH);
+    });
+
     it('classifies 404 as INVALID_INPUT', () => {
         const category = classifyFailureCategory(Object.assign(new Error('Not found'), { statusCode: 404 }));
         expect(category).toBe(FAILURE_CATEGORY.INVALID_INPUT);
@@ -48,6 +63,11 @@ describe('classifyFailureCategory', () => {
     it('classifies generic 4xx as INVALID_INPUT', () => {
         const category = classifyFailureCategory(Object.assign(new Error('Bad request'), { statusCode: 402 }));
         expect(category).toBe(FAILURE_CATEGORY.INVALID_INPUT);
+    });
+
+    it('classifies 5xx as INTERNAL_ERROR', () => {
+        const category = classifyFailureCategory(Object.assign(new Error('Internal'), { statusCode: 500 }));
+        expect(category).toBe(FAILURE_CATEGORY.INTERNAL_ERROR);
     });
 
     it('classifies unexpected errors as INTERNAL_ERROR', () => {
@@ -72,6 +92,7 @@ describe('extractValidationDiagnostics', () => {
             validation_keyword: 'required',
             validation_path: undefined,
             validation_missing_property: 'query',
+            validation_error_count: 1,
         });
     });
 
@@ -88,5 +109,56 @@ describe('extractValidationDiagnostics', () => {
 
         expect(diagnostics.validation_additional_property).toBe('docSource');
         expect(diagnostics.validation_path).toBe('/output');
+        expect(diagnostics.validation_error_count).toBe(1);
+    });
+
+    it('reports error count for multiple validation errors', () => {
+        const diagnostics = extractValidationDiagnostics([
+            { keyword: 'required', instancePath: '', schemaPath: '#/required', params: { missingProperty: 'query' }, message: '' },
+            { keyword: 'required', instancePath: '', schemaPath: '#/required', params: { missingProperty: 'url' }, message: '' },
+            { keyword: 'type', instancePath: '/limit', schemaPath: '#/type', params: { type: 'number' }, message: '' },
+        ]);
+
+        // First error is the canonical summary
+        expect(diagnostics.validation_keyword).toBe('required');
+        expect(diagnostics.validation_missing_property).toBe('query');
+        // Count reflects all errors
+        expect(diagnostics.validation_error_count).toBe(3);
+    });
+
+    it('returns empty for null/undefined errors', () => {
+        expect(extractValidationDiagnostics(null)).toEqual({});
+        expect(extractValidationDiagnostics(undefined)).toEqual({});
+        expect(extractValidationDiagnostics([])).toEqual({});
+    });
+});
+
+describe('extractToolResponseDiagnostics', () => {
+    it('uses internalToolStatus when present and strips internal fields', () => {
+        const res: Record<string, unknown> = {
+            content: 'ok',
+            internalToolStatus: TOOL_STATUS.SOFT_FAIL,
+            internalFailureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+            internalFailureHttpStatus: 404,
+        };
+
+        const { toolStatus, failureDiagnostics } = extractToolResponseDiagnostics(res, 'apify/web-scraper');
+
+        expect(toolStatus).toBe(TOOL_STATUS.SOFT_FAIL);
+        expect(failureDiagnostics).toMatchObject({ failure_category: FAILURE_CATEGORY.INVALID_INPUT, failure_http_status: 404, actor_name: 'apify/web-scraper' });
+        expect(res.internalToolStatus).toBeUndefined();
+        expect(res.content).toBe('ok');
+    });
+
+    it('defaults to SOFT_FAIL when isError without internalToolStatus', () => {
+        const { toolStatus, failureDiagnostics } = extractToolResponseDiagnostics({ isError: true }, undefined);
+        expect(toolStatus).toBe(TOOL_STATUS.SOFT_FAIL);
+        expect(failureDiagnostics.failure_category).toBe(FAILURE_CATEGORY.INTERNAL_ERROR);
+    });
+
+    it('returns SUCCEEDED when no error signals', () => {
+        const { toolStatus, failureDiagnostics } = extractToolResponseDiagnostics({ content: 'ok' }, undefined);
+        expect(toolStatus).toBe(TOOL_STATUS.SUCCEEDED);
+        expect(failureDiagnostics).toEqual({});
     });
 });

--- a/tests/unit/utils.tool_status.test.ts
+++ b/tests/unit/utils.tool_status.test.ts
@@ -145,7 +145,9 @@ describe('extractToolResponseDiagnostics', () => {
         const { toolStatus, failureDiagnostics } = extractToolResponseDiagnostics(res, 'apify/web-scraper');
 
         expect(toolStatus).toBe(TOOL_STATUS.SOFT_FAIL);
-        expect(failureDiagnostics).toMatchObject({ failure_category: FAILURE_CATEGORY.INVALID_INPUT, failure_http_status: 404, actor_name: 'apify/web-scraper' });
+        expect(failureDiagnostics).toMatchObject(
+            { failure_category: FAILURE_CATEGORY.INVALID_INPUT, failure_http_status: 404, actor_name: 'apify/web-scraper' },
+        );
         expect(res.internalToolStatus).toBeUndefined();
         expect(res.content).toBe('ok');
     });


### PR DESCRIPTION
## Summary

Tool failures in Mixpanel were blind spots — every failure was FAILED/SOFT_FAIL with no way to tell a user typo from a server crash

- Add `failure_category` (INVALID_INPUT | AUTH | INTERNAL_ERROR), `failure_http_status`, `failure_detail`, `actor_name`, and AJV validation diagnostics to telemetry on non-success outcomes
- Rename `preparePayment` → `prepareToolCallContext` (misleading name — handles all tool calls, not just paid ones); `cleanArgs` → `toolArgs`, `logArgs` → `logSafeArgs`
- `actor_name` extracted via `extractActorName()`
- 402 Payment Required now tracked with `failure_category` instead of empty diagnostics
- actor-mcp is a known gap (opaque `isError`, defaults to INTERNAL_ERROR) — documented as TODO
- Kept server.ts handler structure to minimize structural diff
- Used `dedent` for multi-line error messages in server.ts

closes: https://github.com/apify/apify-mcp-server/issues/630

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` — 409 tests pass
- [x] Live-tested all 8 failure scenarios against apify-dev MCP server
- [x] Verified telemetry events in Mixpanel staging (project 2860300) — all `failure_category`, `actor_name`, `validation_keyword` fields land correctly
- [x] Verified SUCCEEDED events do NOT carry failure fields
- [x] Integration tests (require APIFY_TOKEN — human only)
