### PR TITLE
fix: Handle full permission approval errors in actor calls

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -199,8 +199,12 @@ export const TOOL_STATUS = {
 export const FAILURE_CATEGORY = {
     INVALID_INPUT: 'INVALID_INPUT',
     AUTH: 'AUTH',
+    PERMISSION_APPROVAL_REQUIRED: 'PERMISSION_APPROVAL_REQUIRED',
     INTERNAL_ERROR: 'INTERNAL_ERROR',
 } as const;
+
+// Apify API error types
+export const APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED = 'full-permission-actor-not-approved';
 
 // HTTP status codes
 export const HTTP_UNAUTHORIZED = 401;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -59,6 +59,7 @@ import type { AvailableWidget } from '../resources/widgets.js';
 import { resolveAvailableWidgets } from '../resources/widgets.js';
 import { getTelemetryEnv, trackToolCall } from '../telemetry.js';
 import { appsActorExecutor } from '../tools/apps/actor_executor.js';
+import { buildPermissionApprovalResponse, isPermissionApprovalError } from '../tools/core/call_actor_common.js';
 import { defaultActorExecutor } from '../tools/default/actor_executor.js';
 import { getActorsAsTools } from '../tools/index.js';
 import { decodeDotPropertyNames, legacyToolNameToNew } from '../tools/utils.js';
@@ -1104,6 +1105,17 @@ export class ActorsMcpServer {
                     return buildPaymentRequiredResponse(error);
                 }
 
+                if (isPermissionApprovalError(error)) {
+                    toolStatus = TOOL_STATUS.SOFT_FAIL;
+                    callDiagnostics = {
+                        failure_category: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
+                        failure_http_status: error.statusCode,
+                        ...buildActorFields(actorName, actorId),
+                    };
+                    logHttpError(error, 'Permission approval required while calling tool', { toolName: name, mcpSessionId });
+                    return buildPermissionApprovalResponse(error);
+                }
+
                 // Re-throw MCP protocol errors (e.g. from failInvalidParams) so the SDK
                 // returns them as JSON-RPC errors. failInvalidParams already set callDiagnostics
                 // with the correct semantic category (e.g. AUTH), so we must not overwrite it.
@@ -1400,6 +1412,17 @@ export class ActorsMcpServer {
                 finishTaskTracking(TOOL_STATUS.SOFT_FAIL, {
                     failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                     failure_http_status: 402,
+                    ...buildActorFields(actorName, actorId),
+                });
+                return;
+            }
+
+            if (isPermissionApprovalError(error)) {
+                logHttpError(error, 'Permission approval required while calling tool (task mode)', { toolName: tool.name });
+                await this.taskStore.storeTaskResult(taskId, 'completed', buildPermissionApprovalResponse(error), mcpSessionId);
+                finishTaskTracking(TOOL_STATUS.SOFT_FAIL, {
+                    failure_category: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
+                    failure_http_status: error.statusCode,
                     ...buildActorFields(actorName, actorId),
                 });
                 return;

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -1,4 +1,5 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { ApifyApiError } from 'apify-client';
 import dedent from 'dedent';
 import { z } from 'zod';
 
@@ -6,6 +7,7 @@ import log from '@apify/log';
 
 import { ApifyClient } from '../../apify_client.js';
 import {
+    APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED,
     CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG,
     FAILURE_CATEGORY,
     HelperTools,
@@ -180,6 +182,45 @@ export function buildStartAsyncResponse(params: {
     };
 }
 
+export function isPermissionApprovalError(error: unknown): error is ApifyApiError {
+    return error instanceof ApifyApiError && error.type === APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED;
+}
+
+/** Exported for native actor tool error handling in server.ts — no logging, no telemetry. */
+export function buildPermissionApprovalResponse(error: ApifyApiError): ReturnType<typeof buildMCPResponse> {
+    const approvalUrl = typeof error.data?.approvalUrl === 'string' ? error.data.approvalUrl : undefined;
+    return buildMCPResponse({
+        texts: [
+            error.message,
+            ...(approvalUrl ? [`Approve here: ${approvalUrl}`] : []),
+        ],
+        isError: true,
+    });
+}
+
+function buildPermissionApprovalErrorResponse(
+    actorName: string,
+    error: ApifyApiError,
+    actorId: string | undefined,
+    logContext: { async: boolean; mcpSessionId: string | undefined },
+): ReturnType<typeof buildMCPResponse> {
+    logHttpError(error, 'Failed to call Actor — permission approval required', {
+        actorName,
+        ...logContext,
+        failureCategory: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
+    });
+    return {
+        ...buildPermissionApprovalResponse(error),
+        toolTelemetry: {
+            toolStatus: TOOL_STATUS.SOFT_FAIL,
+            failureCategory: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
+            failureHttpStatus: error.statusCode,
+            failureDetail: APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED,
+            actorId,
+        },
+    };
+}
+
 export function buildCallActorErrorResponse(params: CallActorErrorResponseParams): ReturnType<typeof buildMCPResponse> {
     const {
         actorName,
@@ -189,6 +230,10 @@ export function buildCallActorErrorResponse(params: CallActorErrorResponseParams
         mcpSessionId,
         actorGetDetailsTool,
     } = params;
+
+    if (error instanceof ApifyApiError && error.type === APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED) {
+        return buildPermissionApprovalErrorResponse(actorName, error, actorId, { async: isAsync, mcpSessionId });
+    }
 
     const errMsg = error instanceof Error ? error.message : String(error);
     const failureCategory = classifyFailureCategory(error);

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -1,9 +1,12 @@
+import { ApifyApiError } from 'apify-client';
+import type { AxiosResponse } from 'axios';
 import { describe, expect, it } from 'vitest';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../src/const.js';
 import {
     buildCallActorDescription,
     buildCallActorErrorResponse,
+    buildPermissionApprovalResponse,
     buildStartAsyncResponse,
 } from '../../src/tools/core/call_actor_common.js';
 
@@ -112,6 +115,72 @@ describe('call_actor_common', () => {
             }));
         });
 
+        it('returns approval URL for full-permission-actor-not-approved error', () => {
+            const approvalUrl = 'https://console.apify.com/actors/abc123?approvePermissions=true';
+            const error = new ApifyApiError({
+                data: {
+                    error: {
+                        type: 'full-permission-actor-not-approved',
+                        message: 'This Actor requires full access to your account. You must approve its permissions before running it.',
+                        data: { approvalUrl },
+                    },
+                },
+                status: 403,
+            } as AxiosResponse, 1);
+
+            const response = buildCallActorErrorResponse({
+                actorName: 'apify/some-actor',
+                error,
+                actorId: 'actor-456',
+                isAsync: false,
+                actorGetDetailsTool: HelperTools.ACTOR_GET_DETAILS,
+            });
+
+            expect(response.isError).toBe(true);
+            const allText = response.content.map((c) => c.text).join('\n');
+            expect(allText).toContain('This Actor requires full access to your account');
+            expect(allText).toContain(approvalUrl);
+            expect(response.toolTelemetry).toEqual(expect.objectContaining({
+                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
+                failureHttpStatus: 403,
+                actorId: 'actor-456',
+            }));
+        });
+    });
+
+    describe('buildPermissionApprovalResponse', () => {
+        const makeError = (approvalUrl?: string) => new ApifyApiError({
+            data: {
+                error: {
+                    type: 'full-permission-actor-not-approved',
+                    message: 'This Actor requires full access to your account. You must approve its permissions before running it.',
+                    ...(approvalUrl ? { data: { approvalUrl } } : {}),
+                },
+            },
+            status: 403,
+        } as AxiosResponse, 1);
+
+        it('includes the approval URL when present', () => {
+            const approvalUrl = 'https://console.apify.com/actors/abc123?approvePermissions=true';
+            const response = buildPermissionApprovalResponse(makeError(approvalUrl));
+
+            expect(response.isError).toBe(true);
+            const allText = response.content.map((c) => c.text).join('\n');
+            expect(allText).toContain('This Actor requires full access to your account');
+            expect(allText).toContain(approvalUrl);
+        });
+
+        it('omits the URL line when approvalUrl is missing from error.data', () => {
+            const response = buildPermissionApprovalResponse(makeError());
+
+            expect(response.isError).toBe(true);
+            expect(response.content).toHaveLength(1);
+            expect(response.content[0]?.text).toContain('This Actor requires full access to your account');
+        });
+    });
+
+    describe('buildCallActorErrorResponse', () => {
         it('uses public search helper name in apps mode', () => {
             const response = buildCallActorErrorResponse({
                 actorName: 'apify/rag-web-browser',


### PR DESCRIPTION
<img width="1548" height="643" alt="image" src="https://github.com/user-attachments/assets/782a128b-ca78-466c-a121-50ace41d4faa" />

Context: https://apify.slack.com/archives/C04URRT3934/p1777550325932419