### PR TITLE
refactor: Actor response to use structured content per MCP spec

### DIFF
--- a/src/tools/core/actor_response.ts
+++ b/src/tools/core/actor_response.ts
@@ -20,19 +20,16 @@ export type ActorResponseResult = {
 
 /**
  * Builds the response content for Actor tool calls.
- * Includes Actor run metadata, output schema, and a preview of output items.
  *
- * The response starts with a preview of Actor output items, if available.
- * This must come first. Metadata and instructions for the LLM are provided last.
- * The LLM may ignore metadata and instructions if it is not at the end of the response.
+ * Returns `structuredContent` (the canonical data payload) and a `content` array with:
+ *   [0] serialized JSON of `structuredContent` — per MCP spec 2025-11-25, tools returning
+ *       structured content SHOULD also return the serialized JSON as a TextContent block
+ *       for backwards-compat clients.
+ *   [1] human-readable metadata + instructions — last, because LLMs ignore metadata that
+ *       isn't at the end of the response.
  *
- * If the preview is limited and does not show all items, the response informs the LLM.
- * This is important because the LLM may assume it has all data and hallucinate missing items.
- *
- * @param actorName - The name of the actor.
- * @param result - The result from callActorGetDataset.
- * @param previewOutput - Whether to include preview items (default: true).
- * @returns The content array and structured content for the tool response.
+ * If the preview is limited, the response informs the LLM so it doesn't hallucinate
+ * missing items.
  */
 export function buildActorResponseContent(
     actorName: string,
@@ -62,12 +59,28 @@ export function buildActorResponseContent(
             Be aware of this and inform users about the currently loaded count and the total available output items count.
         `
         : '';
+    let emptyPreviewNote = '';
+    if (result.previewItems.length === 0) {
+        emptyPreviewNote = previewOutput
+            ? 'No items available for preview—either the Actor did not return any items or they are too large for preview.'
+            : 'Preview skipped (previewOutput: false).';
+    }
     const instructions = dedent`
+        ${emptyPreviewNote}
         If you need to retrieve additional data, use the "get-actor-output" tool with datasetId: "${datasetId}".${previewNote}
         Be sure to limit the number of results when using the "get-actor-output" tool, since you never know how large the items may be, and they might exceed the output limits.
     `;
 
-    // Construct text content
+    // Build structured content — the canonical data payload.
+    const structuredContent = {
+        runId: result.runId,
+        datasetId: result.datasetId,
+        totalItemCount: result.totalItemCount,
+        items: result.previewItems,
+        instructions,
+    };
+
+    // Construct the human-readable text block (metadata + instructions) for LLM consumption.
     const textContent = dedent`
         Actor "${actorName}" completed successfully!
 
@@ -87,38 +100,13 @@ export function buildActorResponseContent(
         ${instructions}
     `;
 
-    const getEmptyPreviewMessage = () => {
-        if (previewOutput) {
-            return dedent`
-                No items available for preview—either the Actor did not return any items or they are too large for preview.
-                Use the "get-actor-output" tool with datasetId: "${result.datasetId}" to retrieve results.
-            `;
-        }
-        return dedent`
-            Preview skipped (previewOutput: false).
-            Use the "get-actor-output" tool with datasetId: "${result.datasetId}" to retrieve results or specific fields.
-        `;
-    };
-
-    const itemsPreviewText = result.previewItems.length > 0
-        ? JSON.stringify(result.previewItems)
-        : getEmptyPreviewMessage();
-
-    // Build content array
+    // Per MCP spec 2025-11-25, a tool returning structuredContent SHOULD also return
+    // the serialized JSON in a TextContent block for backwards-compat clients.
+    // The human-readable block must come last — LLMs don't acknowledge metadata otherwise.
     const content: ({ type: 'text'; text: string })[] = [
-        { type: 'text', text: itemsPreviewText },
-        // The metadata and instructions text must be at the end, otherwise the LLM does not acknowledge it.
+        { type: 'text', text: JSON.stringify(structuredContent) },
         { type: 'text', text: textContent },
     ];
-
-    // Build structured content
-    const structuredContent = {
-        runId: result.runId,
-        datasetId: result.datasetId,
-        totalItemCount: result.totalItemCount,
-        items: result.previewItems,
-        instructions,
-    };
 
     return { content, structuredContent };
 }

--- a/tests/unit/tools.actor_response.test.ts
+++ b/tests/unit/tools.actor_response.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CallActorGetDatasetResult } from '../../src/tools/core/actor_execution.js';
+import { buildActorResponseContent } from '../../src/tools/core/actor_response.js';
+
+const baseResult: CallActorGetDatasetResult = {
+    runId: 'run-123',
+    datasetId: 'dataset-123',
+    totalItemCount: 2,
+    previewItemCount: 2,
+    schema: { type: 'array', items: { type: 'object', properties: { title: { type: 'string' } } } },
+    previewItems: [{ title: 'first' }, { title: 'second' }],
+};
+
+describe('buildActorResponseContent', () => {
+    it('serializes structuredContent into a TextContent block (MCP spec conformance)', () => {
+        const { content, structuredContent } = buildActorResponseContent('apify/rag-web-browser', baseResult);
+
+        const serialized = content.find((block) => block.text === JSON.stringify(structuredContent));
+        expect(serialized).toBeDefined();
+    });
+
+    it('keeps a human-readable text block with metadata and instructions', () => {
+        const { content } = buildActorResponseContent('apify/rag-web-browser', baseResult);
+
+        const humanText = content.map((block) => block.text).join('\n');
+        expect(humanText).toContain('apify/rag-web-browser');
+        expect(humanText).toContain('run-123');
+        expect(humanText).toContain('dataset-123');
+        expect(humanText).toContain('get-actor-output');
+    });
+
+    it('still serializes structuredContent when no preview items are available', () => {
+        const emptyResult: CallActorGetDatasetResult = {
+            ...baseResult,
+            totalItemCount: 0,
+            previewItemCount: 0,
+            previewItems: [],
+        };
+
+        const { content, structuredContent } = buildActorResponseContent('apify/rag-web-browser', emptyResult);
+
+        expect(structuredContent.items).toEqual([]);
+        const serialized = content.find((block) => block.text === JSON.stringify(structuredContent));
+        expect(serialized).toBeDefined();
+        expect(structuredContent.instructions).toContain('No items available');
+    });
+});


### PR DESCRIPTION
## Summary
Refactored `buildActorResponseContent` to align with MCP spec 2025-11-25 by returning structured content as the canonical data payload, with backwards-compatibility support for clients that don't yet support structured content.

## Key Changes
- **Structured Content First**: Introduced `structuredContent` object containing `runId`, `datasetId`, `totalItemCount`, `items`, and `instructions` as the canonical response payload
- **Backwards Compatibility**: Added serialized JSON of `structuredContent` as the first TextContent block per MCP spec recommendations for clients that don't support structured content yet
- **Improved Documentation**: Updated JSDoc to clarify the response structure and MCP spec compliance
- **Better Empty State Handling**: Consolidated empty preview message logic into a single `emptyPreviewNote` variable that's included in instructions
- **Content Block Ordering**: Reordered content blocks so serialized JSON comes first, followed by human-readable metadata/instructions (which must be last for LLM acknowledgment)
- **Test Coverage**: Added comprehensive unit tests verifying structured content serialization, backwards compatibility, and empty state handling

## Implementation Details
- The response now returns both `structuredContent` (structured data) and `content` array (text blocks for LLM consumption)
- Empty preview states are now clearly communicated in the instructions rather than as separate message blocks
- All metadata and instructions remain in the final text block to ensure LLMs properly acknowledge them

https://claude.ai/code/session_01XqXmsBHXsMi5ycLsWm7AUX

Closes: #744
