### PR TITLE
refactor: Localize single-consumer constants (issue #643 phase 2)

### DIFF
--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -2,8 +2,9 @@ import type { ApifyClientOptions } from 'apify-client';
 import { ApifyClient as _ApifyClient } from 'apify-client';
 import type { AxiosRequestConfig } from 'axios';
 
-import { USER_AGENT_ORIGIN } from './const.js';
 import type { PaymentHeaders } from './payments/types.js';
+
+const USER_AGENT_ORIGIN = 'Origin/mcp-server';
 
 type ExtendedApifyClientOptions = Omit<ApifyClientOptions, 'token'> & {
     token?: string | null | undefined;

--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -4,6 +4,7 @@ import type { AxiosRequestConfig } from 'axios';
 
 import type { PaymentHeaders } from './payments/types.js';
 
+// User agent headers
 const USER_AGENT_ORIGIN = 'Origin/mcp-server';
 
 type ExtendedApifyClientOptions = Omit<ApifyClientOptions, 'token'> & {

--- a/src/const.ts
+++ b/src/const.ts
@@ -19,9 +19,6 @@ export const TOOL_MAX_OUTPUT_CHARS = 50000;
 // MCP Server
 export const SERVER_NAME = 'apify-mcp-server';
 export const SERVER_TITLE = 'Apify MCP Server';
-// User agent headers
-export const USER_AGENT_ORIGIN = 'Origin/mcp-server';
-
 export enum HelperTools {
     ACTOR_ADD = 'add-actor',
     ACTOR_CALL = 'call-actor',
@@ -95,16 +92,6 @@ export const SKYFIRE_ENABLED_TOOLS = new Set([
 
 export const CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG = `When calling an MCP server Actor, you must specify the tool name in the actor parameter as "{actorName}:{toolName}" in the "actor" input property.`;
 
-// Cache
-export const ACTOR_CACHE_MAX_SIZE = 500;
-export const ACTOR_CACHE_TTL_SECS = 30 * 60; // 30 minutes
-export const APIFY_DOCS_CACHE_MAX_SIZE = 500;
-export const APIFY_DOCS_CACHE_TTL_SECS = 60 * 60; // 1 hour
-export const MCP_SERVER_CACHE_MAX_SIZE = 500;
-export const MCP_SERVER_CACHE_TTL_SECS = 30 * 60; // 30 minutes
-export const USER_CACHE_MAX_SIZE = 200;
-export const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
-
 export const ACTOR_PRICING_MODEL = {
     /** Rental Actors */
     FLAT_PRICE_PER_MONTH: 'FLAT_PRICE_PER_MONTH',
@@ -114,8 +101,6 @@ export const ACTOR_PRICING_MODEL = {
     /** Pay per event (PPE) Actors */
     PAY_PER_EVENT: 'PAY_PER_EVENT',
 } as const;
-
-export const MCP_STREAMABLE_ENDPOINT = '/mcp';
 
 export const DOCS_SOURCES = [
     {
@@ -160,9 +145,6 @@ export const ALLOWED_DOC_DOMAINS = [
     'https://crawlee.dev',
 ] as const;
 
-// The console uses const MIN_OBSERVER_INTERVAL_MILLIS = 3000 so it should be fine.`
-export const PROGRESS_NOTIFICATION_INTERVAL_MS = 3000; // 3 seconds
-
 export const APIFY_STORE_URL = 'https://apify.com';
 export const APIFY_FAVICON_URL = `${APIFY_STORE_URL}/favicon.ico`;
 export const APIFY_MCP_URL = 'https://mcp.apify.com';
@@ -176,14 +158,6 @@ export const TELEMETRY_ENV = {
 
 export const DEFAULT_TELEMETRY_ENABLED = true;
 export const DEFAULT_TELEMETRY_ENV = TELEMETRY_ENV.PROD;
-
-// We are using the same values as apify-core for consistency (despite that we ship events of different types).
-// https://github.com/apify/apify-core/blob/2284766c122c6ac5bc4f27ec28051f4057d6f9c0/src/packages/analytics/src/server/segment.ts#L28
-// Reasoning from the apify-core:
-// Flush at 50 events to avoid sending too many small requests (default is 15)
-export const SEGMENT_FLUSH_AT_EVENTS = 50;
-// Flush interval in milliseconds (default is 10000)
-export const SEGMENT_FLUSH_INTERVAL_MS = 5_000;
 
 // Tool status
 /**

--- a/src/mcp/actors.ts
+++ b/src/mcp/actors.ts
@@ -1,9 +1,9 @@
 import type { ActorDefinition } from 'apify-client';
 
 import { ApifyClient } from '../apify_client.js';
-import { MCP_STREAMABLE_ENDPOINT } from '../const.js';
 import type { ActorDefinitionPruned } from '../types.js';
 import { parseCommaSeparatedList } from '../utils/generic.js';
+import { MCP_STREAMABLE_ENDPOINT } from './const.js';
 
 /**
  * Returns the MCP server path for the given Actor ID.

--- a/src/mcp/const.ts
+++ b/src/mcp/const.ts
@@ -1,3 +1,5 @@
+export const MCP_STREAMABLE_ENDPOINT = '/mcp';
+
 export const MAX_TOOL_NAME_LENGTH = 64;
 export const TOOL_NAME_HASH_LENGTH = 4;
 export const SERVER_ID_LENGTH = 8;

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,13 +1,12 @@
-import {
-    ACTOR_CACHE_MAX_SIZE,
-    ACTOR_CACHE_TTL_SECS,
-    APIFY_DOCS_CACHE_MAX_SIZE,
-    APIFY_DOCS_CACHE_TTL_SECS,
-    MCP_SERVER_CACHE_MAX_SIZE,
-    MCP_SERVER_CACHE_TTL_SECS,
-} from './const.js';
 import type { ActorDefinitionWithInfo, ApifyDocsSearchResult } from './types.js';
 import { TTLLRUCache } from './utils/ttl_lru.js';
+
+const ACTOR_CACHE_MAX_SIZE = 500;
+const ACTOR_CACHE_TTL_SECS = 30 * 60; // 30 minutes
+const APIFY_DOCS_CACHE_MAX_SIZE = 500;
+const APIFY_DOCS_CACHE_TTL_SECS = 60 * 60; // 1 hour
+const MCP_SERVER_CACHE_MAX_SIZE = 500;
+const MCP_SERVER_CACHE_TTL_SECS = 30 * 60; // 30 minutes
 
 export const actorDefinitionPrunedCache = new TTLLRUCache<ActorDefinitionWithInfo>(ACTOR_CACHE_MAX_SIZE, ACTOR_CACHE_TTL_SECS);
 export const searchApifyDocsCache = new TTLLRUCache<ApifyDocsSearchResult[]>(APIFY_DOCS_CACHE_MAX_SIZE, APIFY_DOCS_CACHE_TTL_SECS);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -6,14 +6,20 @@ import log from '@apify/log';
 
 import {
     DEFAULT_TELEMETRY_ENV,
-    SEGMENT_FLUSH_AT_EVENTS,
-    SEGMENT_FLUSH_INTERVAL_MS,
     TELEMETRY_ENV,
 } from './const.js';
 import type { TelemetryEnv, ToolCallTelemetryProperties } from './types.js';
 
 const DEV_WRITE_KEY = '9rPHlMtxX8FJhilGEwkfUoZ0uzWxnzcT';
 const PROD_WRITE_KEY = 'cOkp5EIJaN69gYaN8bcp7KtaD0fGABwJ';
+
+// We are using the same values as apify-core for consistency (despite that we ship events of different types).
+// https://github.com/apify/apify-core/blob/2284766c122c6ac5bc4f27ec28051f4057d6f9c0/src/packages/analytics/src/server/segment.ts#L28
+// Reasoning from the apify-core:
+// Flush at 50 events to avoid sending too many small requests (default is 15)
+const SEGMENT_FLUSH_AT_EVENTS = 50;
+// Flush interval in milliseconds (default is 10000)
+const SEGMENT_FLUSH_INTERVAL_MS = 5_000;
 
 // Event names following apify-core naming convention (Title Case)
 const SEGMENT_EVENTS = {

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -3,7 +3,8 @@ import type { ProgressNotification } from '@modelcontextprotocol/sdk/types.js';
 import type { ApifyClient } from '../apify_client.js';
 import { RELATED_TASK_META_KEY } from '../const.js';
 
-// The console uses const MIN_OBSERVER_INTERVAL_MILLIS = 3000 so it should be fine.`
+// The console uses const MIN_OBSERVER_INTERVAL_MILLIS = 3000 so it should be fine.
+// Exported for tests to keep fake-timer advances in sync with the production interval.
 export const PROGRESS_NOTIFICATION_INTERVAL_MS = 3000; // 3 seconds
 
 const TERMINAL_RUN_STATUSES = new Set(['SUCCEEDED', 'FAILED', 'ABORTED', 'TIMED-OUT']);

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,7 +1,10 @@
 import type { ProgressNotification } from '@modelcontextprotocol/sdk/types.js';
 
 import type { ApifyClient } from '../apify_client.js';
-import { PROGRESS_NOTIFICATION_INTERVAL_MS, RELATED_TASK_META_KEY } from '../const.js';
+import { RELATED_TASK_META_KEY } from '../const.js';
+
+// The console uses const MIN_OBSERVER_INTERVAL_MILLIS = 3000 so it should be fine.
+export const PROGRESS_NOTIFICATION_INTERVAL_MS = 3000; // 3 seconds
 
 const TERMINAL_RUN_STATUSES = new Set(['SUCCEEDED', 'FAILED', 'ABORTED', 'TIMED-OUT']);
 

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -3,7 +3,7 @@ import type { ProgressNotification } from '@modelcontextprotocol/sdk/types.js';
 import type { ApifyClient } from '../apify_client.js';
 import { RELATED_TASK_META_KEY } from '../const.js';
 
-// The console uses const MIN_OBSERVER_INTERVAL_MILLIS = 3000 so it should be fine.
+// The console uses const MIN_OBSERVER_INTERVAL_MILLIS = 3000 so it should be fine.`
 export const PROGRESS_NOTIFICATION_INTERVAL_MS = 3000; // 3 seconds
 
 const TERMINAL_RUN_STATUSES = new Set(['SUCCEEDED', 'FAILED', 'ABORTED', 'TIMED-OUT']);

--- a/src/utils/userid_cache.ts
+++ b/src/utils/userid_cache.ts
@@ -3,9 +3,11 @@ import { createHash } from 'node:crypto';
 import log from '@apify/log';
 
 import type { ApifyClient } from '../apify_client.js';
-import { USER_CACHE_MAX_SIZE, USER_CACHE_TTL_SECS } from '../const.js';
 import { PRICING_TIERS, type PricingTier } from './pricing_info.js';
 import { TTLLRUCache } from './ttl_lru.js';
+
+const USER_CACHE_MAX_SIZE = 200;
+const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
 
 export type CachedUserInfo = {
     userId: string | null;

--- a/tests/unit/mcp.actors.test.ts
+++ b/tests/unit/mcp.actors.test.ts
@@ -1,8 +1,8 @@
 import type { ActorDefinition } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
-import { MCP_STREAMABLE_ENDPOINT } from '../../src/const.js';
 import { getActorMCPServerPath } from '../../src/mcp/actors.js';
+import { MCP_STREAMABLE_ENDPOINT } from '../../src/mcp/const.js';
 
 // Helper to create a valid ActorDefinition and allow webServerMcpPath for testing
 function makeActorDefinitionWithPath(webServerMcpPath?: unknown): ActorDefinition {

--- a/tests/unit/utils.progress.test.ts
+++ b/tests/unit/utils.progress.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { PROGRESS_NOTIFICATION_INTERVAL_MS, RELATED_TASK_META_KEY } from '../../src/const.js';
-import { createProgressTracker, formatRunStatusMessage, ProgressTracker } from '../../src/utils/progress.js';
+import { RELATED_TASK_META_KEY } from '../../src/const.js';
+import { createProgressTracker, formatRunStatusMessage, PROGRESS_NOTIFICATION_INTERVAL_MS, ProgressTracker } from '../../src/utils/progress.js';
 
 describe('ProgressTracker', () => {
     it('should send progress notifications correctly', async () => {


### PR DESCRIPTION
Phase 2 of #643 — move single-consumer constants from `src/const.ts` to their sole consumer.

## Moves

| Constant(s) | Moved to |
|---|---|
| `ACTOR_CACHE_MAX_SIZE/TTL_SECS`, `APIFY_DOCS_CACHE_MAX_SIZE/TTL_SECS`, `MCP_SERVER_CACHE_MAX_SIZE/TTL_SECS` | `src/state.ts` (private) |
| `USER_CACHE_MAX_SIZE/TTL_SECS` | `src/utils/userid_cache.ts` (private) |
| `MCP_STREAMABLE_ENDPOINT` | `src/mcp/const.ts` (exported — used by unit test) |
| `PROGRESS_NOTIFICATION_INTERVAL_MS` | `src/utils/progress.ts` (exported — used by unit test) |
| `USER_AGENT_ORIGIN` | `src/apify_client.ts` (private) |
| `SEGMENT_FLUSH_AT_EVENTS`, `SEGMENT_FLUSH_INTERVAL_MS` | `src/telemetry.ts` (private) |

## Stale spec note

`ACTOR_SEARCH_ABOVE_LIMIT` was listed in the original Phase 2 plan but is already localized to `src/utils/actor_search.ts` and no longer present in `src/const.ts`. Skipped.

## Verification

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (612 passed, 4 skipped)
- [x] No external imports of the moved constants outside the listed files

Related: #643


---
_Generated by [Claude Code](https://claude.ai/code/session_01J6bAwwvrfHTBhXkTZGyiLA)_