### PR TITLE
fix: Sanitize all env values in evals to prevent ERR_INVALID_CHAR

### DIFF
--- a/evals/config.ts
+++ b/evals/config.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 import log from '@apify/log';
 
 // Re-export shared config
-export { OPENROUTER_CONFIG, sanitizeHeaderValue, validateEnvVars, getRequiredEnvVars } from './shared/config.js';
+export { OPENROUTER_CONFIG, sanitizeEnvValue, validateEnvVars, getRequiredEnvVars } from './shared/config.js';
 
 // Read the version from test-cases.json
 function getTestCasesVersion(): string {

--- a/evals/create_dataset.ts
+++ b/evals/create_dataset.ts
@@ -14,7 +14,7 @@ import { hideBin } from 'yargs/helpers';
 
 import log from '@apify/log';
 
-import { sanitizeHeaderValue, validatePhoenixEnvVars } from './config.js';
+import { sanitizeEnvValue, validatePhoenixEnvVars } from './config.js';
 import { loadTestCases, filterByCategory, filterById, type TestCase } from './evaluation_utils.js';
 
 // Set log level to debug
@@ -98,7 +98,7 @@ async function createDatasetFromTestCases(
     const client = createClient({
         options: {
             baseUrl: process.env.PHOENIX_BASE_URL!,
-            headers: { Authorization: `Bearer ${sanitizeHeaderValue(process.env.PHOENIX_API_KEY)}` },
+            headers: { Authorization: `Bearer ${sanitizeEnvValue(process.env.PHOENIX_API_KEY)}` },
         },
     });
 

--- a/evals/eval_single.ts
+++ b/evals/eval_single.ts
@@ -25,7 +25,9 @@ const EXAMPLES: TestCase[] = [
 EXAMPLES.push(...filterById(loadTestCases('test_cases.json').testCases, 'fetch-actor-details-1'));
 
 async function main() {
-    process.env.OPENROUTER_API_KEY = sanitizeEnvValue(process.env.OPENROUTER_API_KEY);
+    if (process.env.OPENROUTER_API_KEY != null) {
+        process.env.OPENROUTER_API_KEY = sanitizeEnvValue(process.env.OPENROUTER_API_KEY);
+    }
 
     console.log(`\nEvaluating ${EXAMPLES.length} examples\n`);
 

--- a/evals/eval_single.ts
+++ b/evals/eval_single.ts
@@ -9,7 +9,7 @@ import {
     loadTestCases, filterById,
     type TestCase
 } from './evaluation_utils.js';
-import { PASS_THRESHOLD, sanitizeHeaderValue } from './config.js';
+import { PASS_THRESHOLD, sanitizeEnvValue } from './config.js';
 
 dotenv.config({ path: '.env' });
 log.setLevel(log.LEVELS.INFO);
@@ -25,7 +25,7 @@ const EXAMPLES: TestCase[] = [
 EXAMPLES.push(...filterById(loadTestCases('test_cases.json').testCases, 'fetch-actor-details-1'));
 
 async function main() {
-    process.env.OPENROUTER_API_KEY = sanitizeHeaderValue(process.env.OPENROUTER_API_KEY);
+    process.env.OPENROUTER_API_KEY = sanitizeEnvValue(process.env.OPENROUTER_API_KEY);
 
     console.log(`\nEvaluating ${EXAMPLES.length} examples\n`);
 

--- a/evals/eval_single.ts
+++ b/evals/eval_single.ts
@@ -9,7 +9,7 @@ import {
     loadTestCases, filterById,
     type TestCase
 } from './evaluation_utils.js';
-import { PASS_THRESHOLD, sanitizeEnvValue } from './config.js';
+import { PASS_THRESHOLD } from './config.js';
 
 dotenv.config({ path: '.env' });
 log.setLevel(log.LEVELS.INFO);
@@ -25,8 +25,6 @@ const EXAMPLES: TestCase[] = [
 EXAMPLES.push(...filterById(loadTestCases('test_cases.json').testCases, 'fetch-actor-details-1'));
 
 async function main() {
-    process.env.OPENROUTER_API_KEY = sanitizeEnvValue(process.env.OPENROUTER_API_KEY);
-
     console.log(`\nEvaluating ${EXAMPLES.length} examples\n`);
 
     // 1. Load tools

--- a/evals/evaluation_utils.ts
+++ b/evals/evaluation_utils.ts
@@ -18,7 +18,7 @@ import {
     TOOL_SELECTION_EVAL_MODEL,
     EVALUATOR_NAMES,
     TEMPERATURE,
-    sanitizeHeaderValue
+    sanitizeEnvValue
 } from './config.js';
 import { loadTestCases as loadTestCasesShared, filterByCategory, filterById } from './shared/test_case_loader.js';
 import { transformToolsToOpenAIFormat } from './shared/openai_tools.js';
@@ -57,8 +57,8 @@ export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
         reference: string;
     }> => {
         const client = new OpenAI({
-            baseURL: process.env.OPENROUTER_BASE_URL,
-            apiKey: sanitizeHeaderValue(process.env.OPENROUTER_API_KEY),
+            baseURL: sanitizeEnvValue(process.env.OPENROUTER_BASE_URL),
+            apiKey: sanitizeEnvValue(process.env.OPENROUTER_API_KEY),
         });
 
         log.info(`Input: ${JSON.stringify(example)}`);
@@ -105,8 +105,8 @@ export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
 
 export function createClassifierEvaluator() {
     const openai = createOpenAI({
-        baseURL: process.env.OPENROUTER_BASE_URL,
-        apiKey: process.env.OPENROUTER_API_KEY,
+        baseURL: sanitizeEnvValue(process.env.OPENROUTER_BASE_URL),
+        apiKey: sanitizeEnvValue(process.env.OPENROUTER_API_KEY),
     });
 
     return createClassifierFn({

--- a/evals/evaluation_utils.ts
+++ b/evals/evaluation_utils.ts
@@ -18,7 +18,7 @@ import {
     TOOL_SELECTION_EVAL_MODEL,
     EVALUATOR_NAMES,
     TEMPERATURE,
-    sanitizeEnvValue
+    OPENROUTER_CONFIG,
 } from './config.js';
 import { loadTestCases as loadTestCasesShared, filterByCategory, filterById } from './shared/test_case_loader.js';
 import { transformToolsToOpenAIFormat } from './shared/openai_tools.js';
@@ -56,10 +56,7 @@ export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
         context: string;
         reference: string;
     }> => {
-        const client = new OpenAI({
-            baseURL: sanitizeEnvValue(process.env.OPENROUTER_BASE_URL),
-            apiKey: sanitizeEnvValue(process.env.OPENROUTER_API_KEY),
-        });
+        const client = new OpenAI(OPENROUTER_CONFIG);
 
         log.info(`Input: ${JSON.stringify(example)}`);
 
@@ -104,10 +101,7 @@ export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
 }
 
 export function createClassifierEvaluator() {
-    const openai = createOpenAI({
-        baseURL: sanitizeEnvValue(process.env.OPENROUTER_BASE_URL),
-        apiKey: sanitizeEnvValue(process.env.OPENROUTER_API_KEY),
-    });
+    const openai = createOpenAI(OPENROUTER_CONFIG);
 
     return createClassifierFn({
         model: openai(TOOL_SELECTION_EVAL_MODEL),

--- a/evals/run_evaluation.ts
+++ b/evals/run_evaluation.ts
@@ -29,7 +29,7 @@ import {
     PHOENIX_RETRY_DELAY_MS,
     PHOENIX_MAX_RETRIES,
     type EvaluatorName,
-    sanitizeHeaderValue,
+    sanitizeEnvValue,
     validatePhoenixEnvVars
 } from './config.js';
 
@@ -79,7 +79,7 @@ const argv = yargs(hideBin(process.argv))
     .parseSync() as CliArgs;
 
 // Sanitize secrets early to avoid invalid header characters in CI
-process.env.OPENROUTER_API_KEY = sanitizeHeaderValue(process.env.OPENROUTER_API_KEY);
+process.env.OPENROUTER_API_KEY = sanitizeEnvValue(process.env.OPENROUTER_API_KEY);
 
 // Tools match evaluator: returns score 1 if expected tool_calls match output list, 0 otherwise
 const toolsExactMatch = asEvaluator({
@@ -197,7 +197,7 @@ async function main(datasetName: string): Promise<number> {
     const client = createClient({
         options: {
             baseUrl: process.env.PHOENIX_BASE_URL!,
-            headers: { Authorization: `Bearer ${sanitizeHeaderValue(process.env.PHOENIX_API_KEY)}` },
+            headers: { Authorization: `Bearer ${sanitizeEnvValue(process.env.PHOENIX_API_KEY)}` },
         },
     });
 

--- a/evals/run_evaluation.ts
+++ b/evals/run_evaluation.ts
@@ -78,9 +78,6 @@ const argv = yargs(hideBin(process.argv))
     .epilogue('  npm run evals:run -- --dataset-name custom_v1  # Via npm script')
     .parseSync() as CliArgs;
 
-// Sanitize secrets early to avoid invalid header characters in CI
-process.env.OPENROUTER_API_KEY = sanitizeEnvValue(process.env.OPENROUTER_API_KEY);
-
 // Tools match evaluator: returns score 1 if expected tool_calls match output list, 0 otherwise
 const toolsExactMatch = asEvaluator({
     name: EVALUATOR_NAMES.TOOLS_EXACT_MATCH,

--- a/evals/run_evaluation.ts
+++ b/evals/run_evaluation.ts
@@ -79,7 +79,9 @@ const argv = yargs(hideBin(process.argv))
     .parseSync() as CliArgs;
 
 // Sanitize secrets early to avoid invalid header characters in CI
-process.env.OPENROUTER_API_KEY = sanitizeEnvValue(process.env.OPENROUTER_API_KEY);
+if (process.env.OPENROUTER_API_KEY != null) {
+    process.env.OPENROUTER_API_KEY = sanitizeEnvValue(process.env.OPENROUTER_API_KEY);
+}
 
 // Tools match evaluator: returns score 1 if expected tool_calls match output list, 0 otherwise
 const toolsExactMatch = asEvaluator({

--- a/evals/shared/config.ts
+++ b/evals/shared/config.ts
@@ -8,8 +8,8 @@
  * OPENROUTER_BASE_URL is optional and defaults to the standard OpenRouter API URL
  */
 export const OPENROUTER_CONFIG = {
-    baseURL: process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1',
-    apiKey: process.env.OPENROUTER_API_KEY || '',
+    baseURL: sanitizeEnvValue(process.env.OPENROUTER_BASE_URL) || 'https://openrouter.ai/api/v1',
+    apiKey: sanitizeEnvValue(process.env.OPENROUTER_API_KEY) || '',
 };
 
 /**
@@ -23,10 +23,10 @@ export function getRequiredEnvVars(): Record<string, string | undefined> {
 }
 
 /**
- * Removes newlines and trims whitespace. Useful for Authorization header values
- * because CI secrets sometimes include trailing newlines or quotes.
+ * Removes newlines, trims whitespace, and strips surrounding quotes from env values.
+ * CI secrets often include trailing newlines or quotes that break HTTP headers and URLs.
  */
-export function sanitizeHeaderValue(value?: string): string | undefined {
+export function sanitizeEnvValue(value?: string): string | undefined {
     if (value == null) return value;
     return value.replace(/[\r\n]/g, '').trim().replace(/^"|"$/g, '');
 }

--- a/evals/workflows/config.ts
+++ b/evals/workflows/config.ts
@@ -6,7 +6,7 @@
  */
 
 // Re-export shared config for convenience
-export { OPENROUTER_CONFIG, sanitizeHeaderValue, validateEnvVars } from '../shared/config.js';
+export { OPENROUTER_CONFIG, sanitizeEnvValue, validateEnvVars } from '../shared/config.js';
 
 /**
  * Default model configuration for agent and judge

--- a/evals/workflows/run_workflow_evals.ts
+++ b/evals/workflows/run_workflow_evals.ts
@@ -212,7 +212,7 @@ async function main() {
 
     // Check environment variables
     const apifyToken = sanitizeEnvValue(process.env.APIFY_TOKEN);
-    const openrouterKey = process.env.OPENROUTER_API_KEY;
+    const openrouterKey = sanitizeEnvValue(process.env.OPENROUTER_API_KEY);
 
     if (!apifyToken) {
         console.error('❌ Error: APIFY_TOKEN environment variable is required');

--- a/evals/workflows/run_workflow_evals.ts
+++ b/evals/workflows/run_workflow_evals.ts
@@ -21,7 +21,7 @@ import { hideBin } from 'yargs/helpers';
 import { filterByLineRanges } from '../shared/line_range_filter.js';
 import type { LineRange } from '../shared/line_range_parser.js';
 import { checkRangesOutOfBounds, parseLineRanges, validateLineRanges } from '../shared/line_range_parser.js';
-import { DEFAULT_TOOL_TIMEOUT_SECONDS, MODELS } from './config.js';
+import { DEFAULT_TOOL_TIMEOUT_SECONDS, MODELS, sanitizeEnvValue } from './config.js';
 import { executeConversation } from './conversation_executor.js';
 import { LlmClient } from './llm_client.js';
 import { McpClient } from './mcp_client.js';
@@ -211,7 +211,7 @@ async function main() {
     console.log();
 
     // Check environment variables
-    const apifyToken = process.env.APIFY_TOKEN;
+    const apifyToken = sanitizeEnvValue(process.env.APIFY_TOKEN);
     const openrouterKey = process.env.OPENROUTER_API_KEY;
 
     if (!apifyToken) {

--- a/tests/unit/evals.config.test.ts
+++ b/tests/unit/evals.config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeEnvValue } from '../../evals/shared/config.js';
+
+describe('sanitizeEnvValue', () => {
+    it('returns undefined for undefined', () => {
+        expect(sanitizeEnvValue(undefined)).toBeUndefined();
+    });
+
+    it('returns null for null', () => {
+        expect(sanitizeEnvValue(null as unknown as undefined)).toBeNull();
+    });
+
+    it('strips trailing newline', () => {
+        expect(sanitizeEnvValue('sk-abc123\n')).toBe('sk-abc123');
+    });
+
+    it('strips carriage-return + newline', () => {
+        expect(sanitizeEnvValue('sk-abc123\r\n')).toBe('sk-abc123');
+    });
+
+    it('strips embedded newlines', () => {
+        expect(sanitizeEnvValue('sk-\nabc\r\n123\n')).toBe('sk-abc123');
+    });
+
+    it('trims surrounding whitespace', () => {
+        expect(sanitizeEnvValue('  sk-abc123  ')).toBe('sk-abc123');
+    });
+
+    it('strips surrounding double quotes', () => {
+        expect(sanitizeEnvValue('"sk-abc123"')).toBe('sk-abc123');
+    });
+
+    it('strips only outer quotes (not inner)', () => {
+        expect(sanitizeEnvValue('"sk-"abc"-123"')).toBe('sk-"abc"-123');
+    });
+
+    it('does not strip single quotes', () => {
+        expect(sanitizeEnvValue("'sk-abc123'")).toBe("'sk-abc123'");
+    });
+
+    it('handles combined whitespace, newlines, and quotes', () => {
+        expect(sanitizeEnvValue('  "sk-abc123"\n')).toBe('sk-abc123');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(sanitizeEnvValue('')).toBe('');
+    });
+
+    it('is idempotent', () => {
+        const value = '  "sk-abc123"\r\n';
+        expect(sanitizeEnvValue(sanitizeEnvValue(value))).toBe(sanitizeEnvValue(value));
+    });
+});


### PR DESCRIPTION
## Summary
- Sanitize `OPENROUTER_CONFIG` (apiKey + baseURL) at capture time in `shared/config.ts` so all consumers get clean values
- Sanitize `APIFY_TOKEN` in workflow evals before passing to MCP subprocess
- Sanitize both OpenRouter clients in `evaluation_utils.ts` — `createClassifierEvaluator()` was completely unsanitized, causing 73/73 eval failures in CI
- Rename `sanitizeHeaderValue` → `sanitizeEnvValue` since it's used for URLs and tokens, not just headers

## Test plan
- [ ] CI evals pass without `ERR_INVALID_CHAR` errors
- [ ] Type-check and lint pass (verified locally)
- [ ] Unit tests pass (verified locally, 450/450)

🤖 Generated with [Claude Code](https://claude.com/claude-code)