### PR TITLE
refactor: search-actors schemas to share base definition

### DIFF
--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -10,9 +10,30 @@ import { buildMCPResponse } from '../../utils/mcp.js';
 import { actorSearchOutputSchema } from '../structured_output_schemas.js';
 
 /**
+ * Shared base schema for search-actors arguments. Used directly by the internal
+ * variant; extended by `searchActorsArgsSchema` with a longer `keywords` description.
+ */
+export const searchActorsBaseArgsSchema = z.object({
+    keywords: z.string()
+        .default('')
+        .describe('Keywords used to search for Actors in the Apify Store.'),
+    limit: z.number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(5)
+        .describe('The maximum number of Actors to return (default = 5)'),
+    offset: z.number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe('The number of elements to skip from the start (default = 0)'),
+});
+
+/**
  * Zod schema for search-actors arguments — shared between default and openai variants.
  */
-export const searchActorsArgsSchema = z.object({
+export const searchActorsArgsSchema = searchActorsBaseArgsSchema.extend({
     keywords: z.string()
         .default('')
         .describe(dedent`
@@ -32,17 +53,6 @@ export const searchActorsArgsSchema = z.object({
             ❌ Bad: "Instagram posts profiles comments hashtags reels stories followers..." (too long, too many terms)
             ❌ Bad: "data extraction scraping tools" (too generic)
         `),
-    limit: z.number()
-        .int()
-        .min(1)
-        .max(100)
-        .default(5)
-        .describe('The maximum number of Actors to return (default = 5)'),
-    offset: z.number()
-        .int()
-        .min(0)
-        .default(0)
-        .describe('The number of elements to skip from the start (default = 0)'),
 });
 
 const SEARCH_ACTORS_DESCRIPTION = `

--- a/src/tools/openai/search_actors_internal.ts
+++ b/src/tools/openai/search_actors_internal.ts
@@ -6,24 +6,8 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { searchAndFilterActors } from '../../utils/actor_search.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { searchActorsBaseArgsSchema } from '../core/search_actors_common.js';
 import { actorSearchInternalOutputSchema } from '../structured_output_schemas.js';
-
-const searchActorsInternalArgsSchema = z.object({
-    limit: z.number()
-        .int()
-        .min(1)
-        .max(100)
-        .default(5)
-        .describe('The maximum number of Actors to return (default = 5)'),
-    offset: z.number()
-        .int()
-        .min(0)
-        .default(0)
-        .describe('The number of elements to skip from the start (default = 0)'),
-    keywords: z.string()
-        .default('')
-        .describe('Keywords used to search for Actors in the Apify Store.'),
-});
 
 export const searchActorsInternalTool: ToolEntry = Object.freeze({
     type: 'internal',
@@ -40,9 +24,9 @@ export const searchActorsInternalTool: ToolEntry = Object.freeze({
 
         Returns only minimal fields (fullName, title, description) needed for subsequent calls.
     `,
-    inputSchema: z.toJSONSchema(searchActorsInternalArgsSchema) as ToolInputSchema,
+    inputSchema: z.toJSONSchema(searchActorsBaseArgsSchema) as ToolInputSchema,
     outputSchema: actorSearchInternalOutputSchema,
-    ajvValidate: compileSchema(z.toJSONSchema(searchActorsInternalArgsSchema)),
+    ajvValidate: compileSchema(z.toJSONSchema(searchActorsBaseArgsSchema)),
     annotations: {
         title: 'Search Actors (internal)',
         readOnlyHint: true,
@@ -52,7 +36,7 @@ export const searchActorsInternalTool: ToolEntry = Object.freeze({
     },
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyToken, userRentedActorIds, apifyMcpServer } = toolArgs;
-        const parsed = searchActorsInternalArgsSchema.parse(args);
+        const parsed = searchActorsBaseArgsSchema.parse(args);
         const actors = await searchAndFilterActors({
             keywords: parsed.keywords,
             apifyToken,

--- a/src/tools/openai/search_actors_internal.ts
+++ b/src/tools/openai/search_actors_internal.ts
@@ -9,6 +9,8 @@ import { buildMCPResponse } from '../../utils/mcp.js';
 import { searchActorsBaseArgsSchema } from '../core/search_actors_common.js';
 import { actorSearchInternalOutputSchema } from '../structured_output_schemas.js';
 
+const searchActorsInternalInputSchema = z.toJSONSchema(searchActorsBaseArgsSchema);
+
 export const searchActorsInternalTool: ToolEntry = Object.freeze({
     type: 'internal',
     name: HelperTools.STORE_SEARCH_INTERNAL,
@@ -24,9 +26,9 @@ export const searchActorsInternalTool: ToolEntry = Object.freeze({
 
         Returns only minimal fields (fullName, title, description) needed for subsequent calls.
     `,
-    inputSchema: z.toJSONSchema(searchActorsBaseArgsSchema) as ToolInputSchema,
+    inputSchema: searchActorsInternalInputSchema as ToolInputSchema,
     outputSchema: actorSearchInternalOutputSchema,
-    ajvValidate: compileSchema(z.toJSONSchema(searchActorsBaseArgsSchema)),
+    ajvValidate: compileSchema(searchActorsInternalInputSchema),
     annotations: {
         title: 'Search Actors (internal)',
         readOnlyHint: true,

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -8,9 +8,11 @@
  * - _meta stripping works for non-openai modes
  */
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import { ALLOWED_TASK_TOOL_EXECUTION_MODES, HelperTools } from '../../src/const.js';
 import { searchApifyDocsTool } from '../../src/tools/common/search_apify_docs.js';
+import { searchActorsBaseArgsSchema } from '../../src/tools/core/search_actors_common.js';
 import { CATEGORY_NAMES, getCategoryTools } from '../../src/tools/index.js';
 import type { ToolBase, ToolEntry } from '../../src/types.js';
 import { SERVER_MODES } from '../../src/types.js';
@@ -124,6 +126,14 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
                 expect(defaultTool!.inputSchema).toEqual(openaiTool!.inputSchema);
             });
         }
+
+        // Locks the invariant that search-actors-internal reuses the shared base schema
+        // verbatim (see #700). Prevents silent drift on limit/offset/keywords.
+        it('should use searchActorsBaseArgsSchema for search-actors-internal inputSchema', () => {
+            const internalTool = openaiCategories.ui.find((t) => t.name === HelperTools.STORE_SEARCH_INTERNAL);
+            expect(internalTool).toBeDefined();
+            expect(internalTool!.inputSchema).toEqual(z.toJSONSchema(searchActorsBaseArgsSchema));
+        });
     });
 
     describe('mode-specific call-actor behavior guidance', () => {


### PR DESCRIPTION
## Summary
Extracted a shared base schema for search-actors arguments to eliminate duplication and ensure consistency between the internal and public variants of the search-actors tool.

## Key Changes
- Created `searchActorsBaseArgsSchema` in `search_actors_common.ts` containing the core schema definition for `keywords`, `limit`, and `offset` fields
- Updated `searchActorsArgsSchema` to extend the base schema and override only the `keywords` description with more detailed guidance
- Removed duplicate schema definition from `search_actors_internal.ts` and replaced it with an import of `searchActorsBaseArgsSchema`
- Added a test assertion to lock the invariant that the internal tool uses the shared base schema verbatim, preventing silent drift on field definitions

## Implementation Details
- The base schema is used directly by the internal variant without modification
- The public variant extends the base schema to provide a more comprehensive `keywords` description with examples of good and bad search patterns
- This approach maintains the DRY principle while allowing schema customization where needed
- The new test in `tools.mode_contract.test.ts` ensures the internal tool's input schema exactly matches the base schema definition

close: https://github.com/apify/apify-mcp-server/issues/700

https://claude.ai/code/session_01SP9KeucjLSLNsTb2YBzJh4