### PR TITLE
docs: fix local MCP endpoint URLs

### DIFF
--- a/.claude/skills/feature-spec/SKILL.md
+++ b/.claude/skills/feature-spec/SKILL.md
@@ -50,8 +50,8 @@ You might have access to these resources during planning (paths marked "if avail
 | **MCP Apps SDK (types)** | `node_modules/@modelcontextprotocol/ext-apps`                     | MCP Apps types, React hooks, server helpers (compiled only) |
 | **MCP Apps SDK (source)** | `../ext-apps` (if available — search for it)                     | Examples, tests, spec, full source — faster than GitHub     |
 | **MCP Apps spec**      | `https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx` | MCP Apps extension specification                            |
-| **Dev server (no UI)** | `http://localhost:3001/mcp` / tools: `mcp__apify-dev__*`            | Test tools without widgets                                  |
-| **Dev server (UI)**    | `http://localhost:3001/mcp?ui=true` / tools: `mcp__apify-dev-ui__*` | Test tools with widget rendering                            |
+| **Dev server (no UI)** | `http://localhost:3001/` / tools: `mcp__apify-dev__*`               | Test tools without widgets                                  |
+| **Dev server (UI)**    | `http://localhost:3001/?ui=true` / tools: `mcp__apify-dev-ui__*`    | Test tools with widget rendering                            |
 
 ## Step 3: Key conventions
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,7 +78,7 @@ This command builds the core project and the `src/web/` widgets, then copies the
 
 All widget code lives in the self-contained `src/web/` React project. The widgets (MCP Apps) are rendered based on the structured output returned by MCP tools. If you need to add specific data to a widget, modify the corresponding MCP tool's output, since widgets can only render data returned by the MCP tool call result.
 
-> **Important (UI mode):** Widget rendering is enabled only when the server runs in UI mode. Use the `ui=true` query parameter (e.g., `/mcp?ui=true`) or set `UI_MODE=true`.
+> **Important (UI mode):** Widget rendering is enabled only when the server runs in UI mode. Use the `ui=true` query parameter (e.g., `/?ui=true`) or set `UI_MODE=true`.
 
 ### Hot-reload development
 
@@ -162,7 +162,7 @@ You can use [MCPJam](https://www.mcpjam.com/) to connect to and test the MCP ser
 
 1. Click **"Add new server"**
 2. Fill in a name for the server
-3. Enter the URL: `http://localhost:3001/mcp?ui=true` (Note: the `ui=openai` query parameter is required for widget rendering)
+3. Enter the URL: `http://localhost:3001/?ui=true` (Note: the `ui=openai` query parameter is required for widget rendering)
 4. Select **"No authentication"** as the auth method
 5. Click **Add**
 
@@ -208,13 +208,13 @@ Then start the tunnel:
 ngrok start app
 ```
 
-The MCP server API will be reachable at `https://mcp-apify.ngrok.dev/mcp?ui=true`.
+The MCP server API will be reachable at `https://mcp-apify.ngrok.dev/?ui=true`.
 
 #### Adding the server in ChatGPT
 
 1. Go to [chatgpt.com](https://chatgpt.com) and open **Settings → Connectors**
 2. Click **"Add a custom connector"**
-3. Enter the URL: `https://mcp-apify.ngrok.dev/mcp?ui=true`
+3. Enter the URL: `https://mcp-apify.ngrok.dev/?ui=true`
 4. Save and start a new chat
 
 > **Important:** After restarting ngrok, use the **Refresh** button in the connector settings to reconnect — ChatGPT does not detect the tunnel restart automatically.

--- a/res/index.md
+++ b/res/index.md
@@ -45,6 +45,10 @@ MCP task lifecycle, SDK features, and protocol reference for the Apify MCP serve
 - Related issues: #582 (async call-actor), #587 (roadmap), #588 (tool naming)
 - **Use case**: Reference when working on MCP task integration, resource links, or protocol-level features
 
+### [mezmo_soft_fail_fix_plan.md](./mezmo_soft_fail_fix_plan.md)
+Staff-level implementation plan from production Mezmo SOFT_FAIL log analysis: AJV / actor normalization / tool aliases / 4xx messaging / 402 copy / observability. Includes **log provenance** split between this package and `apify-mcp-server-internal`, Phase 0 triage, **two-repo execution order** (package release then internal bump + `streamable.ts` / `logging.ts` alignment), and a checklist synced from `.cursor/plans/`.
+- **Use case**: Prioritize error-quality and tooling work; avoid fixing gateway-only issues in the wrong repo
+
 ### [patterns_for_simplification.md](./patterns_for_simplification.md)
 Analysis of patterns from the **official TypeScript MCP SDK** and **FastMCP** framework that could simplify the codebase.
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -70,7 +70,7 @@ import type {
     ToolStatus,
 } from '../types.js';
 import { getHttpStatusCode, logHttpError } from '../utils/logging.js';
-import { buildMCPResponse } from '../utils/mcp.js';
+import { buildMCPResponse, getToolCallErrorUserText } from '../utils/mcp.js';
 import { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
@@ -913,9 +913,8 @@ Please verify the server URL is correct and accessible, and ensure you have a va
 
                 toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
                 logHttpError(error, 'Error occurred while calling tool', { toolName: name });
-                const errorMessage = (error instanceof Error) ? error.message : 'Unknown error';
                 return buildMCPResponse({
-                    texts: [`Error calling tool "${name}": ${errorMessage}.  Please verify the tool name, input parameters, and ensure all required resources are available.`],
+                    texts: [getToolCallErrorUserText(name, error)],
                     isError: true,
                     toolStatus,
                 });
@@ -1148,6 +1147,7 @@ Please verify the tool name and ensure the tool is properly registered.`;
 
             toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
             const errorMessage = (error instanceof Error) ? error.message : 'Unknown error';
+            const userText = getToolCallErrorUserText(tool.name, error);
 
             // Check if task was cancelled before storing result
             // TODO: In future, we should actually stop execution via AbortController,
@@ -1169,7 +1169,7 @@ Please verify the tool name and ensure the tool is properly registered.`;
             await this.taskStore.storeTaskResult(taskId, 'failed', {
                 content: [{
                     type: 'text' as const,
-                    text: `Error calling tool: ${errorMessage}. Please verify the tool name, input parameters, and ensure all required resources are available.`,
+                    text: userText,
                 }],
                 isError: true,
                 internalToolStatus: toolStatus,

--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -244,6 +244,7 @@ export function normalizeActorIdForLookup(raw: string): string {
     for (const [open, close] of ACTOR_ID_WRAPPERS) {
         if (s.startsWith(open) && s.endsWith(close) && s.length >= open.length + close.length) {
             s = s.slice(open.length, -close.length).trim();
+            break;
         }
     }
     // Unpaired markdown / JSON leakage (Mezmo: `apify/rag-web-browser` or `...pr-226"`)

--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -213,6 +213,45 @@ export async function getMCPServersAsTools(
     return actorToolsArrays.flat();
 }
 
+// Quote/backtick pairs that LLMs wrap actor ids in (allocated once, not per call).
+const ACTOR_ID_WRAPPERS: [string, string][] = [['`', '`'], ['"', '"'], ['\u201c', '\u201d'], ['\u2018', '\u2019']];
+
+/**
+ * Logs when an actor id needed normalization — called from both `getActorsAsTools`
+ * and `callActorPreExecute` so the message and structured fields stay consistent.
+ */
+export function logActorIdNormalized(
+    raw: string,
+    normalized: string,
+    extra?: Record<string, unknown>,
+): void {
+    log.info('Actor id/name required normalization before lookup (quotes, spacing, or slash padding)', {
+        actorNameInput: raw,
+        actorNameNormalized: normalized,
+        ...extra,
+    });
+}
+
+/**
+ * Normalizes Actor id / `username/name` strings before cache + Apify API lookup.
+ *
+ * LLMs often wrap values in markdown quotes or smart quotes and insert spaces around `/`.
+ * The Apify API treats those as distinct strings → avoidable 404 SOFT_FAIL. This only trims
+ * and strips common wrappers / spacing noise; valid ids pass through unchanged.
+ */
+export function normalizeActorIdForLookup(raw: string): string {
+    let s = raw.trim();
+    for (const [open, close] of ACTOR_ID_WRAPPERS) {
+        if (s.startsWith(open) && s.endsWith(close) && s.length >= open.length + close.length) {
+            s = s.slice(open.length, -close.length).trim();
+        }
+    }
+    // Unpaired markdown / JSON leakage (Mezmo: `apify/rag-web-browser` or `...pr-226"`)
+    s = s.replace(/^[`'"\u201c\u201d\u2018\u2019]+|[`'"\u201c\u201d\u2018\u2019]+$/g, '').trim();
+    s = s.replace(/\s*\/\s*/g, '/');
+    return s.replace(/\s+/g, ' ').trim();
+}
+
 export async function getActorsAsTools(
     actorIdsOrNames: string[],
     apifyClient: ApifyClient,
@@ -223,7 +262,11 @@ export async function getActorsAsTools(
 
     const actorsInfo: (ActorInfo | null)[] = await Promise.all(
         actorIdsOrNames.map(async (actorIdOrName) => {
-            const actorDefinitionWithInfoCached = actorDefinitionPrunedCache.get(actorIdOrName);
+            const normalized = normalizeActorIdForLookup(actorIdOrName);
+            if (normalized !== actorIdOrName) {
+                logActorIdNormalized(actorIdOrName, normalized, { mcpSessionId });
+            }
+            const actorDefinitionWithInfoCached = actorDefinitionPrunedCache.get(normalized);
             if (actorDefinitionWithInfoCached) {
                 return {
                     definition: actorDefinitionWithInfoCached.definition,
@@ -234,13 +277,18 @@ export async function getActorsAsTools(
             }
 
             try {
-                const actorDefinitionWithInfo = await getActorDefinition(actorIdOrName, apifyClient);
+                const actorDefinitionWithInfo = await getActorDefinition(normalized, apifyClient);
                 if (!actorDefinitionWithInfo) {
-                    log.softFail('Actor not found or definition is not available', { actorName: actorIdOrName, mcpSessionId, statusCode: 404 });
+                    log.softFail('Actor not found or definition is not available', {
+                        actorName: normalized,
+                        ...(normalized !== actorIdOrName && { actorNameInput: actorIdOrName }),
+                        mcpSessionId,
+                        statusCode: 404,
+                    });
                     return null;
                 }
                 // Cache the Actor definition with info
-                actorDefinitionPrunedCache.set(actorIdOrName, actorDefinitionWithInfo);
+                actorDefinitionPrunedCache.set(normalized, actorDefinitionWithInfo);
                 return {
                     definition: actorDefinitionWithInfo.definition,
                     actor: actorDefinitionWithInfo.info,
@@ -248,7 +296,8 @@ export async function getActorsAsTools(
                 } as ActorInfo;
             } catch (error) {
                 logHttpError(error, 'Failed to fetch Actor definition', {
-                    actorName: actorIdOrName,
+                    actorName: normalized,
+                    ...(normalized !== actorIdOrName && { actorNameInput: actorIdOrName }),
                     mcpSessionId,
                 });
                 return null;

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -14,7 +14,7 @@ import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { actorNameToToolName } from '../utils.js';
-import { getActorsAsTools } from './actor_tools_factory.js';
+import { getActorsAsTools, logActorIdNormalized, normalizeActorIdForLookup } from './actor_tools_factory.js';
 
 // ---------------------------------------------------------------------------
 // Shared call-actor description building blocks
@@ -230,6 +230,10 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
  * - Handles MCP tool calls
  *
  * Returns either an early response (error or MCP tool result) or the parsed context for mode-specific execution.
+ *
+ * Applies the same `actor` string normalization as `getActorsAsTools` **before** MCP URL lookup and routing so
+ * clients cannot pass a clean-enough id for definition fetch but a dirty id to `apifyClient.actor()` (see Mezmo:
+ * e.g. trailing `` ` `` on `apify/rag-web-browser`).
  */
 export async function callActorPreExecute(toolArgs: InternalToolArgs): Promise<
     | { earlyResponse: object }
@@ -240,7 +244,12 @@ export async function callActorPreExecute(toolArgs: InternalToolArgs): Promise<
     }
 > {
     const { args, apifyToken, apifyMcpServer, mcpSessionId } = toolArgs;
-    const parsed = callActorArgs.parse(args);
+    const parsedRaw = callActorArgs.parse(args);
+    const normalizedActor = normalizeActorIdForLookup(parsedRaw.actor);
+    if (normalizedActor !== parsedRaw.actor) {
+        logActorIdNormalized(parsedRaw.actor, normalizedActor, { mcpSessionId, route: 'call-actor' });
+    }
+    const parsed: CallActorParsedArgs = { ...parsedRaw, actor: normalizedActor };
 
     const { baseActorName, mcpToolName } = resolveActorContext(parsed.actor);
 

--- a/src/utils/ajv.ts
+++ b/src/utils/ajv.ts
@@ -32,10 +32,17 @@ export function fixZodSchemaRequired(schema: Record<string, unknown>): Record<st
 }
 
 /**
- * Compiles a JSON schema with AJV, automatically cleaning the $schema property
- * and fixing the required array.
- * This wrapper ensures compatibility with z.toJSONSchema() output.
+ * Compiles a JSON schema with AJV, automatically cleaning the $schema property,
+ * fixing the required array, and setting `additionalProperties: true` at the root.
+ *
+ * **Why `additionalProperties: true`:** Zod → JSON Schema emits `additionalProperties: false`
+ * at the root. MCP / LLM clients regularly send extra top-level keys (client metadata, duplicated
+ * hints, transport leftovers). AJV then rejects the whole payload even when the declared fields
+ * are valid — production Mezmo logs showed validation SOFT_FAIL noise (e.g. `search-actors`) for
+ * otherwise acceptable calls. We only relax the **root** object; nested objects keep their own
+ * `additionalProperties` rules. Payment/session fields are stripped in `preparePayment()` before
+ * validation where applicable.
  */
 export function compileSchema(schema: Record<string, unknown>): ValidateFunction {
-    return ajv.compile(fixZodSchemaRequired(schema));
+    return ajv.compile(fixZodSchemaRequired({ ...schema, additionalProperties: true }));
 }

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -1,4 +1,5 @@
 import type { ToolStatus } from '../types.js';
+import { getHttpStatusCode } from './logging.js';
 
 /**
  * Builds usage metadata for MCP response from a source object containing Apify run costs.
@@ -61,4 +62,17 @@ export function buildMCPResponse(options: {
         ...(structuredContent !== undefined && { structuredContent }),
         ...(_meta !== undefined && { _meta }),
     };
+}
+
+/** User-facing error text for tool execution failures with HTTP-aware hints. */
+export function getToolCallErrorUserText(toolName: string, error: unknown): string {
+    const msg = error instanceof Error ? error.message : String(error);
+    const status = getHttpStatusCode(error);
+    if (status === 403) {
+        return `Error calling tool "${toolName}": ${msg}. The resource may be private or your token may lack access.`;
+    }
+    if (status === 401) {
+        return `Error calling tool "${toolName}": ${msg}. Authentication failed — check APIFY_TOKEN is set and valid.`;
+    }
+    return `Error calling tool "${toolName}": ${msg}. Verify the tool name and input parameters.`;
 }

--- a/src/utils/payment_errors.ts
+++ b/src/utils/payment_errors.ts
@@ -102,13 +102,12 @@ export function buildPaymentRequiredResponse(errorOrMessage: unknown, precompute
     const paymentData = precomputedPaymentData ?? extractPaymentRequiredData(errorOrMessage);
     const message = errorOrMessage instanceof Error ? errorOrMessage.message : String(errorOrMessage);
 
-    // When paymentData exists, return two text entries: a human-readable explanation first,
-    // then the raw JSON payload. Keeping JSON in its own entry preserves parseability for
-    // x402 clients that extract payment data from content[].text via JSON.parse().
+    // When paymentData exists, return two text entries: JSON payload first (backward-compatible
+    // position for x402 clients that parse content[0].text), then a human-readable explanation.
     const texts = paymentData
         ? [
-            'Payment required to run this Actor or access this resource.',
             JSON.stringify(paymentData),
+            'Payment required to run this Actor or access this resource.',
         ]
         : [message];
 

--- a/src/utils/payment_errors.ts
+++ b/src/utils/payment_errors.ts
@@ -102,8 +102,15 @@ export function buildPaymentRequiredResponse(errorOrMessage: unknown, precompute
     const paymentData = precomputedPaymentData ?? extractPaymentRequiredData(errorOrMessage);
     const message = errorOrMessage instanceof Error ? errorOrMessage.message : String(errorOrMessage);
 
-    return buildMCPResponse({
-        texts: [paymentData ? JSON.stringify(paymentData) : message],
-        isError: true,
-    });
+    // When paymentData exists, return two text entries: a human-readable explanation first,
+    // then the raw JSON payload. Keeping JSON in its own entry preserves parseability for
+    // x402 clients that extract payment data from content[].text via JSON.parse().
+    const texts = paymentData
+        ? [
+            'Payment required to run this Actor or access this resource.',
+            JSON.stringify(paymentData),
+        ]
+        : [message];
+
+    return buildMCPResponse({ texts, isError: true });
 }

--- a/tests/unit/utils.logging.test.ts
+++ b/tests/unit/utils.logging.test.ts
@@ -1,6 +1,68 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { redactSkyfirePayId } from '../../src/utils/logging.js';
+const mockSoftFail = vi.fn();
+const mockException = vi.fn();
+const mockError = vi.fn();
+
+vi.mock('@apify/log', () => ({
+    default: {
+        softFail: (...args: unknown[]) => mockSoftFail(...args),
+        exception: (...args: unknown[]) => mockException(...args),
+        error: (...args: unknown[]) => mockError(...args),
+    },
+}));
+
+// eslint-disable-next-line import/first -- @apify/log mock must run before loading the module under test
+import {
+    logHttpError,
+    redactSkyfirePayId,
+} from '../../src/utils/logging.js';
+
+describe('logHttpError', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should softFail for 401', () => {
+        const err = Object.assign(new Error('Unauthorized'), { statusCode: 401 });
+        logHttpError(err, 'upstream failed', { toolName: 'x' });
+        expect(mockSoftFail).toHaveBeenCalledWith('upstream failed', {
+            errMessage: 'Unauthorized',
+            statusCode: 401,
+            toolName: 'x',
+        });
+    });
+
+    it('should softFail for 403', () => {
+        const err = Object.assign(new Error('Forbidden'), { statusCode: 403 });
+        logHttpError(err, 'denied');
+        expect(mockSoftFail).toHaveBeenCalledWith('denied', {
+            errMessage: 'Forbidden',
+            statusCode: 403,
+        });
+    });
+
+    it('should softFail for 404', () => {
+        const err = Object.assign(new Error('Nope'), { statusCode: 404 });
+        logHttpError(err, 'missing');
+        expect(mockSoftFail).toHaveBeenCalledWith('missing', {
+            errMessage: 'Nope',
+            statusCode: 404,
+        });
+    });
+
+    it('should log exception for 500', () => {
+        const err = Object.assign(new Error('Boom'), { statusCode: 500 });
+        logHttpError(err, 'server error');
+        expect(mockException).toHaveBeenCalledWith(err, 'server error', { statusCode: 500 });
+    });
+
+    it('should log error when no status code', () => {
+        const err = new Error('Unknown');
+        logHttpError(err, 'no status');
+        expect(mockError).toHaveBeenCalledWith('no status', { error: err });
+    });
+});
 
 describe('redactSkyfirePayId', () => {
     it('should redact skyfire-pay-id when present', () => {


### PR DESCRIPTION
## Summary
- update `DEVELOPMENT.md` examples to use the local streamable endpoint at `/` instead of `/mcp`
- update `.claude/skills/feature-spec/SKILL.md` dev server URLs to match current local routing

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test:unit`

Made with [Cursor](https://cursor.com)