### PR TITLE
fix: Validate fetch-apify-docs URL by hostname, not prefix

### DIFF
--- a/src/tools/common/fetch_apify_docs.ts
+++ b/src/tools/common/fetch_apify_docs.ts
@@ -32,6 +32,23 @@ export function buildMarkdownUrl(url: string): string {
     return parsed.toString();
 }
 
+const ALLOWED_DOC_HOSTS: ReadonlySet<string> = new Set(
+    ALLOWED_DOC_DOMAINS.map((d) => new URL(d).hostname),
+);
+
+// `startsWith` on the raw URL is bypassable via `https://docs.apify.com.evil.com/`
+// or `https://docs.apify.com@evil.com/` — parse and compare the hostname instead.
+export function isAllowedDocsUrl(url: string): boolean {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+    if (parsed.protocol !== 'https:') return false;
+    return ALLOWED_DOC_HOSTS.has(parsed.hostname);
+}
+
 function buildFetchErrorMessage(url: string, detail: string): string {
     return `Failed to fetch the documentation page at "${url}". ${detail} \
 Please verify the URL is correct and accessible. \
@@ -68,7 +85,7 @@ USAGE EXAMPLES:
         const url = parsed.url.trim();
 
         // Allow URLs from Apify and Crawlee documentation
-        const isAllowedDomain = ALLOWED_DOC_DOMAINS.some((domain) => url.startsWith(domain));
+        const isAllowedDomain = isAllowedDocsUrl(url);
 
         if (!isAllowedDomain) {
             log.softFail(`[fetch-apify-docs] Invalid URL domain: ${url}`);

--- a/tests/unit/tools.fetch_apify_docs.test.ts
+++ b/tests/unit/tools.fetch_apify_docs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildMarkdownUrl } from '../../src/tools/common/fetch_apify_docs.js';
+import { buildMarkdownUrl, isAllowedDocsUrl } from '../../src/tools/common/fetch_apify_docs.js';
 
 describe('buildMarkdownUrl', () => {
     it.each([
@@ -14,5 +14,36 @@ describe('buildMarkdownUrl', () => {
         ['https://docs.apify.com/platform/actors/running#builds', 'https://docs.apify.com/platform/actors/running.md'],
     ])('%s → %s', (input, expected) => {
         expect(buildMarkdownUrl(input)).toBe(expected);
+    });
+});
+
+describe('isAllowedDocsUrl', () => {
+    it.each([
+        'https://docs.apify.com',
+        'https://docs.apify.com/',
+        'https://docs.apify.com/platform/actors/running',
+        'https://docs.apify.com/platform/actors/running#builds',
+        'https://crawlee.dev',
+        'https://crawlee.dev/docs/quick-start',
+    ])('allows %s', (url) => {
+        expect(isAllowedDocsUrl(url)).toBe(true);
+    });
+
+    it.each([
+        // Bypasses called out in GHSA-jwp7-wg77-3w9v
+        'https://docs.apify.com.evil.com/payload',
+        'https://docs.apify.com.evil.com:8080/path',
+        'https://docs.apify.com@evil.com/payload',
+        // Other rejections
+        'https://crawlee.dev.evil.com/',
+        'https://evil.com/docs.apify.com',
+        'http://docs.apify.com/',
+        'ftp://docs.apify.com/',
+        // eslint-disable-next-line no-script-url
+        'javascript:alert(1)',
+        'not-a-url',
+        '',
+    ])('rejects %s', (url) => {
+        expect(isAllowedDocsUrl(url)).toBe(false);
     });
 });


### PR DESCRIPTION
GHSA-jwp7-wg77-3w9v: `url.startsWith(domain)` against allowlist entries
like `https://docs.apify.com` is bypassable by URLs such as
`https://docs.apify.com.evil.com/`, `https://docs.apify.com@evil.com/`,
or `https://docs.apify.com.evil.com:8080/`. The bypass lets the tool
fetch attacker-controlled HTML and return it to the LLM, enabling
prompt injection.

Replace the prefix check with a parsed-URL comparison: derive allowed
hostnames from `ALLOWED_DOC_DOMAINS` once at module load and require
`new URL(url)` to have `protocol === 'https:'` and a hostname in that
set. Add unit coverage for the bypass cases and other rejections.

Fixes https://github.com/apify/apify-mcp-server/security/advisories/GHSA-jwp7-wg77-3w9v