### PR TITLE
refactor: Colocate fetch-actor-details schemas and response builders

### DIFF
--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -1,22 +1,79 @@
 import { z } from 'zod';
 
 import { ApifyClient } from '../../apify_client.js';
-import { HelperTools } from '../../const.js';
+import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { HelperTool, InternalToolArgs, ToolInputSchema } from '../../types.js';
 import {
-    actorDetailsOutputOptionsSchema,
-    buildActorDetailsTextResponse,
-    buildActorNotFoundResponse,
+    type ActorDetailsResult,
     buildCardOptions,
     fetchActorDetails,
     getMcpToolsMessage,
-    resolveOutputOptions,
+    resolveReadmeContent,
+    typeObjectToString,
 } from '../../utils/actor_details.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { actorDetailsOutputSchema } from '../structured_output_schemas.js';
 import { fixActorNameInputAndLog } from './actor_tools_factory.js';
+
+/**
+ * Shared schema for actor details output options.
+ *
+ * Behavior:
+ * - If output is undefined or empty object: use defaults (all true except mcpTools and outputSchema)
+ * - If any property is explicitly set: only include sections with explicit true values
+ */
+export const actorDetailsOutputOptionsSchema = z.object({
+    description: z.boolean().optional().describe('Include Actor description text only.'),
+    stats: z.boolean().optional().describe('Include usage statistics (users, runs, success rate).'),
+    pricing: z.boolean().optional().describe('Include pricing model and costs.'),
+    rating: z.boolean().optional().describe('Include user rating (out of 5 stars).'),
+    metadata: z.boolean().optional().describe('Include developer, categories, last modified date, and deprecation status.'),
+    inputSchema: z.boolean().optional().describe('Include required input parameters schema.'),
+    readme: z.boolean().optional().describe('Include Actor README documentation (summary when available, full otherwise).'),
+    outputSchema: z.boolean().optional().describe('Include inferred output schema from recent successful runs (TypeScript type).'),
+    mcpTools: z.boolean().optional().describe('List available tools (only for MCP server Actors).'),
+});
+
+export const actorDetailsOutputDefaults = {
+    description: true,
+    stats: true,
+    pricing: true,
+    rating: true,
+    metadata: true,
+    inputSchema: true,
+    readme: true,
+    outputSchema: false,
+    mcpTools: false,
+};
+
+export type ResolvedOutputOptions = typeof actorDetailsOutputDefaults;
+
+/**
+ * Resolve output options with smart defaults.
+ * If output is undefined/empty, returns defaults.
+ * If any property is explicitly set, undefined properties are treated as false.
+ */
+export function resolveOutputOptions(output?: z.infer<typeof actorDetailsOutputOptionsSchema>): ResolvedOutputOptions {
+    const hasExplicitOptions = output && Object.values(output).some((v) => v !== undefined);
+
+    if (!hasExplicitOptions) {
+        return actorDetailsOutputDefaults;
+    }
+
+    return {
+        description: output?.description === true,
+        stats: output?.stats === true,
+        pricing: output?.pricing === true,
+        rating: output?.rating === true,
+        metadata: output?.metadata === true,
+        inputSchema: output?.inputSchema === true,
+        readme: output?.readme === true,
+        outputSchema: output?.outputSchema === true,
+        mcpTools: output?.mcpTools === true,
+    };
+}
 
 /**
  * Zod schema for fetch-actor-details arguments — shared between default and openai variants.
@@ -67,6 +124,80 @@ export const fetchActorDetailsMetadata: Omit<HelperTool, 'call'> = {
         openWorldHint: false,
     },
 };
+
+/**
+ * Build error response for when actor is not found.
+ */
+export function buildActorNotFoundResponse(actorName: string): ReturnType<typeof buildMCPResponse> {
+    return buildMCPResponse({
+        texts: [`Actor information for '${actorName}' was not found.
+Please verify Actor ID or name format and ensure that the Actor exists.
+You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.`],
+        isError: true,
+        telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
+    });
+}
+
+/**
+ * Build text and structured response for actor details.
+ * Pure/sync: the caller pre-resolves `mcpToolsMessage` when `output.mcpTools` is true.
+ */
+export function buildActorDetailsTextResponse(options: {
+    details: ActorDetailsResult;
+    output: ResolvedOutputOptions;
+    actorOutputSchema?: Record<string, unknown> | null;
+    mcpToolsMessage?: string;
+}): {
+    texts: string[];
+    structuredContent: Record<string, unknown>;
+} {
+    const { details, output, actorOutputSchema, mcpToolsMessage } = options;
+
+    const actorUrl = `https://apify.com/${details.actorInfo.username}/${details.actorInfo.name}`;
+
+    const texts: string[] = [];
+
+    const needsCard = output.description
+        || output.stats
+        || output.pricing
+        || output.rating
+        || output.metadata;
+
+    if (needsCard) {
+        texts.push(`# Actor information\n${details.actorCard}`);
+    }
+
+    const resolvedReadme = output.readme ? resolveReadmeContent(details) : undefined;
+    if (resolvedReadme) {
+        texts.push(`${resolvedReadme.heading}\n${resolvedReadme.content}`);
+    }
+
+    if (output.inputSchema) {
+        texts.push(`# [Input schema](${actorUrl}/input)\n\`\`\`json\n${JSON.stringify(details.inputSchema)}\n\`\`\``);
+    }
+
+    if (output.outputSchema) {
+        if (actorOutputSchema && Object.keys(actorOutputSchema).length > 0) {
+            const typeString = typeObjectToString(actorOutputSchema);
+            texts.push(`# Output Schema (TypeScript)\nInferred from recent successful runs:\n\`\`\`typescript\ntype ActorOutput = ${typeString}\n\`\`\``);
+        } else {
+            texts.push(`# Output Schema\nNo output schema available. The Actor may not have recent successful runs, or the output structure could not be determined.`);
+        }
+    }
+
+    if (mcpToolsMessage) {
+        texts.push(mcpToolsMessage);
+    }
+
+    const structuredContent: Record<string, unknown> = {
+        actorInfo: needsCard ? details.actorCardStructured : undefined,
+        readme: resolvedReadme?.content,
+        inputSchema: output.inputSchema ? details.inputSchema : undefined,
+        outputSchema: output.outputSchema ? (actorOutputSchema ?? {}) : undefined,
+    };
+
+    return { texts, structuredContent };
+}
 
 /**
  * Shared handler for default and internal fetch-actor-details variants.

--- a/src/tools/openai/fetch_actor_details.ts
+++ b/src/tools/openai/fetch_actor_details.ts
@@ -4,17 +4,17 @@ import { ApifyClient } from '../../apify_client.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
 import {
-    buildActorNotFoundResponse,
     buildCardOptions,
     fetchActorDetails,
     processActorDetailsForResponse,
-    resolveOutputOptions,
 } from '../../utils/actor_details.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { fixActorNameInputAndLog } from '../core/actor_tools_factory.js';
 import {
+    buildActorNotFoundResponse,
     fetchActorDetailsMetadata,
     fetchActorDetailsToolArgsSchema,
+    resolveOutputOptions,
 } from '../core/fetch_actor_details_common.js';
 
 /**

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -1,8 +1,6 @@
 import type { Build } from 'apify-client';
-import { z } from 'zod';
 
 import type { ApifyClient } from '../apify_client.js';
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../const.js';
 import { connectMCPClient } from '../mcp/client.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { filterSchemaProperties, shortenProperties } from '../tools/utils.js';
@@ -11,7 +9,6 @@ import { getActorMcpUrlCached } from './actor.js';
 import { formatActorForWidget, formatActorToActorCard, formatActorToStructuredCard } from './actor_card.js';
 import { searchActorsByKeywords } from './actor_search.js';
 import { logHttpError } from './logging.js';
-import { buildMCPResponse } from './mcp.js';
 
 const ACTOR_DETAILS_PICTURE_SEARCH_LIMIT = 5;
 
@@ -23,7 +20,7 @@ const ACTOR_DETAILS_PICTURE_SEARCH_LIMIT = 5;
  * Input:  { first_number: "number", tags: ["string"], user: { name: "string" } }
  * Output: "{ first_number: number, tags: string[], user: { name: string } }"
  */
-function typeObjectToString(obj: Record<string, unknown>): string {
+export function typeObjectToString(obj: Record<string, unknown>): string {
     const pairs: string[] = [];
 
     for (const [key, value] of Object.entries(obj)) {
@@ -167,67 +164,6 @@ export function processActorDetailsForResponse(details: ActorDetailsResult) {
 }
 
 /**
- * Shared schema for actor details output options.
- * Used by both public and internal fetch-actor-details tools.
- *
- * Behavior:
- * - If output is undefined or empty object: use defaults (all true except mcpTools and outputSchema)
- * - If any property is explicitly set: only include sections with explicit true values
- */
-export const actorDetailsOutputOptionsSchema = z.object({
-    description: z.boolean().optional().describe('Include Actor description text only.'),
-    stats: z.boolean().optional().describe('Include usage statistics (users, runs, success rate).'),
-    pricing: z.boolean().optional().describe('Include pricing model and costs.'),
-    rating: z.boolean().optional().describe('Include user rating (out of 5 stars).'),
-    metadata: z.boolean().optional().describe('Include developer, categories, last modified date, and deprecation status.'),
-    inputSchema: z.boolean().optional().describe('Include required input parameters schema.'),
-    readme: z.boolean().optional().describe('Include Actor README documentation (summary when available, full otherwise).'),
-    outputSchema: z.boolean().optional().describe('Include inferred output schema from recent successful runs (TypeScript type).'),
-    mcpTools: z.boolean().optional().describe('List available tools (only for MCP server Actors).'),
-});
-
-export const actorDetailsOutputDefaults = {
-    description: true,
-    stats: true,
-    pricing: true,
-    rating: true,
-    metadata: true,
-    inputSchema: true,
-    readme: true,
-    outputSchema: false,
-    mcpTools: false,
-};
-
-export type ResolvedOutputOptions = typeof actorDetailsOutputDefaults;
-
-/**
- * Resolve output options with smart defaults.
- * If output is undefined/empty, returns defaults.
- * If any property is explicitly set, undefined properties are treated as false.
- */
-export function resolveOutputOptions(output?: z.infer<typeof actorDetailsOutputOptionsSchema>): ResolvedOutputOptions {
-    // Check if the output has any explicit true/false values
-    const hasExplicitOptions = output && Object.values(output).some((v) => v !== undefined);
-
-    if (!hasExplicitOptions) {
-        return actorDetailsOutputDefaults;
-    }
-
-    // Return output with undefined treated as false (explicit true required)
-    return {
-        description: output?.description === true,
-        stats: output?.stats === true,
-        pricing: output?.pricing === true,
-        rating: output?.rating === true,
-        metadata: output?.metadata === true,
-        inputSchema: output?.inputSchema === true,
-        readme: output?.readme === true,
-        outputSchema: output?.outputSchema === true,
-        mcpTools: output?.mcpTools === true,
-    };
-}
-
-/**
  * Gets MCP tools information for an Actor.
  * Returns a message about available tools, error, or that the Actor is not an MCP server.
  */
@@ -289,83 +225,4 @@ export function buildCardOptions(output: {
         includeRating: output.rating,
         includeMetadata: output.metadata,
     };
-}
-
-/**
- * Build error response for when actor is not found.
- */
-export function buildActorNotFoundResponse(actorName: string): ReturnType<typeof buildMCPResponse> {
-    return buildMCPResponse({
-        texts: [`Actor information for '${actorName}' was not found.
-Please verify Actor ID or name format and ensure that the Actor exists.
-You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.`],
-        isError: true,
-        telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
-    });
-}
-
-/**
- * Build text and structured response for actor details.
- * Pure/sync: the caller pre-resolves `mcpToolsMessage` when `output.mcpTools` is true.
- */
-export function buildActorDetailsTextResponse(options: {
-    details: ActorDetailsResult;
-    output: ResolvedOutputOptions;
-    actorOutputSchema?: Record<string, unknown> | null;
-    mcpToolsMessage?: string;
-}): {
-    texts: string[];
-    structuredContent: Record<string, unknown>;
-} {
-    const { details, output, actorOutputSchema, mcpToolsMessage } = options;
-
-    const actorUrl = `https://apify.com/${details.actorInfo.username}/${details.actorInfo.name}`;
-
-    const texts: string[] = [];
-
-    // Build actor card only if any card section is requested
-    const needsCard = output.description
-        || output.stats
-        || output.pricing
-        || output.rating
-        || output.metadata;
-
-    if (needsCard) {
-        texts.push(`# Actor information\n${details.actorCard}`);
-    }
-
-    // Add README content if requested (prefer readmeSummary, fall back to full readme)
-    const resolvedReadme = output.readme ? resolveReadmeContent(details) : undefined;
-    if (resolvedReadme) {
-        texts.push(`${resolvedReadme.heading}\n${resolvedReadme.content}`);
-    }
-
-    // Add input schema if requested
-    if (output.inputSchema) {
-        texts.push(`# [Input schema](${actorUrl}/input)\n\`\`\`json\n${JSON.stringify(details.inputSchema)}\n\`\`\``);
-    }
-
-    // Add output schema if requested
-    if (output.outputSchema) {
-        if (actorOutputSchema && Object.keys(actorOutputSchema).length > 0) {
-            const typeString = typeObjectToString(actorOutputSchema);
-            texts.push(`# Output Schema (TypeScript)\nInferred from recent successful runs:\n\`\`\`typescript\ntype ActorOutput = ${typeString}\n\`\`\``);
-        } else {
-            texts.push(`# Output Schema\nNo output schema available. The Actor may not have recent successful runs, or the output structure could not be determined.`);
-        }
-    }
-
-    if (mcpToolsMessage) {
-        texts.push(mcpToolsMessage);
-    }
-
-    // Build structured content
-    const structuredContent: Record<string, unknown> = {
-        actorInfo: needsCard ? details.actorCardStructured : undefined,
-        readme: resolvedReadme?.content,
-        inputSchema: output.inputSchema ? details.inputSchema : undefined,
-        outputSchema: output.outputSchema ? (actorOutputSchema ?? {}) : undefined,
-    };
-
-    return { texts, structuredContent };
 }


### PR DESCRIPTION
> **PR chain:** #690 → #691 → **#692 (you are here)** → #693 → #694

Follow-up to #691 (stacked: base → #690 → #691 → this).

## Summary

Match the structure of \`src/tools/core/search_actors_common.ts\`: tool-specific schemas and response builders live in \`tools/core/\`, not \`utils/\`.

Moved from \`src/utils/actor_details.ts\` → \`src/tools/core/fetch_actor_details_common.ts\`:
- \`actorDetailsOutputOptionsSchema\`
- \`actorDetailsOutputDefaults\`
- \`ResolvedOutputOptions\`
- \`resolveOutputOptions\`
- \`buildActorNotFoundResponse\`
- \`buildActorDetailsTextResponse\`

\`utils/actor_details.ts\` now holds only shared data-fetching/formatting helpers (\`fetchActorDetails\`, \`getMcpToolsMessage\`, \`processActorDetailsForResponse\`, \`resolveReadmeContent\`, \`buildCardOptions\`, \`typeObjectToString\`, \`ActorDetailsResult\`).

Exported \`typeObjectToString\` — still used by the moved \`buildActorDetailsTextResponse\`.

No behavior change.

## Test plan
- [x] \`npm run type-check\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run test:unit\` — all 482 tests pass
- [x] Integration tests (requires APIFY_TOKEN, human-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

