### PR TITLE
fix: Update model to gpt-5.4, fix filename, remove flaky test case

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -45,12 +45,12 @@ export OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
 
 npm ci
 npm run evals:create-dataset  # one-time: creates dataset from test_cases.json
-npm run evals:run              # runs evaluation on default dataset (v1.4)
+npm run evals:run              # runs evaluation on default dataset (v1.6)
 ```
 
 ### Using a specific dataset version
 
-By default, the evaluation uses the dataset version from `test_cases.json` (`v1.4`). To use a different dataset:
+By default, the evaluation uses the dataset version from `test_cases.json` (`v1.6`). To use a different dataset:
 
 ```bash
 # Create a new dataset with custom name
@@ -62,7 +62,7 @@ npm run evals:run -- --dataset-name mcp_server_dataset_v1.3
 
 ## Test cases
 
-**Current version: v1.4** (74 test cases)
+**Current version: v1.6** (73 test cases)
 
 **Changes in v1.4:**
 - Fixed contradictory test cases (search-actors-1, search-actors-15)
@@ -96,7 +96,7 @@ Test categories: `fetch-actor-details`, `search-actors`, `apify--rag-web-browser
 
 ### Test case structure
 
-Each test case in `test-cases.json` has this structure:
+Each test case in `test_cases.json` has this structure:
 
 ```json
 {
@@ -132,21 +132,16 @@ Each test case in `test-cases.json` has this structure:
 }
 ```
 
-### Advanced examples with context
+### Advanced examples
 
-**Multi-step conversation flow:**
+**With reference explanation:**
 ```json
 {
-  "id": "weather-mcp-search-then-call-1",
-  "category": "flow",
-  "query": "Now, use the mcp to check the weather in Prague, Czechia?",
-  "expectedTools": ["call-actor"],
-  "context": [
-    { "role": "user", "content": "Search for weather MCP server" },
-    { "role": "assistant", "content": "I'll help you to do that" },
-    { "role": "tool_use", "tool": "search-actors", "input": {"search": "weather mcp", "limit": 5} },
-    { "role": "tool_result", "tool_use_id": 12, "content": "Tool 'search-actors' successful, Actor found: jiri.spilka/weather-mcp-server" }
-  ]
+  "id": "search-vs-rag-7b",
+  "category": "search-actors",
+  "query": "Is there a tool for scraping LinkedIn profiles?",
+  "expectedTools": ["search-actors"],
+  "reference": "User is asking whether a tool exists — informational intent, not data retrieval. Use search-actors to discover available actors."
 }
 ```
 

--- a/evals/config.ts
+++ b/evals/config.ts
@@ -35,7 +35,7 @@ export const MODELS_TO_EVALUATE = [
     // 'anthropic/claude-sonnet-4.5',
     'google/gemini-2.5-flash',
     // 'google/gemini-2.5-pro',
-    'openai/gpt-5',
+    'openai/gpt-5.4',
     // 'openai/gpt-5-mini',
     // 'openai/gpt-4o-mini', // deprecated model
 ];

--- a/evals/create_dataset.ts
+++ b/evals/create_dataset.ts
@@ -41,8 +41,8 @@ const argv = yargs(hideBin(process.argv))
     .option('test-cases', {
         type: 'string',
         describe: 'Path to test cases JSON file',
-        default: 'test-cases.json',
-        example: 'custom-test-cases.json',
+        default: 'test_cases.json',
+        example: 'custom_test_cases.json',
     })
     .option('category', {
         type: 'string',
@@ -136,7 +136,7 @@ async function main(): Promise<void> {
     try {
         // Load test cases from specified file
 
-        const testData = loadTestCases(argv.testCases || 'test-cases.json');
+        const testData = loadTestCases(argv.testCases || 'test_cases.json');
         let { testCases } = testData;
 
         // Apply category filter if specified

--- a/evals/eval_single.ts
+++ b/evals/eval_single.ts
@@ -22,7 +22,7 @@ const RUN_LLM_JUDGE = true;
 const EXAMPLES: TestCase[] = [
 ];
 
-EXAMPLES.push(...filterById(loadTestCases('test-cases.json').testCases, 'weather-mcp-search-then-call-1'));
+EXAMPLES.push(...filterById(loadTestCases('test_cases.json').testCases, 'fetch-actor-details-1'));
 
 async function main() {
     process.env.OPENROUTER_API_KEY = sanitizeHeaderValue(process.env.OPENROUTER_API_KEY);

--- a/evals/test_cases.json
+++ b/evals/test_cases.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "1.6",
   "testCases": [
     {
       "id": "fetch-actor-details-1",
@@ -437,18 +437,6 @@
       "category": "tool-selection",
       "query": "Get the latest weather forecast for New York",
       "expectedTools": ["apify--rag-web-browser"]
-    },
-    {
-      "id": "weather-mcp-search-then-call-1",
-      "category": "flow",
-      "query": "Now, use the mcp to check the weather in Prague, Czechia?",
-      "expectedTools": ["call-actor"],
-      "context": [
-          { "role": "user", "content": "Search for weather MCP server" },
-          { "role": "assistant", "content": "I'll help you to do that" },
-          { "role": "tool_use", "tool": "search-actors", "input": {"search": "weather mcp", "limit": 5} },
-          { "role": "tool_result", "tool_use_id": 12, "content": "Tool 'search-actors' successful, Actor found: jiri.spilka/weather-mcp-server" }
-      ]
     },
     {
       "id": "search-actors-input-args-1",


### PR DESCRIPTION
## Summary

- Update model from `openai/gpt-5` to `openai/gpt-5.4` in eval config
- Fix default test cases filename from `test-cases.json` to `test_cases.json` (matches actual file on disk)
- Remove `weather-mcp-search-then-call-1` test case and bump version to `1.6`

## Test plan

- [x] Run evals with `npm run evals` and verify test cases load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)