### PR TITLE
refactor: Apply dedent / texts[] array convention to long strings

### DIFF
--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
 import { ApifyClient } from '../../apify_client.js';
@@ -130,9 +131,11 @@ export const fetchActorDetailsMetadata: Omit<HelperTool, 'call'> = {
  */
 export function buildActorNotFoundResponse(actorName: string): ReturnType<typeof buildMCPResponse> {
     return buildMCPResponse({
-        texts: [`Actor information for '${actorName}' was not found.
-Please verify Actor ID or name format and ensure that the Actor exists.
-You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.`],
+        texts: [dedent`
+            Actor information for '${actorName}' was not found.
+            Please verify Actor ID or name format and ensure that the Actor exists.
+            You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
+        `],
         isError: true,
         telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
     });
@@ -173,15 +176,29 @@ export function buildActorDetailsTextResponse(options: {
     }
 
     if (output.inputSchema) {
-        texts.push(`# [Input schema](${actorUrl}/input)\n\`\`\`json\n${JSON.stringify(details.inputSchema)}\n\`\`\``);
+        texts.push([
+            `# [Input schema](${actorUrl}/input)`,
+            '```json',
+            JSON.stringify(details.inputSchema),
+            '```',
+        ].join('\n'));
     }
 
     if (output.outputSchema) {
         if (actorOutputSchema && Object.keys(actorOutputSchema).length > 0) {
             const typeString = typeObjectToString(actorOutputSchema);
-            texts.push(`# Output Schema (TypeScript)\nInferred from recent successful runs:\n\`\`\`typescript\ntype ActorOutput = ${typeString}\n\`\`\``);
+            texts.push(dedent`
+                # Output Schema (TypeScript)
+                Inferred from recent successful runs:
+                \`\`\`typescript
+                type ActorOutput = ${typeString}
+                \`\`\`
+            `);
         } else {
-            texts.push(`# Output Schema\nNo output schema available. The Actor may not have recent successful runs, or the output structure could not be determined.`);
+            texts.push(dedent`
+                # Output Schema
+                No output schema available. The Actor may not have recent successful runs, or the output structure could not be determined.
+            `);
         }
     }
 

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -195,10 +195,23 @@ export async function getMcpToolsMessage(
     try {
         const toolsResponse = await client.listTools();
         const mcpToolsInfo = toolsResponse.tools
-            .map((tool) => `**${tool.name}**\n${tool.description || 'No description'}\nInput schema:\n\`\`\`json\n${JSON.stringify(tool.inputSchema)}\n\`\`\``)
+            .map((tool) => [
+                `**${tool.name}**`,
+                tool.description || 'No description',
+                'Input schema:',
+                '```json',
+                JSON.stringify(tool.inputSchema),
+                '```',
+            ].join('\n'))
             .join('\n\n');
 
-        return `# Available MCP Tools\nThis Actor is an MCP server with ${toolsResponse.tools.length} tools.\nTo call a tool, use: "${actorName}:{toolName}"\n\n${mcpToolsInfo}`;
+        return [
+            '# Available MCP Tools',
+            `This Actor is an MCP server with ${toolsResponse.tools.length} tools.`,
+            `To call a tool, use: "${actorName}:{toolName}"`,
+            '',
+            mcpToolsInfo,
+        ].join('\n');
     } catch (error) {
         logHttpError(error, `Failed to list MCP tools for Actor '${actorName}'`, { actorName });
         return `Failed to retrieve MCP tools for Actor '${actorName}'. The MCP server may be temporarily unavailable.`;


### PR DESCRIPTION
> **PR chain:** #690 → #691 → #692 → **#693 (you are here)** → #694

Follow-up to #692. Applies the CONTRIBUTING.md multi-line string convention to files we touched in this stack.

## Summary

Replace long single-line templates with \`\n\` escapes using the appropriate pattern:

**\`dedent\` (multi-line, safe interpolations)**
- \`buildActorNotFoundResponse\` — 3-line error text
- Output Schema TypeScript block — \`typeString\` is single-line, safe
- "No output schema available" fallback

**\`texts[]\` array joined with \`\n\` (per CONTRIBUTING.md: don't use \`dedent\` when interpolating \`JSON.stringify\` output or multi-line values)**
- Input schema block — embeds \`JSON.stringify(details.inputSchema)\`
- Per-tool MCP formatting in \`getMcpToolsMessage\` — embeds \`JSON.stringify(tool.inputSchema)\`
- Final \`# Available MCP Tools\` wrapper — embeds multi-line \`mcpToolsInfo\`

No behavior change — same output strings, just cleaner source.

## Test plan
- [x] \`npm run type-check\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run test:unit\` — all 482 tests pass
- [x] Integration tests (requires APIFY_TOKEN, human-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
