### PR TITLE
fix: Add actor id data to actor info

### DIFF
--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -101,6 +101,7 @@ export const actorInfoSchema = {
     properties: {
         title: { type: 'string', description: 'Actor title' },
         url: { type: 'string', description: 'Actor URL' },
+        id: { type: 'string', description: 'Actor ID' },
         fullName: { type: 'string', description: 'Full Actor name (username/name)' },
         developer: developerSchema,
         description: { type: 'string', description: 'Actor description' },
@@ -121,7 +122,7 @@ export const actorInfoSchema = {
         modifiedAt: { type: 'string', description: 'Last modification date' },
         isDeprecated: { type: 'boolean', description: 'Whether the Actor is deprecated' },
     },
-    required: ['url', 'fullName', 'developer', 'description', 'categories', 'pricing'],
+    required: ['url', 'id', 'fullName', 'developer', 'description', 'categories', 'pricing'],
 };
 
 /**

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -122,7 +122,7 @@ export const actorInfoSchema = {
         modifiedAt: { type: 'string', description: 'Last modification date' },
         isDeprecated: { type: 'boolean', description: 'Whether the Actor is deprecated' },
     },
-    required: ['url', 'id', 'fullName', 'developer', 'description', 'categories', 'pricing'],
+    required: ['url', 'id', 'fullName', 'developer', 'description', 'categories', 'pricing', 'isDeprecated'],
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -576,6 +576,7 @@ export type ActorsMcpServerOptions = {
 export type StructuredActorCard = {
     title?: string;
     url: string;
+    id: string;
     fullName: string;
     pictureUrl?: string;
     developer: {

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -227,6 +227,7 @@ export function formatActorToStructuredCard(
     return {
         title: data.title,
         url: data.actorUrl,
+        id: actor.id,
         fullName: data.actorFullName,
         pictureUrl: data.pictureUrl,
         developer: data.developer,


### PR DESCRIPTION
The chat reponse in console has links that point to apify.com. If I don't receive ids in any way, I'm afraid I can't do anything.

So I want to receive actor ids in the structured data, then prompt the console AI chat to use that id to generate the links and ignore the apify.com url that is sent. I hope this will work!