### PR TITLE
feat: Shorten task ID to <tool-name>-<12-char-suffix>

### DIFF
--- a/res/mcp_task_reference.md
+++ b/res/mcp_task_reference.md
@@ -42,7 +42,7 @@ Tools declare task support via `execution.taskSupport`:
 ```typescript
 // Task object
 interface Task {
-    taskId: string;            // 32 hex chars
+    taskId: string;            // Format: "<tool-name>-<12-char-suffix>"
     status: TaskStatus;        // "working" | "input_required" | "completed" | "failed" | "cancelled"
     ttl: number | null;
     createdAt: string;         // ISO 8601

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,7 +2,7 @@
  * Model Context Protocol (MCP) server for Apify Actors
  */
 
-import { randomUUID } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
@@ -783,7 +783,7 @@ export class ActorsMcpServer {
                         {
                             ttl: request.params.task.ttl,
                         },
-                        `call-tool-${name}-${randomUUID()}`,
+                        `${tool.name}-${randomBytes(9).toString('base64url')}`,
                         request,
                     );
                     log.debug('Created task for tool execution', { taskId: task.taskId, toolName: tool.name, mcpSessionId });

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2289,6 +2289,8 @@ export function createIntegrationTestsSuite(
             for await (const message of stream) {
                 if (message.type === 'taskCreated') {
                     taskId = message.task.taskId;
+                    // Format: "<tool-name>-<12 base64url chars>" (see src/mcp/server.ts, issue #705)
+                    expect(taskId).toMatch(new RegExp(`^${actorNameToToolName(ACTOR_PYTHON_EXAMPLE)}-[A-Za-z0-9_-]{12}$`));
 
                     // Now we can get the task status
                     const taskStatus = await client.experimental.tasks.getTask(taskId);


### PR DESCRIPTION
Closes #705.

## Summary
- Task IDs were long and noisy — `call-tool-apify--rag-web-browser-550e8400-e29b-41d4-a716-446655440000` (~70 chars).
- New form: `${tool.name}-${randomBytes(9).toString('base64url')}` → `apify--rag-web-browser-x7kQ9mZpA1bC` (~35 chars).
- Uses Node built-in `randomBytes`; no new dependency (avoids pulling `nanoid` for one call).
- Uses `tool.name` (canonical, slash-safe) rather than raw request `name` (which can be the legacy `apify-slash-…` form).

## MCP spec compliance
- `taskId` MUST be a string — ✓
- MUST be unique — ✓ (prefix + 72-bit random suffix; session-scoped `taskStore`)
- MUST be receiver-generated — ✓
- Entropy: 72 bits, plus the spec's preferred auth-context binding via `mcpSessionId` (see `src/mcp/server.ts:543`).

Spec ref: https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks

## Changes
- `src/mcp/server.ts` — swap `randomUUID` import for `randomBytes`; replace the task-ID expression.
- `res/mcp_task_reference.md` — update stale `// 32 hex chars` comment.
- `tests/integration/suite.ts` — add format assertion to the existing task-flow test.

## Test plan
- [x] `npm run type-check` — passes
- [x] `npm run lint` — passes
- [x] `npm run test:unit` (515/515) — passes
- [ ] `npm run test:integration` — requires `APIFY_TOKEN`; task-flow suite includes a new format assertion
- [ ] mcpc probe: `tools-call <actor> task:='{"ttl":60000}' <args>` → inspect `taskCreated.taskId` shape
- [ ] Non-task path: `tools-call <actor> <args>` returns unchanged `CallToolResult` (regression check)

https://claude.ai/code/session_012N7gXd5tWLp9Xic5JDVif9