### PR TITLE
refactor: OpenAI actor executor to use shared response builder

### DIFF
--- a/src/tools/openai/actor_executor.ts
+++ b/src/tools/openai/actor_executor.ts
@@ -1,8 +1,7 @@
 import log from '@apify/log';
 
-import { HelperTools } from '../../const.js';
-import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { ActorExecutionParams, ActorExecutionResult, ActorExecutor } from '../../types.js';
+import { buildStartAsyncResponse } from '../core/call_actor_common.js';
 
 /**
  * OpenAI actor executor for UI mode.
@@ -24,32 +23,11 @@ export const openaiActorExecutor: ActorExecutor = {
             mcpSessionId: params.mcpSessionId,
         });
 
-        const structuredContent: Record<string, unknown> = {
-            runId: actorRun.id,
+        return buildStartAsyncResponse({
             actorName: params.actorFullName,
-            status: actorRun.status,
-            startedAt: actorRun.startedAt?.toISOString() || '',
+            actorRun,
             input: params.input,
-        };
-
-        const responseText = `Started Actor "${params.actorFullName}" (Run ID: ${actorRun.id}).
-
-A live progress widget has been rendered that automatically tracks this run and refreshes status every few seconds until completion.
-
-The widget will update the context with run status and datasetId when the run completes. Once complete (or if the user requests results), use ${HelperTools.ACTOR_OUTPUT_GET} with the datasetId to retrieve the output.
-
-Do NOT proactively poll using ${HelperTools.ACTOR_RUNS_GET}. Wait for the widget state update or user instructions. Ask the user what they would like to do next.`;
-
-        // _meta carries widget rendering config (not usage meta — the run is still in progress)
-        const widgetConfig = getWidgetConfig(WIDGET_URIS.ACTOR_RUN);
-        return {
-            content: [{ type: 'text' as const, text: responseText }],
-            structuredContent,
-            // Response-level meta; only returned in openai mode (this executor is openai-only)
-            _meta: {
-                ...widgetConfig?.meta,
-                'openai/widgetDescription': `Actor run progress for ${params.actorFullName}`,
-            },
-        };
+            widget: true,
+        });
     },
 };


### PR DESCRIPTION
## Summary
Refactored the OpenAI actor executor to eliminate code duplication by delegating response construction to a shared `buildStartAsyncResponse` utility function.

## Key Changes
- Removed direct imports of `HelperTools` and widget configuration utilities (`getWidgetConfig`, `WIDGET_URIS`)
- Added import of `buildStartAsyncResponse` from the shared core utilities
- Simplified the executor's return logic by delegating to `buildStartAsyncResponse` instead of manually constructing the response object
- Removed inline response text generation and widget configuration logic that is now handled by the shared utility
- Reduced code from ~30 lines to ~10 lines by eliminating duplicated response formatting

## Implementation Details
The refactoring maintains the same external behavior while centralizing the response construction logic. The executor now passes relevant parameters (`actorName`, `actorRun`, `input`, and a `widget: true` flag) to the shared builder function, which handles:
- Formatting the response text with instructions
- Structuring the content with run metadata
- Configuring widget rendering and metadata

close #698 

https://claude.ai/code/session_01MaDJ297GLPpF5U9fdUFDTo