### PR TITLE
Consolidate MCP references and streamline documentation

### DIFF
--- a/.claude/skills/dig/SKILL.md
+++ b/.claude/skills/dig/SKILL.md
@@ -133,16 +133,12 @@ Present issue content to the user for review before creating. Use `gh issue crea
 
 ## Available resources
 
+For MCP spec URLs, SDK paths, and internal repo location, see [CLAUDE.md § MCP development — references](../../../CLAUDE.md#mcp-development--references).
+
+Dig-specific workflow resources:
+
 | Resource               | Path / URL                                                          | Use for                                                     |
 |------------------------|---------------------------------------------------------------------|-------------------------------------------------------------|
-| **Public repo**        | `.` (this repo root)                                                | Main codebase — tools, widgets, tests                       |
-| **Internal repo**      | `../apify-mcp-server-internal` (if available)                       | Hosted server — assess impact of changes                    |
-| **MCP SDK (types)**    | `node_modules/@modelcontextprotocol/sdk`                            | Protocol types, server/client APIs (compiled only)          |
-| **MCP SDK (source)**   | `../typescript-sdk` (if available)                                  | Examples, tests, full source — faster than GitHub           |
-| **MCP spec**           | `https://modelcontextprotocol.io/specification/2025-11-25`          | Protocol-level features                                     |
-| **MCP Apps SDK (types)** | `node_modules/@modelcontextprotocol/ext-apps`                     | MCP Apps types, React hooks, server helpers (compiled only) |
-| **MCP Apps SDK (source)** | `../ext-apps` (if available)                                     | Examples, tests, spec, full source — faster than GitHub     |
-| **MCP Apps spec**      | `https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx` | MCP Apps extension specification                            |
 | **Dev server (no UI)** | `http://localhost:3001/` / tools: `mcp__apify-dev__*`               | Test tools without widgets                                  |
 | **Dev server (UI)**    | `http://localhost:3001/?ui=true` / tools: `mcp__apify-dev-ui__*`    | Test tools with widget rendering                            |
 | **mcpc stdio**         | `mcpc @stdio tools-call ...` (requires `npm run build`)             | Test tools — no running server needed                       |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,80 +62,32 @@ After completing ANY code change (feature, fix, refactor), you MUST:
 - **Do NOT use `npm run build` for type-checking.** Use `npm run type-check` — it is faster and skips JavaScript output generation. Only use `npm run build` when compiled output is explicitly needed (e.g., before mcpc probing).
 - **Do NOT run integration tests as an agent.** They require a valid `APIFY_TOKEN` and are slow.
 
-## Testing the MCP server end-to-end
+## MCP development — references
 
-After code changes, verify the server works — not just that it compiles. There are two ways:
+Basic references for work on MCP protocol, SDK, and MCP Apps (widgets). Deeper docs live in [res/index.md](./res/index.md).
 
-**1. mcpc** — CLI client, best for scripted/automated verification.
-- Requires `APIFY_TOKEN` in the environment (see [DEVELOPMENT.md](./DEVELOPMENT.md) § *Configuring APIFY_TOKEN*).
-- Requires `npm run build` before each session (mcpc runs `dist/stdio.js`).
-- Discover tools with `mcpc @stdio tools-list`.
-- Test all default tools: `search-actors`, `fetch-actor-details`, `call-actor`, `get-actor-run`, `get-actor-output`, `search-apify-docs`, `fetch-apify-docs`.
+| Resource | Location |
+|---|---|
+| MCP spec | https://modelcontextprotocol.io/specification/2025-11-25 |
+| MCP Apps spec | https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx |
+| MCP SDK (types) | `node_modules/@modelcontextprotocol/sdk` |
+| MCP SDK (source, if cloned) | `../typescript-sdk` |
+| MCP Apps SDK (types) | `node_modules/@modelcontextprotocol/ext-apps` |
+| MCP Apps SDK (source, if cloned) | `../ext-apps` |
+| Internal (hosted) server repo | `../apify-mcp-server-internal` |
 
-```bash
-npm run build
-mcpc connect .mcp.json:stdio @stdio   # first time
-mcpc @stdio restart                    # after code changes
-mcpc @stdio tools-call search-actors keywords:="web scraper"
-```
+**Transport modes and key files:**
+- stdio → `src/stdio.ts`
+- Streamable HTTP and legacy SSE → `src/dev_server.ts`, `src/mcp/server.ts`
 
-**2. Native MCP client** (e.g. Claude Code, Cursor) — the server is already connected and tools are in context.
-- Auth is handled by the user's MCP config (token or OAuth).
-- Tools are already discoverable — just call them directly.
-- Use this when verifying behavior as a real client sees it.
-
-If unsure which approach to use or how to authenticate, ask the user.
-
-See [DEVELOPMENT.md](./DEVELOPMENT.md) for mcpc setup details and examples.
+**Deep-dives in [res/](./res/index.md):** task lifecycle, Server→McpServer refactor, resources analysis, SDK/FastMCP patterns for simplification.
 
 ## Testing
 
-### Running tests
-
-- **Unit tests**: `npm run test:unit` (runs `vitest run tests/unit`)
-- **Integration tests**: `npm run test:integration` (requires build first, requires `APIFY_TOKEN` — humans only)
-
-### Test structure
-
-- `tests/unit/` — unit tests for individual modules
-- `tests/integration/` — integration tests for MCP server functionality
-  - `tests/integration/suite.ts` — **main integration test suite** where all test cases should be added
-  - Other files in this directory set up different transport modes (stdio, SSE, streamable-http) that all use `suite.ts`
-- `tests/helpers.ts` — shared test utilities
-- `tests/const.ts` — test constants
-
-### Test guidelines
-
-- Write tests for new features and bug fixes
-- Use descriptive test names that explain what is being tested
-- Follow existing test patterns in the codebase
-- Ensure all tests pass before submitting a PR
-
-### Adding integration tests
-
-**IMPORTANT**: Add integration test cases to `tests/integration/suite.ts`, NOT as separate test files.
-
-`suite.ts` exports `createIntegrationTestsSuite()`, used by all transport modes (stdio, SSE, streamable-http). Adding tests here ensures they run across all transport types.
-
-**How to add a test case:**
-1. Open `tests/integration/suite.ts`
-2. Add your test case inside the `describe` block
-3. Use `it()` or `it.runIf()` for conditional tests
-4. Use `client = await createClientFn(options)` to create the test client
-5. Always call `await client.close()` when done
-
-**Example:**
-```typescript
-it('should do something awesome', async () => {
-    client = await createClientFn({ tools: ['actors'] });
-    const result = await client.callTool({
-        name: HelperTools.SOME_TOOL,
-        arguments: { /* ... */ },
-    });
-    expect(result.content).toBeDefined();
-    await client.close();
-});
-```
+- Unit tests: `npm run test:unit`
+- Integration tests: requires `APIFY_TOKEN` and `npm run build` — humans only. See [DEVELOPMENT.md § Testing](./DEVELOPMENT.md#testing).
+- Add integration test cases to `tests/integration/suite.ts` — shared across all transport modes.
+- End-to-end probing with mcpc: see [DEVELOPMENT.md § Live probing with mcpc](./DEVELOPMENT.md#live-probing-with-mcpc).
 
 ## External dependencies
 

--- a/res/index.md
+++ b/res/index.md
@@ -2,15 +2,9 @@
 
 This directory contains useful documents and insights about the repository architecture, design decisions, and implementation details that don't belong in code comments or JSDoc.
 
-## Files
+Basic MCP references (spec URLs, SDK paths, transport mode → file pointers) live in [CLAUDE.md § MCP development — references](../CLAUDE.md#mcp-development--references). The MCP docs below are the deep-dives.
 
-### [algolia.md](./algolia.md)
-Technical analysis of Algolia search API responses for each documentation source.
-- Data structure overview for each doc source (apify, crawlee-js, crawlee-py)
-- Field availability patterns (content, hierarchy, anchors)
-- Example response payloads
-- Recommendations for response processing logic
-- **Use case**: Understand what data is actually returned by Algolia to inform simplification decisions
+## MCP protocol & SDK
 
 ### [mcp_server_refactor_analysis.md](./mcp_server_refactor_analysis.md)
 Implementation plan for migrating from low-level `Server` to high-level `McpServer` API.
@@ -65,6 +59,8 @@ Analysis of patterns from the **official TypeScript MCP SDK** and **FastMCP** fr
 - Benefits for each pattern
 - **Use case**: Reference for incremental codebase improvements
 
+## MCP Apps / widgets
+
 ### [web-widget-bundle-size.md](./web-widget-bundle-size.md)
 Notes on keeping widget bundles small (narrow `@apify/ui-library` imports, markdown stack cost).
 - **Use case**: When changing widget dependencies or markdown rendering, re-measure bundle impact
@@ -72,6 +68,16 @@ Notes on keeping widget bundles small (narrow `@apify/ui-library` imports, markd
 ### [chatgpt-app-submission.md](./chatgpt-app-submission.md)
 Checklist and notes for ChatGPT MCP Apps store submission (verify line references against current source before relying on them).
 - **Use case**: Submission prep and audits
+
+## Other
+
+### [algolia.md](./algolia.md)
+Technical analysis of Algolia search API responses for each documentation source.
+- Data structure overview for each doc source (apify, crawlee-js, crawlee-py)
+- Field availability patterns (content, hierarchy, anchors)
+- Example response payloads
+- Recommendations for response processing logic
+- **Use case**: Understand what data is actually returned by Algolia to inform simplification decisions
 
 ---
 


### PR DESCRIPTION
## Summary
Reorganized and consolidated MCP protocol/SDK references across documentation files to reduce duplication and improve discoverability. Moved foundational MCP references to a centralized location in CLAUDE.md and updated cross-references throughout the codebase.

## Key changes

- **CLAUDE.md**: Replaced detailed "Testing the MCP server end-to-end" section with a concise "MCP development — references" table containing:
  - MCP spec and MCP Apps spec URLs
  - SDK type and source paths (local and node_modules)
  - Transport mode → file pointers (stdio, HTTP, SSE)
  - Link to deep-dive docs in `res/index.md`

- **res/index.md**: Reorganized file structure with new sections:
  - Added header note directing readers to CLAUDE.md for basic MCP references
  - Grouped docs into "MCP protocol & SDK", "MCP Apps / widgets", and "Other" sections
  - Moved `algolia.md` to "Other" section (non-MCP resource)
  - Preserved all deep-dive documentation with updated context

- **.claude/skills/dig/SKILL.md**: Simplified resource table by:
  - Removing redundant MCP SDK/spec entries (now in CLAUDE.md)
  - Adding header note with link to centralized MCP references
  - Keeping only dig-specific workflow resources (dev servers, mcpc)

- **Testing guidance**: Condensed test documentation in CLAUDE.md to brief pointers with cross-references to DEVELOPMENT.md for detailed instructions

## Rationale
This change eliminates scattered MCP reference information across multiple files, making it easier for developers to find authoritative URLs and paths in one place while preserving detailed implementation guides in their original locations.

https://claude.ai/code/session_01GcfVhaVo8NYpYUe52Q3SBR