### PR TITLE
fix: Strip leading whitespace from search-actors text output

### DIFF
--- a/src/tools/default/search_actors.ts
+++ b/src/tools/default/search_actors.ts
@@ -54,15 +54,18 @@ export const defaultSearchActors: ToolEntry = Object.freeze({
             `,
         };
 
-        const instructions = dedent`
+        // Build header and footer with separate `dedent` calls and concatenate around
+        // `actorCardText` — Actor cards may contain tab-indented lines (pay-per-event
+        // pricing) that would corrupt `dedent`'s indent detection if interpolated into
+        // the surrounding template.
+        const header = dedent`
             # Search results:
             - **Search query:** ${parsed.keywords}
             - **Number of Actors found:** ${actors.length}
 
             # Actors:
-
-            ${actorCardText}
-
+        `;
+        const footer = dedent`
             If you need more detailed information about any of these Actors, including their input
             schemas and usage instructions, use the ${HelperTools.ACTOR_GET_DETAILS} tool with the
             specific Actor name.
@@ -70,6 +73,7 @@ export const defaultSearchActors: ToolEntry = Object.freeze({
             (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
             you haven't missed a better Actor.
         `;
-        return buildMCPResponse({ texts: [instructions], structuredContent });
+        const texts = [`${header}\n\n${actorCardText}\n\n${footer}`];
+        return buildMCPResponse({ texts, structuredContent });
     },
 } as const);

--- a/src/utils/pricing_info.ts
+++ b/src/utils/pricing_info.ts
@@ -268,7 +268,7 @@ function formatPayPerEventComplete(
 
     const eventLines = Object.values(pricingPerEvent.actorChargeEvents).map((event) => {
         const detail = formatCompleteEventDetail(event);
-        return `\t- **${event.eventTitle}**: ${event.eventDescription ?? ''} (${detail})`;
+        return `  - **${event.eventTitle}**: ${event.eventDescription ?? ''} (${detail})`;
     });
 
     return `This Actor is paid per event:\n${eventLines.join('\n')}`;
@@ -414,8 +414,8 @@ function formatPayPerEventSimplified(
         }
 
         const detail = typeof price === 'number' ? `$${price} per event` : 'No price info';
-        if (omitDescriptions) return `\t- **${event.eventTitle}**: ${detail}`;
-        return `\t- **${event.eventTitle}**: ${event.eventDescription ?? ''} (${detail})`;
+        if (omitDescriptions) return `  - **${event.eventTitle}**: ${detail}`;
+        return `  - **${event.eventTitle}**: ${event.eventDescription ?? ''} (${detail})`;
     });
 
     const body = `This Actor is paid per event:\n${eventLines.join('\n')}`;

--- a/tests/unit/utils.pricing_info.test.ts
+++ b/tests/unit/utils.pricing_info.test.ts
@@ -226,17 +226,17 @@ describe('pricingInfoToString (complete mode)', () => {
         const out = pricingInfoToString(multiTierPayPerEvent);
         expect(out).toBe(
             'This Actor is paid per event:\n'
-            + '\t- **Scraped place**: A Google Maps place scraped '
+            + '  - **Scraped place**: A Google Maps place scraped '
             + '(FREE: $0.004, BRONZE: $0.004, SILVER: $0.003, '
             + 'GOLD: $0.0021, PLATINUM: $0.00126, DIAMOND: $0.00076 per event)\n'
-            + '\t- **Actor start**: Initial fee for starting the Actor ($0.00005 per event)',
+            + '  - **Actor start**: Initial fee for starting the Actor ($0.00005 per event)',
         );
     });
 
     it('E4: single-tier event renders as flat (no tier label)', () => {
         expect(pricingInfoToString(singleTierPayPerEvent)).toBe(
             'This Actor is paid per event:\n'
-            + '\t- **Scraped place**: A Google Maps place scraped ($0.004 per event)',
+            + '  - **Scraped place**: A Google Maps place scraped ($0.004 per event)',
         );
     });
 
@@ -420,8 +420,8 @@ describe('pricingInfoToSimplifiedString (simplified mode)', () => {
     it('E2: user on GOLD — one price per event, pricingNote appended', () => {
         expect(pricingInfoToSimplifiedString(multiTierPayPerEvent, 'GOLD')).toBe(
             `This Actor is paid per event:\n`
-            + `\t- **Scraped place**: A Google Maps place scraped ($0.0021 per event)\n`
-            + `\t- **Actor start**: Initial fee for starting the Actor ($0.00005 per event)\n${
+            + `  - **Scraped place**: A Google Maps place scraped ($0.0021 per event)\n`
+            + `  - **Actor start**: Initial fee for starting the Actor ($0.00005 per event)\n${
                 NOTE_GOLD}`,
         );
     });
@@ -429,7 +429,7 @@ describe('pricingInfoToSimplifiedString (simplified mode)', () => {
     it('E4: single-tier actor — flat price, no pricingNote', () => {
         expect(pricingInfoToSimplifiedString(singleTierPayPerEvent, 'GOLD')).toBe(
             'This Actor is paid per event:\n'
-            + '\t- **Scraped place**: A Google Maps place scraped ($0.004 per event)',
+            + '  - **Scraped place**: A Google Maps place scraped ($0.004 per event)',
         );
     });
 
@@ -469,20 +469,20 @@ describe('pricingInfoToSimplifiedString (simplified mode)', () => {
     it('omits pricingNote text when PAY_PER_EVENT events resolve to different tiers', () => {
         expect(pricingInfoToSimplifiedString(mixedTierPayPerEvent, 'GOLD')).toBe(
             'This Actor is paid per event:\n'
-            + '\t- **A**:  ($0.005 per event)\n'
-            + '\t- **B**:  ($0.02 per event)',
+            + '  - **A**:  ($0.005 per event)\n'
+            + '  - **B**:  ($0.02 per event)',
         );
     });
 
     it('omits event descriptions in text when PAY_PER_EVENT has more than 5 events', () => {
         expect(pricingInfoToSimplifiedString(longPayPerEvent, 'FREE')).toBe(
             'This Actor is paid per event:\n'
-            + '\t- **Result**: $0.0037 per event\n'
-            + '\t- **Add-on: Date filter**: $0.0013 per event\n'
-            + '\t- **Add-on: Popularity filter**: $0.0013 per event\n'
-            + '\t- **Add-on: Follower / Following**: $0.004 per event\n'
-            + '\t- **Add-on: Search video sorting**: $0.0013 per event\n'
-            + `\t- **Actor start**: $0.001 per event\n${EVENT_DESCRIPTIONS_OMITTED_NOTE}`,
+            + '  - **Result**: $0.0037 per event\n'
+            + '  - **Add-on: Date filter**: $0.0013 per event\n'
+            + '  - **Add-on: Popularity filter**: $0.0013 per event\n'
+            + '  - **Add-on: Follower / Following**: $0.004 per event\n'
+            + '  - **Add-on: Search video sorting**: $0.0013 per event\n'
+            + `  - **Actor start**: $0.001 per event\n${EVENT_DESCRIPTIONS_OMITTED_NOTE}`,
         );
     });
 });


### PR DESCRIPTION
Actor cards can contain tab-indented lines (pay-per-event pricing), which made `dedent` detect a 1-char minimum indent and only strip 1 space from the surrounding 12-space-indented template. Emit header, Actor cards, and footer as separate `texts[]` entries so each `dedent` block computes its own indent independently (CONTRIBUTING.md string formatting guidance).

Fixes #740

<img width="734" height="606" alt="image" src="https://github.com/user-attachments/assets/842f4110-8eb6-423c-954d-5fc026755012" />
