### PR TITLE
refactor: Deduplicate fetch-actor-details handler logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -473,7 +473,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -1802,7 +1801,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2379,7 +2377,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2402,7 +2399,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
       "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -2415,7 +2411,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -2512,7 +2507,6 @@
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -4564,7 +4558,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
       "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4710,7 +4703,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -4777,7 +4769,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6107,7 +6098,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -6472,7 +6462,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7838,7 +7827,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8877,7 +8865,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9556,7 +9543,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -10586,7 +10572,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11819,7 +11804,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -11956,7 +11940,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11971,7 +11954,6 @@
       "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.58.1",
         "@typescript-eslint/parser": "8.58.1",
@@ -12122,7 +12104,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12475,7 +12456,6 @@
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -12568,7 +12548,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -73,7 +73,7 @@ export const fetchActorDetailsMetadata: Omit<HelperTool, 'call'> = {
  */
 export async function buildFetchActorDetailsResult(
     toolArgs: InternalToolArgs,
-    route: string,
+    route: HelperTools.ACTOR_GET_DETAILS | HelperTools.ACTOR_GET_DETAILS_INTERNAL,
 ): Promise<ReturnType<typeof buildMCPResponse>> {
     const { args, apifyToken, apifyMcpServer, mcpSessionId } = toolArgs;
     const parsed = fetchActorDetailsToolArgsSchema.parse(args);

--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -1,13 +1,21 @@
 import { z } from 'zod';
 
+import { ApifyClient } from '../../apify_client.js';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
-import type { HelperTool, ToolInputSchema } from '../../types.js';
+import type { HelperTool, InternalToolArgs, ToolInputSchema } from '../../types.js';
 import {
     actorDetailsOutputOptionsSchema,
+    buildActorDetailsTextResponse,
+    buildActorNotFoundResponse,
+    buildCardOptions,
+    fetchActorDetails,
+    resolveOutputOptions,
 } from '../../utils/actor_details.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
 import { actorDetailsOutputSchema } from '../structured_output_schemas.js';
+import { fixActorNameInputAndLog } from './actor_tools_factory.js';
 
 /**
  * Zod schema for fetch-actor-details arguments — shared between default and openai variants.
@@ -58,3 +66,45 @@ export const fetchActorDetailsMetadata: Omit<HelperTool, 'call'> = {
         openWorldHint: false,
     },
 };
+
+/**
+ * Shared handler for default and internal fetch-actor-details variants.
+ * Both return the same text + structured response; only the telemetry route differs.
+ */
+export async function buildFetchActorDetailsResult(
+    toolArgs: InternalToolArgs,
+    route: string,
+): Promise<ReturnType<typeof buildMCPResponse>> {
+    const { args, apifyToken, apifyMcpServer, mcpSessionId } = toolArgs;
+    const parsed = fetchActorDetailsToolArgsSchema.parse(args);
+    const actorName = fixActorNameInputAndLog(parsed.actor, { mcpSessionId, route });
+    const apifyClient = new ApifyClient({ token: apifyToken });
+
+    const resolvedOutput = resolveOutputOptions(parsed.output);
+    const cardOptions = buildCardOptions(resolvedOutput);
+
+    const details = await fetchActorDetails(apifyClient, actorName, cardOptions);
+    if (!details) {
+        return buildActorNotFoundResponse(actorName);
+    }
+
+    const actorOutputSchema = resolvedOutput.outputSchema
+        ? await apifyMcpServer.actorStore?.getActorOutputSchemaAsTypeObject(actorName).catch(() => null)
+        : undefined;
+
+    // NOTE: Data duplication between texts and structuredContent is intentional and required.
+    // Some MCP clients only read text content, while others only read structured content.
+    const { texts, structuredContent } = await buildActorDetailsTextResponse({
+        actorName,
+        details,
+        output: resolvedOutput,
+        cardOptions,
+        apifyClient,
+        apifyToken,
+        actorOutputSchema,
+        paymentProvider: apifyMcpServer?.options.paymentProvider,
+        mcpSessionId,
+    });
+
+    return buildMCPResponse({ texts, structuredContent });
+}

--- a/src/tools/default/fetch_actor_details.ts
+++ b/src/tools/default/fetch_actor_details.ts
@@ -1,3 +1,4 @@
+import { HelperTools } from '../../const.js';
 import type { ToolEntry } from '../../types.js';
 import {
     buildFetchActorDetailsResult,
@@ -10,5 +11,5 @@ import {
  */
 export const defaultFetchActorDetails: ToolEntry = Object.freeze({
     ...fetchActorDetailsMetadata,
-    call: async (toolArgs) => buildFetchActorDetailsResult(toolArgs, 'fetch-actor-details'),
+    call: async (toolArgs) => buildFetchActorDetailsResult(toolArgs, HelperTools.ACTOR_GET_DETAILS),
 } as const);

--- a/src/tools/default/fetch_actor_details.ts
+++ b/src/tools/default/fetch_actor_details.ts
@@ -1,17 +1,7 @@
-import { ApifyClient } from '../../apify_client.js';
-import type { InternalToolArgs, ToolEntry } from '../../types.js';
+import type { ToolEntry } from '../../types.js';
 import {
-    buildActorDetailsTextResponse,
-    buildActorNotFoundResponse,
-    buildCardOptions,
-    fetchActorDetails,
-    resolveOutputOptions,
-} from '../../utils/actor_details.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
-import { fixActorNameInputAndLog } from '../core/actor_tools_factory.js';
-import {
+    buildFetchActorDetailsResult,
     fetchActorDetailsMetadata,
-    fetchActorDetailsToolArgsSchema,
 } from '../core/fetch_actor_details_common.js';
 
 /**
@@ -20,39 +10,5 @@ import {
  */
 export const defaultFetchActorDetails: ToolEntry = Object.freeze({
     ...fetchActorDetailsMetadata,
-    call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyMcpServer, mcpSessionId } = toolArgs;
-        const parsedArgs = fetchActorDetailsToolArgsSchema.parse(args);
-        const actorName = fixActorNameInputAndLog(parsedArgs.actor, { mcpSessionId, route: 'fetch-actor-details' });
-        const apifyClient = new ApifyClient({ token: apifyToken });
-
-        const resolvedOutput = resolveOutputOptions(parsedArgs.output);
-        const cardOptions = buildCardOptions(resolvedOutput);
-
-        const details = await fetchActorDetails(apifyClient, actorName, cardOptions);
-        if (!details) {
-            return buildActorNotFoundResponse(actorName);
-        }
-
-        // Fetch output schema from ActorStore if available and requested
-        const actorOutputSchema = resolvedOutput.outputSchema
-            ? await apifyMcpServer.actorStore?.getActorOutputSchemaAsTypeObject(actorName).catch(() => null)
-            : undefined;
-
-        // NOTE: Data duplication between texts and structuredContent is intentional and required.
-        // Some MCP clients only read text content, while others only read structured content.
-        const { texts, structuredContent: responseStructuredContent } = await buildActorDetailsTextResponse({
-            actorName,
-            details,
-            output: resolvedOutput,
-            cardOptions,
-            apifyClient,
-            apifyToken,
-            actorOutputSchema,
-            paymentProvider: apifyMcpServer?.options.paymentProvider,
-            mcpSessionId,
-        });
-
-        return buildMCPResponse({ texts, structuredContent: responseStructuredContent });
-    },
+    call: async (toolArgs) => buildFetchActorDetailsResult(toolArgs, 'fetch-actor-details'),
 } as const);

--- a/src/tools/openai/fetch_actor_details.ts
+++ b/src/tools/openai/fetch_actor_details.ts
@@ -1,3 +1,5 @@
+import dedent from 'dedent';
+
 import { ApifyClient } from '../../apify_client.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
@@ -42,13 +44,13 @@ export const openaiFetchActorDetails: ToolEntry = Object.freeze({
             actorDetails: processedStructuredContent.actorDetails,
         };
 
-        const texts = [`
-# Actor information:
-- **Actor:** ${actorName}
-- **URL:** ${actorUrl}
+        const texts = [dedent`
+            # Actor information:
+            - **Actor:** ${actorName}
+            - **URL:** ${actorUrl}
 
-An interactive widget has been rendered with detailed Actor information.
-`];
+            An interactive widget has been rendered with detailed Actor information.
+        `];
 
         const widgetConfig = getWidgetConfig(WIDGET_URIS.SEARCH_ACTORS);
         return buildMCPResponse({

--- a/src/tools/openai/fetch_actor_details_internal.ts
+++ b/src/tools/openai/fetch_actor_details_internal.ts
@@ -37,5 +37,5 @@ export const fetchActorDetailsInternalTool: ToolEntry = Object.freeze({
         idempotentHint: true,
         openWorldHint: false,
     },
-    call: async (toolArgs) => buildFetchActorDetailsResult(toolArgs, 'fetch-actor-details-internal'),
+    call: async (toolArgs) => buildFetchActorDetailsResult(toolArgs, HelperTools.ACTOR_GET_DETAILS_INTERNAL),
 } as const);

--- a/src/tools/openai/fetch_actor_details_internal.ts
+++ b/src/tools/openai/fetch_actor_details_internal.ts
@@ -1,47 +1,35 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
-import { ApifyClient } from '../../apify_client.js';
 import { HelperTools } from '../../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import {
-    actorDetailsOutputOptionsSchema,
-    buildActorDetailsTextResponse,
-    buildActorNotFoundResponse,
-    buildCardOptions,
-    fetchActorDetails,
-    resolveOutputOptions,
-} from '../../utils/actor_details.js';
+import type { ToolEntry, ToolInputSchema } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
-import { fixActorNameInputAndLog } from '../core/actor_tools_factory.js';
+import {
+    buildFetchActorDetailsResult,
+    fetchActorDetailsToolArgsSchema,
+} from '../core/fetch_actor_details_common.js';
 import { actorDetailsOutputSchema } from '../structured_output_schemas.js';
-
-const fetchActorDetailsInternalArgsSchema = z.object({
-    actor: z.string()
-        .min(1)
-        .describe(`Actor ID or full name in the format "username/name", e.g., "apify/rag-web-browser".`),
-    output: actorDetailsOutputOptionsSchema.optional()
-        .describe('Specify which information to include in the response to save tokens.'),
-});
 
 export const fetchActorDetailsInternalTool: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.ACTOR_GET_DETAILS_INTERNAL,
-    description: `Fetch Actor details with flexible output options (UI mode internal tool).
+    description: dedent`
+        Fetch Actor details with flexible output options (UI mode internal tool).
 
-This tool is available because the LLM is operating in UI mode. Use it for internal lookups
-where data presentation to the user is NOT needed - this tool does NOT render a widget.
+        This tool is available because the LLM is operating in UI mode. Use it for internal lookups
+        where data presentation to the user is NOT needed - this tool does NOT render a widget.
 
-Use 'output' parameter with boolean flags to control returned information:
-- Default: Fields: description, stats, pricing, rating, metadata, inputSchema, readme - except mcpTools
-- Selective: Set desired fields to true to save tokens (e.g., output: { inputSchema: true, readme: false })
-- Common patterns: inputSchema only for execution prep, readme + inputSchema for documentation, etc.
+        Use 'output' parameter with boolean flags to control returned information:
+        - Default: Fields: description, stats, pricing, rating, metadata, inputSchema, readme - except mcpTools
+        - Selective: Set desired fields to true to save tokens (e.g., output: { inputSchema: true, readme: false })
+        - Common patterns: inputSchema only for execution prep, readme + inputSchema for documentation, etc.
 
-Use this instead of fetch-actor-details when you need Actor information to prepare execution
-but the user did NOT explicitly ask for Actor details presentation.`,
-    inputSchema: z.toJSONSchema(fetchActorDetailsInternalArgsSchema) as ToolInputSchema,
+        Use this instead of fetch-actor-details when you need Actor information to prepare execution
+        but the user did NOT explicitly ask for Actor details presentation.
+    `,
+    inputSchema: z.toJSONSchema(fetchActorDetailsToolArgsSchema) as ToolInputSchema,
     outputSchema: actorDetailsOutputSchema,
-    ajvValidate: compileSchema(z.toJSONSchema(fetchActorDetailsInternalArgsSchema)),
+    ajvValidate: compileSchema(z.toJSONSchema(fetchActorDetailsToolArgsSchema)),
     annotations: {
         title: 'Fetch Actor details internal',
         readOnlyHint: true,
@@ -49,37 +37,5 @@ but the user did NOT explicitly ask for Actor details presentation.`,
         idempotentHint: true,
         openWorldHint: false,
     },
-    call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyMcpServer, mcpSessionId } = toolArgs;
-        const parsed = fetchActorDetailsInternalArgsSchema.parse(args);
-        const actorName = fixActorNameInputAndLog(parsed.actor, { mcpSessionId, route: 'fetch-actor-details-internal' });
-        const apifyClient = new ApifyClient({ token: apifyToken });
-
-        const resolvedOutput = resolveOutputOptions(parsed.output);
-        const cardOptions = buildCardOptions(resolvedOutput);
-
-        const details = await fetchActorDetails(apifyClient, actorName, cardOptions);
-        if (!details) {
-            return buildActorNotFoundResponse(actorName);
-        }
-
-        // Fetch output schema from ActorStore if available and requested
-        const actorOutputSchema = resolvedOutput.outputSchema
-            ? await apifyMcpServer.actorStore?.getActorOutputSchemaAsTypeObject(actorName).catch(() => null)
-            : undefined;
-
-        const { texts, structuredContent } = await buildActorDetailsTextResponse({
-            actorName,
-            details,
-            output: resolvedOutput,
-            cardOptions,
-            apifyClient,
-            apifyToken,
-            actorOutputSchema,
-            paymentProvider: apifyMcpServer?.options.paymentProvider,
-            mcpSessionId,
-        });
-
-        return buildMCPResponse({ texts, structuredContent });
-    },
+    call: async (toolArgs) => buildFetchActorDetailsResult(toolArgs, 'fetch-actor-details-internal'),
 } as const);


### PR DESCRIPTION
> **PR chain:** **#690 (you are here)** → #691 → #692 → #693 → #694

## Summary

Mirrors the `search-actors` refactor pattern (PRs #651, #659, #660) for `fetch-actor-details`.

- Extract `buildFetchActorDetailsResult()` into `fetch_actor_details_common.ts` — removes duplicated handler bodies in `default/fetch_actor_details.ts` and `openai/fetch_actor_details_internal.ts`
- Apply `dedent` to multiline strings in both openai variants
- Remove duplicated `fetchActorDetailsInternalArgsSchema` (was character-for-character identical to the shared schema)
- Type the shared `route` parameter as `HelperTools.ACTOR_GET_DETAILS | HelperTools.ACTOR_GET_DETAILS_INTERNAL` (no magic strings)

Net -56 lines of source. No behavior change.

The openai variant (`openai/fetch_actor_details.ts`) is intentionally left alone — it uses `processActorDetailsForResponse` for widget-formatted output, a genuinely different response path.

## Test plan
- [x] \`npm run type-check\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run test:unit\` — all 482 tests pass
- [x] Integration tests (requires APIFY_TOKEN, human-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

