### PR TITLE
refactor: Simplify buildActorDetailsTextResponse signature

### DIFF
--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -10,6 +10,7 @@ import {
     buildActorNotFoundResponse,
     buildCardOptions,
     fetchActorDetails,
+    getMcpToolsMessage,
     resolveOutputOptions,
 } from '../../utils/actor_details.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -81,9 +82,7 @@ export async function buildFetchActorDetailsResult(
     const apifyClient = new ApifyClient({ token: apifyToken });
 
     const resolvedOutput = resolveOutputOptions(parsed.output);
-    const cardOptions = buildCardOptions(resolvedOutput);
-
-    const details = await fetchActorDetails(apifyClient, actorName, cardOptions);
+    const details = await fetchActorDetails(apifyClient, actorName, buildCardOptions(resolvedOutput));
     if (!details) {
         return buildActorNotFoundResponse(actorName);
     }
@@ -91,19 +90,17 @@ export async function buildFetchActorDetailsResult(
     const actorOutputSchema = resolvedOutput.outputSchema
         ? await apifyMcpServer.actorStore?.getActorOutputSchemaAsTypeObject(actorName).catch(() => null)
         : undefined;
+    const mcpToolsMessage = resolvedOutput.mcpTools
+        ? await getMcpToolsMessage(actorName, apifyClient, apifyToken, apifyMcpServer?.options.paymentProvider, mcpSessionId)
+        : undefined;
 
     // NOTE: Data duplication between texts and structuredContent is intentional and required.
     // Some MCP clients only read text content, while others only read structured content.
-    const { texts, structuredContent } = await buildActorDetailsTextResponse({
-        actorName,
+    const { texts, structuredContent } = buildActorDetailsTextResponse({
         details,
         output: resolvedOutput,
-        cardOptions,
-        apifyClient,
-        apifyToken,
         actorOutputSchema,
-        paymentProvider: apifyMcpServer?.options.paymentProvider,
-        mcpSessionId,
+        mcpToolsMessage,
     });
 
     return buildMCPResponse({ texts, structuredContent });

--- a/src/tools/openai/fetch_actor_details.ts
+++ b/src/tools/openai/fetch_actor_details.ts
@@ -29,9 +29,7 @@ export const openaiFetchActorDetails: ToolEntry = Object.freeze({
         const actorName = fixActorNameInputAndLog(parsed.actor, { mcpSessionId, route: 'fetch-actor-details' });
         const apifyClient = new ApifyClient({ token: apifyToken });
 
-        const resolvedOutput = resolveOutputOptions(parsed.output);
-        const cardOptions = buildCardOptions(resolvedOutput);
-
+        const cardOptions = buildCardOptions(resolveOutputOptions(parsed.output));
         const details = await fetchActorDetails(apifyClient, actorName, cardOptions);
         if (!details) {
             return buildActorNotFoundResponse(actorName);

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -198,13 +198,15 @@ export const actorDetailsOutputDefaults = {
     mcpTools: false,
 };
 
+export type ResolvedOutputOptions = typeof actorDetailsOutputDefaults;
+
 /**
  * Resolve output options with smart defaults.
  * If output is undefined/empty, returns defaults.
  * If any property is explicitly set, undefined properties are treated as false.
  */
-export function resolveOutputOptions(output?: z.infer<typeof actorDetailsOutputOptionsSchema>) {
-    // Check if output has any explicit true/false values
+export function resolveOutputOptions(output?: z.infer<typeof actorDetailsOutputOptionsSchema>): ResolvedOutputOptions {
+    // Check if the output has any explicit true/false values
     const hasExplicitOptions = output && Object.values(output).some((v) => v !== undefined);
 
     if (!hasExplicitOptions) {
@@ -304,45 +306,29 @@ You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
 
 /**
  * Build text and structured response for actor details.
- * Handles all resolved output options: description, stats, readme, inputSchema, outputSchema, mcpTools.
- * All output properties should be boolean (resolved via resolveOutputOptions).
+ * Pure/sync: the caller pre-resolves `mcpToolsMessage` when `output.mcpTools` is true.
  */
-export async function buildActorDetailsTextResponse(options: {
-    actorName: string;
+export function buildActorDetailsTextResponse(options: {
     details: ActorDetailsResult;
-    output: {
-        description: boolean;
-        stats: boolean;
-        pricing: boolean;
-        rating: boolean;
-        metadata: boolean;
-        readme: boolean;
-        inputSchema: boolean;
-        outputSchema: boolean;
-        mcpTools: boolean;
-    };
-    cardOptions: ActorCardOptions;
-    apifyClient: ApifyClient;
-    apifyToken: string;
+    output: ResolvedOutputOptions;
     actorOutputSchema?: Record<string, unknown> | null;
-    paymentProvider?: PaymentProvider;
-    mcpSessionId?: string;
-}): Promise<{
+    mcpToolsMessage?: string;
+}): {
     texts: string[];
     structuredContent: Record<string, unknown>;
-}> {
-    const { actorName, details, output, cardOptions, apifyClient, apifyToken, actorOutputSchema, paymentProvider, mcpSessionId } = options;
+} {
+    const { details, output, actorOutputSchema, mcpToolsMessage } = options;
 
     const actorUrl = `https://apify.com/${details.actorInfo.username}/${details.actorInfo.name}`;
 
     const texts: string[] = [];
 
     // Build actor card only if any card section is requested
-    const needsCard = cardOptions.includeDescription
-        || cardOptions.includeStats
-        || cardOptions.includePricing
-        || cardOptions.includeRating
-        || cardOptions.includeMetadata;
+    const needsCard = output.description
+        || output.stats
+        || output.pricing
+        || output.rating
+        || output.metadata;
 
     if (needsCard) {
         texts.push(`# Actor information\n${details.actorCard}`);
@@ -369,10 +355,8 @@ export async function buildActorDetailsTextResponse(options: {
         }
     }
 
-    // Handle MCP tools
-    if (output.mcpTools) {
-        const message = await getMcpToolsMessage(actorName, apifyClient, apifyToken, paymentProvider, mcpSessionId);
-        texts.push(message);
+    if (mcpToolsMessage) {
+        texts.push(mcpToolsMessage);
     }
 
     // Build structured content


### PR DESCRIPTION
> **PR chain:** #690 → **#691 (you are here)** → #692 → #693 → #694

Follow-up to #690.

## Summary
- Reduce `buildActorDetailsTextResponse` from 9 params to 4 — make it pure/sync
- Caller pre-resolves \`mcpToolsMessage\` when \`output.mcpTools\` is true, removing the \`apifyClient\`/\`apifyToken\`/\`paymentProvider\`/\`mcpSessionId\`/\`actorName\` bleed-through
- Drop redundant \`cardOptions\` param (derivable from \`output\`)
- Extract \`ResolvedOutputOptions\` type from \`actorDetailsOutputDefaults\`
- Collapse two trivial lines in \`openai/fetch_actor_details.ts\` (\`resolvedOutput\` was only used once)

No behavior change.

## Test plan
- [x] \`npm run type-check\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run test:unit\` — all 482 tests pass
- [x] Integration tests (requires APIFY_TOKEN, human-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

