### PR TITLE
refactor: Reduce export scope of internal constants and types

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -66,8 +66,8 @@ export const defaults = {
     ],
 };
 
-export const SKYFIRE_MIN_CHARGE_USD = 5.0;
-export const SKYFIRE_SELLER_ID = process.env.SKYFIRE_SELLER_SERVICE_ID;
+const SKYFIRE_MIN_CHARGE_USD = 5.0;
+const SKYFIRE_SELLER_ID = process.env.SKYFIRE_SELLER_SERVICE_ID;
 
 export const SKYFIRE_TOOL_INSTRUCTIONS = `To run the Actor, you need to provide a Skyfire PAY JWT token in the \`skyfire-pay-id\` input property. You first need to create the Skyfire PAY token by calling the \`create-pay-token\` tool from the Skyfire MCP server and then provide the created JWT token in the \`skyfire-pay-id\` input property when calling Actor tool. IMPORTANT: The value you pass to \`skyfire-pay-id\` must be the JWT token string itself (it starts with "ey"), NOT an ID or UUID. The Skyfire PAY token is used for billing purposes and needs to be charged with at least ${SKYFIRE_MIN_CHARGE_USD} USD.${SKYFIRE_SELLER_ID ? ` The Skyfire seller ID for Apify MCP server is "${SKYFIRE_SELLER_ID}".` : ''} When retrieving Actor output using the \`get-actor-output\` tool, you also need to provide the same Skyfire PAY JWT token (starting with "ey") in the \`skyfire-pay-id\` input property.`;
 

--- a/src/utils/pricing_info.ts
+++ b/src/utils/pricing_info.ts
@@ -55,7 +55,7 @@ import type {
 
 import { ACTOR_PRICING_MODEL } from '../const.js';
 
-export type TieredEventPrice = {
+type TieredEventPrice = {
     tieredEventPriceUsd: number;
 };
 


### PR DESCRIPTION
Convert exported constants and types to private declarations where they are only used internally.

Related to: https://github.com/apify/apify-mcp-server/issues/643