### PR TITLE
feat: Add switch to enable/disable auto-mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ TypeScript, ES modules. Runs in two modes: **stdio** (local CLI clients, `stdio.
 
 Conventional Commits for all three. Branch: `type/short-desc` (e.g. `fix/connection-timeout`). Commit/PR title: `type: Description` (e.g. `fix: Handle connection errors`). Types: `feat`, `fix`, `chore`, `refactor`, `docs`. Append `!` for breaking changes. PR title ≤70 chars.
 
+Use `git mv` (not `mv` + `rm`) when renaming files so git records a rename rather than delete+create.
+
 ## Verification (mandatory)
 
 After every code change, run `npm run type-check`, `npm run lint`, and `npm run test:unit`.

--- a/src/const.ts
+++ b/src/const.ts
@@ -17,6 +17,9 @@ export const ACTOR_MAX_MEMORY_MBYTES = 4_096; // If the Actor requires 8GB of me
 export const TOOL_MAX_OUTPUT_CHARS = 50000;
 
 // MCP Server
+/** When `false`, `resolveServerMode('auto', ...)` forces {@link ServerMode.DEFAULT} regardless of client capabilities. */
+export const SERVER_MODE_AUTO_DETECTION_ENABLED = true;
+
 export const SERVER_NAME = 'apify-mcp-server';
 export const SERVER_TITLE = 'Apify MCP Server';
 // User agent headers

--- a/src/const.ts
+++ b/src/const.ts
@@ -18,7 +18,7 @@ export const TOOL_MAX_OUTPUT_CHARS = 50000;
 
 // MCP Server
 /** When `false`, `resolveServerMode('auto', ...)` forces {@link ServerMode.DEFAULT} regardless of client capabilities. */
-export const SERVER_MODE_AUTO_DETECTION_ENABLED = true;
+export const SERVER_MODE_AUTO_DETECTION_ENABLED = false;
 
 export const SERVER_NAME = 'apify-mcp-server';
 export const SERVER_TITLE = 'Apify MCP Server';

--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -19,7 +19,7 @@ import { ApifyClient } from './apify_client.js';
 import { ActorsMcpServer } from './mcp/server.js';
 import { resolvePaymentProvider } from './payments/index.js';
 import type { ApifyRequestParams } from './types.js';
-import { parseServerMode } from './types.js';
+import { parseServerMode } from './utils/server_mode.js';
 
 enum TransportType {
     HTTP = 'HTTP',

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -76,11 +76,12 @@ import type {
     ToolEntry,
     ToolStatus,
 } from '../types.js';
-import { parseServerMode, resolveServerMode, ServerMode } from '../types.js';
+import { ServerMode } from '../types.js';
 import { getHttpStatusCode, logHttpError } from '../utils/logging.js';
 import { buildMCPResponse, getToolCallErrorUserText } from '../utils/mcp.js';
 import { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
+import { parseServerMode, resolveServerMode } from '../utils/server_mode.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
 import { classifyFailureCategory, extractAjvErrorDetails, extractToolTelemetry, getToolStatusFromError } from '../utils/tool_status.js';
 import { buildActorFields, extractActorId, extractActorName, getToolFullName, getToolPublicFieldOnly } from '../utils/tools.js';

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -36,9 +36,9 @@ import { processInput } from './input.js';
 import { ActorsMcpServer } from './mcp/server.js';
 import { getTelemetryEnv } from './telemetry.js';
 import type { ApifyRequestParams, Input, ServerModeOption, TelemetryEnv, ToolSelector } from './types.js';
-import { parseServerMode } from './types.js';
 import { isApiTokenRequired } from './utils/auth.js';
 import { parseCommaSeparatedList } from './utils/generic.js';
+import { parseServerMode } from './utils/server_mode.js';
 
 // Keeping this type here and not types.ts since
 // it is only relevant to the CLI/STDIO transport in this file

--- a/src/types.ts
+++ b/src/types.ts
@@ -415,45 +415,6 @@ export const SERVER_MODES: readonly ServerMode[] = Object.values(ServerMode);
 export type ServerModeOption = ServerMode | 'auto';
 
 /**
- * Parse an untrusted raw mode string (from CLI flag, env var, or URL param) into a {@link ServerModeOption}.
- *
- * Accepts:
- * - `'default'` / `'apps'` — canonical values
- * - `'true'` / `'on'` / `'false'` / `'off'` — CLI shorthand
- * - `'auto'` — resolve from client capabilities (default for missing/unknown input)
- * - `'openai'` — deprecated alias for `'apps'` (pre-MCP-Apps naming); silently normalized
- *
- * Missing or unrecognized input returns `'auto'`, so a typo in an env var becomes
- * capability-driven resolution instead of silently forcing default mode.
- */
-export function parseServerMode(rawMode: string | null | undefined): ServerModeOption {
-    if (!rawMode) return 'auto';
-    if (rawMode === 'true' || rawMode === 'on' || rawMode === ServerMode.APPS || rawMode === 'openai') return ServerMode.APPS;
-    if (rawMode === 'false' || rawMode === 'off' || rawMode === ServerMode.DEFAULT) return ServerMode.DEFAULT;
-    if (rawMode === 'auto') return 'auto';
-    return 'auto';
-}
-
-/**
- * Emergency kill-switch for capability-driven auto-detection. When `false`,
- * `resolveServerMode('auto', supportsUi)` ignores client capabilities and
- * forces {@link ServerMode.DEFAULT}. Flip to `false` to roll back without
- * reverting code.
- */
-export const IS_SERVER_MODE_AUTO_DETECTION_ENABLED = true;
-
-/**
- * Resolve a {@link ServerModeOption} to a concrete {@link ServerMode}.
- * Concrete modes are returned as-is. `'auto'` resolves to {@link ServerMode.APPS}
- * when the client advertises MCP Apps UI support, {@link ServerMode.DEFAULT} otherwise.
- */
-export function resolveServerMode(option: ServerModeOption, clientSupportsUi: boolean): ServerMode {
-    if (option !== 'auto') return option;
-    if (!IS_SERVER_MODE_AUTO_DETECTION_ENABLED) return ServerMode.DEFAULT;
-    return clientSupportsUi ? ServerMode.APPS : ServerMode.DEFAULT;
-}
-
-/**
  * Parameters for executing a direct actor tool (`type: 'actor'`).
  * Used by ActorExecutor implementations.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -441,11 +441,7 @@ export function parseServerMode(rawMode: string | null | undefined): ServerModeO
  */
 export function resolveServerMode(option: ServerModeOption, clientSupportsUi: boolean): ServerMode {
     if (option !== 'auto') return option;
-    // TODO: re-enable auto-detect from client capabilities. Disabled for the
-    // initial release so APPS mode is opt-in via `?ui=apps` or `UI_MODE=apps`.
-    // return clientSupportsUi ? ServerMode.APPS : ServerMode.DEFAULT;
-    void clientSupportsUi;
-    return ServerMode.DEFAULT;
+    return clientSupportsUi ? ServerMode.APPS : ServerMode.DEFAULT;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -435,12 +435,21 @@ export function parseServerMode(rawMode: string | null | undefined): ServerModeO
 }
 
 /**
+ * Emergency kill-switch for capability-driven auto-detection. When `false`,
+ * `resolveServerMode('auto', supportsUi)` ignores client capabilities and
+ * forces {@link ServerMode.DEFAULT}. Flip to `false` to roll back without
+ * reverting code.
+ */
+export const IS_SERVER_MODE_AUTO_DETECTION_ENABLED = true;
+
+/**
  * Resolve a {@link ServerModeOption} to a concrete {@link ServerMode}.
  * Concrete modes are returned as-is. `'auto'` resolves to {@link ServerMode.APPS}
  * when the client advertises MCP Apps UI support, {@link ServerMode.DEFAULT} otherwise.
  */
 export function resolveServerMode(option: ServerModeOption, clientSupportsUi: boolean): ServerMode {
     if (option !== 'auto') return option;
+    if (!IS_SERVER_MODE_AUTO_DETECTION_ENABLED) return ServerMode.DEFAULT;
     return clientSupportsUi ? ServerMode.APPS : ServerMode.DEFAULT;
 }
 

--- a/src/utils/server_mode.ts
+++ b/src/utils/server_mode.ts
@@ -1,0 +1,33 @@
+import { SERVER_MODE_AUTO_DETECTION_ENABLED } from '../const.js';
+import { ServerMode, type ServerModeOption } from '../types.js';
+
+/**
+ * Parse an untrusted raw mode string (from CLI flag, env var, or URL param) into a {@link ServerModeOption}.
+ *
+ * Accepts:
+ * - `'default'` / `'apps'` — canonical values
+ * - `'true'` / `'on'` / `'false'` / `'off'` — CLI shorthand
+ * - `'auto'` — resolve from client capabilities (default for missing/unknown input)
+ * - `'openai'` — deprecated alias for `'apps'` (pre-MCP-Apps naming); silently normalized
+ *
+ * Missing or unrecognized input returns `'auto'`, so a typo in an env var becomes
+ * capability-driven resolution instead of silently forcing default mode.
+ */
+export function parseServerMode(rawMode: string | null | undefined): ServerModeOption {
+    if (!rawMode) return 'auto';
+    if (rawMode === 'true' || rawMode === 'on' || rawMode === ServerMode.APPS || rawMode === 'openai') return ServerMode.APPS;
+    if (rawMode === 'false' || rawMode === 'off' || rawMode === ServerMode.DEFAULT) return ServerMode.DEFAULT;
+    if (rawMode === 'auto') return 'auto';
+    return 'auto';
+}
+
+/**
+ * Resolve a {@link ServerModeOption} to a concrete {@link ServerMode}.
+ * Concrete modes are returned as-is. `'auto'` resolves to {@link ServerMode.APPS}
+ * when the client advertises MCP Apps UI support, {@link ServerMode.DEFAULT} otherwise.
+ */
+export function resolveServerMode(option: ServerModeOption, clientSupportsUi: boolean): ServerMode {
+    if (option !== 'auto') return option;
+    if (!SERVER_MODE_AUTO_DETECTION_ENABLED) return ServerMode.DEFAULT;
+    return clientSupportsUi ? ServerMode.APPS : ServerMode.DEFAULT;
+}

--- a/src/utils/server_mode.ts
+++ b/src/utils/server_mode.ts
@@ -17,7 +17,6 @@ export function parseServerMode(rawMode: string | null | undefined): ServerModeO
     if (!rawMode) return 'auto';
     if (rawMode === 'true' || rawMode === 'on' || rawMode === ServerMode.APPS || rawMode === 'openai') return ServerMode.APPS;
     if (rawMode === 'false' || rawMode === 'off' || rawMode === ServerMode.DEFAULT) return ServerMode.DEFAULT;
-    if (rawMode === 'auto') return 'auto';
     return 'auto';
 }
 

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2532,10 +2532,7 @@ export function createIntegrationTestsSuite(
             await client.close();
         });
 
-        // TODO(#771): re-enable when auto-detect is re-enabled in resolveServerMode (src/types.ts).
-        // Currently 'auto' resolves to DEFAULT regardless of client UI capability, so these
-        // tests cannot exercise capability-driven mode resolution.
-        it.skip('auto mode: client advertising UI capability receives apps-mode tools with widget metadata', async () => {
+        it('auto mode: client advertising UI capability receives apps-mode tools with widget metadata', async () => {
             // serverMode omitted → server defaults to 'auto'; client sends UI capability → server resolves to 'apps'
             client = await createClientFn({
                 clientCapabilities: {
@@ -2549,7 +2546,7 @@ export function createIntegrationTestsSuite(
             await client.close();
         });
 
-        it.skip('auto mode: client without UI capability receives default-mode tools without widget metadata', async () => {
+        it('auto mode: client without UI capability receives default-mode tools without widget metadata', async () => {
             // serverMode omitted → server defaults to 'auto'; client sends no UI capability → server resolves to 'default'
             client = await createClientFn();
             const tools = await client.listTools();

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -11,7 +11,7 @@ import { RESOURCE_MIME_TYPE } from '../../src/resources/widgets.js';
 import { getCategoryTools, getDefaultTools } from '../../src/tools/index.js';
 import { callActorOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import { actorNameToToolName } from '../../src/tools/utils.js';
-import type { ServerMode, ToolCategory, ToolEntry } from '../../src/types.js';
+import { IS_SERVER_MODE_AUTO_DETECTION_ENABLED, type ServerMode, type ToolCategory, type ToolEntry } from '../../src/types.js';
 import { getExpectedToolNamesByCategories } from '../../src/utils/tool_categories_helpers.js';
 import { ACTOR_MCP_SERVER_ACTOR_NAME, ACTOR_PYTHON_EXAMPLE, DEFAULT_ACTOR_NAMES, getDefaultToolNames } from '../const.js';
 import { addActor, type McpClientOptions } from '../helpers.js';
@@ -2532,7 +2532,8 @@ export function createIntegrationTestsSuite(
             await client.close();
         });
 
-        it('auto mode: client advertising UI capability receives apps-mode tools with widget metadata', async () => {
+        const itIfAutoDetect = IS_SERVER_MODE_AUTO_DETECTION_ENABLED ? it : it.skip;
+        itIfAutoDetect('auto mode: client advertising UI capability receives apps-mode tools with widget metadata', async () => {
             // serverMode omitted → server defaults to 'auto'; client sends UI capability → server resolves to 'apps'
             client = await createClientFn({
                 clientCapabilities: {

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -18,7 +18,7 @@ import { RESOURCE_MIME_TYPE } from '../../src/resources/widgets.js';
 import { getCategoryTools, getDefaultTools } from '../../src/tools/index.js';
 import { callActorOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import { actorNameToToolName } from '../../src/tools/utils.js';
-import { type ServerMode, type ToolCategory, type ToolEntry } from '../../src/types.js';
+import type { ServerMode, ToolCategory, ToolEntry } from '../../src/types.js';
 import { getExpectedToolNamesByCategories } from '../../src/utils/tool_categories_helpers.js';
 import { ACTOR_MCP_SERVER_ACTOR_NAME, ACTOR_PYTHON_EXAMPLE, DEFAULT_ACTOR_NAMES, getDefaultToolNames } from '../const.js';
 import { addActor, type McpClientOptions } from '../helpers.js';

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -5,13 +5,20 @@ import Ajv from 'ajv';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { ApifyClient } from '../../src/apify_client.js';
-import { CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG, defaults, HelperTools, RAG_WEB_BROWSER, SKYFIRE_ENABLED_TOOLS } from '../../src/const.js';
+import {
+    CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG,
+    defaults,
+    HelperTools,
+    RAG_WEB_BROWSER,
+    SERVER_MODE_AUTO_DETECTION_ENABLED,
+    SKYFIRE_ENABLED_TOOLS,
+} from '../../src/const.js';
 import { RESOURCE_MIME_TYPE } from '../../src/resources/widgets.js';
 // Import tools from getCategoryTools instead of directly to avoid circular dependency during module initialization
 import { getCategoryTools, getDefaultTools } from '../../src/tools/index.js';
 import { callActorOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import { actorNameToToolName } from '../../src/tools/utils.js';
-import { IS_SERVER_MODE_AUTO_DETECTION_ENABLED, type ServerMode, type ToolCategory, type ToolEntry } from '../../src/types.js';
+import { type ServerMode, type ToolCategory, type ToolEntry } from '../../src/types.js';
 import { getExpectedToolNamesByCategories } from '../../src/utils/tool_categories_helpers.js';
 import { ACTOR_MCP_SERVER_ACTOR_NAME, ACTOR_PYTHON_EXAMPLE, DEFAULT_ACTOR_NAMES, getDefaultToolNames } from '../const.js';
 import { addActor, type McpClientOptions } from '../helpers.js';
@@ -2532,8 +2539,7 @@ export function createIntegrationTestsSuite(
             await client.close();
         });
 
-        const itIfAutoDetect = IS_SERVER_MODE_AUTO_DETECTION_ENABLED ? it : it.skip;
-        itIfAutoDetect('auto mode: client advertising UI capability receives apps-mode tools with widget metadata', async () => {
+        it.runIf(SERVER_MODE_AUTO_DETECTION_ENABLED)('auto mode: client advertising UI capability receives apps-mode tools with widget metadata', async () => {
             // serverMode omitted → server defaults to 'auto'; client sends UI capability → server resolves to 'apps'
             client = await createClientFn({
                 clientCapabilities: {

--- a/tests/unit/mcp.server.capability_gating.test.ts
+++ b/tests/unit/mcp.server.capability_gating.test.ts
@@ -72,8 +72,7 @@ describe('ActorsMcpServer initialize handler', () => {
             { option: ServerMode.APPS, supportsUi: false, expectedMode: ServerMode.APPS },
             { option: ServerMode.DEFAULT, supportsUi: true, expectedMode: ServerMode.DEFAULT },
             { option: ServerMode.DEFAULT, supportsUi: false, expectedMode: ServerMode.DEFAULT },
-            // TODO: re-enable APPS expectation when auto-detect is restored in resolveServerMode (src/types.ts).
-            { option: 'auto', supportsUi: true, expectedMode: ServerMode.DEFAULT },
+            { option: 'auto', supportsUi: true, expectedMode: ServerMode.APPS },
             { option: 'auto', supportsUi: false, expectedMode: ServerMode.DEFAULT },
         ];
 
@@ -88,8 +87,7 @@ describe('ActorsMcpServer initialize handler', () => {
         }
     });
 
-    // TODO: re-enable when auto-detect is restored in resolveServerMode (src/types.ts).
-    it.skip('flushes pending sources from loadToolsFromInput with the resolved mode after initialize', async () => {
+    it('flushes pending sources from loadToolsFromInput with the resolved mode after initialize', async () => {
         const server = track(makeServer('auto'));
         const apifyClient = new ApifyClient({ token: 'test-token' });
 
@@ -134,8 +132,7 @@ describe('ActorsMcpServer initialize handler', () => {
         expect((server.options as { initializeRequestData?: InitializeRequest }).initializeRequestData).toEqual(request);
     });
 
-    // TODO: re-enable when auto-detect is restored in resolveServerMode (src/types.ts).
-    it.skip('defers helper tools before initialize and recomposes them as apps variants after initialize resolves auto mode to apps', async () => {
+    it('defers helper tools before initialize and recomposes them as apps variants after initialize resolves auto mode to apps', async () => {
         const server = track(makeServer('auto'));
         const apifyClient = new ApifyClient({ token: 'test-token' });
 
@@ -151,8 +148,7 @@ describe('ActorsMcpServer initialize handler', () => {
         expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidgetTool);
     });
 
-    // TODO: re-enable when auto-detect is restored in resolveServerMode (src/types.ts).
-    it.skip('defers apps-only tool names before initialize and registers them after initialize resolves auto mode to apps', async () => {
+    it('defers apps-only tool names before initialize and registers them after initialize resolves auto mode to apps', async () => {
         const server = track(makeServer('auto'));
         const apifyClient = new ApifyClient({ token: 'test-token' });
         const loadActorsAsTools = vi.spyOn(server, 'loadActorsAsTools').mockResolvedValue([]);

--- a/tests/unit/mcp.server.capability_gating.test.ts
+++ b/tests/unit/mcp.server.capability_gating.test.ts
@@ -10,7 +10,7 @@ import { appsCallActor } from '../../src/tools/apps/call_actor.js';
 import { searchActorsWidgetTool } from '../../src/tools/apps/search_actors_widget.js';
 import { defaultSearchActors } from '../../src/tools/default/search_actors.js';
 import type { ServerModeOption } from '../../src/types.js';
-import { ServerMode } from '../../src/types.js';
+import { IS_SERVER_MODE_AUTO_DETECTION_ENABLED, ServerMode } from '../../src/types.js';
 
 type InitHandler = (req: InitializeRequest, ctx: unknown) => Promise<unknown>;
 
@@ -50,6 +50,8 @@ async function dispatchInitialize(server: ActorsMcpServer, request: InitializeRe
     await handler(request, {});
 }
 
+const itIfAutoDetect = IS_SERVER_MODE_AUTO_DETECTION_ENABLED ? it : it.skip;
+
 describe('ActorsMcpServer initialize handler', () => {
     const servers: ActorsMcpServer[] = [];
 
@@ -72,7 +74,11 @@ describe('ActorsMcpServer initialize handler', () => {
             { option: ServerMode.APPS, supportsUi: false, expectedMode: ServerMode.APPS },
             { option: ServerMode.DEFAULT, supportsUi: true, expectedMode: ServerMode.DEFAULT },
             { option: ServerMode.DEFAULT, supportsUi: false, expectedMode: ServerMode.DEFAULT },
-            { option: 'auto', supportsUi: true, expectedMode: ServerMode.APPS },
+            {
+                option: 'auto',
+                supportsUi: true,
+                expectedMode: IS_SERVER_MODE_AUTO_DETECTION_ENABLED ? ServerMode.APPS : ServerMode.DEFAULT,
+            },
             { option: 'auto', supportsUi: false, expectedMode: ServerMode.DEFAULT },
         ];
 
@@ -87,7 +93,7 @@ describe('ActorsMcpServer initialize handler', () => {
         }
     });
 
-    it('flushes pending sources from loadToolsFromInput with the resolved mode after initialize', async () => {
+    itIfAutoDetect('flushes pending sources from loadToolsFromInput with the resolved mode after initialize', async () => {
         const server = track(makeServer('auto'));
         const apifyClient = new ApifyClient({ token: 'test-token' });
 
@@ -132,7 +138,7 @@ describe('ActorsMcpServer initialize handler', () => {
         expect((server.options as { initializeRequestData?: InitializeRequest }).initializeRequestData).toEqual(request);
     });
 
-    it('defers helper tools before initialize and recomposes them as apps variants after initialize resolves auto mode to apps', async () => {
+    itIfAutoDetect('defers helper tools before initialize and recomposes them as apps variants after initialize resolves auto mode to apps', async () => {
         const server = track(makeServer('auto'));
         const apifyClient = new ApifyClient({ token: 'test-token' });
 
@@ -148,7 +154,7 @@ describe('ActorsMcpServer initialize handler', () => {
         expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidgetTool);
     });
 
-    it('defers apps-only tool names before initialize and registers them after initialize resolves auto mode to apps', async () => {
+    itIfAutoDetect('defers apps-only tool names before initialize and registers them after initialize resolves auto mode to apps', async () => {
         const server = track(makeServer('auto'));
         const apifyClient = new ApifyClient({ token: 'test-token' });
         const loadActorsAsTools = vi.spyOn(server, 'loadActorsAsTools').mockResolvedValue([]);

--- a/tests/unit/mcp.server.capability_gating.test.ts
+++ b/tests/unit/mcp.server.capability_gating.test.ts
@@ -3,14 +3,14 @@ import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { ApifyClient } from 'apify-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HelperTools, SERVER_MODE_AUTO_DETECTION_ENABLED } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
 import { RESOURCE_MIME_TYPE } from '../../src/resources/widgets.js';
 import { appsCallActor } from '../../src/tools/apps/call_actor.js';
 import { searchActorsWidgetTool } from '../../src/tools/apps/search_actors_widget.js';
 import { defaultSearchActors } from '../../src/tools/default/search_actors.js';
 import type { ServerModeOption } from '../../src/types.js';
-import { IS_SERVER_MODE_AUTO_DETECTION_ENABLED, ServerMode } from '../../src/types.js';
+import { ServerMode } from '../../src/types.js';
 
 type InitHandler = (req: InitializeRequest, ctx: unknown) => Promise<unknown>;
 
@@ -50,8 +50,6 @@ async function dispatchInitialize(server: ActorsMcpServer, request: InitializeRe
     await handler(request, {});
 }
 
-const itIfAutoDetect = IS_SERVER_MODE_AUTO_DETECTION_ENABLED ? it : it.skip;
-
 describe('ActorsMcpServer initialize handler', () => {
     const servers: ActorsMcpServer[] = [];
 
@@ -77,7 +75,7 @@ describe('ActorsMcpServer initialize handler', () => {
             {
                 option: 'auto',
                 supportsUi: true,
-                expectedMode: IS_SERVER_MODE_AUTO_DETECTION_ENABLED ? ServerMode.APPS : ServerMode.DEFAULT,
+                expectedMode: SERVER_MODE_AUTO_DETECTION_ENABLED ? ServerMode.APPS : ServerMode.DEFAULT,
             },
             { option: 'auto', supportsUi: false, expectedMode: ServerMode.DEFAULT },
         ];
@@ -93,7 +91,7 @@ describe('ActorsMcpServer initialize handler', () => {
         }
     });
 
-    itIfAutoDetect('flushes pending sources from loadToolsFromInput with the resolved mode after initialize', async () => {
+    it.runIf(SERVER_MODE_AUTO_DETECTION_ENABLED)('flushes pending sources from loadToolsFromInput with the resolved mode after initialize', async () => {
         const server = track(makeServer('auto'));
         const apifyClient = new ApifyClient({ token: 'test-token' });
 
@@ -138,34 +136,40 @@ describe('ActorsMcpServer initialize handler', () => {
         expect((server.options as { initializeRequestData?: InitializeRequest }).initializeRequestData).toEqual(request);
     });
 
-    itIfAutoDetect('defers helper tools before initialize and recomposes them as apps variants after initialize resolves auto mode to apps', async () => {
-        const server = track(makeServer('auto'));
-        const apifyClient = new ApifyClient({ token: 'test-token' });
+    it.runIf(SERVER_MODE_AUTO_DETECTION_ENABLED)(
+        'defers helper tools before initialize and recomposes them as apps variants after initialize resolves auto mode to apps',
+        async () => {
+            const server = track(makeServer('auto'));
+            const apifyClient = new ApifyClient({ token: 'test-token' });
 
-        await server.loadToolsByName([HelperTools.STORE_SEARCH, HelperTools.ACTOR_CALL], apifyClient);
+            await server.loadToolsByName([HelperTools.STORE_SEARCH, HelperTools.ACTOR_CALL], apifyClient);
 
-        expect(server.tools.has(HelperTools.STORE_SEARCH)).toBe(false);
-        expect(server.tools.has(HelperTools.ACTOR_CALL)).toBe(false);
+            expect(server.tools.has(HelperTools.STORE_SEARCH)).toBe(false);
+            expect(server.tools.has(HelperTools.ACTOR_CALL)).toBe(false);
 
-        await dispatchInitialize(server, makeInitializeRequest(true));
+            await dispatchInitialize(server, makeInitializeRequest(true));
 
-        expect(server.tools.get(HelperTools.STORE_SEARCH)).toBe(defaultSearchActors);
-        expect(server.tools.get(HelperTools.ACTOR_CALL)).toBe(appsCallActor);
-        expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidgetTool);
-    });
+            expect(server.tools.get(HelperTools.STORE_SEARCH)).toBe(defaultSearchActors);
+            expect(server.tools.get(HelperTools.ACTOR_CALL)).toBe(appsCallActor);
+            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidgetTool);
+        },
+    );
 
-    itIfAutoDetect('defers apps-only tool names before initialize and registers them after initialize resolves auto mode to apps', async () => {
-        const server = track(makeServer('auto'));
-        const apifyClient = new ApifyClient({ token: 'test-token' });
-        const loadActorsAsTools = vi.spyOn(server, 'loadActorsAsTools').mockResolvedValue([]);
+    it.runIf(SERVER_MODE_AUTO_DETECTION_ENABLED)(
+        'defers apps-only tool names before initialize and registers them after initialize resolves auto mode to apps',
+        async () => {
+            const server = track(makeServer('auto'));
+            const apifyClient = new ApifyClient({ token: 'test-token' });
+            const loadActorsAsTools = vi.spyOn(server, 'loadActorsAsTools').mockResolvedValue([]);
 
-        await server.loadToolsByName([HelperTools.STORE_SEARCH_WIDGET], apifyClient);
+            await server.loadToolsByName([HelperTools.STORE_SEARCH_WIDGET], apifyClient);
 
-        expect(loadActorsAsTools).not.toHaveBeenCalled();
-        expect(server.tools.has(HelperTools.STORE_SEARCH_WIDGET)).toBe(false);
+            expect(loadActorsAsTools).not.toHaveBeenCalled();
+            expect(server.tools.has(HelperTools.STORE_SEARCH_WIDGET)).toBe(false);
 
-        await dispatchInitialize(server, makeInitializeRequest(true));
+            await dispatchInitialize(server, makeInitializeRequest(true));
 
-        expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidgetTool);
-    });
+            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidgetTool);
+        },
+    );
 });

--- a/tests/unit/types.resolve_server_mode.test.ts
+++ b/tests/unit/types.resolve_server_mode.test.ts
@@ -10,13 +10,11 @@ describe('resolveServerMode', () => {
         expect(resolveServerMode(ServerMode.DEFAULT, true)).toBe(ServerMode.DEFAULT);
     });
 
-    // TODO: re-enable when auto-detect is restored in resolveServerMode (src/types.ts).
-    it.skip('resolves auto to apps when client supports UI', () => {
+    it('resolves auto to apps when client supports UI', () => {
         expect(resolveServerMode('auto', true)).toBe(ServerMode.APPS);
     });
 
-    it('resolves auto to default regardless of client capabilities (auto-detect disabled)', () => {
+    it('resolves auto to default when client does not support UI', () => {
         expect(resolveServerMode('auto', false)).toBe(ServerMode.DEFAULT);
-        expect(resolveServerMode('auto', true)).toBe(ServerMode.DEFAULT);
     });
 });

--- a/tests/unit/types.resolve_server_mode.test.ts
+++ b/tests/unit/types.resolve_server_mode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveServerMode, ServerMode } from '../../src/types.js';
+import { IS_SERVER_MODE_AUTO_DETECTION_ENABLED, resolveServerMode, ServerMode } from '../../src/types.js';
 
 describe('resolveServerMode', () => {
     it('returns concrete option as-is (capabilities ignored)', () => {
@@ -10,11 +10,21 @@ describe('resolveServerMode', () => {
         expect(resolveServerMode(ServerMode.DEFAULT, true)).toBe(ServerMode.DEFAULT);
     });
 
-    it('resolves auto to apps when client supports UI', () => {
-        expect(resolveServerMode('auto', true)).toBe(ServerMode.APPS);
-    });
-
     it('resolves auto to default when client does not support UI', () => {
         expect(resolveServerMode('auto', false)).toBe(ServerMode.DEFAULT);
     });
+
+    it.runIf(IS_SERVER_MODE_AUTO_DETECTION_ENABLED)(
+        'with kill switch on, resolves auto to apps when client supports UI',
+        () => {
+            expect(resolveServerMode('auto', true)).toBe(ServerMode.APPS);
+        },
+    );
+
+    it.runIf(!IS_SERVER_MODE_AUTO_DETECTION_ENABLED)(
+        'with kill switch off, resolves auto to default regardless of client UI support',
+        () => {
+            expect(resolveServerMode('auto', true)).toBe(ServerMode.DEFAULT);
+        },
+    );
 });

--- a/tests/unit/utils.server_mode.parse.test.ts
+++ b/tests/unit/utils.server_mode.parse.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseServerMode, ServerMode } from '../../src/types.js';
+import { ServerMode } from '../../src/types.js';
+import { parseServerMode } from '../../src/utils/server_mode.js';
 
 describe('parseServerMode', () => {
     it.each([

--- a/tests/unit/utils.server_mode.resolve.test.ts
+++ b/tests/unit/utils.server_mode.resolve.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { IS_SERVER_MODE_AUTO_DETECTION_ENABLED, resolveServerMode, ServerMode } from '../../src/types.js';
+import { SERVER_MODE_AUTO_DETECTION_ENABLED } from '../../src/const.js';
+import { ServerMode } from '../../src/types.js';
+import { resolveServerMode } from '../../src/utils/server_mode.js';
 
 describe('resolveServerMode', () => {
     it('returns concrete option as-is (capabilities ignored)', () => {
@@ -14,15 +16,15 @@ describe('resolveServerMode', () => {
         expect(resolveServerMode('auto', false)).toBe(ServerMode.DEFAULT);
     });
 
-    it.runIf(IS_SERVER_MODE_AUTO_DETECTION_ENABLED)(
-        'with kill switch on, resolves auto to apps when client supports UI',
+    it.runIf(SERVER_MODE_AUTO_DETECTION_ENABLED)(
+        'with auto-detection enabled, resolves auto to apps when client supports UI',
         () => {
             expect(resolveServerMode('auto', true)).toBe(ServerMode.APPS);
         },
     );
 
-    it.runIf(!IS_SERVER_MODE_AUTO_DETECTION_ENABLED)(
-        'with kill switch off, resolves auto to default regardless of client UI support',
+    it.runIf(!SERVER_MODE_AUTO_DETECTION_ENABLED)(
+        'with auto-detection disabled, resolves auto to default regardless of client UI support',
         () => {
             expect(resolveServerMode('auto', true)).toBe(ServerMode.DEFAULT);
         },


### PR DESCRIPTION
Re-enables the capability-driven server mode auto-detection feature that was previously disabled,

- Added `SERVER_MODE_AUTO_DETECTION_ENABLED` 
- The kill switch is a simple boolean constant that can be flipped to `false` to disable auto-detection without reverting code changes
- Kept disabled (`false`) for now, pending further testing before rollout

@MQ37 I'm sorry for a bigger diff than required, but the server-mode helpers were present in the types.ts 🤯 . My bad. Fixed