### PR TITLE
feat: Surface compact input schema on search-actors results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,6 @@ Breaking changes must be coordinated; check whether updates are needed in `apify
 - **Follow [CONTRIBUTING.md](./CONTRIBUTING.md) for all naming and coding standards.** It is the single source of truth for naming rules (function verbs, boolean prefixes, type suffixes, enumerations, file names, etc.), string formatting, parameters, error handling, and anti-patterns. Read it before writing code.
 - **Validate tool inputs with Zod.** No ad-hoc shape checks.
 - **Reference tool names via the `HelperTools` enum**, not hardcoded strings (exception: integration tests).
-- **Put constants in `src/const.ts`**, not as local variables in individual files. This includes cache sizes/TTLs, concurrency limits, magic numbers, and string enums.
 - Always follow the latest [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25) and [MCP Apps spec](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx).
 
 ## Further reading

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ Breaking changes must be coordinated; check whether updates are needed in `apify
 - **Follow [CONTRIBUTING.md](./CONTRIBUTING.md) for all naming and coding standards.** It is the single source of truth for naming rules (function verbs, boolean prefixes, type suffixes, enumerations, file names, etc.), string formatting, parameters, error handling, and anti-patterns. Read it before writing code.
 - **Validate tool inputs with Zod.** No ad-hoc shape checks.
 - **Reference tool names via the `HelperTools` enum**, not hardcoded strings (exception: integration tests).
+- **Put constants in `src/const.ts`**, not as local variables in individual files. This includes cache sizes/TTLs, concurrency limits, magic numbers, and string enums.
 - Always follow the latest [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25) and [MCP Apps spec](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx).
 
 ## Further reading

--- a/src/const.ts
+++ b/src/const.ts
@@ -110,7 +110,7 @@ export const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
 /** API rejects `includeInputSchema=true` above this; mirrors apify-core `MAX_LIMIT_WITH_INPUT_SCHEMA`. */
 export const MAX_LIMIT_WITH_INPUT_SCHEMA = 10;
 /** Max input fields shown inline in the text Actor card; structured output keeps the full schema. */
-export const MAX_INPUT_SCHEMA_TEXT_FIELDS = 20;
+export const MAX_INPUT_FIELDS_IN_TEXT_CARD = 20;
 
 export const ACTOR_PRICING_MODEL = {
     /** Rental Actors */

--- a/src/const.ts
+++ b/src/const.ts
@@ -109,6 +109,8 @@ export const USER_CACHE_MAX_SIZE = 200;
 export const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
 /** API rejects `includeInputSchema=true` above this; mirrors apify-core `MAX_LIMIT_WITH_INPUT_SCHEMA`. */
 export const STORE_INPUT_SCHEMA_PAGE_LIMIT = 10;
+/** Max input properties shown inline in the text Actor card; structured output keeps the full schema. */
+export const STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT = 20;
 
 export const ACTOR_PRICING_MODEL = {
     /** Rental Actors */

--- a/src/const.ts
+++ b/src/const.ts
@@ -107,6 +107,13 @@ export const MCP_SERVER_CACHE_MAX_SIZE = 500;
 export const MCP_SERVER_CACHE_TTL_SECS = 30 * 60; // 30 minutes
 export const USER_CACHE_MAX_SIZE = 200;
 export const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
+/**
+ * Hard cap on `limit` for `GET /v2/store?includeInputSchema=true`. The API
+ * returns 400 above this; matches `MAX_LIMIT_WITH_INPUT_SCHEMA` in apify-core.
+ */
+export const STORE_INPUT_SCHEMA_PAGE_LIMIT = 10;
+/** Max input properties rendered inline in the text Actor card; structured output keeps the full schema. */
+export const STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT = 10;
 
 export const ACTOR_PRICING_MODEL = {
     /** Rental Actors */

--- a/src/const.ts
+++ b/src/const.ts
@@ -108,9 +108,9 @@ export const MCP_SERVER_CACHE_TTL_SECS = 30 * 60; // 30 minutes
 export const USER_CACHE_MAX_SIZE = 200;
 export const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
 /** API rejects `includeInputSchema=true` above this; mirrors apify-core `MAX_LIMIT_WITH_INPUT_SCHEMA`. */
-export const STORE_INPUT_SCHEMA_PAGE_LIMIT = 10;
+export const MAX_LIMIT_WITH_INPUT_SCHEMA = 10;
 /** Max input properties shown inline in the text Actor card; structured output keeps the full schema. */
-export const STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT = 20;
+export const MAX_INPUT_SCHEMA_TEXT_FIELDS = 20;
 
 export const ACTOR_PRICING_MODEL = {
     /** Rental Actors */

--- a/src/const.ts
+++ b/src/const.ts
@@ -112,8 +112,6 @@ export const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
  * returns 400 above this; matches `MAX_LIMIT_WITH_INPUT_SCHEMA` in apify-core.
  */
 export const STORE_INPUT_SCHEMA_PAGE_LIMIT = 10;
-/** Max input properties rendered inline in the text Actor card; structured output keeps the full schema. */
-export const STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT = 10;
 
 export const ACTOR_PRICING_MODEL = {
     /** Rental Actors */

--- a/src/const.ts
+++ b/src/const.ts
@@ -107,10 +107,7 @@ export const MCP_SERVER_CACHE_MAX_SIZE = 500;
 export const MCP_SERVER_CACHE_TTL_SECS = 30 * 60; // 30 minutes
 export const USER_CACHE_MAX_SIZE = 200;
 export const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
-/**
- * Hard cap on `limit` for `GET /v2/store?includeInputSchema=true`. The API
- * returns 400 above this; matches `MAX_LIMIT_WITH_INPUT_SCHEMA` in apify-core.
- */
+/** API rejects `includeInputSchema=true` above this; mirrors apify-core `MAX_LIMIT_WITH_INPUT_SCHEMA`. */
 export const STORE_INPUT_SCHEMA_PAGE_LIMIT = 10;
 
 export const ACTOR_PRICING_MODEL = {

--- a/src/const.ts
+++ b/src/const.ts
@@ -109,7 +109,7 @@ export const USER_CACHE_MAX_SIZE = 200;
 export const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
 /** API rejects `includeInputSchema=true` above this; mirrors apify-core `MAX_LIMIT_WITH_INPUT_SCHEMA`. */
 export const MAX_LIMIT_WITH_INPUT_SCHEMA = 10;
-/** Max input properties shown inline in the text Actor card; structured output keeps the full schema. */
+/** Max input fields shown inline in the text Actor card; structured output keeps the full schema. */
 export const MAX_INPUT_SCHEMA_TEXT_FIELDS = 20;
 
 export const ACTOR_PRICING_MODEL = {

--- a/src/tools/apps/search_actors_widget.ts
+++ b/src/tools/apps/search_actors_widget.ts
@@ -56,7 +56,7 @@ export const searchActorsWidgetTool: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyClient, userRentedActorIds, apifyMcpServer } = toolArgs;
+        const { args, apifyToken, apifyClient, apifyMcpServer } = toolArgs;
         const parsed = searchActorsWidgetArgsSchema.parse(args);
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
@@ -67,7 +67,6 @@ export const searchActorsWidgetTool: ToolEntry = Object.freeze({
                 limit: parsed.limit,
                 offset: parsed.offset,
                 paymentProvider: apifyMcpServer.options.paymentProvider,
-                userRentedActorIds,
             }),
             getUserInfoCached(apifyToken, apifyClient),
         ]);

--- a/src/tools/apps/search_actors_widget.ts
+++ b/src/tools/apps/search_actors_widget.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { formatActorForWidget } from '../../utils/actor_card.js';
-import { searchAndFilterActors } from '../../utils/actor_search.js';
+import { searchAgentSafeActors } from '../../utils/actor_search.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
@@ -61,7 +61,7 @@ export const searchActorsWidgetTool: ToolEntry = Object.freeze({
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
         const [actors, { userPlanTier }] = await Promise.all([
-            searchAndFilterActors({
+            searchAgentSafeActors({
                 keywords: parsed.keywords,
                 apifyToken,
                 limit: parsed.limit,

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -22,7 +22,7 @@ export const searchActorsBaseArgsSchema = z.object({
         .min(1)
         .max(MAX_LIMIT_WITH_INPUT_SCHEMA)
         .default(5)
-        .describe(`The maximum number of Actors to return (1–${MAX_LIMIT_WITH_INPUT_SCHEMA}, default = 5).`),
+        .describe(`The maximum number of Actors to return (max = ${MAX_LIMIT_WITH_INPUT_SCHEMA}, default = 5).`),
     offset: z.number()
         .int()
         .min(0)

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -78,8 +78,8 @@ Usage:
 - You MUST always do at least two searches: first with broad keywords, then optionally with more specific terms if needed.
 
 Important limitations: This tool does not return full Actor documentation or detailed usage instructions - only summary information.
-Each result includes a compact \`inputSchema\` (types only) so you can construct Actor input directly without a separate ${HelperTools.ACTOR_GET_DETAILS} call.
-For complete Actor details (descriptions per field, defaults, README), use the ${HelperTools.ACTOR_GET_DETAILS} tool.
+Each result lists the Actor's input fields with their types (e.g. \`url: string, maxResults?: number\`) so you can construct an Actor call directly without a separate ${HelperTools.ACTOR_GET_DETAILS} round-trip.
+For complete Actor details (per-field descriptions, defaults, README), use the ${HelperTools.ACTOR_GET_DETAILS} tool.
 The search is limited to publicly available Actors and may not include private, rental, or restricted Actors depending on the user's access level.
 
 Returns list of Actor cards with the following info:
@@ -92,7 +92,7 @@ Returns list of Actor cards with the following info:
 - **Pricing:** Details with pricing link
 - **Stats:** Usage, success rate, bookmarks
 - **Rating:** Out of 5 (if available)
-- **Input schema:** Compact JSON Schema of input properties (types only)
+- **Input fields:** Inline list of input field names and types (e.g. \`url: string, maxResults?: number\`); \`?\` marks optional fields
 `;
 
 /**

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../../const.js';
+import { HelperTools } from '../../const.js';
 import type { ActorStoreList, HelperTool, StructuredActorCard, ToolInputSchema } from '../../types.js';
 import { DEFAULT_CARD_OPTIONS, formatActorToActorCard, formatActorToStructuredCard } from '../../utils/actor_card.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -12,11 +12,6 @@ import { actorSearchOutputSchema } from '../structured_output_schemas.js';
 /**
  * Shared base schema for search-actors arguments. Used directly by the widget
  * variant; extended by `searchActorsArgsSchema` with a longer `keywords` description.
- *
- * `limit` is capped at {@link STORE_INPUT_SCHEMA_PAGE_LIMIT} to match the cap that
- * `GET /v2/store?includeInputSchema=true` enforces in apify-core. Larger values
- * would either trigger 400s or require dropping schema enrichment, both worse
- * trade-offs than just narrowing the public range.
  */
 export const searchActorsBaseArgsSchema = z.object({
     keywords: z.string()
@@ -25,9 +20,9 @@ export const searchActorsBaseArgsSchema = z.object({
     limit: z.number()
         .int()
         .min(1)
-        .max(STORE_INPUT_SCHEMA_PAGE_LIMIT)
+        .max(100)
         .default(5)
-        .describe(`The maximum number of Actors to return (default = 5, max = ${STORE_INPUT_SCHEMA_PAGE_LIMIT})`),
+        .describe('The maximum number of Actors to return (default = 5)'),
     offset: z.number()
         .int()
         .min(0)
@@ -97,7 +92,7 @@ Returns list of Actor cards with the following info:
 - **Pricing:** Details with pricing link
 - **Stats:** Usage, success rate, bookmarks
 - **Rating:** Out of 5 (if available)
-- **Input fields:** Compact list of input property names and types
+- **Input schema:** Compact JSON Schema of input properties (types only)
 `;
 
 /**

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../../const.js';
+import { HelperTools, MAX_LIMIT_WITH_INPUT_SCHEMA } from '../../const.js';
 import type { ActorStoreList, HelperTool, StructuredActorCard, ToolInputSchema } from '../../types.js';
 import { DEFAULT_CARD_OPTIONS, formatActorToActorCard, formatActorToStructuredCard } from '../../utils/actor_card.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -20,9 +20,9 @@ export const searchActorsBaseArgsSchema = z.object({
     limit: z.number()
         .int()
         .min(1)
-        .max(STORE_INPUT_SCHEMA_PAGE_LIMIT)
+        .max(MAX_LIMIT_WITH_INPUT_SCHEMA)
         .default(5)
-        .describe(`The maximum number of Actors to return (1–${STORE_INPUT_SCHEMA_PAGE_LIMIT}, default = 5).`),
+        .describe(`The maximum number of Actors to return (1–${MAX_LIMIT_WITH_INPUT_SCHEMA}, default = 5).`),
     offset: z.number()
         .int()
         .min(0)

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -80,7 +80,7 @@ Usage:
 Important limitations: This tool does not return full Actor documentation or detailed usage instructions - only summary information.
 Each result lists the Actor's input fields with their types (e.g. \`url: string, maxResults?: number\`) so you can construct an Actor call directly without a separate ${HelperTools.ACTOR_GET_DETAILS} round-trip.
 For complete Actor details (per-field descriptions, defaults, README), use the ${HelperTools.ACTOR_GET_DETAILS} tool.
-The search is limited to publicly available Actors and may not include private, rental, or restricted Actors depending on the user's access level.
+The search is limited to publicly available Actors and excludes rental and restricted Actors.
 
 Returns list of Actor cards with the following info:
 **Title:** Markdown header linked to Store page

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HelperTools, STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../../const.js';
 import type { ActorStoreList, HelperTool, StructuredActorCard, ToolInputSchema } from '../../types.js';
 import { DEFAULT_CARD_OPTIONS, formatActorToActorCard, formatActorToStructuredCard } from '../../utils/actor_card.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -12,6 +12,11 @@ import { actorSearchOutputSchema } from '../structured_output_schemas.js';
 /**
  * Shared base schema for search-actors arguments. Used directly by the widget
  * variant; extended by `searchActorsArgsSchema` with a longer `keywords` description.
+ *
+ * `limit` is capped at {@link STORE_INPUT_SCHEMA_PAGE_LIMIT} to match the cap that
+ * `GET /v2/store?includeInputSchema=true` enforces in apify-core. Larger values
+ * would either trigger 400s or require dropping schema enrichment, both worse
+ * trade-offs than just narrowing the public range.
  */
 export const searchActorsBaseArgsSchema = z.object({
     keywords: z.string()
@@ -20,9 +25,9 @@ export const searchActorsBaseArgsSchema = z.object({
     limit: z.number()
         .int()
         .min(1)
-        .max(100)
+        .max(STORE_INPUT_SCHEMA_PAGE_LIMIT)
         .default(5)
-        .describe('The maximum number of Actors to return (default = 5)'),
+        .describe(`The maximum number of Actors to return (default = 5, max = ${STORE_INPUT_SCHEMA_PAGE_LIMIT})`),
     offset: z.number()
         .int()
         .min(0)
@@ -77,8 +82,9 @@ Usage:
 - Prefer broad, generic keywords - use just the platform name (e.g. "Instagram" instead of "Instagram scraper").
 - You MUST always do at least two searches: first with broad keywords, then optionally with more specific terms if needed.
 
-Important limitations: This tool does not return full Actor documentation, input schemas, or detailed usage instructions - only summary information.
-For complete Actor details, use the ${HelperTools.ACTOR_GET_DETAILS} tool.
+Important limitations: This tool does not return full Actor documentation or detailed usage instructions - only summary information.
+Each result includes a compact \`inputSchema\` (types only) so you can construct Actor input directly without a separate ${HelperTools.ACTOR_GET_DETAILS} call.
+For complete Actor details (descriptions per field, defaults, README), use the ${HelperTools.ACTOR_GET_DETAILS} tool.
 The search is limited to publicly available Actors and may not include private, rental, or restricted Actors depending on the user's access level.
 
 Returns list of Actor cards with the following info:
@@ -91,6 +97,7 @@ Returns list of Actor cards with the following info:
 - **Pricing:** Details with pricing link
 - **Stats:** Usage, success rate, bookmarks
 - **Rating:** Out of 5 (if available)
+- **Input fields:** Compact list of input property names and types
 `;
 
 /**

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HelperTools, STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../../const.js';
 import type { ActorStoreList, HelperTool, StructuredActorCard, ToolInputSchema } from '../../types.js';
 import { DEFAULT_CARD_OPTIONS, formatActorToActorCard, formatActorToStructuredCard } from '../../utils/actor_card.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -20,9 +20,9 @@ export const searchActorsBaseArgsSchema = z.object({
     limit: z.number()
         .int()
         .min(1)
-        .max(100)
+        .max(STORE_INPUT_SCHEMA_PAGE_LIMIT)
         .default(5)
-        .describe('The maximum number of Actors to return (default = 5)'),
+        .describe(`The maximum number of Actors to return (1–${STORE_INPUT_SCHEMA_PAGE_LIMIT}, default = 5).`),
     offset: z.number()
         .int()
         .min(0)

--- a/src/tools/default/search_actors.ts
+++ b/src/tools/default/search_actors.ts
@@ -19,7 +19,7 @@ import {
 export const defaultSearchActors: ToolEntry = Object.freeze({
     ...searchActorsMetadata,
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyClient, userRentedActorIds, apifyMcpServer } = toolArgs;
+        const { args, apifyToken, apifyClient, apifyMcpServer } = toolArgs;
         const parsed = searchActorsArgsSchema.parse(args);
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
@@ -30,7 +30,6 @@ export const defaultSearchActors: ToolEntry = Object.freeze({
                 limit: parsed.limit,
                 offset: parsed.offset,
                 paymentProvider: apifyMcpServer.options.paymentProvider,
-                userRentedActorIds,
             }),
             getUserInfoCached(apifyToken, apifyClient),
         ]);

--- a/src/tools/default/search_actors.ts
+++ b/src/tools/default/search_actors.ts
@@ -2,7 +2,7 @@ import dedent from 'dedent';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
-import { searchAndFilterActors } from '../../utils/actor_search.js';
+import { searchAgentSafeActors } from '../../utils/actor_search.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
 import {
@@ -24,7 +24,7 @@ export const defaultSearchActors: ToolEntry = Object.freeze({
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
         const [actors, { userPlanTier }] = await Promise.all([
-            searchAndFilterActors({
+            searchAgentSafeActors({
                 keywords: parsed.keywords,
                 apifyToken,
                 limit: parsed.limit,

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -141,9 +141,31 @@ export const actorInfoSchema = {
         },
         modifiedAt: { type: 'string', description: 'Last modification date' },
         isDeprecated: { type: 'boolean', description: 'Whether the Actor is deprecated' },
+        // Mirrors `ActorStoreInputSchema` in src/types.ts; only `type` is preserved per
+        // field by apify-core's `trimInputSchema`, so the per-field shape stays minimal.
         inputFields: {
-            type: 'object' as const,
-            description: 'Input fields with their types (e.g. `url: string, maxResults?: number`).',
+            type: 'object' as const, // Literal type required for MCP SDK type compatibility
+            description: 'Compact JSON-Schema-shaped descriptor of the Actor input; only `type` is preserved per field.',
+            properties: {
+                type: { type: 'string', description: 'Always `"object"`.' },
+                properties: {
+                    type: 'object' as const, // Literal type required for MCP SDK type compatibility
+                    description: 'Map of input field name to its type descriptor.',
+                    additionalProperties: {
+                        type: 'object' as const, // Literal type required for MCP SDK type compatibility
+                        properties: {
+                            type: { description: 'JSON Schema field type — string or array of strings.' },
+                        },
+                        required: ['type'],
+                    },
+                },
+                required: {
+                    type: 'array' as const, // Literal type required for MCP SDK type compatibility
+                    items: { type: 'string' },
+                    description: 'Names of required input fields.',
+                },
+            },
+            required: ['type', 'properties'],
         },
     },
     required: ['url', 'id', 'fullName', 'developer', 'description', 'categories', 'isDeprecated'],

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -141,10 +141,9 @@ export const actorInfoSchema = {
         },
         modifiedAt: { type: 'string', description: 'Last modification date' },
         isDeprecated: { type: 'boolean', description: 'Whether the Actor is deprecated' },
-        inputSchema: {
+        inputFields: {
             type: 'object' as const,
-            description: 'Compact JSON Schema of the Actor\'s input — types only, raw property keys.'
-                + ' LLMs use this to construct valid Actor input without a separate fetch-actor-details call.',
+            description: 'Input fields with their types (e.g. `url: string, maxResults?: number`).',
         },
     },
     required: ['url', 'id', 'fullName', 'developer', 'description', 'categories', 'isDeprecated'],

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -141,6 +141,11 @@ export const actorInfoSchema = {
         },
         modifiedAt: { type: 'string', description: 'Last modification date' },
         isDeprecated: { type: 'boolean', description: 'Whether the Actor is deprecated' },
+        inputSchema: {
+            type: 'object' as const,
+            description: 'Compact JSON Schema of the Actor\'s input — types only, raw property keys.'
+                + ' LLMs use this to construct valid Actor input without a separate fetch-actor-details call.',
+        },
     },
     required: ['url', 'id', 'fullName', 'developer', 'description', 'categories', 'isDeprecated'],
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,6 +246,8 @@ export type ActorStoreList = ActorStoreListOutdated & {
     isWhiteListedForAgenticPayments?: boolean;
     notice?: string | null;
     userFullName?: string;
+    /** Populated when the search call is made with `includeInputSchema=true`. */
+    inputSchema?: ActorStoreInputSchema;
     stats: ActorStats & {
         actorReviewCount?: number;
         actorReviewRating?: number;
@@ -564,6 +566,18 @@ export type ActorsMcpServerOptions = {
     uiMode?: string;
 }
 
+/**
+ * Compact JSON Schema returned by `GET /v2/store?includeInputSchema=true`.
+ * Mirrors the shape produced by apify-core's `trimInputSchema` — types only,
+ * `required` omitted when empty. `properties[].type` may be an array for
+ * mixed-type fields (e.g. `['string', 'integer']`).
+ */
+export type ActorStoreInputSchema = {
+    type: 'object';
+    properties: Record<string, { type: string | string[] }>;
+    required?: string[];
+};
+
 export type StructuredActorCard = {
     title?: string;
     url: string;
@@ -590,6 +604,7 @@ export type StructuredActorCard = {
     };
     modifiedAt?: string;
     isDeprecated: boolean;
+    inputSchema?: ActorStoreInputSchema;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -599,7 +599,7 @@ export type StructuredActorCard = {
     };
     modifiedAt?: string;
     isDeprecated: boolean;
-    inputSchema?: ActorStoreInputSchema;
+    inputFields?: ActorStoreInputSchema;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -566,12 +566,7 @@ export type ActorsMcpServerOptions = {
     uiMode?: string;
 }
 
-/**
- * Compact JSON Schema returned by `GET /v2/store?includeInputSchema=true`.
- * Mirrors the shape produced by apify-core's `trimInputSchema` — types only,
- * `required` omitted when empty. `properties[].type` may be an array for
- * mixed-type fields (e.g. `['string', 'integer']`).
- */
+/** Compact schema returned by `GET /v2/store?includeInputSchema=true`; produced by apify-core `trimInputSchema`. */
 export type ActorStoreInputSchema = {
     type: 'object';
     properties: Record<string, { type: string | string[] }>;

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -1,5 +1,5 @@
-import { APIFY_STORE_URL } from '../const.js';
-import type { Actor, ActorCardOptions, ActorStoreList, StructuredActorCard } from '../types.js';
+import { APIFY_STORE_URL, STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT } from '../const.js';
+import type { Actor, ActorCardOptions, ActorStoreInputSchema, ActorStoreList, StructuredActorCard } from '../types.js';
 import {
     getCurrentPricingInfo,
     type PricingInfo,
@@ -10,6 +10,36 @@ import {
     type PricingTier,
     type StructuredPricingInfo,
 } from './pricing_info.js';
+
+/** `inputSchema` is only attached when the search call requested it; other Actor types don't carry it. */
+function getInputSchema(actor: Actor | ActorStoreList): ActorStoreInputSchema | undefined {
+    return 'inputSchema' in actor ? actor.inputSchema : undefined;
+}
+
+/**
+ * Render an `inputSchema.properties` entry's `type` (string or mixed-type array)
+ * as a human-readable hint. Mixed types come from apify-core's `trimInputSchema`.
+ */
+function formatPropertyType(type: string | string[]): string {
+    return Array.isArray(type) ? type.join('|') : type;
+}
+
+/**
+ * Render the first {@link STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT} properties of `inputSchema`
+ * as a TypeScript-like inline list (`name?: type, name: type, ...`). Returns null
+ * when no properties exist; the structured card always exposes the full schema.
+ */
+function formatInputSchemaForText(inputSchema: ActorStoreInputSchema): string | null {
+    const entries = Object.entries(inputSchema.properties);
+    if (entries.length === 0) return null;
+    const requiredSet = new Set(inputSchema.required ?? []);
+    const shown = entries.slice(0, STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT);
+    const fields = shown
+        .map(([name, prop]) => `${name}${requiredSet.has(name) ? '' : '?'}: ${formatPropertyType(prop.type)}`)
+        .join(', ');
+    const suffix = entries.length > shown.length ? ` (${shown.length} of ${entries.length})` : '';
+    return `- **Input fields${suffix}:** ${fields}`;
+}
 
 // Helper function to format categories from uppercase with underscores to a proper case
 function formatCategories(categories?: string[]): string[] {
@@ -217,6 +247,11 @@ export function formatActorToActorCard(
             markdownLines.push('\n>This Actor is deprecated and may not be maintained anymore.');
         }
     }
+    const inputSchema = getInputSchema(actor);
+    if (inputSchema) {
+        const line = formatInputSchemaForText(inputSchema);
+        if (line) markdownLines.push(line);
+    }
     return markdownLines.join('\n');
 }
 
@@ -249,6 +284,7 @@ export function formatActorToStructuredCard(
         rating: data.rating,
         modifiedAt: data.modifiedAt,
         isDeprecated: data.isDeprecated,
+        inputSchema: getInputSchema(actor),
     };
 }
 

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -15,7 +15,7 @@ function getInputSchema(actor: Actor | ActorStoreList): ActorStoreInputSchema | 
     return 'inputSchema' in actor ? actor.inputSchema : undefined;
 }
 
-function formatInputSchemaForText(inputSchema: ActorStoreInputSchema): string | null {
+function inputFieldsToString(inputSchema: ActorStoreInputSchema): string | null {
     const entries = Object.entries(inputSchema.properties);
     if (entries.length === 0) return null;
 
@@ -27,7 +27,7 @@ function formatInputSchemaForText(inputSchema: ActorStoreInputSchema): string | 
     const overflow = entries.length - shown.length;
     const suffix = overflow > 0 ? ` ... (+${overflow} more)` : '';
 
-    return `- **Input schema:** ${fields}${suffix}`;
+    return `- **Input fields:** ${fields}${suffix}`;
 }
 
 // Helper function to format categories from uppercase with underscores to a proper case
@@ -238,7 +238,7 @@ export function formatActorToActorCard(
     }
     const inputSchema = getInputSchema(actor);
     if (inputSchema) {
-        const line = formatInputSchemaForText(inputSchema);
+        const line = inputFieldsToString(inputSchema);
         if (line) markdownLines.push(line);
     }
     return markdownLines.join('\n');

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -1,4 +1,4 @@
-import { APIFY_STORE_URL, STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT } from '../const.js';
+import { APIFY_STORE_URL, MAX_INPUT_SCHEMA_TEXT_FIELDS } from '../const.js';
 import type { Actor, ActorCardOptions, ActorStoreInputSchema, ActorStoreList, StructuredActorCard } from '../types.js';
 import {
     getCurrentPricingInfo,
@@ -20,7 +20,7 @@ function formatInputSchemaForText(inputSchema: ActorStoreInputSchema): string | 
     if (entries.length === 0) return null;
 
     const requiredSet = new Set(inputSchema.required ?? []);
-    const shown = entries.slice(0, STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT);
+    const shown = entries.slice(0, MAX_INPUT_SCHEMA_TEXT_FIELDS);
     const fields = shown
         .map(([name, prop]) => `${name}${requiredSet.has(name) ? '' : '?'}: ${Array.isArray(prop.type) ? prop.type.join('|') : prop.type}`)
         .join(', ');

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -1,4 +1,4 @@
-import { APIFY_STORE_URL, MAX_INPUT_SCHEMA_TEXT_FIELDS } from '../const.js';
+import { APIFY_STORE_URL, MAX_INPUT_FIELDS_IN_TEXT_CARD } from '../const.js';
 import type { Actor, ActorCardOptions, ActorStoreInputSchema, ActorStoreList, StructuredActorCard } from '../types.js';
 import {
     getCurrentPricingInfo,
@@ -20,7 +20,7 @@ function inputFieldsToString(inputSchema: ActorStoreInputSchema): string | null 
     if (entries.length === 0) return null;
 
     const requiredSet = new Set(inputSchema.required ?? []);
-    const shown = entries.slice(0, MAX_INPUT_SCHEMA_TEXT_FIELDS);
+    const shown = entries.slice(0, MAX_INPUT_FIELDS_IN_TEXT_CARD);
     const fields = shown
         .map(([name, prop]) => `${name}${requiredSet.has(name) ? '' : '?'}: ${Array.isArray(prop.type) ? prop.type.join('|') : prop.type}`)
         .join(', ');

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -1,4 +1,4 @@
-import { APIFY_STORE_URL } from '../const.js';
+import { APIFY_STORE_URL, STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT } from '../const.js';
 import type { Actor, ActorCardOptions, ActorStoreInputSchema, ActorStoreList, StructuredActorCard } from '../types.js';
 import {
     getCurrentPricingInfo,
@@ -20,11 +20,14 @@ function formatInputSchemaForText(inputSchema: ActorStoreInputSchema): string | 
     if (entries.length === 0) return null;
 
     const requiredSet = new Set(inputSchema.required ?? []);
-    const fields = entries
+    const shown = entries.slice(0, STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT);
+    const fields = shown
         .map(([name, prop]) => `${name}${requiredSet.has(name) ? '' : '?'}: ${Array.isArray(prop.type) ? prop.type.join('|') : prop.type}`)
         .join(', ');
+    const overflow = entries.length - shown.length;
+    const suffix = overflow > 0 ? ` ... (+${overflow} more)` : '';
 
-    return `- **Input schema:** ${fields}`;
+    return `- **Input schema:** ${fields}${suffix}`;
 }
 
 // Helper function to format categories from uppercase with underscores to a proper case

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -273,7 +273,7 @@ export function formatActorToStructuredCard(
         rating: data.rating,
         modifiedAt: data.modifiedAt,
         isDeprecated: data.isDeprecated,
-        inputSchema: getInputSchema(actor),
+        inputFields: getInputSchema(actor),
     };
 }
 

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -11,31 +11,19 @@ import {
     type StructuredPricingInfo,
 } from './pricing_info.js';
 
-/** `inputSchema` is only attached when the search call requested it; other Actor types don't carry it. */
 function getInputSchema(actor: Actor | ActorStoreList): ActorStoreInputSchema | undefined {
     return 'inputSchema' in actor ? actor.inputSchema : undefined;
 }
 
-/**
- * Render an `inputSchema.properties` entry's `type` (string or mixed-type array)
- * as a human-readable hint. Mixed types come from apify-core's `trimInputSchema`.
- */
-function formatPropertyType(type: string | string[]): string {
-    return Array.isArray(type) ? type.join('|') : type;
-}
-
-/**
- * Render every property of `inputSchema` as a TypeScript-like inline list
- * (`name?: type, name: type, ...`). Returns null when no properties exist.
- * Mirrors the structured card so important-but-late fields are not lost.
- */
 function formatInputSchemaForText(inputSchema: ActorStoreInputSchema): string | null {
     const entries = Object.entries(inputSchema.properties);
     if (entries.length === 0) return null;
+
     const requiredSet = new Set(inputSchema.required ?? []);
     const fields = entries
-        .map(([name, prop]) => `${name}${requiredSet.has(name) ? '' : '?'}: ${formatPropertyType(prop.type)}`)
+        .map(([name, prop]) => `${name}${requiredSet.has(name) ? '' : '?'}: ${Array.isArray(prop.type) ? prop.type.join('|') : prop.type}`)
         .join(', ');
+
     return `- **Input schema:** ${fields}`;
 }
 

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -1,4 +1,4 @@
-import { APIFY_STORE_URL, STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT } from '../const.js';
+import { APIFY_STORE_URL } from '../const.js';
 import type { Actor, ActorCardOptions, ActorStoreInputSchema, ActorStoreList, StructuredActorCard } from '../types.js';
 import {
     getCurrentPricingInfo,
@@ -25,20 +25,18 @@ function formatPropertyType(type: string | string[]): string {
 }
 
 /**
- * Render the first {@link STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT} properties of `inputSchema`
- * as a TypeScript-like inline list (`name?: type, name: type, ...`). Returns null
- * when no properties exist; the structured card always exposes the full schema.
+ * Render every property of `inputSchema` as a TypeScript-like inline list
+ * (`name?: type, name: type, ...`). Returns null when no properties exist.
+ * Mirrors the structured card so important-but-late fields are not lost.
  */
 function formatInputSchemaForText(inputSchema: ActorStoreInputSchema): string | null {
     const entries = Object.entries(inputSchema.properties);
     if (entries.length === 0) return null;
     const requiredSet = new Set(inputSchema.required ?? []);
-    const shown = entries.slice(0, STORE_INPUT_SCHEMA_TEXT_FIELD_LIMIT);
-    const fields = shown
+    const fields = entries
         .map(([name, prop]) => `${name}${requiredSet.has(name) ? '' : '?'}: ${formatPropertyType(prop.type)}`)
         .join(', ');
-    const suffix = entries.length > shown.length ? ` (${shown.length} of ${entries.length})` : '';
-    return `- **Input fields${suffix}:** ${fields}`;
+    return `- **Input schema:** ${fields}`;
 }
 
 // Helper function to format categories from uppercase with underscores to a proper case

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -75,7 +75,11 @@ export async function fetchActorDetails(
         const [actorInfo, buildInfo, storeActors]: [Actor | undefined, Build | undefined, ActorStoreList[]] = await Promise.all([
             actor.get(),
             actor.defaultBuild().then(async (build) => build.get()),
-            searchActorsByKeywords(actorSlug, apifyClient.token || '', ACTOR_DETAILS_PICTURE_SEARCH_LIMIT).catch(() => []),
+            searchActorsByKeywords({
+                search: actorSlug,
+                apifyToken: apifyClient.token || '',
+                limit: ACTOR_DETAILS_PICTURE_SEARCH_LIMIT,
+            }).catch(() => []),
         ]);
         if (!actorInfo || !buildInfo || !buildInfo.actorDefinition) return null;
 

--- a/src/utils/actor_search.ts
+++ b/src/utils/actor_search.ts
@@ -15,7 +15,7 @@ import type { ActorStoreList } from '../types.js';
 export type SearchActorsByKeywordsOptions = {
     search: string;
     apifyToken: string;
-    limit?: number;
+    limit: number;
     offset?: number;
     allowsAgenticUsers?: boolean;
     /** Throws when set with `limit > MAX_LIMIT_WITH_INPUT_SCHEMA` (apify-core 400s above the cap). */
@@ -34,7 +34,7 @@ export async function searchActorsByKeywords(
     options: SearchActorsByKeywordsOptions,
 ): Promise<ActorStoreList[]> {
     const { search, apifyToken, limit, offset, allowsAgenticUsers, includeInputSchema } = options;
-    if (includeInputSchema === true && limit !== undefined && limit > MAX_LIMIT_WITH_INPUT_SCHEMA) {
+    if (includeInputSchema === true && limit > MAX_LIMIT_WITH_INPUT_SCHEMA) {
         throw new Error(
             `searchActorsByKeywords: limit (${limit}) exceeds API cap of ${MAX_LIMIT_WITH_INPUT_SCHEMA} when includeInputSchema=true.`,
         );

--- a/src/utils/actor_search.ts
+++ b/src/utils/actor_search.ts
@@ -8,7 +8,6 @@
  */
 
 import { ApifyClient } from '../apify_client.js';
-import { MAX_LIMIT_WITH_INPUT_SCHEMA } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
 import type { ActorStoreList } from '../types.js';
 
@@ -18,7 +17,7 @@ export type SearchActorsByKeywordsOptions = {
     limit: number;
     offset?: number;
     allowsAgenticUsers?: boolean;
-    /** Throws when set with `limit > MAX_LIMIT_WITH_INPUT_SCHEMA` (apify-core 400s above the cap). */
+    /** API rejects values above `MAX_LIMIT_WITH_INPUT_SCHEMA` (apify-core cap). */
     includeInputSchema?: boolean;
 };
 
@@ -34,11 +33,6 @@ export async function searchActorsByKeywords(
     options: SearchActorsByKeywordsOptions,
 ): Promise<ActorStoreList[]> {
     const { search, apifyToken, limit, offset, allowsAgenticUsers, includeInputSchema } = options;
-    if (includeInputSchema === true && limit > MAX_LIMIT_WITH_INPUT_SCHEMA) {
-        throw new Error(
-            `searchActorsByKeywords: limit (${limit}) exceeds API cap of ${MAX_LIMIT_WITH_INPUT_SCHEMA} when includeInputSchema=true.`,
-        );
-    }
     const client = new ApifyClient({ token: apifyToken });
     const storeClient = client.store();
     if (allowsAgenticUsers !== undefined) storeClient.params = { ...storeClient.params, allowsAgenticUsers };

--- a/src/utils/actor_search.ts
+++ b/src/utils/actor_search.ts
@@ -17,7 +17,7 @@ export type SearchActorsByKeywordsOptions = {
     limit?: number;
     offset?: number;
     allowsAgenticUsers?: boolean;
-    /** Caller must keep `limit` within apify-core's `MAX_LIMIT_WITH_INPUT_SCHEMA` (10); apify-core 400s above the cap. */
+    /** Caller must keep `limit` within `MAX_LIMIT_WITH_INPUT_SCHEMA`; apify-core 400s above the cap. */
     includeInputSchema?: boolean;
 };
 

--- a/src/utils/actor_search.ts
+++ b/src/utils/actor_search.ts
@@ -1,20 +1,18 @@
 /**
- * Shared utility for searching and filtering actors.
- * Combines searchActorsByKeywords with filterRentalActors to prevent accidental omission
- * of the filtering step and reduce code duplication.
+ * Shared utility for searching Actors via `GET /v2/store`.
+ *
+ * `GET /v2/store` returns only `[FREE, PAY_PER_EVENT]` Actors by default
+ * (apify-core's `AGENT_SAFE_PRICING_MODELS`) and additionally drops Actors
+ * that fail safety checks (KYC, full-permission low-usage, etc.) — so no
+ * MCP-side rental over-fetch / filter is needed.
  */
+
+import log from '@apify/log';
 
 import { ApifyClient } from '../apify_client.js';
 import { ACTOR_PRICING_MODEL, STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
 import type { ActorStoreList } from '../types.js';
-
-/**
- * Used in search Actors tool to search above the input supplied limit,
- * so we can safely filter out rental Actors from the search and ensure we return some results.
- */
-const ACTOR_SEARCH_ABOVE_LIMIT = 50;
-type ActorPricingModel = (typeof ACTOR_PRICING_MODEL)[keyof typeof ACTOR_PRICING_MODEL];
 
 export type SearchActorsByKeywordsOptions = {
     search: string;
@@ -23,7 +21,7 @@ export type SearchActorsByKeywordsOptions = {
     offset?: number;
     allowsAgenticUsers?: boolean;
     /**
-     * Ask `GET /v2/store` to project a compact `inputSchema` per Actor (apify-core #27466).
+     * Ask `GET /v2/store` to project a compact `inputSchema` per Actor (apify-core#27466).
      * Forces `limit <= STORE_INPUT_SCHEMA_PAGE_LIMIT`; the API rejects larger pages.
      */
     includeInputSchema?: boolean;
@@ -35,7 +33,6 @@ export type SearchAndFilterActorsOptions = {
     limit: number;
     offset: number;
     paymentProvider?: PaymentProvider;
-    userRentedActorIds?: string[];
 };
 
 export async function searchActorsByKeywords(
@@ -44,75 +41,45 @@ export async function searchActorsByKeywords(
     const { search, apifyToken, limit, offset, allowsAgenticUsers, includeInputSchema } = options;
     const client = new ApifyClient({ token: apifyToken });
     const storeClient = client.store();
-    // `params` are merged with endpoint params on every request; both flags are
-    // passed through here because `StoreCollectionListOptions` does not type them.
-    const params: Record<string, unknown> = { ...storeClient.params };
-    if (allowsAgenticUsers !== undefined) params.allowsAgenticUsers = allowsAgenticUsers;
-    if (includeInputSchema !== undefined) params.includeInputSchema = includeInputSchema;
-    storeClient.params = params;
+    if (allowsAgenticUsers !== undefined) storeClient.params = { ...storeClient.params, allowsAgenticUsers };
+    if (includeInputSchema !== undefined) storeClient.params = { ...storeClient.params, includeInputSchema };
 
     const results = await storeClient.list({ search, limit, offset });
     return results.items as ActorStoreList[];
 }
 
 /**
- * Search actors by keywords and filter rental actors. Pages through `/v2/store`
- * with `includeInputSchema=true` (capped at {@link STORE_INPUT_SCHEMA_PAGE_LIMIT}
- * per page by the API) until `limit` non-rental Actors are collected or the
- * `ACTOR_SEARCH_ABOVE_LIMIT` scan budget is exhausted.
- *
- * @param options Search and filter options
- * @returns Array of filtered actors, limited to the specified limit
+ * Search Actors by keywords. Requests `includeInputSchema=true` when the
+ * caller's `limit` fits within the API cap ({@link STORE_INPUT_SCHEMA_PAGE_LIMIT});
+ * larger requests fall back to a plain search since the API rejects the flag
+ * above the cap. Tracked in apify-mcp-server#791.
  */
 export async function searchAndFilterActors(
     options: SearchAndFilterActorsOptions,
 ): Promise<ActorStoreList[]> {
-    const { keywords, apifyToken, limit, offset, paymentProvider, userRentedActorIds } = options;
-    const allowsAgenticUsers = paymentProvider ? true : undefined;
-    const scanBudget = limit + ACTOR_SEARCH_ABOVE_LIMIT;
-    const filtered: ActorStoreList[] = [];
-    let pageOffset = offset;
-    let scanned = 0;
+    const { keywords, apifyToken, limit, offset, paymentProvider } = options;
+    const includeInputSchema = limit <= STORE_INPUT_SCHEMA_PAGE_LIMIT;
 
-    while (filtered.length < limit && scanned < scanBudget) {
-        const pageSize = Math.min(STORE_INPUT_SCHEMA_PAGE_LIMIT, scanBudget - scanned);
-        const page = await searchActorsByKeywords({
-            search: keywords,
-            apifyToken,
-            limit: pageSize,
-            offset: pageOffset,
-            allowsAgenticUsers,
-            includeInputSchema: true,
-        });
-        if (page.length === 0) break; // no more results upstream
-        filtered.push(...filterRentalActors(page, userRentedActorIds || []));
-        scanned += page.length;
-        pageOffset += page.length;
-        // Store API returned fewer items than requested → end of results, no point in another roundtrip.
-        if (page.length < pageSize) break;
-    }
-    return filtered.slice(0, limit);
-}
+    const actors = await searchActorsByKeywords({
+        search: keywords,
+        apifyToken,
+        limit,
+        offset,
+        allowsAgenticUsers: paymentProvider ? true : undefined,
+        includeInputSchema: includeInputSchema || undefined,
+    });
 
-/**
- * Filters out actors with the 'FLAT_PRICE_PER_MONTH' pricing model (rental actors),
- * unless the actor's ID is present in the user's rented actor IDs list.
- *
- * This is necessary because the Store list API does not support filtering by multiple pricing models at once.
- *
- * @param actors - Array of ActorStorePruned objects to filter.
- * @param userRentedActorIds - Array of Actor IDs that the user has rented.
- * @returns Array of Actors excluding those with 'FLAT_PRICE_PER_MONTH' pricing model (= rental Actors),
- *  except for Actors that the user has rented (whose IDs are in userRentedActorIds).
- */
-export function filterRentalActors(
-    actors: ActorStoreList[],
-    userRentedActorIds: string[],
-): ActorStoreList[] {
-    // Store list API does not support filtering by two pricing models at once,
-    // so we filter the results manually after fetching them.
-    return actors.filter((actor) => (
-        actor.currentPricingInfo.pricingModel as ActorPricingModel) !== ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH
-        || userRentedActorIds.includes(actor.id),
+    // Observability: the API filters rentals by default (apify-core's `AGENT_SAFE_PRICING_MODELS`),
+    // so a rental in our results means an upstream contract change we should notice.
+    const rentals = actors.filter(
+        (actor) => actor.currentPricingInfo?.pricingModel === ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH,
     );
+    if (rentals.length > 0) {
+        log.error('Unexpected rental Actors in store search results', {
+            keywords,
+            rentalActors: rentals.map((actor) => `${actor.username}/${actor.name}`),
+        });
+    }
+
+    return actors;
 }

--- a/src/utils/actor_search.ts
+++ b/src/utils/actor_search.ts
@@ -8,6 +8,7 @@
  */
 
 import { ApifyClient } from '../apify_client.js';
+import { MAX_LIMIT_WITH_INPUT_SCHEMA } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
 import type { ActorStoreList } from '../types.js';
 
@@ -17,7 +18,7 @@ export type SearchActorsByKeywordsOptions = {
     limit?: number;
     offset?: number;
     allowsAgenticUsers?: boolean;
-    /** Caller must keep `limit` within `MAX_LIMIT_WITH_INPUT_SCHEMA`; apify-core 400s above the cap. */
+    /** Throws when set with `limit > MAX_LIMIT_WITH_INPUT_SCHEMA` (apify-core 400s above the cap). */
     includeInputSchema?: boolean;
 };
 
@@ -33,6 +34,11 @@ export async function searchActorsByKeywords(
     options: SearchActorsByKeywordsOptions,
 ): Promise<ActorStoreList[]> {
     const { search, apifyToken, limit, offset, allowsAgenticUsers, includeInputSchema } = options;
+    if (includeInputSchema === true && limit !== undefined && limit > MAX_LIMIT_WITH_INPUT_SCHEMA) {
+        throw new Error(
+            `searchActorsByKeywords: limit (${limit}) exceeds API cap of ${MAX_LIMIT_WITH_INPUT_SCHEMA} when includeInputSchema=true.`,
+        );
+    }
     const client = new ApifyClient({ token: apifyToken });
     const storeClient = client.store();
     if (allowsAgenticUsers !== undefined) storeClient.params = { ...storeClient.params, allowsAgenticUsers };

--- a/src/utils/actor_search.ts
+++ b/src/utils/actor_search.ts
@@ -69,16 +69,12 @@ export async function searchAndFilterActors(
         includeInputSchema: includeInputSchema || undefined,
     });
 
-    // Observability: the API filters rentals by default (apify-core's `AGENT_SAFE_PRICING_MODELS`),
-    // so a rental in our results means an upstream contract change we should notice.
-    const rentals = actors.filter(
-        (actor) => actor.currentPricingInfo?.pricingModel === ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH,
-    );
-    if (rentals.length > 0) {
-        log.error('Unexpected rental Actors in store search results', {
-            keywords,
-            rentalActors: rentals.map((actor) => `${actor.username}/${actor.name}`),
-        });
+    // Observability: apify-core's `AGENT_SAFE_PRICING_MODELS` filter should mean we never see rentals here.
+    const rentalActors = actors
+        .filter((actor) => actor.currentPricingInfo?.pricingModel === ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH)
+        .map((actor) => `${actor.username}/${actor.name}`);
+    if (rentalActors.length > 0) {
+        log.error('Unexpected rental Actors in store search results', { keywords, rentalActors });
     }
 
     return actors;

--- a/src/utils/actor_search.ts
+++ b/src/utils/actor_search.ts
@@ -7,10 +7,7 @@
  * MCP-side rental over-fetch / filter is needed.
  */
 
-import log from '@apify/log';
-
 import { ApifyClient } from '../apify_client.js';
-import { ACTOR_PRICING_MODEL, STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
 import type { ActorStoreList } from '../types.js';
 
@@ -20,7 +17,7 @@ export type SearchActorsByKeywordsOptions = {
     limit?: number;
     offset?: number;
     allowsAgenticUsers?: boolean;
-    /** When true, `limit` is clamped to `STORE_INPUT_SCHEMA_PAGE_LIMIT` since apify-core rejects larger pages. */
+    /** Caller must keep `limit` within apify-core's `MAX_LIMIT_WITH_INPUT_SCHEMA` (10); apify-core 400s above the cap. */
     includeInputSchema?: boolean;
 };
 
@@ -41,40 +38,26 @@ export async function searchActorsByKeywords(
     if (allowsAgenticUsers !== undefined) storeClient.params = { ...storeClient.params, allowsAgenticUsers };
     if (includeInputSchema !== undefined) storeClient.params = { ...storeClient.params, includeInputSchema };
 
-    const effectiveLimit = includeInputSchema && limit !== undefined
-        ? Math.min(limit, STORE_INPUT_SCHEMA_PAGE_LIMIT)
-        : limit;
-    const results = await storeClient.list({ search, limit: effectiveLimit, offset });
+    const results = await storeClient.list({ search, limit, offset });
     return results.items as ActorStoreList[];
 }
 
 /**
- * Search Actors by keywords. Requests `includeInputSchema=true` when the
- * caller's `limit` fits within the API cap ({@link STORE_INPUT_SCHEMA_PAGE_LIMIT});
- * larger requests fall back to a plain search since the API rejects the flag
- * above the cap. Tracked in apify-mcp-server#791.
+ * Search Actors by keywords with compact input-schema enrichment via
+ * `includeInputSchema=true`. The public arg schema caps `limit` at
+ * apify-core's hard cap (10), so every result includes `inputSchema`.
  */
 export async function searchAndFilterActors(
     options: SearchAndFilterActorsOptions,
 ): Promise<ActorStoreList[]> {
     const { keywords, apifyToken, limit, offset, paymentProvider } = options;
 
-    const actors = await searchActorsByKeywords({
+    return searchActorsByKeywords({
         search: keywords,
         apifyToken,
         limit,
         offset,
         allowsAgenticUsers: paymentProvider ? true : undefined,
-        includeInputSchema: limit <= STORE_INPUT_SCHEMA_PAGE_LIMIT || undefined,
+        includeInputSchema: true,
     });
-
-    // Observability: apify-core's `AGENT_SAFE_PRICING_MODELS` filter should mean we never see rentals here.
-    const rentalActors = actors
-        .filter((actor) => actor.currentPricingInfo?.pricingModel === ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH)
-        .map((actor) => `${actor.username}/${actor.name}`);
-    if (rentalActors.length > 0) {
-        log.error('Unexpected rental Actors in store search results', { keywords, rentalActors });
-    }
-
-    return actors;
 }

--- a/src/utils/actor_search.ts
+++ b/src/utils/actor_search.ts
@@ -20,10 +20,7 @@ export type SearchActorsByKeywordsOptions = {
     limit?: number;
     offset?: number;
     allowsAgenticUsers?: boolean;
-    /**
-     * Ask `GET /v2/store` to project a compact `inputSchema` per Actor (apify-core#27466).
-     * Forces `limit <= STORE_INPUT_SCHEMA_PAGE_LIMIT`; the API rejects larger pages.
-     */
+    /** When true, `limit` is clamped to `STORE_INPUT_SCHEMA_PAGE_LIMIT` since apify-core rejects larger pages. */
     includeInputSchema?: boolean;
 };
 
@@ -44,7 +41,10 @@ export async function searchActorsByKeywords(
     if (allowsAgenticUsers !== undefined) storeClient.params = { ...storeClient.params, allowsAgenticUsers };
     if (includeInputSchema !== undefined) storeClient.params = { ...storeClient.params, includeInputSchema };
 
-    const results = await storeClient.list({ search, limit, offset });
+    const effectiveLimit = includeInputSchema && limit !== undefined
+        ? Math.min(limit, STORE_INPUT_SCHEMA_PAGE_LIMIT)
+        : limit;
+    const results = await storeClient.list({ search, limit: effectiveLimit, offset });
     return results.items as ActorStoreList[];
 }
 
@@ -58,7 +58,6 @@ export async function searchAndFilterActors(
     options: SearchAndFilterActorsOptions,
 ): Promise<ActorStoreList[]> {
     const { keywords, apifyToken, limit, offset, paymentProvider } = options;
-    const includeInputSchema = limit <= STORE_INPUT_SCHEMA_PAGE_LIMIT;
 
     const actors = await searchActorsByKeywords({
         search: keywords,
@@ -66,7 +65,7 @@ export async function searchAndFilterActors(
         limit,
         offset,
         allowsAgenticUsers: paymentProvider ? true : undefined,
-        includeInputSchema: includeInputSchema || undefined,
+        includeInputSchema: limit <= STORE_INPUT_SCHEMA_PAGE_LIMIT || undefined,
     });
 
     // Observability: apify-core's `AGENT_SAFE_PRICING_MODELS` filter should mean we never see rentals here.

--- a/src/utils/actor_search.ts
+++ b/src/utils/actor_search.ts
@@ -5,7 +5,7 @@
  */
 
 import { ApifyClient } from '../apify_client.js';
-import { ACTOR_PRICING_MODEL } from '../const.js';
+import { ACTOR_PRICING_MODEL, STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
 import type { ActorStoreList } from '../types.js';
 
@@ -15,6 +15,19 @@ import type { ActorStoreList } from '../types.js';
  */
 const ACTOR_SEARCH_ABOVE_LIMIT = 50;
 type ActorPricingModel = (typeof ACTOR_PRICING_MODEL)[keyof typeof ACTOR_PRICING_MODEL];
+
+export type SearchActorsByKeywordsOptions = {
+    search: string;
+    apifyToken: string;
+    limit?: number;
+    offset?: number;
+    allowsAgenticUsers?: boolean;
+    /**
+     * Ask `GET /v2/store` to project a compact `inputSchema` per Actor (apify-core #27466).
+     * Forces `limit <= STORE_INPUT_SCHEMA_PAGE_LIMIT`; the API rejects larger pages.
+     */
+    includeInputSchema?: boolean;
+};
 
 export type SearchAndFilterActorsOptions = {
     keywords: string;
@@ -26,23 +39,27 @@ export type SearchAndFilterActorsOptions = {
 };
 
 export async function searchActorsByKeywords(
-    search: string,
-    apifyToken: string,
-    limit: number | undefined = undefined,
-    offset: number | undefined = undefined,
-    allowsAgenticUsers: boolean | undefined = undefined,
+    options: SearchActorsByKeywordsOptions,
 ): Promise<ActorStoreList[]> {
+    const { search, apifyToken, limit, offset, allowsAgenticUsers, includeInputSchema } = options;
     const client = new ApifyClient({ token: apifyToken });
     const storeClient = client.store();
-    if (allowsAgenticUsers !== undefined) storeClient.params = { ...storeClient.params, allowsAgenticUsers };
+    // `params` are merged with endpoint params on every request; both flags are
+    // passed through here because `StoreCollectionListOptions` does not type them.
+    const params: Record<string, unknown> = { ...storeClient.params };
+    if (allowsAgenticUsers !== undefined) params.allowsAgenticUsers = allowsAgenticUsers;
+    if (includeInputSchema !== undefined) params.includeInputSchema = includeInputSchema;
+    storeClient.params = params;
 
     const results = await storeClient.list({ search, limit, offset });
     return results.items as ActorStoreList[];
 }
 
 /**
- * Search actors by keywords and filter rental actors.
- * This combines two operations that should always happen together to ensure consistency.
+ * Search actors by keywords and filter rental actors. Pages through `/v2/store`
+ * with `includeInputSchema=true` (capped at {@link STORE_INPUT_SCHEMA_PAGE_LIMIT}
+ * per page by the API) until `limit` non-rental Actors are collected or the
+ * `ACTOR_SEARCH_ABOVE_LIMIT` scan budget is exhausted.
  *
  * @param options Search and filter options
  * @returns Array of filtered actors, limited to the specified limit
@@ -51,16 +68,30 @@ export async function searchAndFilterActors(
     options: SearchAndFilterActorsOptions,
 ): Promise<ActorStoreList[]> {
     const { keywords, apifyToken, limit, offset, paymentProvider, userRentedActorIds } = options;
+    const allowsAgenticUsers = paymentProvider ? true : undefined;
+    const scanBudget = limit + ACTOR_SEARCH_ABOVE_LIMIT;
+    const filtered: ActorStoreList[] = [];
+    let pageOffset = offset;
+    let scanned = 0;
 
-    const actors = await searchActorsByKeywords(
-        keywords,
-        apifyToken,
-        limit + ACTOR_SEARCH_ABOVE_LIMIT,
-        offset,
-        paymentProvider ? true : undefined,
-    );
-
-    return filterRentalActors(actors || [], userRentedActorIds || []).slice(0, limit) as ActorStoreList[];
+    while (filtered.length < limit && scanned < scanBudget) {
+        const pageSize = Math.min(STORE_INPUT_SCHEMA_PAGE_LIMIT, scanBudget - scanned);
+        const page = await searchActorsByKeywords({
+            search: keywords,
+            apifyToken,
+            limit: pageSize,
+            offset: pageOffset,
+            allowsAgenticUsers,
+            includeInputSchema: true,
+        });
+        if (page.length === 0) break; // no more results upstream
+        filtered.push(...filterRentalActors(page, userRentedActorIds || []));
+        scanned += page.length;
+        pageOffset += page.length;
+        // Store API returned fewer items than requested → end of results, no point in another roundtrip.
+        if (page.length < pageSize) break;
+    }
+    return filtered.slice(0, limit);
 }
 
 /**

--- a/src/utils/actor_search.ts
+++ b/src/utils/actor_search.ts
@@ -22,7 +22,7 @@ export type SearchActorsByKeywordsOptions = {
     includeInputSchema?: boolean;
 };
 
-export type SearchAndFilterActorsOptions = {
+export type SearchAgentSafeActorsOptions = {
     keywords: string;
     apifyToken: string;
     limit: number;
@@ -49,12 +49,13 @@ export async function searchActorsByKeywords(
 }
 
 /**
- * Search Actors by keywords with compact input-schema enrichment via
- * `includeInputSchema=true`. The public arg schema caps `limit` at
- * apify-core's hard cap (10), so every result includes `inputSchema`.
+ * Preset around `searchActorsByKeywords` for the agent-facing search tool:
+ * always sets `includeInputSchema=true` and forwards `allowsAgenticUsers`
+ * when a `paymentProvider` is in play. The public arg schema caps `limit`
+ * at apify-core's hard cap (`MAX_LIMIT_WITH_INPUT_SCHEMA`).
  */
-export async function searchAndFilterActors(
-    options: SearchAndFilterActorsOptions,
+export async function searchAgentSafeActors(
+    options: SearchAgentSafeActorsOptions,
 ): Promise<ActorStoreList[]> {
     const { keywords, apifyToken, limit, offset, paymentProvider } = options;
 

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -9,6 +9,7 @@ import {
     CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG,
     defaults,
     HelperTools,
+    MAX_LIMIT_WITH_INPUT_SCHEMA,
     RAG_WEB_BROWSER,
     SERVER_MODE_AUTO_DETECTION_ENABLED,
     SKYFIRE_ENABLED_TOOLS,
@@ -754,28 +755,26 @@ export function createIntegrationTestsSuite(
             expect(content.some((item) => item.text.includes(ACTOR_PYTHON_EXAMPLE))).toBe(true);
         });
 
-        // It should filter out all rental Actors only if we run locally or as standby, where
-        // we cannot access MongoDB to get the user's rented Actors.
-        // In case of apify-mcp-server it should include user's rented Actors.
-        it('should filter out all rental Actors from store search', async () => {
+        // Upstream-contract canary: apify-core's `AGENT_SAFE_PRICING_MODELS` filter
+        // (`GET /v2/store`) is what excludes rental Actors. If that contract ever
+        // drifts, this test catches the regression on the MCP side.
+        it('should not return rental Actors from store search', async () => {
             client = await createClientFn();
 
             const result = await client.callTool({
                 name: HelperTools.STORE_SEARCH,
                 arguments: {
                     keywords: 'rental',
-                    limit: 100,
+                    limit: MAX_LIMIT_WITH_INPUT_SCHEMA,
                 },
             });
             const content = result.content as { text: string }[];
             expect(content.length).toBe(1);
             const outputText = content[0].text;
 
-            // Check to ensure that the output string format remains the same.
-            // If someone changes the output format, this test may stop working
-            // without actually failing.
+            // Sanity check that the output format hasn't drifted in a way that
+            // would make the negative assertion below silently meaningless.
             expect(outputText).toContain('This Actor');
-            // Check that no rental Actors are present
             expect(outputText).not.toContain('This Actor is rental');
         });
 

--- a/tests/unit/tools.search_actors.default.response.test.ts
+++ b/tests/unit/tools.search_actors.default.response.test.ts
@@ -4,7 +4,7 @@ import { APIFY_STORE_URL, HelperTools } from '../../src/const.js';
 import { defaultSearchActors } from '../../src/tools/default/search_actors.js';
 import type { HelperTool } from '../../src/types.js';
 import { formatActorToStructuredCard } from '../../src/utils/actor_card.js';
-import { searchAndFilterActors } from '../../src/utils/actor_search.js';
+import { searchAgentSafeActors } from '../../src/utils/actor_search.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import { MOCK_STORE_ACTOR, SEARCH_KEYWORDS, stubInternalToolArgs } from './tools.search_actors.fixtures.js';
 
@@ -13,7 +13,7 @@ import { MOCK_STORE_ACTOR, SEARCH_KEYWORDS, stubInternalToolArgs } from './tools
  * (no widgetActors, no tool _meta).
  */
 vi.mock('../../src/utils/actor_search.js', () => ({
-    searchAndFilterActors: vi.fn(),
+    searchAgentSafeActors: vi.fn(),
 }));
 
 vi.mock('../../src/utils/userid_cache.js', () => ({
@@ -22,13 +22,13 @@ vi.mock('../../src/utils/userid_cache.js', () => ({
 
 describe('search-actors without widget (defaultSearchActors)', () => {
     beforeEach(() => {
-        vi.mocked(searchAndFilterActors).mockReset();
+        vi.mocked(searchAgentSafeActors).mockReset();
         vi.mocked(getUserInfoCached).mockReset();
         vi.mocked(getUserInfoCached).mockResolvedValue({ userId: null, userPlanTier: 'FREE' });
     });
 
     it('returns structured actors and markdown text; no widget payload', async () => {
-        vi.mocked(searchAndFilterActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
 
         const result = await (defaultSearchActors as HelperTool).call(stubInternalToolArgs({
             keywords: SEARCH_KEYWORDS,
@@ -70,7 +70,7 @@ describe('search-actors without widget (defaultSearchActors)', () => {
     });
 
     it('returns empty structured content and retry instructions when no actors match', async () => {
-        vi.mocked(searchAndFilterActors).mockResolvedValue([]);
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([]);
 
         const result = await (defaultSearchActors as HelperTool).call(stubInternalToolArgs({
             keywords: SEARCH_KEYWORDS,

--- a/tests/unit/tools.search_actors.widget.response.test.ts
+++ b/tests/unit/tools.search_actors.widget.response.test.ts
@@ -5,7 +5,7 @@ import { searchActorsWidgetTool } from '../../src/tools/apps/search_actors_widge
 import type { HelperTool } from '../../src/types.js';
 import type { formatActorToStructuredCard } from '../../src/utils/actor_card.js';
 import { formatActorForWidget } from '../../src/utils/actor_card.js';
-import { searchAndFilterActors } from '../../src/utils/actor_search.js';
+import { searchAgentSafeActors } from '../../src/utils/actor_search.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import { MOCK_STORE_ACTOR, SEARCH_KEYWORDS, stubInternalToolArgs } from './tools.search_actors.fixtures.js';
 
@@ -15,7 +15,7 @@ import { MOCK_STORE_ACTOR, SEARCH_KEYWORDS, stubInternalToolArgs } from './tools
  * on both the tool definition and the response.
  */
 vi.mock('../../src/utils/actor_search.js', () => ({
-    searchAndFilterActors: vi.fn(),
+    searchAgentSafeActors: vi.fn(),
 }));
 
 vi.mock('../../src/utils/userid_cache.js', () => ({
@@ -24,13 +24,13 @@ vi.mock('../../src/utils/userid_cache.js', () => ({
 
 describe('search-actors-widget response', () => {
     beforeEach(() => {
-        vi.mocked(searchAndFilterActors).mockReset();
+        vi.mocked(searchAgentSafeActors).mockReset();
         vi.mocked(getUserInfoCached).mockReset();
         vi.mocked(getUserInfoCached).mockResolvedValue({ userId: null, userPlanTier: 'FREE' });
     });
 
     it('returns widgetActors plus widget _meta and short pointer text', async () => {
-        vi.mocked(searchAndFilterActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
 
         const result = await (searchActorsWidgetTool as HelperTool).call(stubInternalToolArgs({
             keywords: SEARCH_KEYWORDS,
@@ -69,7 +69,7 @@ describe('search-actors-widget response', () => {
     });
 
     it('returns empty widgetActors and omits widget _meta when there are no results', async () => {
-        vi.mocked(searchAndFilterActors).mockResolvedValue([]);
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([]);
 
         const result = await (searchActorsWidgetTool as HelperTool).call(stubInternalToolArgs({
             keywords: SEARCH_KEYWORDS,

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -610,15 +610,17 @@ describe('formatActorToActorCard inputSchema rendering', () => {
     it('renders input schema as a TypeScript-like inline list with required marker', () => {
         const actor = { ...mockActorStoreList, inputSchema } as ActorStoreList;
         const result = formatActorToActorCard(actor);
-        expect(result).toContain('- **Input fields:** url: string, maxResults?: number');
+        expect(result).toContain('- **Input schema:** url: string, maxResults?: number');
     });
 
-    it('renders an `(N of M)` truncation suffix when properties exceed the text-render cap', () => {
+    it('renders every property without truncation so structured output and text stay in sync', () => {
         const properties: Record<string, { type: string }> = {};
         for (let i = 0; i < 15; i++) properties[`field${i}`] = { type: 'string' };
         const actor = { ...mockActorStoreList, inputSchema: { type: 'object' as const, properties } } as ActorStoreList;
         const result = formatActorToActorCard(actor);
-        expect(result).toContain('- **Input fields (10 of 15):**');
+        expect(result).toContain('field0?: string');
+        expect(result).toContain('field14?: string');
+        expect(result).not.toMatch(/Input schema \(\d+ of \d+\)/);
     });
 
     it('joins mixed-type property arrays with `|`', () => {
@@ -627,20 +629,20 @@ describe('formatActorToActorCard inputSchema rendering', () => {
             inputSchema: { type: 'object' as const, properties: { mixed: { type: ['string', 'integer'] } } },
         } as unknown as ActorStoreList;
         const result = formatActorToActorCard(actor);
-        expect(result).toContain('- **Input fields:** mixed?: string|integer');
+        expect(result).toContain('- **Input schema:** mixed?: string|integer');
     });
 
-    it('omits the input fields line when no inputSchema is present', () => {
+    it('omits the input schema line when no inputSchema is present', () => {
         const result = formatActorToActorCard(mockActor);
-        expect(result).not.toContain('Input fields');
+        expect(result).not.toContain('Input schema');
     });
 
-    it('omits the input fields line when inputSchema has no properties', () => {
+    it('omits the input schema line when inputSchema has no properties', () => {
         const actor = {
             ...mockActorStoreList,
             inputSchema: { type: 'object' as const, properties: {} },
         } as ActorStoreList;
         const result = formatActorToActorCard(actor);
-        expect(result).not.toContain('Input fields');
+        expect(result).not.toContain('Input schema');
     });
 });

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -590,15 +590,6 @@ describe('formatActorToActorCard inputSchema rendering', () => {
         const actor = { ...mockActorStoreList, inputSchema } as ActorStoreList;
         const result = formatActorToActorCard(actor);
         expect(result).toContain('- **Input fields:** url: string, maxResults?: number');
-    });
-
-    it(`renders all input fields when count is within MAX_INPUT_SCHEMA_TEXT_FIELDS (${MAX_INPUT_SCHEMA_TEXT_FIELDS})`, () => {
-        const properties: Record<string, { type: string }> = {};
-        for (let i = 0; i < MAX_INPUT_SCHEMA_TEXT_FIELDS; i++) properties[`field${i}`] = { type: 'string' };
-        const actor = { ...mockActorStoreList, inputSchema: { type: 'object' as const, properties } } as ActorStoreList;
-        const result = formatActorToActorCard(actor);
-        expect(result).toContain('field0?: string');
-        expect(result).toContain(`field${MAX_INPUT_SCHEMA_TEXT_FIELDS - 1}?: string`);
         expect(result).not.toMatch(/\(\+\d+ more\)/);
     });
 

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -574,28 +574,6 @@ describe('formatActorToStructuredCard', () => {
             expect(result.modifiedAt).toBeUndefined();
         });
     });
-
-    describe('inputSchema', () => {
-        const inputSchema = {
-            type: 'object' as const,
-            properties: {
-                url: { type: 'string' },
-                maxResults: { type: 'number' },
-            },
-            required: ['url'],
-        };
-
-        it('passes inputSchema through from ActorStoreList to the structured card', () => {
-            const actor = { ...mockActorStoreList, inputSchema } as ActorStoreList;
-            const result = formatActorToStructuredCard(actor);
-            expect(result.inputSchema).toEqual(inputSchema);
-        });
-
-        it('omits inputSchema when the actor has no schema', () => {
-            const result = formatActorToStructuredCard(mockActor);
-            expect(result.inputSchema).toBeUndefined();
-        });
-    });
 });
 
 describe('formatActorToActorCard inputSchema rendering', () => {

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -1,6 +1,7 @@
 import type { Actor } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
+import { MAX_INPUT_SCHEMA_TEXT_FIELDS } from '../../src/const.js';
 import type { ActorStoreList } from '../../src/types.js';
 import { formatActorToActorCard, formatActorToStructuredCard } from '../../src/utils/actor_card.js';
 
@@ -613,14 +614,26 @@ describe('formatActorToActorCard inputSchema rendering', () => {
         expect(result).toContain('- **Input fields:** url: string, maxResults?: number');
     });
 
-    it('renders every property without truncation so structured output and text stay in sync', () => {
+    it(`renders all input fields when count is within MAX_INPUT_SCHEMA_TEXT_FIELDS (${MAX_INPUT_SCHEMA_TEXT_FIELDS})`, () => {
         const properties: Record<string, { type: string }> = {};
-        for (let i = 0; i < 15; i++) properties[`field${i}`] = { type: 'string' };
+        for (let i = 0; i < MAX_INPUT_SCHEMA_TEXT_FIELDS; i++) properties[`field${i}`] = { type: 'string' };
         const actor = { ...mockActorStoreList, inputSchema: { type: 'object' as const, properties } } as ActorStoreList;
         const result = formatActorToActorCard(actor);
         expect(result).toContain('field0?: string');
-        expect(result).toContain('field14?: string');
-        expect(result).not.toMatch(/Input schema \(\d+ of \d+\)/);
+        expect(result).toContain(`field${MAX_INPUT_SCHEMA_TEXT_FIELDS - 1}?: string`);
+        expect(result).not.toMatch(/\(\+\d+ more\)/);
+    });
+
+    it(`truncates to MAX_INPUT_SCHEMA_TEXT_FIELDS and appends "... (+N more)" when count exceeds the cap`, () => {
+        const overflow = 5;
+        const total = MAX_INPUT_SCHEMA_TEXT_FIELDS + overflow;
+        const properties: Record<string, { type: string }> = {};
+        for (let i = 0; i < total; i++) properties[`field${i}`] = { type: 'string' };
+        const actor = { ...mockActorStoreList, inputSchema: { type: 'object' as const, properties } } as ActorStoreList;
+        const result = formatActorToActorCard(actor);
+        expect(result).toContain(`field${MAX_INPUT_SCHEMA_TEXT_FIELDS - 1}?: string`);
+        expect(result).not.toContain(`field${MAX_INPUT_SCHEMA_TEXT_FIELDS}?: string`);
+        expect(result).toContain(` ... (+${overflow} more)`);
     });
 
     it('joins mixed-type property arrays with `|`', () => {

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -632,11 +632,6 @@ describe('formatActorToActorCard inputSchema rendering', () => {
         expect(result).toContain('- **Input schema:** mixed?: string|integer');
     });
 
-    it('omits the input schema line when no inputSchema is present', () => {
-        const result = formatActorToActorCard(mockActor);
-        expect(result).not.toContain('Input schema');
-    });
-
     it('omits the input schema line when inputSchema has no properties', () => {
         const actor = {
             ...mockActorStoreList,

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -607,10 +607,10 @@ describe('formatActorToActorCard inputSchema rendering', () => {
         required: ['url'],
     };
 
-    it('renders input schema as a TypeScript-like inline list with required marker', () => {
+    it('renders input fields as a TypeScript-like inline list with required marker', () => {
         const actor = { ...mockActorStoreList, inputSchema } as ActorStoreList;
         const result = formatActorToActorCard(actor);
-        expect(result).toContain('- **Input schema:** url: string, maxResults?: number');
+        expect(result).toContain('- **Input fields:** url: string, maxResults?: number');
     });
 
     it('renders every property without truncation so structured output and text stay in sync', () => {
@@ -629,15 +629,15 @@ describe('formatActorToActorCard inputSchema rendering', () => {
             inputSchema: { type: 'object' as const, properties: { mixed: { type: ['string', 'integer'] } } },
         } as unknown as ActorStoreList;
         const result = formatActorToActorCard(actor);
-        expect(result).toContain('- **Input schema:** mixed?: string|integer');
+        expect(result).toContain('- **Input fields:** mixed?: string|integer');
     });
 
-    it('omits the input schema line when inputSchema has no properties', () => {
+    it('omits the input fields line when inputSchema has no properties', () => {
         const actor = {
             ...mockActorStoreList,
             inputSchema: { type: 'object' as const, properties: {} },
         } as ActorStoreList;
         const result = formatActorToActorCard(actor);
-        expect(result).not.toContain('Input schema');
+        expect(result).not.toContain('Input fields');
     });
 });

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -1,7 +1,7 @@
 import type { Actor } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
-import { MAX_INPUT_SCHEMA_TEXT_FIELDS } from '../../src/const.js';
+import { MAX_INPUT_FIELDS_IN_TEXT_CARD } from '../../src/const.js';
 import type { ActorStoreList } from '../../src/types.js';
 import { formatActorToActorCard, formatActorToStructuredCard } from '../../src/utils/actor_card.js';
 
@@ -593,15 +593,15 @@ describe('formatActorToActorCard inputSchema rendering', () => {
         expect(result).not.toMatch(/\(\+\d+ more\)/);
     });
 
-    it(`truncates to MAX_INPUT_SCHEMA_TEXT_FIELDS and appends "... (+N more)" when count exceeds the cap`, () => {
+    it(`truncates to MAX_INPUT_FIELDS_IN_TEXT_CARD and appends "... (+N more)" when count exceeds the cap`, () => {
         const overflow = 5;
-        const total = MAX_INPUT_SCHEMA_TEXT_FIELDS + overflow;
+        const total = MAX_INPUT_FIELDS_IN_TEXT_CARD + overflow;
         const properties: Record<string, { type: string }> = {};
         for (let i = 0; i < total; i++) properties[`field${i}`] = { type: 'string' };
         const actor = { ...mockActorStoreList, inputSchema: { type: 'object' as const, properties } } as ActorStoreList;
         const result = formatActorToActorCard(actor);
-        expect(result).toContain(`field${MAX_INPUT_SCHEMA_TEXT_FIELDS - 1}?: string`);
-        expect(result).not.toContain(`field${MAX_INPUT_SCHEMA_TEXT_FIELDS}?: string`);
+        expect(result).toContain(`field${MAX_INPUT_FIELDS_IN_TEXT_CARD - 1}?: string`);
+        expect(result).not.toContain(`field${MAX_INPUT_FIELDS_IN_TEXT_CARD}?: string`);
         expect(result).toContain(` ... (+${overflow} more)`);
     });
 

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -573,4 +573,74 @@ describe('formatActorToStructuredCard', () => {
             expect(result.modifiedAt).toBeUndefined();
         });
     });
+
+    describe('inputSchema', () => {
+        const inputSchema = {
+            type: 'object' as const,
+            properties: {
+                url: { type: 'string' },
+                maxResults: { type: 'number' },
+            },
+            required: ['url'],
+        };
+
+        it('passes inputSchema through from ActorStoreList to the structured card', () => {
+            const actor = { ...mockActorStoreList, inputSchema } as ActorStoreList;
+            const result = formatActorToStructuredCard(actor);
+            expect(result.inputSchema).toEqual(inputSchema);
+        });
+
+        it('omits inputSchema when the actor has no schema', () => {
+            const result = formatActorToStructuredCard(mockActor);
+            expect(result.inputSchema).toBeUndefined();
+        });
+    });
+});
+
+describe('formatActorToActorCard inputSchema rendering', () => {
+    const inputSchema = {
+        type: 'object' as const,
+        properties: {
+            url: { type: 'string' },
+            maxResults: { type: 'number' },
+        },
+        required: ['url'],
+    };
+
+    it('renders input schema as a TypeScript-like inline list with required marker', () => {
+        const actor = { ...mockActorStoreList, inputSchema } as ActorStoreList;
+        const result = formatActorToActorCard(actor);
+        expect(result).toContain('- **Input fields:** url: string, maxResults?: number');
+    });
+
+    it('renders an `(N of M)` truncation suffix when properties exceed the text-render cap', () => {
+        const properties: Record<string, { type: string }> = {};
+        for (let i = 0; i < 15; i++) properties[`field${i}`] = { type: 'string' };
+        const actor = { ...mockActorStoreList, inputSchema: { type: 'object' as const, properties } } as ActorStoreList;
+        const result = formatActorToActorCard(actor);
+        expect(result).toContain('- **Input fields (10 of 15):**');
+    });
+
+    it('joins mixed-type property arrays with `|`', () => {
+        const actor = {
+            ...mockActorStoreList,
+            inputSchema: { type: 'object' as const, properties: { mixed: { type: ['string', 'integer'] } } },
+        } as unknown as ActorStoreList;
+        const result = formatActorToActorCard(actor);
+        expect(result).toContain('- **Input fields:** mixed?: string|integer');
+    });
+
+    it('omits the input fields line when no inputSchema is present', () => {
+        const result = formatActorToActorCard(mockActor);
+        expect(result).not.toContain('Input fields');
+    });
+
+    it('omits the input fields line when inputSchema has no properties', () => {
+        const actor = {
+            ...mockActorStoreList,
+            inputSchema: { type: 'object' as const, properties: {} },
+        } as ActorStoreList;
+        const result = formatActorToActorCard(actor);
+        expect(result).not.toContain('Input fields');
+    });
 });

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { MAX_LIMIT_WITH_INPUT_SCHEMA } from '../../src/const.js';
 import type { ActorStoreList } from '../../src/types.js';
 import { searchActorsByKeywords, searchAgentSafeActors } from '../../src/utils/actor_search.js';
 
@@ -69,16 +68,6 @@ describe('searchActorsByKeywords', () => {
         await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok', limit: 5 });
         expect(paramsHolder.params).not.toHaveProperty('includeInputSchema');
         expect(paramsHolder.params).not.toHaveProperty('allowsAgenticUsers');
-    });
-
-    it('throws when `includeInputSchema=true` is paired with `limit > MAX_LIMIT_WITH_INPUT_SCHEMA`', async () => {
-        await expect(searchActorsByKeywords({
-            search: 'foo',
-            apifyToken: 'tok',
-            limit: MAX_LIMIT_WITH_INPUT_SCHEMA + 1,
-            includeInputSchema: true,
-        })).rejects.toThrow(/exceeds API cap/);
-        expect(listMock).not.toHaveBeenCalled();
     });
 });
 

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { MAX_LIMIT_WITH_INPUT_SCHEMA } from '../../src/const.js';
 import type { ActorStoreList } from '../../src/types.js';
 import { searchActorsByKeywords, searchAndFilterActors } from '../../src/utils/actor_search.js';
 
@@ -53,10 +54,20 @@ describe('searchActorsByKeywords', () => {
         expect(paramsHolder.params).not.toHaveProperty('allowsAgenticUsers');
     });
 
-    it('forwards `limit` verbatim — caller is responsible for the API cap', async () => {
+    it('forwards `limit` verbatim when `includeInputSchema` is omitted', async () => {
         listMock.mockResolvedValueOnce({ items: [] });
-        await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok', limit: 5 });
-        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 5, offset: undefined });
+        await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok', limit: 50 });
+        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 50, offset: undefined });
+    });
+
+    it('throws when `includeInputSchema=true` is paired with `limit > MAX_LIMIT_WITH_INPUT_SCHEMA`', async () => {
+        await expect(searchActorsByKeywords({
+            search: 'foo',
+            apifyToken: 'tok',
+            limit: MAX_LIMIT_WITH_INPUT_SCHEMA + 1,
+            includeInputSchema: true,
+        })).rejects.toThrow(/exceeds API cap/);
+        expect(listMock).not.toHaveBeenCalled();
     });
 });
 

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../../src/const.js';
 import type { ActorStoreList } from '../../src/types.js';
 import { searchActorsByKeywords, searchAndFilterActors } from '../../src/utils/actor_search.js';
 
@@ -51,6 +52,23 @@ describe('searchActorsByKeywords', () => {
         await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok' });
         expect(paramsHolder.params).not.toHaveProperty('includeInputSchema');
         expect(paramsHolder.params).not.toHaveProperty('allowsAgenticUsers');
+    });
+
+    it('clamps `limit` to STORE_INPUT_SCHEMA_PAGE_LIMIT when `includeInputSchema=true` (apify-core would otherwise 400)', async () => {
+        listMock.mockResolvedValueOnce({ items: [] });
+        await searchActorsByKeywords({
+            search: 'foo',
+            apifyToken: 'tok',
+            limit: 50,
+            includeInputSchema: true,
+        });
+        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: STORE_INPUT_SCHEMA_PAGE_LIMIT, offset: undefined });
+    });
+
+    it('does not clamp `limit` when `includeInputSchema` is omitted', async () => {
+        listMock.mockResolvedValueOnce({ items: [] });
+        await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok', limit: 50 });
+        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 50, offset: undefined });
     });
 });
 

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -86,17 +86,6 @@ describe('searchAndFilterActors', () => {
         expect(result).toHaveLength(25);
     });
 
-    it('passes the caller limit straight through (no over-fetch — API filters rentals)', async () => {
-        listMock.mockResolvedValueOnce({ items: [] });
-        await searchAndFilterActors({
-            keywords: 'foo',
-            apifyToken: 'tok',
-            limit: 7,
-            offset: 0,
-        });
-        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 7, offset: 0 });
-    });
-
     it('forwards allowsAgenticUsers when paymentProvider is set', async () => {
         listMock.mockResolvedValueOnce({ items: [makeActor(1)] });
         await searchAndFilterActors({

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MAX_LIMIT_WITH_INPUT_SCHEMA } from '../../src/const.js';
 import type { ActorStoreList } from '../../src/types.js';
-import { searchActorsByKeywords, searchAndFilterActors } from '../../src/utils/actor_search.js';
+import { searchActorsByKeywords, searchAgentSafeActors } from '../../src/utils/actor_search.js';
 
 const listMock = vi.fn();
 const paramsHolder: { params: Record<string, unknown> } = { params: {} };
@@ -82,7 +82,7 @@ describe('searchActorsByKeywords', () => {
     });
 });
 
-describe('searchAndFilterActors', () => {
+describe('searchAgentSafeActors', () => {
     beforeEach(() => {
         listMock.mockReset();
         paramsHolder.params = {};
@@ -90,7 +90,7 @@ describe('searchAndFilterActors', () => {
 
     it('always sets includeInputSchema=true (public limit is capped at the API max)', async () => {
         listMock.mockResolvedValueOnce({ items: [makeActor(), makeActor(), makeActor()] });
-        const result = await searchAndFilterActors({
+        const result = await searchAgentSafeActors({
             keywords: 'foo',
             apifyToken: 'tok',
             limit: 3,
@@ -103,7 +103,7 @@ describe('searchAndFilterActors', () => {
 
     it('forwards allowsAgenticUsers when paymentProvider is set', async () => {
         listMock.mockResolvedValueOnce({ items: [makeActor()] });
-        await searchAndFilterActors({
+        await searchAgentSafeActors({
             keywords: 'foo',
             apifyToken: 'tok',
             limit: 1,

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ACTOR_PRICING_MODEL, STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../../src/const.js';
+import type { ActorStoreList } from '../../src/types.js';
+import { filterRentalActors, searchAndFilterActors } from '../../src/utils/actor_search.js';
+
+const listMock = vi.fn();
+const paramsHolder: { params: Record<string, unknown> } = { params: {} };
+
+vi.mock('../../src/apify_client.js', () => ({
+    ApifyClient: vi.fn().mockImplementation(() => ({
+        store: () => ({
+            get params(): Record<string, unknown> { return paramsHolder.params; },
+            set params(value: Record<string, unknown>) { paramsHolder.params = value; },
+            list: listMock,
+        }),
+    })),
+}));
+
+function makeActor(idSuffix: number, pricingModel: string = ACTOR_PRICING_MODEL.FREE): ActorStoreList {
+    return {
+        id: `id-${idSuffix}`,
+        name: `actor-${idSuffix}`,
+        username: 'user',
+        currentPricingInfo: { pricingModel },
+        stats: {},
+    } as unknown as ActorStoreList;
+}
+
+describe('filterRentalActors', () => {
+    it('drops rental actors that the user has not rented', () => {
+        const actors = [
+            makeActor(1, ACTOR_PRICING_MODEL.FREE),
+            makeActor(2, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH),
+            makeActor(3, ACTOR_PRICING_MODEL.PAY_PER_EVENT),
+        ];
+        const filtered = filterRentalActors(actors, []);
+        expect(filtered.map((a) => a.id)).toEqual(['id-1', 'id-3']);
+    });
+
+    it('keeps rental actors that the user has rented', () => {
+        const actors = [
+            makeActor(1, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH),
+            makeActor(2, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH),
+        ];
+        expect(filterRentalActors(actors, ['id-1']).map((a) => a.id)).toEqual(['id-1']);
+    });
+});
+
+describe('searchAndFilterActors', () => {
+    beforeEach(() => {
+        listMock.mockReset();
+        paramsHolder.params = {};
+    });
+
+    it('passes includeInputSchema=true and a page-sized limit to the API', async () => {
+        listMock.mockResolvedValueOnce({ items: [makeActor(1), makeActor(2), makeActor(3)] });
+        const result = await searchAndFilterActors({
+            keywords: 'foo',
+            apifyToken: 'tok',
+            limit: 3,
+            offset: 0,
+        });
+        expect(listMock).toHaveBeenCalledTimes(1);
+        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: STORE_INPUT_SCHEMA_PAGE_LIMIT, offset: 0 });
+        expect(paramsHolder.params).toMatchObject({ includeInputSchema: true });
+        expect(result).toHaveLength(3);
+    });
+
+    it('paginates when the first page does not yield enough non-rental actors', async () => {
+        // First page: all rentals → 0 non-rentals; second page: 3 non-rentals.
+        listMock
+            .mockResolvedValueOnce({ items: Array.from({ length: 10 }, (_, i) => makeActor(i, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH)) })
+            .mockResolvedValueOnce({ items: [makeActor(100), makeActor(101), makeActor(102)] });
+        const result = await searchAndFilterActors({
+            keywords: 'foo',
+            apifyToken: 'tok',
+            limit: 3,
+            offset: 0,
+        });
+        expect(listMock).toHaveBeenCalledTimes(2);
+        expect(listMock.mock.calls[1][0]).toMatchObject({ offset: 10 });
+        expect(result.map((a) => a.id)).toEqual(['id-100', 'id-101', 'id-102']);
+    });
+
+    it('returns at most `limit` actors even when more are accumulated across pages', async () => {
+        listMock
+            .mockResolvedValueOnce({ items: Array.from({ length: 10 }, (_, i) => makeActor(i)) })
+            .mockResolvedValueOnce({ items: Array.from({ length: 10 }, (_, i) => makeActor(i + 100)) });
+        const result = await searchAndFilterActors({
+            keywords: 'foo',
+            apifyToken: 'tok',
+            limit: 5,
+            offset: 0,
+        });
+        // First page already covers `limit`; no second call should happen.
+        expect(listMock).toHaveBeenCalledTimes(1);
+        expect(result).toHaveLength(5);
+    });
+
+    it('short-circuits when a page returns fewer items than requested (end of upstream results)', async () => {
+        // Single rental in a 10-slot page → upstream has nothing more; should not roundtrip again.
+        listMock.mockResolvedValueOnce({ items: [makeActor(1, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH)] });
+        const result = await searchAndFilterActors({
+            keywords: 'foo',
+            apifyToken: 'tok',
+            limit: 5,
+            offset: 0,
+        });
+        expect(listMock).toHaveBeenCalledTimes(1);
+        expect(result).toEqual([]);
+    });
+
+    it('stops on an empty page when previous pages were full (rentals burned the budget)', async () => {
+        listMock
+            .mockResolvedValueOnce({ items: Array.from({ length: 10 }, (_, i) => makeActor(i, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH)) })
+            .mockResolvedValueOnce({ items: [] });
+        const result = await searchAndFilterActors({
+            keywords: 'foo',
+            apifyToken: 'tok',
+            limit: 5,
+            offset: 0,
+        });
+        expect(listMock).toHaveBeenCalledTimes(2);
+        expect(result).toEqual([]);
+    });
+
+    it('forwards allowsAgenticUsers when paymentProvider is set', async () => {
+        listMock.mockResolvedValueOnce({ items: [makeActor(1)] });
+        await searchAndFilterActors({
+            keywords: 'foo',
+            apifyToken: 'tok',
+            limit: 1,
+            offset: 0,
+            // The actual provider is not consumed here; only its presence flips the flag.
+            paymentProvider: {} as never,
+        });
+        expect(paramsHolder.params).toMatchObject({ allowsAgenticUsers: true, includeInputSchema: true });
+    });
+});

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -71,12 +71,6 @@ describe('searchActorsByKeywords', () => {
         expect(paramsHolder.params).not.toHaveProperty('allowsAgenticUsers');
     });
 
-    it('forwards `limit` verbatim when `includeInputSchema` is omitted', async () => {
-        listMock.mockResolvedValueOnce({ items: [] });
-        await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok', limit: 50 });
-        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 50, offset: undefined });
-    });
-
     it('throws when `includeInputSchema=true` is paired with `limit > MAX_LIMIT_WITH_INPUT_SCHEMA`', async () => {
         await expect(searchActorsByKeywords({
             search: 'foo',

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -66,7 +66,7 @@ describe('searchActorsByKeywords', () => {
 
     it('omits both flags when not provided', async () => {
         listMock.mockResolvedValueOnce({ items: [] });
-        await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok' });
+        await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok', limit: 5 });
         expect(paramsHolder.params).not.toHaveProperty('includeInputSchema');
         expect(paramsHolder.params).not.toHaveProperty('allowsAgenticUsers');
     });

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -17,14 +17,31 @@ vi.mock('../../src/apify_client.js', () => ({
     })),
 }));
 
-function makeActor(idSuffix: number): ActorStoreList {
-    return {
-        id: `id-${idSuffix}`,
-        name: `actor-${idSuffix}`,
-        username: 'user',
-        currentPricingInfo: { pricingModel: 'FREE' },
-        stats: {},
-    } as unknown as ActorStoreList;
+const baseStoreActor: ActorStoreList = {
+    id: 'id-default',
+    name: 'actor-default',
+    username: 'user',
+    url: 'https://apify.com/user/actor-default',
+    currentPricingInfo: {
+        pricingModel: 'FREE',
+        apifyMarginPercentage: 0,
+        createdAt: new Date(0),
+        startedAt: new Date(0),
+    },
+    stats: {
+        totalBuilds: 0,
+        totalRuns: 0,
+        totalUsers: 0,
+        totalUsers7Days: 0,
+        totalUsers30Days: 0,
+        totalUsers90Days: 0,
+        totalMetamorphs: 0,
+        lastRunStartedAt: new Date(0),
+    },
+};
+
+function makeActor(overrides: Partial<ActorStoreList> = {}): ActorStoreList {
+    return { ...baseStoreActor, ...overrides };
 }
 
 describe('searchActorsByKeywords', () => {
@@ -78,7 +95,7 @@ describe('searchAndFilterActors', () => {
     });
 
     it('always sets includeInputSchema=true (public limit is capped at the API max)', async () => {
-        listMock.mockResolvedValueOnce({ items: [makeActor(1), makeActor(2), makeActor(3)] });
+        listMock.mockResolvedValueOnce({ items: [makeActor(), makeActor(), makeActor()] });
         const result = await searchAndFilterActors({
             keywords: 'foo',
             apifyToken: 'tok',
@@ -91,7 +108,7 @@ describe('searchAndFilterActors', () => {
     });
 
     it('forwards allowsAgenticUsers when paymentProvider is set', async () => {
-        listMock.mockResolvedValueOnce({ items: [makeActor(1)] });
+        listMock.mockResolvedValueOnce({ items: [makeActor()] });
         await searchAndFilterActors({
             keywords: 'foo',
             apifyToken: 'tok',

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../../src/const.js';
 import type { ActorStoreList } from '../../src/types.js';
 import { searchActorsByKeywords, searchAndFilterActors } from '../../src/utils/actor_search.js';
 
@@ -54,21 +53,10 @@ describe('searchActorsByKeywords', () => {
         expect(paramsHolder.params).not.toHaveProperty('allowsAgenticUsers');
     });
 
-    it('clamps `limit` to STORE_INPUT_SCHEMA_PAGE_LIMIT when `includeInputSchema=true` (apify-core would otherwise 400)', async () => {
+    it('forwards `limit` verbatim — caller is responsible for the API cap', async () => {
         listMock.mockResolvedValueOnce({ items: [] });
-        await searchActorsByKeywords({
-            search: 'foo',
-            apifyToken: 'tok',
-            limit: 50,
-            includeInputSchema: true,
-        });
-        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: STORE_INPUT_SCHEMA_PAGE_LIMIT, offset: undefined });
-    });
-
-    it('does not clamp `limit` when `includeInputSchema` is omitted', async () => {
-        listMock.mockResolvedValueOnce({ items: [] });
-        await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok', limit: 50 });
-        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 50, offset: undefined });
+        await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok', limit: 5 });
+        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 5, offset: undefined });
     });
 });
 
@@ -78,7 +66,7 @@ describe('searchAndFilterActors', () => {
         paramsHolder.params = {};
     });
 
-    it('requests includeInputSchema=true when caller limit fits the API cap', async () => {
+    it('always sets includeInputSchema=true (public limit is capped at the API max)', async () => {
         listMock.mockResolvedValueOnce({ items: [makeActor(1), makeActor(2), makeActor(3)] });
         const result = await searchAndFilterActors({
             keywords: 'foo',
@@ -89,19 +77,6 @@ describe('searchAndFilterActors', () => {
         expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 3, offset: 0 });
         expect(paramsHolder.params).toMatchObject({ includeInputSchema: true });
         expect(result).toHaveLength(3);
-    });
-
-    it('drops includeInputSchema when caller limit exceeds the API cap', async () => {
-        listMock.mockResolvedValueOnce({ items: Array.from({ length: 25 }, (_, i) => makeActor(i)) });
-        const result = await searchAndFilterActors({
-            keywords: 'foo',
-            apifyToken: 'tok',
-            limit: 25,
-            offset: 0,
-        });
-        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 25, offset: 0 });
-        expect(paramsHolder.params).not.toHaveProperty('includeInputSchema');
-        expect(result).toHaveLength(25);
     });
 
     it('forwards allowsAgenticUsers when paymentProvider is set', async () => {

--- a/tests/unit/utils.actor_search.test.ts
+++ b/tests/unit/utils.actor_search.test.ts
@@ -1,8 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ACTOR_PRICING_MODEL, STORE_INPUT_SCHEMA_PAGE_LIMIT } from '../../src/const.js';
 import type { ActorStoreList } from '../../src/types.js';
-import { filterRentalActors, searchAndFilterActors } from '../../src/utils/actor_search.js';
+import { searchActorsByKeywords, searchAndFilterActors } from '../../src/utils/actor_search.js';
 
 const listMock = vi.fn();
 const paramsHolder: { params: Record<string, unknown> } = { params: {} };
@@ -17,33 +16,41 @@ vi.mock('../../src/apify_client.js', () => ({
     })),
 }));
 
-function makeActor(idSuffix: number, pricingModel: string = ACTOR_PRICING_MODEL.FREE): ActorStoreList {
+function makeActor(idSuffix: number): ActorStoreList {
     return {
         id: `id-${idSuffix}`,
         name: `actor-${idSuffix}`,
         username: 'user',
-        currentPricingInfo: { pricingModel },
+        currentPricingInfo: { pricingModel: 'FREE' },
         stats: {},
     } as unknown as ActorStoreList;
 }
 
-describe('filterRentalActors', () => {
-    it('drops rental actors that the user has not rented', () => {
-        const actors = [
-            makeActor(1, ACTOR_PRICING_MODEL.FREE),
-            makeActor(2, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH),
-            makeActor(3, ACTOR_PRICING_MODEL.PAY_PER_EVENT),
-        ];
-        const filtered = filterRentalActors(actors, []);
-        expect(filtered.map((a) => a.id)).toEqual(['id-1', 'id-3']);
+describe('searchActorsByKeywords', () => {
+    beforeEach(() => {
+        listMock.mockReset();
+        paramsHolder.params = {};
     });
 
-    it('keeps rental actors that the user has rented', () => {
-        const actors = [
-            makeActor(1, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH),
-            makeActor(2, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH),
-        ];
-        expect(filterRentalActors(actors, ['id-1']).map((a) => a.id)).toEqual(['id-1']);
+    it('forwards `includeInputSchema` and `allowsAgenticUsers` as store-client params', async () => {
+        listMock.mockResolvedValueOnce({ items: [] });
+        await searchActorsByKeywords({
+            search: 'foo',
+            apifyToken: 'tok',
+            limit: 5,
+            offset: 0,
+            includeInputSchema: true,
+            allowsAgenticUsers: true,
+        });
+        expect(paramsHolder.params).toMatchObject({ includeInputSchema: true, allowsAgenticUsers: true });
+        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 5, offset: 0 });
+    });
+
+    it('omits both flags when not provided', async () => {
+        listMock.mockResolvedValueOnce({ items: [] });
+        await searchActorsByKeywords({ search: 'foo', apifyToken: 'tok' });
+        expect(paramsHolder.params).not.toHaveProperty('includeInputSchema');
+        expect(paramsHolder.params).not.toHaveProperty('allowsAgenticUsers');
     });
 });
 
@@ -53,7 +60,7 @@ describe('searchAndFilterActors', () => {
         paramsHolder.params = {};
     });
 
-    it('passes includeInputSchema=true and a page-sized limit to the API', async () => {
+    it('requests includeInputSchema=true when caller limit fits the API cap', async () => {
         listMock.mockResolvedValueOnce({ items: [makeActor(1), makeActor(2), makeActor(3)] });
         const result = await searchAndFilterActors({
             keywords: 'foo',
@@ -61,68 +68,33 @@ describe('searchAndFilterActors', () => {
             limit: 3,
             offset: 0,
         });
-        expect(listMock).toHaveBeenCalledTimes(1);
-        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: STORE_INPUT_SCHEMA_PAGE_LIMIT, offset: 0 });
+        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 3, offset: 0 });
         expect(paramsHolder.params).toMatchObject({ includeInputSchema: true });
         expect(result).toHaveLength(3);
     });
 
-    it('paginates when the first page does not yield enough non-rental actors', async () => {
-        // First page: all rentals → 0 non-rentals; second page: 3 non-rentals.
-        listMock
-            .mockResolvedValueOnce({ items: Array.from({ length: 10 }, (_, i) => makeActor(i, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH)) })
-            .mockResolvedValueOnce({ items: [makeActor(100), makeActor(101), makeActor(102)] });
+    it('drops includeInputSchema when caller limit exceeds the API cap', async () => {
+        listMock.mockResolvedValueOnce({ items: Array.from({ length: 25 }, (_, i) => makeActor(i)) });
         const result = await searchAndFilterActors({
             keywords: 'foo',
             apifyToken: 'tok',
-            limit: 3,
+            limit: 25,
             offset: 0,
         });
-        expect(listMock).toHaveBeenCalledTimes(2);
-        expect(listMock.mock.calls[1][0]).toMatchObject({ offset: 10 });
-        expect(result.map((a) => a.id)).toEqual(['id-100', 'id-101', 'id-102']);
+        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 25, offset: 0 });
+        expect(paramsHolder.params).not.toHaveProperty('includeInputSchema');
+        expect(result).toHaveLength(25);
     });
 
-    it('returns at most `limit` actors even when more are accumulated across pages', async () => {
-        listMock
-            .mockResolvedValueOnce({ items: Array.from({ length: 10 }, (_, i) => makeActor(i)) })
-            .mockResolvedValueOnce({ items: Array.from({ length: 10 }, (_, i) => makeActor(i + 100)) });
-        const result = await searchAndFilterActors({
+    it('passes the caller limit straight through (no over-fetch — API filters rentals)', async () => {
+        listMock.mockResolvedValueOnce({ items: [] });
+        await searchAndFilterActors({
             keywords: 'foo',
             apifyToken: 'tok',
-            limit: 5,
+            limit: 7,
             offset: 0,
         });
-        // First page already covers `limit`; no second call should happen.
-        expect(listMock).toHaveBeenCalledTimes(1);
-        expect(result).toHaveLength(5);
-    });
-
-    it('short-circuits when a page returns fewer items than requested (end of upstream results)', async () => {
-        // Single rental in a 10-slot page → upstream has nothing more; should not roundtrip again.
-        listMock.mockResolvedValueOnce({ items: [makeActor(1, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH)] });
-        const result = await searchAndFilterActors({
-            keywords: 'foo',
-            apifyToken: 'tok',
-            limit: 5,
-            offset: 0,
-        });
-        expect(listMock).toHaveBeenCalledTimes(1);
-        expect(result).toEqual([]);
-    });
-
-    it('stops on an empty page when previous pages were full (rentals burned the budget)', async () => {
-        listMock
-            .mockResolvedValueOnce({ items: Array.from({ length: 10 }, (_, i) => makeActor(i, ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH)) })
-            .mockResolvedValueOnce({ items: [] });
-        const result = await searchAndFilterActors({
-            keywords: 'foo',
-            apifyToken: 'tok',
-            limit: 5,
-            offset: 0,
-        });
-        expect(listMock).toHaveBeenCalledTimes(2);
-        expect(result).toEqual([]);
+        expect(listMock).toHaveBeenCalledWith({ search: 'foo', limit: 7, offset: 0 });
     });
 
     it('forwards allowsAgenticUsers when paymentProvider is set', async () => {


### PR DESCRIPTION
## Context
LLMs hitting `search-actors` previously had to make an N+1 round-trip (`fetch-actor-details` per hit) to learn each Actor's input shape. apify-core#27466 added `includeInputSchema=true` on `GET /v2/store` to project a compact schema server-side.

## Solution
Pass `includeInputSchema=true` and surface the returned shape as `inputFields` on both the structured card and the text card.

## Worth your attention
- **Public `limit` capped at 10** — `searchActorsBaseArgsSchema.limit.max(MAX_LIMIT_WITH_INPUT_SCHEMA)` so every search is uniformly enriched. Closes #791.
- **`searchActorsByKeywords` throws fail-fast** on `includeInputSchema=true` with `limit > MAX_LIMIT_WITH_INPUT_SCHEMA` rather than silently clamping or letting apify-core 400. Public path is Zod-capped, so this is a guard against future internal-caller misuse.
- **Rental filtering is upstream's job** — apify-core's `AGENT_SAFE_PRICING_MODELS` already filters rentals. The legacy `+50` over-fetch, `filterRentalActors`, and the `log.error` observability check are gone.
- **"Input schema" terminology dropped from LLM-facing text** — what we emit is a flat typed field list, not a real JSON Schema. Field name (`inputFields`), card label, helper (`inputFieldsToString`), and tool description all use "input fields" now; `actorInfoSchema.inputFields` encodes the wire shape so strict consumers can validate it.

## Follow-up
- apify-mcp-server-internal#500 — drop the dead Mongo lookup that populated `_meta.userRentedActorIds`
- #805 — drop the now-dead `userRentedActorIds` plumbing in this repo (`InternalToolArgs`, `_meta`, `mcp/server.ts`)
