### PR TITLE
refactor: Localize single-consumer types (issue #643 phase 3)

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -7,7 +7,7 @@ import log from '@apify/log';
 
 import { ACTOR_ENUM_MAX_LENGTH, ACTOR_MAX_DESCRIPTION_LENGTH, RAG_WEB_BROWSER_WHITELISTED_FIELDS } from '../const.js';
 import { MAX_TOOL_NAME_LENGTH, TOOL_NAME_HASH_LENGTH } from '../mcp/const.js';
-import type { ActorInfo, ActorInputSchema, ActorInputSchemaProperties, SchemaProperties } from '../types.js';
+import type { ActorInfo, ActorInputSchema, SchemaProperties } from '../types.js';
 import {
     addGlobsProperties,
     addKeyValueProperties,
@@ -16,6 +16,8 @@ import {
     addRequestListSourcesProperties,
     addResourcePickerProperties as addArrayResourcePickerProperties,
 } from '../utils/apify_properties.js';
+
+type ActorInputSchemaProperties = Record<string, SchemaProperties>;
 
 /*
  * Checks if the given ActorInfo represents an MCP server Actor.

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,7 +312,6 @@ export type PromptBase = Prompt & {
     render: (args: Record<string, string>) => string;
 };
 
-export type ActorInputSchemaProperties = Record<string, SchemaProperties>;
 export type DatasetItem = Record<number | string, unknown>;
 /**
  * Apify token type.


### PR DESCRIPTION
Phase 3 of #643 — localize single-consumer types from `src/types.ts`.

## Move applied

| Type | Moved to | Notes |
|---|---|---|
| `ActorInputSchemaProperties` | `src/tools/utils.ts` (private) | Only consumer; not exported via any `index*.ts` |

## Stale spec items (already in place on master)

The following Phase 3 items were already done in earlier work — no change needed:
- `ActorChargeEvent` — already in `src/utils/pricing_info.ts`
- `ActorPricingModel` — already private in `src/utils/actor_search.ts`
- `TieredPricing`, `PricingInfo`, `PricePerEventActorPricingInfo` — already in `src/utils/pricing_info.ts` (`PricePerEventActorPricingInfo` is already private)
- `src/utils/actor_card.ts` already imports `PricingInfo` from `./pricing_info.js`

## Verification

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (613 passed, 4 skipped)

Related: #643

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6bAwwvrfHTBhXkTZGyiLA)_