### PR TITLE
docs(buildUsageMeta): remove misleading 'com.apify/ prefix' claim from doc comment

### DIFF
--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -3,7 +3,7 @@ import { getHttpStatusCode } from './logging.js';
 
 /**
  * Builds usage metadata for MCP response from a source object containing Apify run costs.
- * Uses MCP-compliant key names with com.apify/ prefix as per MCP specification.
+ * Returned keys: `usageTotalUsd`, `usageUsd`.
  * @param source - Object containing usage cost information
  * @param source.usageTotalUsd - Total cost in USD (optional)
  * @param source.usageUsd - Breakdown of costs by resource type (optional)


### PR DESCRIPTION
## Summary

\`buildUsageMeta\` comment in \`src/utils/mcp.ts\` said the returned keys use a \`com.apify/\` prefix 'as per MCP specification', but the function returns unprefixed \`usageTotalUsd\` and \`usageUsd\` keys. Picked Option A from #732 (doc-only fix) to avoid a breaking change for any client already consuming the unprefixed names.

Closes #732

## Testing

Comment-only change. Runtime behavior and returned keys are unchanged.