### PR TITLE
refactor: Use dedent for multiline strings in search_actors tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ Use comments to guide reviewers:
         * Inline `dedent` directly as a property or variable value — do not extract it to a named constant.
         * For top-level string constants that are already flush-left, use a plain template literal — `dedent` only helps when indentation from surrounding code would otherwise be embedded in the string.
         * `dedent` introduces `\n` at each source line break. This is fine for LLM-facing strings (tool descriptions, instructions, notes), but avoid it for strings where whitespace is significant or where `\n` would break rendering (e.g. UI labels, log messages, URLs).
+        * Do not interpolate values that start at column 0 (e.g. `JSON.stringify` output) inside `dedent` — `dedent` computes minimum indentation across all lines including interpolated ones, so a flush-left value sets `mindent = 0` and leaves all template lines with stray leading spaces. Use a `texts[]` array or plain template literal instead.
         * For strings where `\n` is not acceptable, use string concatenation (`+`) to split across lines for `max-len` compliance.
         ```typescript
         import dedent from 'dedent';

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ Use comments to guide reviewers:
     * Use plain single-quoted strings for short one-liners.
     * Use `dedent` (tagged template literal) for any string that would otherwise exceed `max-len` or span multiple lines — including tool `description` fields, LLM instructions, and single-sentence strings that are simply long.
         * Inline `dedent` directly as a property or variable value — do not extract it to a named constant.
+        * For top-level string constants that are already flush-left, use a plain template literal — `dedent` only helps when indentation from surrounding code would otherwise be embedded in the string.
         * `dedent` introduces `\n` at each source line break. This is fine for LLM-facing strings (tool descriptions, instructions, notes), but avoid it for strings where whitespace is significant or where `\n` would break rendering (e.g. UI labels, log messages, URLs).
         * For strings where `\n` is not acceptable, use string concatenation (`+`) to split across lines for `max-len` compliance.
         ```typescript

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
@@ -12,22 +13,23 @@ import { actorSearchOutputSchema } from '../structured_output_schemas.js';
 export const searchActorsArgsSchema = z.object({
     keywords: z.string()
         .default('')
-        .describe(`Space-separated keywords used to search pre-built solutions (Actors) in the Apify Store.
-The search engine searches across Actor's name, description, username, and readme content.
+        .describe(dedent`
+            Space-separated keywords used to search pre-built solutions (Actors) in the Apify Store.
+            The search engine searches across Actor's name, description, username, and readme content.
 
-Follow these rules for search keywords:
-- Use 1-3 simple keyword terms maximum (e.g., "Instagram posts", "Twitter", "Amazon products")
-- Actors are named using platform or service name together with the type of data or task they perform
-- The most effective keywords are specific platform names (Instagram, Twitter, TikTok) and specific data types (posts, products, profiles, weather, news, reviews, comments)
-- Avoid generic terms like "crawler", "data extraction" as these are less effective
-- If a user asks about "fetching Instagram posts", use "Instagram posts" as keywords
-- The goal is to find Actors that specifically handle the platform and data type the user mentioned
+            Follow these rules for search keywords:
+            - Use 1-3 simple keyword terms maximum (e.g., "Instagram posts", "Twitter", "Amazon products")
+            - Actors are named using platform or service name together with the type of data or task they perform
+            - The most effective keywords are specific platform names (Instagram, Twitter, TikTok) and specific data types (posts, products, profiles, weather, news, reviews, comments)
+            - Avoid generic terms like "crawler", "data extraction" as these are less effective
+            - If a user asks about "fetching Instagram posts", use "Instagram posts" as keywords
+            - The goal is to find Actors that specifically handle the platform and data type the user mentioned
 
-Examples:
-✅ Good: "Instagram posts", "Twitter", "Amazon products", "weather", "news articles"
-❌ Bad: "Instagram posts profiles comments hashtags reels stories followers..." (too long, too many terms)
-❌ Bad: "data extraction scraping tools" (too generic)
-`),
+            Examples:
+            ✅ Good: "Instagram posts", "Twitter", "Amazon products", "weather", "news articles"
+            ❌ Bad: "Instagram posts profiles comments hashtags reels stories followers..." (too long, too many terms)
+            ❌ Bad: "data extraction scraping tools" (too generic)
+        `),
     limit: z.number()
         .int()
         .min(1)
@@ -81,7 +83,7 @@ Returns list of Actor cards with the following info:
 
 /**
  * Shared tool metadata for search-actors — everything except the `call` handler.
- * Used by both default and openai variants.
+ * Used by both default and OpenAI variants.
  */
 export const searchActorsMetadata: Omit<HelperTool, 'call'> = {
     type: 'internal',
@@ -91,9 +93,7 @@ export const searchActorsMetadata: Omit<HelperTool, 'call'> = {
     outputSchema: actorSearchOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(searchActorsArgsSchema)),
     // openai/* and ui keys are stripped in non-openai mode by stripWidgetMeta() in src/utils/tools.ts
-    _meta: {
-        ...getWidgetConfig(WIDGET_URIS.SEARCH_ACTORS)?.meta,
-    },
+    _meta: { ...getWidgetConfig(WIDGET_URIS.SEARCH_ACTORS)?.meta },
     annotations: {
         title: 'Search Actors',
         readOnlyHint: true,

--- a/src/tools/default/get_actor_run.ts
+++ b/src/tools/default/get_actor_run.ts
@@ -30,10 +30,7 @@ export const defaultGetActorRun: ToolEntry = Object.freeze({
             }
 
             const { run, structuredContent } = fetchResult.result;
-
-            const texts = [
-                `# Actor Run Information\n\`\`\`json\n${JSON.stringify(run, null, 2)}\n\`\`\``,
-            ];
+            const texts = [`# Actor Run Information\n\`\`\`json\n${JSON.stringify(run)}\n\`\`\``];
 
             return buildMCPResponse({
                 texts,

--- a/src/tools/default/search_actors.ts
+++ b/src/tools/default/search_actors.ts
@@ -1,37 +1,39 @@
+import dedent from 'dedent';
+
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
 import { formatActorToActorCard, formatActorToStructuredCard } from '../../utils/actor_card.js';
 import { searchAndFilterActors } from '../../utils/actor_search.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
-import {
-    searchActorsArgsSchema,
-    searchActorsMetadata,
-} from '../core/search_actors_common.js';
+import { searchActorsArgsSchema, searchActorsMetadata } from '../core/search_actors_common.js';
 
 /**
  * Default mode search-actors tool.
- * Returns text-based actor cards without widget metadata.
+ * Returns text-based Actor cards without widget metadata.
  */
 export const defaultSearchActors: ToolEntry = Object.freeze({
     ...searchActorsMetadata,
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyToken, userRentedActorIds, apifyMcpServer } = toolArgs;
-        const parsed = searchActorsArgsSchema.parse(args);
+        const parsedArgs = searchActorsArgsSchema.parse(args);
         const actors = await searchAndFilterActors({
-            keywords: parsed.keywords,
+            keywords: parsedArgs.keywords,
             apifyToken,
-            limit: parsed.limit,
-            offset: parsed.offset,
+            limit: parsedArgs.limit,
+            offset: parsedArgs.offset,
             paymentProvider: apifyMcpServer.options.paymentProvider,
             userRentedActorIds,
         });
 
         if (actors.length === 0) {
-            const instructions = `No Actors were found for the search query "${parsed.keywords}".
-You MUST retry with broader, more generic keywords - use just the platform name (e.g., "TikTok" instead of "TikTok posts") before concluding no Actor exists.`;
+            const instructions = dedent`
+                No Actors were found for the search query "${parsedArgs.keywords}".
+                You MUST retry with broader, more generic keywords - use just the platform name
+                (e.g., "TikTok" instead of "TikTok posts") before concluding no Actor exists.
+            `;
             const structuredContent = {
                 actors: [],
-                query: parsed.keywords,
+                query: parsedArgs.keywords,
                 count: 0,
                 instructions,
             };
@@ -41,30 +43,36 @@ You MUST retry with broader, more generic keywords - use just the platform name 
         const structuredActorCards = actors.map((actor) => formatActorToStructuredCard(actor));
         const structuredContent = {
             actors: structuredActorCards,
-            query: parsed.keywords,
+            query: parsedArgs.keywords,
             count: actors.length,
-            instructions: `If you need more detailed information about any of these Actors, including their input schemas and usage instructions, please use the ${HelperTools.ACTOR_GET_DETAILS} tool with the specific Actor name.
-IMPORTANT: You MUST always do a second search with broader, more generic keywords (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure you haven't missed a better Actor.`,
+            instructions: dedent`
+                If you need more detailed information about any of these Actors, including their
+                input schemas and usage instructions, please use the ${HelperTools.ACTOR_GET_DETAILS}
+                tool with the specific Actor name.
+                IMPORTANT: You MUST always do a second search with broader, more generic keywords
+                (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
+                you haven't missed a better Actor.
+            `,
         };
 
         const actorCards = actors.map((actor) => formatActorToActorCard(actor));
         const actorsText = actorCards.join('\n\n');
-        const instructions = `
- # Search results:
- - **Search query:** ${parsed.keywords}
- - **Number of Actors found:** ${actors.length}
+        const instructions = dedent`
+            # Search results:
+            - **Search query:** ${parsedArgs.keywords}
+            - **Number of Actors found:** ${actors.length}
 
- # Actors:
+            # Actors:
 
- ${actorsText}
+            ${actorsText}
 
-If you need more detailed information about any of these Actors, including their input schemas and usage instructions, use the ${HelperTools.ACTOR_GET_DETAILS} tool with the specific Actor name.
-IMPORTANT: You MUST always do a second search with broader, more generic keywords (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure you haven't missed a better Actor.
- `;
-
-        return buildMCPResponse({
-            texts: [instructions],
-            structuredContent,
-        });
+            If you need more detailed information about any of these Actors, including their input
+            schemas and usage instructions, use the ${HelperTools.ACTOR_GET_DETAILS} tool with the
+            specific Actor name.
+            IMPORTANT: You MUST always do a second search with broader, more generic keywords
+            (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
+            you haven't missed a better Actor.
+        `;
+        return buildMCPResponse({ texts: [instructions], structuredContent });
     },
 } as const);

--- a/src/tools/default/search_actors.ts
+++ b/src/tools/default/search_actors.ts
@@ -15,25 +15,25 @@ export const defaultSearchActors: ToolEntry = Object.freeze({
     ...searchActorsMetadata,
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyToken, userRentedActorIds, apifyMcpServer } = toolArgs;
-        const parsedArgs = searchActorsArgsSchema.parse(args);
+        const parsed = searchActorsArgsSchema.parse(args);
         const actors = await searchAndFilterActors({
-            keywords: parsedArgs.keywords,
+            keywords: parsed.keywords,
             apifyToken,
-            limit: parsedArgs.limit,
-            offset: parsedArgs.offset,
+            limit: parsed.limit,
+            offset: parsed.offset,
             paymentProvider: apifyMcpServer.options.paymentProvider,
             userRentedActorIds,
         });
 
         if (actors.length === 0) {
             const instructions = dedent`
-                No Actors were found for the search query "${parsedArgs.keywords}".
+                No Actors were found for the search query "${parsed.keywords}".
                 You MUST retry with broader, more generic keywords - use just the platform name
                 (e.g., "TikTok" instead of "TikTok posts") before concluding no Actor exists.
             `;
             const structuredContent = {
                 actors: [],
-                query: parsedArgs.keywords,
+                query: parsed.keywords,
                 count: 0,
                 instructions,
             };
@@ -43,7 +43,7 @@ export const defaultSearchActors: ToolEntry = Object.freeze({
         const structuredActorCards = actors.map((actor) => formatActorToStructuredCard(actor));
         const structuredContent = {
             actors: structuredActorCards,
-            query: parsedArgs.keywords,
+            query: parsed.keywords,
             count: actors.length,
             instructions: dedent`
                 If you need more detailed information about any of these Actors, including their
@@ -59,7 +59,7 @@ export const defaultSearchActors: ToolEntry = Object.freeze({
         const actorsText = actorCards.join('\n\n');
         const instructions = dedent`
             # Search results:
-            - **Search query:** ${parsedArgs.keywords}
+            - **Search query:** ${parsed.keywords}
             - **Number of Actors found:** ${actors.length}
 
             # Actors:

--- a/src/tools/openai/search_actors.ts
+++ b/src/tools/openai/search_actors.ts
@@ -1,3 +1,5 @@
+import dedent from 'dedent';
+
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
@@ -28,8 +30,11 @@ export const openaiSearchActors: ToolEntry = Object.freeze({
         });
 
         if (actors.length === 0) {
-            const instructions = `No Actors were found for the search query "${parsed.keywords}".
-You MUST retry with broader, more generic keywords - use just the platform name (e.g., "TikTok" instead of "TikTok posts") before concluding no Actor exists.`;
+            const instructions = dedent`
+                No Actors were found for the search query "${parsed.keywords}".
+                You MUST retry with broader, more generic keywords - use just the platform name
+                (e.g., "TikTok" instead of "TikTok posts") before concluding no Actor exists.
+            `;
             const structuredContent = {
                 actors: [],
                 query: parsed.keywords,
@@ -50,8 +55,15 @@ You MUST retry with broader, more generic keywords - use just the platform name 
             actors: structuredActorCards,
             query: parsed.keywords,
             count: actors.length,
-            instructions: `Choosing the right details tool: Use ${HelperTools.ACTOR_GET_DETAILS} when the user wants to browse or explore Actors (e.g., "show me", "find me"). Use ${HelperTools.ACTOR_GET_DETAILS_INTERNAL} when the user wants to execute a task and you need the input schema (e.g., "scrape", "extract").
-IMPORTANT: You MUST always do a second search with broader, more generic keywords (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure you haven't missed a better Actor.`,
+            instructions: dedent`
+                Choosing the right details tool: Use ${HelperTools.ACTOR_GET_DETAILS} when the user
+                wants to browse or explore Actors (e.g., "show me", "find me").
+                Use ${HelperTools.ACTOR_GET_DETAILS_INTERNAL} when the user wants to execute a task and
+                you need the input schema (e.g., "scrape", "extract").
+                IMPORTANT: You MUST always do a second search with broader, more generic keywords
+                (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
+                you haven't missed a better Actor.
+            `,
         };
 
         // Add widget-formatted actors for the interactive UI
@@ -59,29 +71,38 @@ IMPORTANT: You MUST always do a second search with broader, more generic keyword
 
         const actorCards = actors.map((actor) => formatActorToActorCard(actor));
         const actorsText = actorCards.join('\n\n');
-        const texts = [`
- # Search results:
- - **Search query:** ${parsed.keywords}
- - **Number of Actors found:** ${actors.length}
+        const texts = [dedent`
+            # Search results:
+            - **Search query:** ${parsed.keywords}
+            - **Number of Actors found:** ${actors.length}
 
-An interactive widget has been rendered with the search results. The user can already see the list of Actors visually in the widget, so do NOT print or summarize the Actor list in your response.
+            An interactive widget has been rendered with the search results. The user can already see
+            the list of Actors visually in the widget, so do NOT print or summarize the Actor list
+            in your response.
 
- # Actors:
+            # Actors:
 
- ${actorsText}
+            ${actorsText}
 
-## Choosing the right details tool:
-- Use ${HelperTools.ACTOR_GET_DETAILS} when the user wants to **browse or explore** Actors (e.g., "show me Google Maps scrapers", "find me a TikTok scraper", "what Actors exist for LinkedIn"). This renders an interactive widget for the user.
-- Use ${HelperTools.ACTOR_GET_DETAILS_INTERNAL} when the user wants to **execute a task** and you need the Actor's input schema to prepare the run (e.g., "scrape Google Maps for restaurants", "extract emails from this website"). This is a silent lookup — no widget is rendered.
+            ## Choosing the right details tool:
+            - Use ${HelperTools.ACTOR_GET_DETAILS} when the user wants to **browse or explore**
+              Actors (e.g., "show me Google Maps scrapers", "find me a TikTok scraper", "what Actors
+              exist for LinkedIn"). This renders an interactive widget for the user.
+            - Use ${HelperTools.ACTOR_GET_DETAILS_INTERNAL} when the user wants to **execute a task**
+              and you need the Actor's input schema to prepare the run (e.g., "scrape Google Maps for
+              restaurants", "extract emails from this website"). This is a silent lookup — no widget
+              is rendered.
 
-IMPORTANT: You MUST always do a second search with broader, more generic keywords (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure you haven't missed a better Actor.
-`];
+            IMPORTANT: You MUST always do a second search with broader, more generic keywords
+            (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
+            you haven't missed a better Actor.
+        `];
 
         const widgetConfig = getWidgetConfig(WIDGET_URIS.SEARCH_ACTORS);
         return buildMCPResponse({
             texts,
             structuredContent,
-            // Response-level meta; only returned in openai mode (this handler is openai-only)
+            // Response-level meta; only returned in OpenAI mode (this handler is openai-only)
             _meta: {
                 ...widgetConfig?.meta,
                 'openai/widgetDescription': `Interactive actor search results showing ${actors.length} actors from Apify Store`,

--- a/src/tools/openai/search_actors_internal.ts
+++ b/src/tools/openai/search_actors_internal.ts
@@ -69,14 +69,11 @@ export const searchActorsInternalTool: ToolEntry = Object.freeze({
         }));
 
         return buildMCPResponse({
-            texts: [dedent`
-                Found ${minimalActors.length} Actors for "${parsed.keywords}".
-                Query: ${parsed.keywords}
-                Actors:
-                \`\`\`json
-                ${JSON.stringify(minimalActors, null, 2)}
-                \`\`\`
-            `],
+            texts: [
+                `Found ${minimalActors.length} Actors for "${parsed.keywords}".`,
+                `Query: ${parsed.keywords}`,
+                `Actors:\n\`\`\`json\n${JSON.stringify(minimalActors)}\n\`\`\``,
+            ],
             structuredContent: {
                 actors: minimalActors,
                 query: parsed.keywords,

--- a/src/tools/openai/search_actors_internal.ts
+++ b/src/tools/openai/search_actors_internal.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
@@ -27,16 +28,18 @@ const searchActorsInternalArgsSchema = z.object({
 export const searchActorsInternalTool: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.STORE_SEARCH_INTERNAL,
-    description: `Search Actors internally (UI mode internal tool).
+    description: dedent`
+        Search Actors internally (UI mode internal tool).
 
-This tool is available because the LLM is operating in UI mode. Use it for internal lookups 
-where data presentation to the user is NOT needed - this tool does NOT render a widget.
+        This tool is available because the LLM is operating in UI mode. Use it for internal lookups
+        where data presentation to the user is NOT needed - this tool does NOT render a widget.
 
-Use this instead of ${HelperTools.STORE_SEARCH} when you need to find an Actor but the user 
-did NOT explicitly ask to search Actors. For example, when user says "scrape me google maps" 
-and you need to find the right Actor for the task, then fetch its schema and call it.
+        Use this instead of ${HelperTools.STORE_SEARCH} when you need to find an Actor but the user
+        did NOT explicitly ask to search Actors. For example, when user says "scrape me google maps"
+        and you need to find the right Actor for the task, then fetch its schema and call it.
 
-Returns only minimal fields (fullName, title, description) needed for subsequent calls.`,
+        Returns only minimal fields (fullName, title, description) needed for subsequent calls.
+    `,
     inputSchema: z.toJSONSchema(searchActorsInternalArgsSchema) as ToolInputSchema,
     outputSchema: actorSearchInternalOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(searchActorsInternalArgsSchema)),
@@ -66,13 +69,14 @@ Returns only minimal fields (fullName, title, description) needed for subsequent
         }));
 
         return buildMCPResponse({
-            texts: [
-                `Found ${minimalActors.length} Actors for "${parsed.keywords}".`,
-                '',
-                `Query: ${parsed.keywords}`,
-                '',
-                `Actors:\n\`\`\`json\n${JSON.stringify(minimalActors, null, 2)}\n\`\`\``,
-            ],
+            texts: [dedent`
+                Found ${minimalActors.length} Actors for "${parsed.keywords}".
+                Query: ${parsed.keywords}
+                Actors:
+                \`\`\`json
+                ${JSON.stringify(minimalActors, null, 2)}
+                \`\`\`
+            `],
             structuredContent: {
                 actors: minimalActors,
                 query: parsed.keywords,

--- a/tests/unit/tools.search_actors.default.response.test.ts
+++ b/tests/unit/tools.search_actors.default.response.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { APIFY_STORE_URL, HelperTools } from '../../src/const.js';
+import { defaultSearchActors } from '../../src/tools/default/search_actors.js';
+import type { HelperTool } from '../../src/types.js';
+import { formatActorToStructuredCard } from '../../src/utils/actor_card.js';
+import { searchAndFilterActors } from '../../src/utils/actor_search.js';
+import { MOCK_STORE_ACTOR, SEARCH_KEYWORDS, stubInternalToolArgs } from './tools.search_actors.fixtures.js';
+
+/**
+ * Default server mode: search-actors returns markdown + structured cards for the LLM only
+ * (no widgetActors, no tool _meta).
+ */
+vi.mock('../../src/utils/actor_search.js', () => ({
+    searchAndFilterActors: vi.fn(),
+}));
+
+describe('search-actors without widget (defaultSearchActors)', () => {
+    beforeEach(() => {
+        vi.mocked(searchAndFilterActors).mockReset();
+    });
+
+    it('returns structured actors and markdown text; no widget payload', async () => {
+        vi.mocked(searchAndFilterActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+
+        const result = await (defaultSearchActors as HelperTool).call(stubInternalToolArgs({
+            keywords: SEARCH_KEYWORDS,
+            limit: 5,
+            offset: 0,
+        }));
+
+        const { structuredContent, content } = result as {
+            structuredContent: {
+                actors: ReturnType<typeof formatActorToStructuredCard>[];
+                query: string;
+                count: number;
+                instructions?: string;
+                widgetActors?: unknown;
+            };
+            content: { type: string; text: string }[];
+            _meta?: unknown;
+        };
+
+        expect(structuredContent.widgetActors).toBeUndefined();
+        expect(structuredContent.query).toBe(SEARCH_KEYWORDS);
+        expect(structuredContent.count).toBe(1);
+        expect(structuredContent.actors).toHaveLength(1);
+        expect(structuredContent.actors[0]).toStrictEqual(formatActorToStructuredCard(MOCK_STORE_ACTOR));
+        expect(structuredContent.instructions).toContain(HelperTools.ACTOR_GET_DETAILS);
+
+        expect(content).toHaveLength(1);
+        expect((result as { _meta?: unknown })._meta).toBeUndefined();
+
+        const { text } = content[0];
+        expect(text).toContain('# Search results:');
+        expect(text).toContain(SEARCH_KEYWORDS);
+        expect(text).toContain('Number of Actors found:** 1');
+        expect(text).toContain('# Actors:');
+        expect(text).toContain(HelperTools.ACTOR_GET_DETAILS);
+        expect(text).toContain(`## [${MOCK_STORE_ACTOR.title}](${APIFY_STORE_URL}/apify/web-scraper)`);
+        expect(text).toContain('`apify/web-scraper`');
+        expect(text).not.toContain('do NOT print or summarize');
+    });
+
+    it('returns empty structured content and retry instructions when no actors match', async () => {
+        vi.mocked(searchAndFilterActors).mockResolvedValue([]);
+
+        const result = await (defaultSearchActors as HelperTool).call(stubInternalToolArgs({
+            keywords: SEARCH_KEYWORDS,
+            limit: 5,
+            offset: 0,
+        }));
+
+        const { structuredContent, content } = result as {
+            structuredContent: {
+                actors: unknown[];
+                query: string;
+                count: number;
+                instructions: string;
+                widgetActors?: unknown;
+            };
+            content: { type: string; text: string }[];
+        };
+
+        expect(structuredContent.widgetActors).toBeUndefined();
+        expect(structuredContent.actors).toEqual([]);
+        expect(structuredContent.count).toBe(0);
+        expect(structuredContent.query).toBe(SEARCH_KEYWORDS);
+        expect(structuredContent.instructions).toContain('broader, more generic keywords');
+
+        expect(content).toHaveLength(1);
+        expect(content[0].text).toContain('No Actors were found');
+        expect(content[0].text).toContain(SEARCH_KEYWORDS);
+    });
+});

--- a/tests/unit/tools.search_actors.fixtures.ts
+++ b/tests/unit/tools.search_actors.fixtures.ts
@@ -1,0 +1,38 @@
+import { ACTOR_PRICING_MODEL } from '../../src/const.js';
+import type { ActorStoreList, InternalToolArgs } from '../../src/types.js';
+
+/** Minimal store-list row for formatActorToStructuredCard / formatActorForWidget. */
+export const MOCK_STORE_ACTOR = {
+    id: 'actor-id-1',
+    title: 'Web Scraper',
+    name: 'web-scraper',
+    username: 'apify',
+    description: 'A web scraper for tests.',
+    pictureUrl: 'https://example.com/pic.png',
+    notice: null,
+    badge: null,
+    bookmarkCount: 42,
+    actorReviewRating: 4.5,
+    actorReviewCount: 10,
+    stats: {
+        totalUsers: 1000,
+        totalUsers30Days: 100,
+        actorReviewRating: 4.5,
+        actorReviewCount: 10,
+    },
+    categories: ['SCRAPING'],
+    currentPricingInfo: { pricingModel: ACTOR_PRICING_MODEL.FREE },
+} as unknown as ActorStoreList;
+
+export const SEARCH_KEYWORDS = 'web scraper';
+
+export function stubInternalToolArgs(args: Record<string, unknown>): InternalToolArgs {
+    return {
+        args,
+        apifyToken: 'test-token',
+        extra: {} as InternalToolArgs['extra'],
+        mcpServer: {} as InternalToolArgs['mcpServer'],
+        apifyClient: {} as InternalToolArgs['apifyClient'],
+        apifyMcpServer: { options: { paymentProvider: undefined } } as InternalToolArgs['apifyMcpServer'],
+    };
+}

--- a/tests/unit/tools.search_actors.widget.response.test.ts
+++ b/tests/unit/tools.search_actors.widget.response.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HelperTools } from '../../src/const.js';
+import { WIDGET_URIS } from '../../src/resources/widgets.js';
+import { openaiSearchActors } from '../../src/tools/openai/search_actors.js';
+import type { HelperTool } from '../../src/types.js';
+import { formatActorForWidget, formatActorToStructuredCard } from '../../src/utils/actor_card.js';
+import { searchAndFilterActors } from '../../src/utils/actor_search.js';
+import { MOCK_STORE_ACTOR, SEARCH_KEYWORDS, stubInternalToolArgs } from './tools.search_actors.fixtures.js';
+
+/**
+ * OpenAI / UI mode: search-actors adds widgetActors and tool _meta for the Actor Search widget.
+ */
+vi.mock('../../src/utils/actor_search.js', () => ({
+    searchAndFilterActors: vi.fn(),
+}));
+
+describe('search-actors with widget (openaiSearchActors)', () => {
+    beforeEach(() => {
+        vi.mocked(searchAndFilterActors).mockReset();
+    });
+
+    it('returns widgetActors, _meta, and OpenAI-specific instructions and text', async () => {
+        vi.mocked(searchAndFilterActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+
+        const result = await (openaiSearchActors as HelperTool).call(stubInternalToolArgs({
+            keywords: SEARCH_KEYWORDS,
+            limit: 5,
+            offset: 0,
+        }));
+
+        const { structuredContent, content, _meta } = result as {
+            structuredContent: {
+                actors: ReturnType<typeof formatActorToStructuredCard>[];
+                widgetActors?: ReturnType<typeof formatActorForWidget>[];
+                query: string;
+                count: number;
+                instructions?: string;
+            };
+            content: { type: string; text: string }[];
+            _meta?: { ui?: { resourceUri?: string }; 'openai/widgetDescription'?: string };
+        };
+
+        expect(structuredContent.query).toBe(SEARCH_KEYWORDS);
+        expect(structuredContent.count).toBe(1);
+        expect(structuredContent.actors).toHaveLength(1);
+        expect(structuredContent.actors[0]).toStrictEqual(formatActorToStructuredCard(MOCK_STORE_ACTOR));
+
+        expect(structuredContent.widgetActors).toBeDefined();
+        expect(structuredContent.widgetActors!.length).toBe(structuredContent.actors.length);
+        expect(structuredContent.widgetActors![0]).toStrictEqual(formatActorForWidget(MOCK_STORE_ACTOR));
+
+        expect(structuredContent.instructions).toContain(HelperTools.ACTOR_GET_DETAILS_INTERNAL);
+
+        expect(content).toHaveLength(1);
+        const { text } = content[0];
+        expect(text).toContain('do NOT print or summarize the Actor list');
+        expect(text).toContain(HelperTools.ACTOR_GET_DETAILS_INTERNAL);
+        expect(text).toContain('Choosing the right details tool:');
+
+        expect(_meta?.ui?.resourceUri).toBe(WIDGET_URIS.SEARCH_ACTORS);
+        expect(_meta?.['openai/widgetDescription']).toContain('1 actors');
+    });
+
+    it('omits widget _meta when there are no results (same empty payload as default)', async () => {
+        vi.mocked(searchAndFilterActors).mockResolvedValue([]);
+
+        const result = await (openaiSearchActors as HelperTool).call(stubInternalToolArgs({
+            keywords: SEARCH_KEYWORDS,
+            limit: 5,
+            offset: 0,
+        }));
+
+        const { structuredContent, content, _meta } = result as {
+            structuredContent: {
+                actors: unknown[];
+                query: string;
+                count: number;
+                instructions: string;
+                widgetActors?: unknown;
+            };
+            content: { type: string; text: string }[];
+            _meta?: unknown;
+        };
+
+        expect(structuredContent.actors).toEqual([]);
+        expect(structuredContent.count).toBe(0);
+        expect(structuredContent.widgetActors).toBeUndefined();
+        expect(content).toHaveLength(1);
+        expect(content[0].text).toContain('No Actors were found');
+        expect(_meta).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary
- Apply `dedent` to multiline strings in search_actors tool files per CONTRIBUTING.md guidelines
- Add guideline: skip `dedent` for top-level flush-left constants — no indentation to strip

## Test plan
- [x] type-check, lint, unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)