### PR TITLE
refactor: Deduplicate get-actor-run response handling and improve error messaging, fix multi-line strings

### DIFF
--- a/src/tools/core/get_actor_run_common.ts
+++ b/src/tools/core/get_actor_run_common.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
 import log from '@apify/log';
@@ -7,7 +8,7 @@ import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { HelperTool, ToolInputSchema } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { buildMCPResponse, buildUsageMeta } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
 import { getActorRunOutputSchema } from '../structured_output_schemas.js';
 
@@ -85,6 +86,52 @@ export type FetchActorRunResult = {
     run: Record<string, unknown>;
     structuredContent: ActorRunStructuredContent;
 };
+
+/**
+ * Builds the standard tool error response for get-actor-run.
+ */
+export function buildGetActorRunError(runId: string, error: unknown): ReturnType<typeof buildMCPResponse> {
+    return buildMCPResponse({
+        texts: [dedent`
+            Failed to get Actor run '${runId}': ${error instanceof Error ? error.message : String(error)}.
+            Please verify the run ID and ensure that the run exists.
+        `],
+        isError: true,
+        telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL },
+    });
+}
+
+/**
+ * Builds the tool success response for get-actor-run in default or widget mode.
+ */
+export function buildGetActorRunSuccessResponse(
+    params: FetchActorRunResult & { widget: boolean },
+): ReturnType<typeof buildMCPResponse> {
+    const { run, structuredContent, widget } = params;
+
+    if (!widget) {
+        return buildMCPResponse({
+            texts: [`# Actor Run Information\n\`\`\`json\n${JSON.stringify(run)}\n\`\`\``],
+            structuredContent,
+            _meta: buildUsageMeta(run),
+        });
+    }
+
+    const statusText = structuredContent.status === 'SUCCEEDED' && structuredContent.dataset
+        ? dedent`Actor run ${structuredContent.runId} completed successfully with
+            ${structuredContent.dataset.totalItemCount} items. A widget has been rendered with the details.`
+        : dedent`Actor run ${structuredContent.runId} status: ${structuredContent.status}.
+            A progress widget has been rendered.`;
+
+    return buildMCPResponse({
+        texts: [statusText],
+        structuredContent,
+        _meta: {
+            ...(getWidgetConfig(WIDGET_URIS.ACTOR_RUN)?.meta ?? {}),
+            ...(buildUsageMeta(run) ?? {}),
+        },
+    });
+}
 
 /**
  * Fetches actor run data, resolves actor name, and fetches dataset results if completed.

--- a/src/tools/core/get_actor_run_common.ts
+++ b/src/tools/core/get_actor_run_common.ts
@@ -118,10 +118,8 @@ export function buildGetActorRunSuccessResponse(
     }
 
     const statusText = structuredContent.status === 'SUCCEEDED' && structuredContent.dataset
-        ? dedent`Actor run ${structuredContent.runId} completed successfully with
-            ${structuredContent.dataset.totalItemCount} items. A widget has been rendered with the details.`
-        : dedent`Actor run ${structuredContent.runId} status: ${structuredContent.status}.
-            A progress widget has been rendered.`;
+        ? `Actor run ${structuredContent.runId} completed successfully with ${structuredContent.dataset.totalItemCount} items. A widget has been rendered with the details.`
+        : `Actor run ${structuredContent.runId} status: ${structuredContent.status}. A progress widget has been rendered.`;
 
     return buildMCPResponse({
         texts: [statusText],

--- a/src/tools/default/get_actor_run.ts
+++ b/src/tools/default/get_actor_run.ts
@@ -1,8 +1,8 @@
-import { TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
 import { logHttpError } from '../../utils/logging.js';
-import { buildMCPResponse, buildUsageMeta } from '../../utils/mcp.js';
 import {
+    buildGetActorRunError,
+    buildGetActorRunSuccessResponse,
     fetchActorRunData,
     getActorRunArgs,
     getActorRunMetadata,
@@ -29,22 +29,10 @@ export const defaultGetActorRun: ToolEntry = Object.freeze({
                 return fetchResult.error;
             }
 
-            const { run, structuredContent } = fetchResult.result;
-            const texts = [`# Actor Run Information\n\`\`\`json\n${JSON.stringify(run)}\n\`\`\``];
-
-            return buildMCPResponse({
-                texts,
-                structuredContent,
-                _meta: buildUsageMeta(run),
-            });
+            return buildGetActorRunSuccessResponse({ ...fetchResult.result, widget: false });
         } catch (error) {
             logHttpError(error, 'Failed to get Actor run', { runId: parsed.runId });
-            return buildMCPResponse({
-                texts: [`Failed to get Actor run '${parsed.runId}': ${error instanceof Error ? error.message : String(error)}.
-Please verify the run ID and ensure that the run exists.`],
-                isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL },
-            });
+            return buildGetActorRunError(parsed.runId, error);
         }
     },
 } as const);

--- a/src/tools/openai/get_actor_run.ts
+++ b/src/tools/openai/get_actor_run.ts
@@ -1,9 +1,8 @@
-import { TOOL_STATUS } from '../../const.js';
-import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
 import { logHttpError } from '../../utils/logging.js';
-import { buildMCPResponse, buildUsageMeta } from '../../utils/mcp.js';
 import {
+    buildGetActorRunError,
+    buildGetActorRunSuccessResponse,
     fetchActorRunData,
     getActorRunArgs,
     getActorRunMetadata,
@@ -30,31 +29,10 @@ export const openaiGetActorRun: ToolEntry = Object.freeze({
                 return fetchResult.error;
             }
 
-            const { run, structuredContent } = fetchResult.result;
-
-            const statusText = run.status === 'SUCCEEDED' && structuredContent.dataset
-                ? `Actor run ${parsed.runId} completed successfully with ${structuredContent.dataset.totalItemCount} items. A widget has been rendered with the details.`
-                : `Actor run ${parsed.runId} status: ${run.status as string}. A progress widget has been rendered.`;
-
-            const widgetConfig = getWidgetConfig(WIDGET_URIS.ACTOR_RUN);
-            const usageMeta = buildUsageMeta(run);
-            return buildMCPResponse({
-                texts: [statusText],
-                structuredContent,
-                // Response-level meta; only returned in openai mode (this handler is openai-only)
-                _meta: {
-                    ...widgetConfig?.meta,
-                    ...usageMeta,
-                },
-            });
+            return buildGetActorRunSuccessResponse({ ...fetchResult.result, widget: true });
         } catch (error) {
             logHttpError(error, 'Failed to get Actor run', { runId: parsed.runId });
-            return buildMCPResponse({
-                texts: [`Failed to get Actor run '${parsed.runId}': ${error instanceof Error ? error.message : String(error)}.
-Please verify the run ID and ensure that the run exists.`],
-                isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL },
-            });
+            return buildGetActorRunError(parsed.runId, error);
         }
     },
 } as const);


### PR DESCRIPTION
Extract shared `buildGetActorRunError` and `buildGetActorRunSuccessResponse` helpers into `get_actor_run_common.ts`, removing duplicated response logic from default and openai handlers. Apply `dedent` convention to multiline strings.

Follows the same pattern established in #694 for `fetch-actor-details`.

close: https://github.com/apify/apify-mcp-server/issues/699

## Testing

Compared dev vs prod MCP servers against the same runId/inputs via native MCP clients.

| Scenario | Result |
|---|---|
| `get-actor-run` — RUNNING | identical JSON |
| `get-actor-run` — SUCCEEDED (with dataset) | identical JSON |
| `get-actor-run` — invalid runId | identical error |
| `search-actors` | no divergence attributable to this PR |
| `fetch-actor-details` | no divergence attributable to this PR |
| `get-actor-output` | identical |
| `search-apify-docs` | identical |

Also: `type-check`, `lint`, `test:unit` (509 passed).