### PR TITLE
fix: Stop sending request headers to Sentry

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -20,7 +20,6 @@ const isTelemetryDisabled = process.argv.includes('--telemetry-enabled=false')
 Sentry.init({
     dsn: 'https://916ec26e2f0abda151403acb5d8370c7@o272833.ingest.us.sentry.io/4510662589808640',
     release: getPackageVersion() ?? undefined,
-    sendDefaultPii: true,
     enabled: !isTelemetryDisabled,
 });
 


### PR DESCRIPTION
Sentry's sendDefaultPii: true override caused outgoing HTTP request
headers - to be attached
to error events. Reverting to the SDK default (false) keeps stack traces
and breadcrumbs while no longer exfiltrating credentials.

https://claude.ai/code/session_016eoqvSPV9G62bY8ThRrfA1