### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,30 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@47895cf40f6214511c713628dbbafd0c3316f4dd
+        with:
+          mode: validate
+          skill-dir: .claude/skills/feature-spec
+          annotate: "false"
+          preview-upload: "false"


### PR DESCRIPTION
This adds a lightweight CI workflow for skill metadata validation.

- Ideal for local integrations and CLI tools like Claude for Desktop
- Works with `npx @apify/actors-mcp-server --help` for setup options
- MCP client config updates needed before April 1, 2026

This PR adds one workflow for `.` that runs the HOL skill validator in validate mode. It checks schema and trust signals only, stays validate-only, and leaves runtime code alone.

Happy to rename the workflow file or adjust the skill directory if you'd prefer a different structure.