### PR TITLE
fix: Required fields dropped from tools/list for all Actors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ __pycache__/
 *.pyo
 *.pyd
 .Python
+dev.log

--- a/res/actor_input_schema_required_fields.md
+++ b/res/actor_input_schema_required_fields.md
@@ -1,0 +1,104 @@
+# Actor Input Schema: required vs default vs prefill
+
+Reference for the `fixZodSchemaRequired()` pipeline (fix for [#637](https://github.com/apify/apify-mcp-server/issues/637)).
+
+## Apify spec semantics
+
+Per [Apify input-schema spec](https://docs.apify.com/platform/actors/development/actor-definition/input-schema/specification):
+
+| Key | Who fills it | User must provide? |
+|---|---|---|
+| `required` | User | Yes — Actor cannot run without it (e.g. API token, search keyword) |
+| `default` | Platform | No — platform fills it in if omitted (e.g. `maxResults: 3`) |
+| `prefill` | UI hint only | No — shown in Apify Console as an example value; doesn't reach the API |
+
+**Spec rule**: "The combination of Default + Required doesn't make sense to use." A field with a real default is effectively optional — advertise it in `required` and MCP clients will force users to supply something the platform would have filled in anyway.
+
+## Worked example — `apify/rag-web-browser`
+
+Upstream `INPUT_SCHEMA.json` (abbreviated):
+
+```json
+{
+    "properties": {
+        "query":         { "type": "string",  "prefill": "web browser for RAG pipelines" },
+        "maxResults":    { "type": "integer", "default": 3 },
+        "outputFormats": { "type": "array",   "default": ["markdown"] }
+    },
+    "required": ["query"]
+}
+```
+
+What MCP `tools/list` should advertise: `"required": ["query"]`
+
+- `query` — required, no default, has prefill. User MUST supply it.
+- `maxResults` — has default. Not in required; platform passes `3`.
+- `outputFormats` — has default. Not in required; platform passes `["markdown"]`.
+
+## Real Actors and their field outcomes
+
+| Actor | Field | required | default | Outcome in `required` |
+|---|---|---|---|---|
+| apify/rag-web-browser | `query` | yes | (none) | stays |
+| apify/rag-web-browser | `maxResults` | no | `3` | n/a (not required upstream) |
+| apify/website-content-crawler | `startUrls` | yes | (none) | stays |
+| apify/website-content-crawler | `proxyConfiguration` | yes | `{...}` | removed (spec-discouraged combo; default wins) |
+| apify/google-search-scraper | `queries` | yes | (none) | stays |
+| apify/instagram-post-scraper | `username` | yes | (none) | stays |
+
+## The bug (#637) and the fix
+
+### Root cause
+
+`filterSchemaProperties()` (`src/tools/utils.ts`) unconditionally assigns every whitelisted key,
+including `default: property.default`, creating a phantom `default: undefined` in-memory key on
+every property that had no upstream default.
+
+Before the fix, `fixZodSchemaRequired()` used a key-presence check:
+
+```typescript
+// OLD — broken: 'default' in field matches phantom `default: undefined`
+return !('default' in fieldSchema);
+```
+
+This stripped every field from `required` for every Actor. Every Actor input looked fully optional.
+
+### Fix (value-check)
+
+```typescript
+// NEW — value-check: only real defaults (non-undefined) count
+return (fieldSchema as { default?: unknown }).default === undefined;
+```
+
+Schema before fix reaching `fixZodSchemaRequired` (after `filterSchemaProperties`):
+
+```json
+{
+    "properties": {
+        "query":         { "type": "string", "default": undefined, "prefill": "…" },
+        "maxResults":    { "type": "integer", "default": 3 }
+    },
+    "required": ["query"]
+}
+```
+
+After fix — output:
+
+```json
+{ "required": ["query"] }
+```
+
+### Canonical reference
+
+The same value-check (`field?.default !== undefined`) is used by Apify's platform-side
+input-schema validator. The fix deliberately mirrors that pattern.
+
+## Follow-up cleanup (#675)
+
+The phantom-key corruption originates in `filterSchemaProperties()`. The downstream value-check
+in `fixZodSchemaRequired()` is a symptom fix. The follow-up PR should:
+
+1. Make `filterSchemaProperties()` preserve only keys whose upstream value is not `undefined`.
+2. Update the test assertion in `tools.utils.test.ts` (~line 725) that currently codifies the bug.
+3. Consider extracting shared helpers to `@apify/input_schema` so public and internal repos
+   share the same normalisation logic.

--- a/res/index.md
+++ b/res/index.md
@@ -65,6 +65,13 @@ Analysis of patterns from the **official TypeScript MCP SDK** and **FastMCP** fr
 - Benefits for each pattern
 - **Use case**: Reference for incremental codebase improvements
 
+### [actor_input_schema_required_fields.md](./actor_input_schema_required_fields.md)
+Apify input-schema spec semantics (required vs default vs prefill), the root cause of #637
+(phantom `default: undefined` keys from `filterSchemaProperties`), before/after examples for
+`apify/rag-web-browser`, a table of 6 real Actor fields, and the follow-up cleanup plan (#675).
+- **Use case**: Reference when touching `fixZodSchemaRequired`, `filterSchemaProperties`, or any
+  Actor input-schema normalisation logic.
+
 ### [web-widget-bundle-size.md](./web-widget-bundle-size.md)
 Notes on keeping widget bundles small (narrow `@apify/ui-library` imports, markdown stack cost).
 - **Use case**: When changing widget dependencies or markdown rendering, re-measure bundle impact

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -115,6 +115,13 @@ export function buildApifySpecificProperties(properties: Record<string, SchemaPr
 /**
  * Filters schema properties to include only the necessary fields.
  * This is done to reduce the size of the input schema and to make it more readable.
+ *
+ * TODO(#675): This object literal unconditionally assigns every whitelisted key,
+ * including `default: undefined`, on properties that didn't declare them upstream.
+ * This creates phantom keys that broke `fixZodSchemaRequired()` via key-presence
+ * checks (#637). The symptom is patched in `src/utils/ajv.ts` (value-check), but
+ * this function should only emit keys whose upstream value is not `undefined`.
+ *
  * @param properties
  */
 export function filterSchemaProperties(properties: { [key: string]: SchemaProperties }): {

--- a/src/utils/ajv.ts
+++ b/src/utils/ajv.ts
@@ -4,26 +4,30 @@ import Ajv from 'ajv';
 export const ajv = new Ajv({ coerceTypes: 'array', strict: false, removeAdditional: true });
 
 /**
- * Removes the $schema property and fixes the required array from a JSON schema.
- * The z.toJSONSchema() function in Zod 4.x has two issues:
- * 1. Includes a $schema reference that can cause issues when compiling with AJV
- * 2. Incorrectly marks fields with default values as required
+ * Removes the `$schema` property and drops fields with real `default` values from `required`.
  *
- * This function fixes both issues to ensure proper schema validation.
- * Exported so MCP tool listings can apply the same fix via `fixZodInputSchemaRequired` (see `getToolPublicFieldOnly`).
+ * Per Apify's input-schema spec, "Default + Required doesn't make sense" — a field with a
+ * default is effectively optional because the platform fills it in. Zod 4.x `toJSONSchema()`
+ * has the same issue: it lists `.default()` fields as required and emits `$schema` that
+ * breaks AJV compilation.
+ *
+ * Uses a value-check (`field.default !== undefined`) instead of key-presence (`'default' in field`)
+ * because `filterSchemaProperties()` assigns phantom `default: undefined` on every property (#675).
+ *
+ * @see https://github.com/apify/apify-mcp-server/issues/637
  */
 export function fixZodSchemaRequired(schema: Record<string, unknown>): Record<string, unknown> {
     const cleaned = { ...schema };
     delete cleaned.$schema;
 
-    // Fix the required array: remove fields that have default values
     if (Array.isArray(cleaned.required) && typeof cleaned.properties === 'object' && cleaned.properties !== null) {
         const properties = cleaned.properties as Record<string, unknown>;
         cleaned.required = (cleaned.required as string[]).filter(
             (fieldName) => {
                 const fieldSchema = properties[fieldName];
-                // Only include in required if the field doesn't have a default value
-                return !(typeof fieldSchema === 'object' && fieldSchema !== null && 'default' in fieldSchema);
+                if (typeof fieldSchema !== 'object' || fieldSchema === null) return true;
+                // Value-check (NOT `'default' in fieldSchema`) — see docstring for why.
+                return (fieldSchema as { default?: unknown }).default === undefined;
             },
         );
     }

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { searchApifyDocsTool } from '../../src/tools/common/search_apify_docs.js';
 import { CATEGORY_NAMES, getCategoryTools } from '../../src/tools/index.js';
-import type { ToolEntry } from '../../src/types.js';
+import type { ToolBase, ToolEntry } from '../../src/types.js';
 import { SERVER_MODES } from '../../src/types.js';
 import { getToolPublicFieldOnly } from '../../src/utils/tools.js';
 
@@ -240,5 +240,47 @@ describe('getToolPublicFieldOnly inputSchema normalization', () => {
         expect(schema.properties?.docSource).toMatchObject({ default: 'apify' });
         expect(schema.properties?.limit).toMatchObject({ default: 5 });
         expect(schema.properties?.offset).toMatchObject({ default: 0 });
+    });
+
+    // Regression: #637 — Actor required fields were dropped from tools/list output.
+    it('should preserve required fields from Apify Actor-shape inputSchemas', () => {
+        const actorShapeTool = {
+            name: 'apify--some-actor',
+            description: 'Test Actor tool',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    query: { type: 'string', description: 'Search query' },
+                    maxResults: { type: 'integer', description: 'Limit', default: 3 },
+                },
+                required: ['query'],
+            },
+        } as unknown as ToolBase;
+
+        const { inputSchema } = getToolPublicFieldOnly(actorShapeTool, { filterWidgetMeta: false });
+        const schema = inputSchema as { required?: string[] };
+
+        expect(schema.required).toEqual(['query']);
+    });
+
+    // Regression: #637 — phantom `default: undefined` from filterSchemaProperties must not clear required.
+    it('should preserve required fields even when upstream writes `default: undefined`', () => {
+        const toolWithPhantomDefaults = {
+            name: 'apify--some-actor',
+            description: 'Test Actor tool',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    query: { type: 'string', description: 'Search query', default: undefined },
+                    maxResults: { type: 'integer', description: 'Limit', default: 3 },
+                },
+                required: ['query'],
+            },
+        } as unknown as ToolBase;
+
+        const { inputSchema } = getToolPublicFieldOnly(toolWithPhantomDefaults, { filterWidgetMeta: false });
+        const schema = inputSchema as { required?: string[] };
+
+        expect(schema.required).toEqual(['query']);
     });
 });

--- a/tests/unit/tools.utils.test.ts
+++ b/tests/unit/tools.utils.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
 import { ACTOR_ENUM_MAX_LENGTH, ACTOR_MAX_DESCRIPTION_LENGTH } from '../../src/const.js';
-import { buildApifySpecificProperties, decodeDotPropertyNames, encodeDotPropertyNames,
-    filterAndShortenEnum, inferArrayItemsTypeIfMissing, inferArrayItemType, markInputPropertiesAsRequired, shortenProperties,
-    transformActorInputSchemaProperties } from '../../src/tools/utils.js';
-import type { ActorInputSchema, SchemaProperties, ToolEntry } from '../../src/types.js';
-import { extractActorName, getToolFullName } from '../../src/utils/tools.js';
+import {
+    buildActorInputSchema,
+    buildApifySpecificProperties,
+    decodeDotPropertyNames,
+    encodeDotPropertyNames,
+    filterAndShortenEnum,
+    inferArrayItemsTypeIfMissing,
+    inferArrayItemType,
+    markInputPropertiesAsRequired,
+    shortenProperties,
+    transformActorInputSchemaProperties,
+} from '../../src/tools/utils.js';
+import type { ActorInputSchema, SchemaProperties, ToolBase, ToolEntry } from '../../src/types.js';
+import { extractActorName, getToolFullName, getToolPublicFieldOnly } from '../../src/utils/tools.js';
 
 describe('buildApifySpecificProperties', () => {
     it('should add resource picker structure to array items with editor resourcePicker', () => {
@@ -722,6 +731,7 @@ describe('transformActorInputSchemaProperties', () => {
         expect(result.sources.items).toBeDefined();
         expect(result.sources.items?.properties?.url).toBeDefined();
         // 3. filterSchemaProperties: only allowed fields present
+        // NOTE: includes phantom `default: undefined` etc. from filterSchemaProperties (#675).
         expect(Object.keys(result['foo-dot-bar'])).toEqual(
             expect.arrayContaining(['title', 'description', 'type', 'default', 'prefill', 'properties', 'items', 'required', 'enum']),
         );
@@ -946,5 +956,44 @@ describe('extractActorName', () => {
     it('returns undefined for internal tools without actor arg', () => {
         const tool = { type: 'internal', name: 'store-search' } as unknown as ToolEntry;
         expect(extractActorName(tool)).toBeUndefined();
+    });
+});
+
+describe('buildActorInputSchema + getToolPublicFieldOnly pipeline', () => {
+    // Regression: #637 — end-to-end check that required fields survive the full pipeline.
+    it('keeps `query` in required across the full tools/list pipeline for a rag-web-browser-shaped schema', () => {
+        const upstream: ActorInputSchema = {
+            type: 'object',
+            properties: {
+                query: {
+                    type: 'string',
+                    title: 'Search term or URL',
+                    description: 'Enter Google Search keywords or a URL.',
+                    prefill: 'web browser for RAG pipelines',
+                },
+                maxResults: {
+                    type: 'integer',
+                    title: 'Maximum results',
+                    description: 'Max organic results to return.',
+                    default: 3,
+                },
+            },
+            required: ['query'],
+        };
+
+        const { inputSchema } = buildActorInputSchema('apify/rag-web-browser', upstream, false);
+
+        const tool = {
+            name: 'apify--rag-web-browser',
+            description: 'RAG web browser',
+            inputSchema,
+        } as ToolBase;
+
+        const pub = getToolPublicFieldOnly(tool, { filterWidgetMeta: false });
+        const schema = pub.inputSchema as { required?: string[]; properties?: Record<string, { description?: string }> };
+
+        expect(schema.required).toEqual(['query']);
+        expect(schema.properties?.query?.description).toMatch(/^\*\*REQUIRED\*\*/);
+        expect(schema.properties?.maxResults?.description).not.toMatch(/^\*\*REQUIRED\*\*/);
     });
 });

--- a/tests/unit/utils.ajv.test.ts
+++ b/tests/unit/utils.ajv.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { ajv, compileSchema } from '../../src/utils/ajv.js';
+import { ajv, compileSchema, fixZodSchemaRequired } from '../../src/utils/ajv.js';
 
 describe('compileSchema', () => {
     it('should validate declared properties normally', () => {
@@ -48,7 +48,7 @@ describe('compileSchema', () => {
         expect(validate({ name: [1, 2] })).toBe(false); // wrong type (array, not coercible to string)
     });
 
-    it('should strip fields with defaults from the required array', () => {
+    it('should allow omitting a field that has a default even when it is listed as required', () => {
         const validate = compileSchema({
             type: 'object',
             properties: {
@@ -61,6 +61,51 @@ describe('compileSchema', () => {
 
         // 'format' has a default so it shouldn't be required
         expect(validate({ name: 'test' })).toBe(true);
+    });
+});
+
+describe('fixZodSchemaRequired', () => {
+    // Regression: #637 — phantom `default: undefined` must not clear required fields.
+    it('keeps required fields whose `default` is explicitly undefined', () => {
+        const result = fixZodSchemaRequired({
+            type: 'object',
+            properties: {
+                query: { type: 'string', default: undefined },
+                maxResults: { type: 'integer', default: 3 },
+            },
+            required: ['query', 'maxResults'],
+        });
+
+        expect(result.required).toEqual(['query']);
+    });
+
+    it('removes fields with a real default from the `required` array (properties are left intact)', () => {
+        const schema = {
+            type: 'object',
+            properties: {
+                name: { type: 'string' },
+                format: { type: 'string', default: 'json' },
+            },
+            required: ['name', 'format'],
+        };
+
+        const result = fixZodSchemaRequired(schema);
+
+        expect(result.required).toEqual(['name']);
+        // `format` must still be in `properties` — we only edited `required`, not the fields.
+        expect(result.properties).toEqual(schema.properties);
+    });
+
+    it('keeps required fields when properties have no `default` key at all', () => {
+        const result = fixZodSchemaRequired({
+            type: 'object',
+            properties: {
+                url: { type: 'string' },
+            },
+            required: ['url'],
+        });
+
+        expect(result.required).toEqual(['url']);
     });
 });
 


### PR DESCRIPTION
Fixes #637.

## Root cause

`filterSchemaProperties()` unconditionally assigns `default: property.default` on every whitelisted property, creating a phantom `default: undefined` key on properties with no upstream default. The previous key-presence check (`'default' in field`) matched these phantoms and cleared the `required` array for **every** Actor in `tools/list` — so `query`, `startUrls`, `queries`, etc. all appeared optional.

## Fix

Switch to a value-check (`field.default !== undefined`) in `fixZodSchemaRequired()` — same pattern used by the Apify platform-side input-schema validator.

## Verified

Tested with mcpc on `@stdio-full` against `apify/rag-web-browser`, `apify/google-search-scraper`, `apify/web-scraper`, `apify/instagram-scraper`, and others — all required fields now correctly populated.

## Follow-up

The phantom-key corruption itself (in `filterSchemaProperties`) is tracked in #675.