### PR TITLE
fix: Log MCP client errors and disconnects as softFail

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -406,10 +406,14 @@ export class ActorsMcpServer {
 
     private setupErrorHandling(setupSIGINTHandler = true): void {
         this.server.onerror = (error) => {
-            if (error.message?.includes('No connection established')) {
+            // Client-disconnect noise from the MCP SDK (protocol.js). Two messages we see in prod:
+            //   - "No connection established" (sendRequest before transport attached)
+            //   - "Failed to send response: Error: Not connected" (client vanished mid-flight)
+            // Both are expected; log as softFail so they don't flood Mezmo error alerts.
+            if (/Not connected|No connection established/i.test(error.message ?? '')) {
                 // Mezmo (logDNA) promotes log entries to errors when the message contains "error".
                 // Use errMessage key and sanitize the string to preserve the soft-fail log level.
-                const errMessage = error.message.replace(/ error:/gi, ' failure:');
+                const errMessage = (error.message ?? '').replace(/ error:/gi, ' failure:');
                 log.softFail('MCP client disconnected before response could be sent', { errMessage });
             } else {
                 log.error('[MCP Error]', { error });
@@ -1284,16 +1288,35 @@ export class ActorsMcpServer {
                 failure_detail: failureDetail,
                 ...buildActorFields(actorName, actorId),
             };
-            log.error('Error executing tool for task', {
-                taskId,
-                toolName: tool.name,
-                toolStatus,
-                mcpSessionId,
-                failureCategory: callDiagnostics.failure_category,
-                failureHttpStatus: callDiagnostics.failure_http_status,
-                actorName: callDiagnostics.actor_name,
-                error,
-            });
+            // Log level follows the already-classified toolStatus:
+            //   SOFT_FAIL (e.g. 402/403 user quota, client-side issues) → softFail
+            //   FAILED/ABORTED/other                                    → error
+            if (toolStatus === TOOL_STATUS.SOFT_FAIL) {
+                // Mezmo promotes on "error" in message/keys — use errMessage key, sanitized.
+                const errMessage = (error instanceof Error ? error.message : String(error))
+                    .replace(/ error:/gi, ' failure:');
+                log.softFail('Tool execution soft-failed for task', {
+                    taskId,
+                    toolName: tool.name,
+                    toolStatus,
+                    mcpSessionId,
+                    failureCategory: callDiagnostics.failure_category,
+                    failureHttpStatus: callDiagnostics.failure_http_status,
+                    actorName: callDiagnostics.actor_name,
+                    errMessage,
+                });
+            } else {
+                log.error('Error executing tool for task', {
+                    taskId,
+                    toolName: tool.name,
+                    toolStatus,
+                    mcpSessionId,
+                    failureCategory: callDiagnostics.failure_category,
+                    failureHttpStatus: callDiagnostics.failure_http_status,
+                    actorName: callDiagnostics.actor_name,
+                    error,
+                });
+            }
             const userText = getToolCallErrorUserText(tool.name, error);
 
             // Check if task was cancelled before storing result

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -66,11 +66,14 @@ function getMcpErrorCode(error: unknown): number | undefined {
  */
 export function logHttpError<T extends object>(error: unknown, message: string, data?: T): void {
     const statusCode = getHttpStatusCode(error);
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    const rawErrorMessage = error instanceof Error ? error.message : String(error);
+    // Mezmo (logDNA) promotes log entries to error level when message/keys contain "error".
+    // Sanitize for softFail paths (see CONTRIBUTING.md § Logging → Mezmo promotion rule).
+    const softErrMessage = rawErrorMessage.replace(/ error:/gi, ' failure:');
 
     if (statusCode !== undefined && statusCode < 500) {
         // HTTP client errors (< 500) - softFail without stack trace
-        log.softFail(message, { errMessage: errorMessage, statusCode, ...data });
+        log.softFail(message, { errMessage: softErrMessage, statusCode, ...data });
         return;
     }
     if (statusCode !== undefined && statusCode >= 500) {
@@ -83,7 +86,7 @@ export function logHttpError<T extends object>(error: unknown, message: string, 
     const mcpErrorCode = getMcpErrorCode(error);
     if (mcpErrorCode !== undefined) {
         if (SOFT_MCP_ERROR_CODES.has(mcpErrorCode)) {
-            log.softFail(message, { errMessage: errorMessage, mcpErrorCode, ...data });
+            log.softFail(message, { errMessage: softErrMessage, mcpErrorCode, ...data });
         } else {
             const errorObj = error instanceof Error ? error : new Error(String(error));
             log.exception(errorObj, message, { mcpErrorCode, ...data });

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,3 +1,5 @@
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+
 import log from '@apify/log';
 
 /**
@@ -29,8 +31,34 @@ export function getHttpStatusCode(error: unknown): number | undefined {
 }
 
 /**
- * Logs HTTP errors based on status code, following apify-core pattern.
- * Uses `softFail` for status < 500 (API client errors) and `exception` for status >= 500 (API server errors).
+ * Client/caller faults and transient transport conditions that shouldn't trigger error alerts.
+ * Anything else in the JSON-RPC reserved range (-32768..-32000) is treated as a server fault.
+ */
+const SOFT_MCP_ERROR_CODES: ReadonlySet<number> = new Set([
+    ErrorCode.ParseError,
+    ErrorCode.InvalidRequest,
+    ErrorCode.MethodNotFound,
+    ErrorCode.InvalidParams,
+    ErrorCode.ConnectionClosed,
+    ErrorCode.RequestTimeout,
+]);
+
+/**
+ * Extract a JSON-RPC error code from an `McpError`-shaped object.
+ * Returns `undefined` if the `code` field is absent or outside the JSON-RPC reserved range.
+ */
+function getMcpErrorCode(error: unknown): number | undefined {
+    if (typeof error !== 'object' || error === null || !('code' in error)) return undefined;
+    const { code } = error as { code?: unknown };
+    if (typeof code === 'number' && code >= -32768 && code <= -32000) return code;
+    return undefined;
+}
+
+/**
+ * Logs HTTP or MCP errors at the appropriate level:
+ * - Client errors (HTTP < 500, or JSON-RPC client/transient codes) → softFail (no stack).
+ * - Server errors (HTTP >= 500, or JSON-RPC server codes) → exception (with stack).
+ * - Anything unclassifiable → error.
  *
  * @param error - The error object
  * @param message - The log message
@@ -41,16 +69,30 @@ export function logHttpError<T extends object>(error: unknown, message: string, 
     const errorMessage = error instanceof Error ? error.message : String(error);
 
     if (statusCode !== undefined && statusCode < 500) {
-        // Client errors (< 500) - log as softFail without stack trace
+        // HTTP client errors (< 500) - softFail without stack trace
         log.softFail(message, { errMessage: errorMessage, statusCode, ...data });
-    } else if (statusCode !== undefined && statusCode >= 500) {
-        // Server errors (>= 500) - log as exception with full error (includes stack trace)
+        return;
+    }
+    if (statusCode !== undefined && statusCode >= 500) {
+        // HTTP server errors (>= 500) - exception with full error (includes stack trace)
         const errorObj = error instanceof Error ? error : new Error(String(error));
         log.exception(errorObj, message, { statusCode, ...data });
-    } else {
-        // No status code available - log as error
-        log.error(message, { error, ...data });
+        return;
     }
+
+    const mcpErrorCode = getMcpErrorCode(error);
+    if (mcpErrorCode !== undefined) {
+        if (SOFT_MCP_ERROR_CODES.has(mcpErrorCode)) {
+            log.softFail(message, { errMessage: errorMessage, mcpErrorCode, ...data });
+        } else {
+            const errorObj = error instanceof Error ? error : new Error(String(error));
+            log.exception(errorObj, message, { mcpErrorCode, ...data });
+        }
+        return;
+    }
+
+    // No status code available - log as error
+    log.error(message, { error, ...data });
 }
 
 const SKYFIRE_PAY_ID_KEY = 'skyfire-pay-id';


### PR DESCRIPTION
## Summary

Three fixes to stop client-side MCP failures from flooding error logs:

- **`logHttpError`** (`src/utils/logging.ts`): recognize `McpError` codes via the SDK's `ErrorCode` enum. Client/transient codes (`ParseError`, `InvalidRequest`, `MethodNotFound`, `InvalidParams`, `ConnectionClosed`, `RequestTimeout`) → softFail without stack. Server codes (`InternalError`, other server-defined) → exception with stack. Previously `McpError.code` (negative JSON-RPC integers) fell outside the HTTP `[100, 600)` check and everything landed at `log.error`.
- **`Server.onerror`** (`src/mcp/server.ts`): also match `"Not connected"` (client disconnected mid-flight — the actual SDK message) alongside `"No connection established"`. The existing narrow check was effectively dead code for the mid-flight disconnect case.
- **`executeToolAndUpdateTask`** (`src/mcp/server.ts`): branch on `toolStatus` — when `SOFT_FAIL` (e.g. 403 quota hits that already self-classify), log as softFail; otherwise `log.error`. Fixes the "Monthly usage hard limit exceeded" entries that logged `toolStatus: SOFT_FAIL` yet landed at ERROR level.

Only the `error`/`softFail` routing changes — `McpError` responses returned to clients are unchanged.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:unit` — all pass (482 tests)
- [ ] After deploy, confirm Mezmo no longer promotes these patterns to error:
  - `"Failed to call MCP tool '<name>' on Actor '<actor>'"` (InvalidParams / MethodNotFound from actors-mcp-server proxy)
  - `"[MCP Error]"` with message `"Failed to send response: Error: Not connected"`
  - `"Error executing tool for task"` with `toolStatus: SOFT_FAIL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)