### PR TITLE
refactor: Move Skyfire constants to src/payments/ (issue #643 phase 4)

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -69,35 +69,6 @@ export const defaults = {
     ],
 };
 
-const SKYFIRE_MIN_CHARGE_USD = 5.0;
-const SKYFIRE_SELLER_ID = process.env.SKYFIRE_SELLER_SERVICE_ID;
-
-export const SKYFIRE_TOOL_INSTRUCTIONS = `To run the Actor, you need to provide a Skyfire PAY JWT token in the \`skyfire-pay-id\` input property. You first need to create the Skyfire PAY token by calling the \`create-pay-token\` tool from the Skyfire MCP server and then provide the created JWT token in the \`skyfire-pay-id\` input property when calling Actor tool. IMPORTANT: The value you pass to \`skyfire-pay-id\` must be the JWT token string itself (it starts with "ey"), NOT an ID or UUID. The Skyfire PAY token is used for billing purposes and needs to be charged with at least ${SKYFIRE_MIN_CHARGE_USD} USD.${SKYFIRE_SELLER_ID ? ` The Skyfire seller ID for Apify MCP server is "${SKYFIRE_SELLER_ID}".` : ''} When retrieving Actor output using the \`get-actor-output\` tool, you also need to provide the same Skyfire PAY JWT token (starting with "ey") in the \`skyfire-pay-id\` input property.`;
-
-export const SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION = `Skyfire PAY JWT token used for billing purposes. This must be the JWT token string returned by the create-pay-token tool (starts with "ey"), NOT a token ID or UUID.`;
-
-export const SKYFIRE_README_CONTENT = `The Apify MCP Server allows clients to interact with Apify Actors, storage, and documentation. Before running any Apify Actor, you need to set up a Skyfire PAY token for billing purposes. To set up the PAY token you need to use the create-pay-token tool from the Skyfire MCP server. The PAY token must be charged with a minimum of ${SKYFIRE_MIN_CHARGE_USD} USD to be valid.${SKYFIRE_SELLER_ID ? ` The Skyfire seller ID for Apify MCP server is "${SKYFIRE_SELLER_ID}".` : ''} When running an Actor using the call-actor tool, you must provide the Skyfire PAY JWT token in the \`skyfire-pay-id\` input property. IMPORTANT: The value for \`skyfire-pay-id\` must be the actual JWT token string (starting with "ey") returned by the create-pay-token tool, NOT a token ID or UUID. Similarly, when retrieving Actor output using the get-actor-output tool, you must also provide the same Skyfire PAY JWT token (starting with "ey") in the \`skyfire-pay-id\` input property.`;
-
-/**
- * Set of internal tool names that require Skyfire PAY token ID in Skyfire mode.
- * These tools interact with Actor runs, datasets, or key-value stores and need billing support.
- */
-export const SKYFIRE_ENABLED_TOOLS = new Set([
-    HelperTools.ACTOR_CALL,
-    HelperTools.ACTOR_OUTPUT_GET,
-    HelperTools.ACTOR_RUNS_GET,
-    HelperTools.ACTOR_RUNS_LOG,
-    HelperTools.ACTOR_RUNS_ABORT,
-    HelperTools.DATASET_GET,
-    HelperTools.DATASET_GET_ITEMS,
-    HelperTools.DATASET_SCHEMA_GET,
-    HelperTools.KEY_VALUE_STORE_GET,
-    HelperTools.KEY_VALUE_STORE_KEYS_GET,
-    HelperTools.KEY_VALUE_STORE_RECORD_GET,
-]);
-
-export const CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG = `When calling an MCP server Actor, you must specify the tool name in the actor parameter as "{actorName}:{toolName}" in the "actor" input property.`;
-
 // Cache
 export const ACTOR_CACHE_MAX_SIZE = 500;
 export const ACTOR_CACHE_TTL_SECS = 30 * 60; // 30 minutes

--- a/src/payments/const.ts
+++ b/src/payments/const.ts
@@ -1,0 +1,28 @@
+import { HelperTools } from '../const.js';
+
+const SKYFIRE_MIN_CHARGE_USD = 5.0;
+const SKYFIRE_SELLER_ID = process.env.SKYFIRE_SELLER_SERVICE_ID;
+
+export const SKYFIRE_TOOL_INSTRUCTIONS = `To run the Actor, you need to provide a Skyfire PAY JWT token in the \`skyfire-pay-id\` input property. You first need to create the Skyfire PAY token by calling the \`create-pay-token\` tool from the Skyfire MCP server and then provide the created JWT token in the \`skyfire-pay-id\` input property when calling Actor tool. IMPORTANT: The value you pass to \`skyfire-pay-id\` must be the JWT token string itself (it starts with "ey"), NOT an ID or UUID. The Skyfire PAY token is used for billing purposes and needs to be charged with at least ${SKYFIRE_MIN_CHARGE_USD} USD.${SKYFIRE_SELLER_ID ? ` The Skyfire seller ID for Apify MCP server is "${SKYFIRE_SELLER_ID}".` : ''} When retrieving Actor output using the \`get-actor-output\` tool, you also need to provide the same Skyfire PAY JWT token (starting with "ey") in the \`skyfire-pay-id\` input property.`;
+
+export const SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION = `Skyfire PAY JWT token used for billing purposes. This must be the JWT token string returned by the create-pay-token tool (starts with "ey"), NOT a token ID or UUID.`;
+
+export const SKYFIRE_README_CONTENT = `The Apify MCP Server allows clients to interact with Apify Actors, storage, and documentation. Before running any Apify Actor, you need to set up a Skyfire PAY token for billing purposes. To set up the PAY token you need to use the create-pay-token tool from the Skyfire MCP server. The PAY token must be charged with a minimum of ${SKYFIRE_MIN_CHARGE_USD} USD to be valid.${SKYFIRE_SELLER_ID ? ` The Skyfire seller ID for Apify MCP server is "${SKYFIRE_SELLER_ID}".` : ''} When running an Actor using the call-actor tool, you must provide the Skyfire PAY JWT token in the \`skyfire-pay-id\` input property. IMPORTANT: The value for \`skyfire-pay-id\` must be the actual JWT token string (starting with "ey") returned by the create-pay-token tool, NOT a token ID or UUID. Similarly, when retrieving Actor output using the get-actor-output tool, you must also provide the same Skyfire PAY JWT token (starting with "ey") in the \`skyfire-pay-id\` input property.`;
+
+/**
+ * Set of internal tool names that require Skyfire PAY token ID in Skyfire mode.
+ * These tools interact with Actor runs, datasets, or key-value stores and need billing support.
+ */
+export const SKYFIRE_ENABLED_TOOLS = new Set([
+    HelperTools.ACTOR_CALL,
+    HelperTools.ACTOR_OUTPUT_GET,
+    HelperTools.ACTOR_RUNS_GET,
+    HelperTools.ACTOR_RUNS_LOG,
+    HelperTools.ACTOR_RUNS_ABORT,
+    HelperTools.DATASET_GET,
+    HelperTools.DATASET_GET_ITEMS,
+    HelperTools.DATASET_SCHEMA_GET,
+    HelperTools.KEY_VALUE_STORE_GET,
+    HelperTools.KEY_VALUE_STORE_KEYS_GET,
+    HelperTools.KEY_VALUE_STORE_RECORD_GET,
+]);

--- a/src/payments/skyfire.ts
+++ b/src/payments/skyfire.ts
@@ -1,11 +1,11 @@
+import type { ToolEntry } from '../types.js';
+import { redactSkyfirePayId } from '../utils/logging.js';
+import { cloneToolEntry } from '../utils/tools.js';
 import {
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
     SKYFIRE_README_CONTENT,
     SKYFIRE_TOOL_INSTRUCTIONS,
-} from '../const.js';
-import type { ToolEntry } from '../types.js';
-import { redactSkyfirePayId } from '../utils/logging.js';
-import { cloneToolEntry } from '../utils/tools.js';
+} from './const.js';
 import type { PaymentHeaders, PaymentProvider } from './types.js';
 
 const SKYFIRE_PAY_ID_KEY = 'skyfire-pay-id';

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -8,7 +8,6 @@ import log from '@apify/log';
 import { ApifyClient } from '../../apify_client.js';
 import {
     APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED,
-    CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG,
     FAILURE_CATEGORY,
     HelperTools,
     TOOL_STATUS,
@@ -30,6 +29,8 @@ import { fixActorNameInputAndLog, getActorsAsTools } from './actor_tools_factory
 // ---------------------------------------------------------------------------
 
 const RAG_WEB_BROWSER_TOOL = actorNameToToolName('apify/rag-web-browser');
+
+export const CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG = `When calling an MCP server Actor, you must specify the tool name in the actor parameter as "{actorName}:{toolName}" in the "actor" input property.`;
 
 /** Shared MCP server instructions — identical in both modes. */
 export const CALL_ACTOR_MCP_SERVER_SECTION = `For MCP server Actors:

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,9 +1,9 @@
+import { type HelperTools } from '../const.js';
 import {
-    type HelperTools,
     SKYFIRE_ENABLED_TOOLS,
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
     SKYFIRE_TOOL_INSTRUCTIONS,
-} from '../const.js';
+} from '../payments/const.js';
 import type { CallDiagnostics, HelperTool, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
 import { ServerMode } from '../types.js';
 import { fixZodSchemaRequired } from './ajv.js';

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -6,14 +6,14 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 
 import { ApifyClient } from '../../src/apify_client.js';
 import {
-    CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG,
     defaults,
     HelperTools,
     RAG_WEB_BROWSER,
     SERVER_MODE_AUTO_DETECTION_ENABLED,
-    SKYFIRE_ENABLED_TOOLS,
 } from '../../src/const.js';
+import { SKYFIRE_ENABLED_TOOLS } from '../../src/payments/const.js';
 import { RESOURCE_MIME_TYPE } from '../../src/resources/widgets.js';
+import { CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG } from '../../src/tools/core/call_actor_common.js';
 // Import tools from getCategoryTools instead of directly to avoid circular dependency during module initialization
 import { getCategoryTools, getDefaultTools } from '../../src/tools/index.js';
 import { callActorOutputSchema } from '../../src/tools/structured_output_schemas.js';

--- a/tests/unit/mcp.utils.test.ts
+++ b/tests/unit/mcp.utils.test.ts
@@ -1,8 +1,8 @@
 import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
 import { describe, expect, it, vi } from 'vitest';
 
-import { SKYFIRE_README_CONTENT } from '../../src/const.js';
 import { isTaskCancelled, parseInputParamsFromUrl } from '../../src/mcp/utils.js';
+import { SKYFIRE_README_CONTENT } from '../../src/payments/const.js';
 import { resolvePaymentProvider } from '../../src/payments/index.js';
 import { createResourceService } from '../../src/resources/resource_service.js';
 import type { AvailableWidget } from '../../src/resources/widgets.js';

--- a/tests/unit/tools.skyfire.test.ts
+++ b/tests/unit/tools.skyfire.test.ts
@@ -10,12 +10,12 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 
+import { HelperTools } from '../../src/const.js';
 import {
-    HelperTools,
     SKYFIRE_ENABLED_TOOLS,
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
     SKYFIRE_TOOL_INSTRUCTIONS,
-} from '../../src/const.js';
+} from '../../src/payments/const.js';
 import type { ActorMcpTool, ActorTool, HelperTool, ToolEntry } from '../../src/types.js';
 import { applySkyfireAugmentation, cloneToolEntry } from '../../src/utils/tools.js';
 


### PR DESCRIPTION
Phase 4 of #643 — move Skyfire and call-actor constants out of `src/const.ts`.

## New file

`src/payments/const.ts` holding the full Skyfire cluster:
- `SKYFIRE_MIN_CHARGE_USD` (private)
- `SKYFIRE_SELLER_ID` (private)
- `SKYFIRE_TOOL_INSTRUCTIONS`
- `SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION`
- `SKYFIRE_README_CONTENT`
- `SKYFIRE_ENABLED_TOOLS`

The two private constants stay private (their only references are inside the same file via template literals).

## Move

`CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG` → `src/tools/core/call_actor_common.ts` (its sole production consumer; integration test import updated).

## Consumers updated

- `src/payments/skyfire.ts` → import from `./const.js`
- `src/utils/tools.ts` → import Skyfire consts from `../payments/const.js`
- `src/tools/core/call_actor_common.ts` → declares `CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG` locally
- `tests/unit/tools.skyfire.test.ts` → Skyfire consts from `src/payments/const.js`
- `tests/unit/mcp.utils.test.ts` → `SKYFIRE_README_CONTENT` from `src/payments/const.js`
- `tests/integration/suite.ts` → splits imports across `src/payments/const.js` and `src/tools/core/call_actor_common.js`

## Spec verification

Spec matched current code. Phase 1 already un-exported `SKYFIRE_MIN_CHARGE_USD` / `SKYFIRE_SELLER_ID` — preserved here.

## Verification

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (613 passed, 4 skipped)

Related: #643

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6bAwwvrfHTBhXkTZGyiLA)_