### PR TITLE
refactor: reorganize mcp.utils and resource service tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Default tools to cover: `search-actors`, `fetch-actor-details`, `call-actor`, `g
 - **Integration tests**: `npm run test:integration` (needs build + `APIFY_TOKEN`, humans only).
 - `tests/integration/suite.ts` is the main suite, reused by stdio/streamable-http transports. Add new integration cases there, NOT in separate files.
 - Follow existing test patterns (names, structure) — check neighboring files.
+- **Test naming**: `describe('fnName()')`, plain-verb `it()` names (no `should` prefix). Group with nested `describe()` per method when a factory/class exposes several.
 
 ## External dependencies
 

--- a/tests/unit/mcp.utils.test.ts
+++ b/tests/unit/mcp.utils.test.ts
@@ -3,80 +3,80 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { isTaskCancelled, parseInputParamsFromUrl } from '../../src/mcp/utils.js';
 
-describe('parseInputParamsFromUrl', () => {
-    it('should handle URL without query params', () => {
+describe('parseInputParamsFromUrl()', () => {
+    it('handles URL without query params', () => {
         const url = 'https://mcp.apify.com';
         const result = parseInputParamsFromUrl(url);
         expect(result.actors).toBeUndefined();
     });
 
-    it('should parse Actors from URL query params (as tools)', () => {
+    it('parses Actors from URL query params as tools', () => {
         const url = 'https://mcp.apify.com?token=123&actors=apify/web-scraper';
         const result = parseInputParamsFromUrl(url);
         expect(result.tools).toEqual(['apify/web-scraper']);
         expect(result.actors).toBeUndefined();
     });
 
-    it('should parse multiple Actors from URL (as tools)', () => {
+    it('parses multiple Actors from URL as tools', () => {
         const url = 'https://mcp.apify.com?actors=apify/instagram-scraper,lukaskrivka/google-maps';
         const result = parseInputParamsFromUrl(url);
         expect(result.tools).toEqual(['apify/instagram-scraper', 'lukaskrivka/google-maps']);
         expect(result.actors).toBeUndefined();
     });
 
-    it('should handle Actors as string parameter (as tools)', () => {
+    it('handles Actors as string parameter as tools', () => {
         const url = 'https://mcp.apify.com?actors=apify/rag-web-browser';
         const result = parseInputParamsFromUrl(url);
         expect(result.tools).toEqual(['apify/rag-web-browser']);
         expect(result.actors).toBeUndefined();
     });
 
-    it('should parse the deprecated enableActorAutoLoading flag as enableAddingActors', () => {
+    it('parses the deprecated enableActorAutoLoading flag as enableAddingActors', () => {
         const url = 'https://mcp.apify.com?enableActorAutoLoading=true';
         const result = parseInputParamsFromUrl(url);
         expect(result.enableAddingActors).toBe(true);
     });
 
-    it('should parse enableAddingActors=true', () => {
+    it('parses enableAddingActors=true', () => {
         const url = 'https://mcp.apify.com?enableAddingActors=true';
         const result = parseInputParamsFromUrl(url);
         expect(result.enableAddingActors).toBe(true);
     });
 
-    it('should parse enableAddingActors=false', () => {
+    it('parses enableAddingActors=false', () => {
         const url = 'https://mcp.apify.com?enableAddingActors=false';
         const result = parseInputParamsFromUrl(url);
         expect(result.enableAddingActors).toBe(false);
     });
 });
 
-describe('isTaskCancelled', () => {
+describe('isTaskCancelled()', () => {
     const makeTaskStore = (getTaskReturn: unknown) => ({
         getTask: vi.fn().mockResolvedValue(getTaskReturn),
     } as unknown as TaskStore);
 
-    it('should return true when task status is cancelled', async () => {
+    it('returns true when task status is cancelled', async () => {
         const taskStore = makeTaskStore({ status: 'cancelled' });
         const result = await isTaskCancelled('task-1', 'session-1', taskStore);
 
         expect(result).toBe(true);
     });
 
-    it('should return false when task status is not cancelled', async () => {
+    it('returns false when task status is not cancelled', async () => {
         const taskStore = makeTaskStore({ status: 'working' });
         const result = await isTaskCancelled('task-1', 'session-1', taskStore);
 
         expect(result).toBe(false);
     });
 
-    it('should return false when task is not found (getTask returns undefined)', async () => {
+    it('returns false when task is not found (getTask returns undefined)', async () => {
         const taskStore = makeTaskStore(undefined);
         const result = await isTaskCancelled('task-1', 'session-1', taskStore);
 
         expect(result).toBe(false);
     });
 
-    it('should pass taskId and mcpSessionId through to taskStore.getTask', async () => {
+    it('passes taskId and mcpSessionId through to taskStore.getTask', async () => {
         const taskStore = makeTaskStore({ status: 'working' });
         await isTaskCancelled('task-42', 'session-xyz', taskStore);
 

--- a/tests/unit/mcp.utils.test.ts
+++ b/tests/unit/mcp.utils.test.ts
@@ -4,6 +4,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { isTaskCancelled, parseInputParamsFromUrl } from '../../src/mcp/utils.js';
 
 describe('parseInputParamsFromUrl', () => {
+    it('should handle URL without query params', () => {
+        const url = 'https://mcp.apify.com';
+        const result = parseInputParamsFromUrl(url);
+        expect(result.actors).toBeUndefined();
+    });
+
     it('should parse Actors from URL query params (as tools)', () => {
         const url = 'https://mcp.apify.com?token=123&actors=apify/web-scraper';
         const result = parseInputParamsFromUrl(url);
@@ -18,35 +24,29 @@ describe('parseInputParamsFromUrl', () => {
         expect(result.actors).toBeUndefined();
     });
 
-    it('should handle URL without query params', () => {
-        const url = 'https://mcp.apify.com';
-        const result = parseInputParamsFromUrl(url);
-        expect(result.actors).toBeUndefined();
-    });
-
-    it('should parse enableActorAutoLoading flag', () => {
-        const url = 'https://mcp.apify.com?enableActorAutoLoading=true';
-        const result = parseInputParamsFromUrl(url);
-        expect(result.enableAddingActors).toBe(true);
-    });
-
-    it('should parse enableAddingActors flag', () => {
-        const url = 'https://mcp.apify.com?enableAddingActors=true';
-        const result = parseInputParamsFromUrl(url);
-        expect(result.enableAddingActors).toBe(true);
-    });
-
-    it('should parse enableAddingActors flag', () => {
-        const url = 'https://mcp.apify.com?enableAddingActors=false';
-        const result = parseInputParamsFromUrl(url);
-        expect(result.enableAddingActors).toBe(false);
-    });
-
     it('should handle Actors as string parameter (as tools)', () => {
         const url = 'https://mcp.apify.com?actors=apify/rag-web-browser';
         const result = parseInputParamsFromUrl(url);
         expect(result.tools).toEqual(['apify/rag-web-browser']);
         expect(result.actors).toBeUndefined();
+    });
+
+    it('should parse the deprecated enableActorAutoLoading flag as enableAddingActors', () => {
+        const url = 'https://mcp.apify.com?enableActorAutoLoading=true';
+        const result = parseInputParamsFromUrl(url);
+        expect(result.enableAddingActors).toBe(true);
+    });
+
+    it('should parse enableAddingActors=true', () => {
+        const url = 'https://mcp.apify.com?enableAddingActors=true';
+        const result = parseInputParamsFromUrl(url);
+        expect(result.enableAddingActors).toBe(true);
+    });
+
+    it('should parse enableAddingActors=false', () => {
+        const url = 'https://mcp.apify.com?enableAddingActors=false';
+        const result = parseInputParamsFromUrl(url);
+        expect(result.enableAddingActors).toBe(false);
     });
 });
 

--- a/tests/unit/mcp.utils.test.ts
+++ b/tests/unit/mcp.utils.test.ts
@@ -1,19 +1,7 @@
 import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
 import { describe, expect, it, vi } from 'vitest';
 
-import { SKYFIRE_README_CONTENT } from '../../src/const.js';
 import { isTaskCancelled, parseInputParamsFromUrl } from '../../src/mcp/utils.js';
-import { resolvePaymentProvider } from '../../src/payments/index.js';
-import { createResourceService } from '../../src/resources/resource_service.js';
-import type { AvailableWidget } from '../../src/resources/widgets.js';
-import { WIDGET_REGISTRY, WIDGET_URIS } from '../../src/resources/widgets.js';
-
-vi.mock('node:fs', () => ({
-    readFileSync: vi.fn(),
-    default: {
-        readFileSync: vi.fn(),
-    },
-}));
 
 describe('parseInputParamsFromUrl', () => {
     it('should parse Actors from URL query params (as tools)', () => {
@@ -93,115 +81,5 @@ describe('isTaskCancelled', () => {
         await isTaskCancelled('task-42', 'session-xyz', taskStore);
 
         expect(taskStore.getTask).toHaveBeenCalledWith('task-42', 'session-xyz');
-    });
-});
-
-describe('MCP resources', () => {
-    const buildAvailableWidget = (uri: string, exists: boolean): AvailableWidget => ({
-        ...WIDGET_REGISTRY[uri],
-        jsPath: `/tmp/${WIDGET_REGISTRY[uri].jsFilename}`,
-        exists,
-    });
-
-    it('lists the Skyfire readme only when enabled', async () => {
-        const skyfireService = createResourceService({
-            getMode: () => 'default',
-            paymentProvider: await resolvePaymentProvider('skyfire'),
-            getAvailableWidgets: () => new Map(),
-        });
-        const defaultService = createResourceService({
-            getMode: () => 'default',
-            paymentProvider: undefined,
-            getAvailableWidgets: () => new Map(),
-        });
-
-        const skyfireResources = await skyfireService.listResources();
-        const defaultResources = await defaultService.listResources();
-
-        expect(skyfireResources.resources.some((resource) => resource.uri === 'file://readme.md')).toBe(true);
-        expect(defaultResources.resources.some((resource) => resource.uri === 'file://readme.md')).toBe(false);
-    });
-
-    it('lists apps widgets only when available', async () => {
-        const widgets = new Map<string, AvailableWidget>([
-            [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, true)],
-            [WIDGET_URIS.ACTOR_RUN, buildAvailableWidget(WIDGET_URIS.ACTOR_RUN, false)],
-        ]);
-        const service = createResourceService({
-            getMode: () => 'apps',
-            getAvailableWidgets: () => widgets,
-        });
-
-        const { resources } = await service.listResources();
-
-        expect(resources.map((resource) => resource.uri)).toEqual([WIDGET_URIS.SEARCH_ACTORS]);
-    });
-
-    it('returns a plain-text message for missing resources', async () => {
-        const service = createResourceService({
-            getMode: () => 'default',
-            getAvailableWidgets: () => new Map(),
-        });
-
-        const result = await service.readResource('file://missing.md');
-
-        expect(result.contents[0].text).toBe('Resource file://missing.md not found');
-        expect(result.contents[0].mimeType).toBe('text/plain');
-    });
-
-    it('returns the Skyfire readme content when requested', async () => {
-        const service = createResourceService({
-            getMode: () => 'default',
-            paymentProvider: await resolvePaymentProvider('skyfire'),
-            getAvailableWidgets: () => new Map(),
-        });
-
-        const result = await service.readResource('file://readme.md');
-
-        expect(result.contents[0].text).toBe(SKYFIRE_README_CONTENT);
-        expect(result.contents[0].mimeType).toBe('text/markdown');
-    });
-
-    it('returns a plain-text message for unknown widgets', async () => {
-        const service = createResourceService({
-            getMode: () => 'apps',
-            getAvailableWidgets: () => new Map(),
-        });
-
-        const result = await service.readResource('ui://widget/unknown.html');
-
-        expect(result.contents[0].text).toContain('Not found in registry.');
-        expect(result.contents[0].mimeType).toBe('text/plain');
-    });
-
-    it('returns widget HTML when a widget exists', async () => {
-        const fs = await import('node:fs');
-        const readFileSync = vi.mocked(fs.readFileSync);
-        readFileSync.mockReturnValue('console.log("widget");');
-
-        const widgets = new Map<string, AvailableWidget>([
-            [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, true)],
-        ]);
-        const service = createResourceService({
-            getMode: () => 'apps',
-            getAvailableWidgets: () => widgets,
-        });
-
-        const result = await service.readResource(WIDGET_URIS.SEARCH_ACTORS);
-
-        expect(result.contents[0].mimeType).toBe('text/html;profile=mcp-app');
-        expect(result.contents[0].text).toContain('console.log("widget");');
-        expect(result.contents[0].html).toContain('<script type="module">console.log("widget");</script>');
-    });
-
-    it('returns an empty resource templates list', async () => {
-        const service = createResourceService({
-            getMode: () => 'default',
-            getAvailableWidgets: () => new Map(),
-        });
-
-        const result = await service.listResourceTemplates();
-
-        expect(result).toEqual({ resourceTemplates: [] });
     });
 });

--- a/tests/unit/resources.service.test.ts
+++ b/tests/unit/resources.service.test.ts
@@ -14,141 +14,147 @@ vi.mock('node:fs', () => ({
     },
 }));
 
-describe('MCP resources', () => {
-    const buildAvailableWidget = (uri: string, exists: boolean): AvailableWidget => ({
-        ...WIDGET_REGISTRY[uri],
-        jsPath: `/tmp/${WIDGET_REGISTRY[uri].jsFilename}`,
-        exists,
+const buildAvailableWidget = (uri: string, exists: boolean): AvailableWidget => ({
+    ...WIDGET_REGISTRY[uri],
+    jsPath: `/tmp/${WIDGET_REGISTRY[uri].jsFilename}`,
+    exists,
+});
+
+describe('createResourceService', () => {
+    describe('listResources', () => {
+        it('should list the Skyfire readme only when enabled', async () => {
+            const skyfireService = createResourceService({
+                getMode: () => 'default',
+                paymentProvider: await resolvePaymentProvider('skyfire'),
+                getAvailableWidgets: () => new Map(),
+            });
+            const defaultService = createResourceService({
+                getMode: () => 'default',
+                paymentProvider: undefined,
+                getAvailableWidgets: () => new Map(),
+            });
+
+            const skyfireResources = await skyfireService.listResources();
+            const defaultResources = await defaultService.listResources();
+
+            expect(skyfireResources.resources.some((resource) => resource.uri === 'file://readme.md')).toBe(true);
+            expect(defaultResources.resources.some((resource) => resource.uri === 'file://readme.md')).toBe(false);
+        });
+
+        it('should not list the readme when the provider returns no usage guide', async () => {
+            const provider = { getUsageGuide: () => null } as unknown as PaymentProvider;
+            const service = createResourceService({
+                getMode: () => 'default',
+                paymentProvider: provider,
+                getAvailableWidgets: () => new Map(),
+            });
+
+            const { resources } = await service.listResources();
+
+            expect(resources.some((resource) => resource.uri === 'file://readme.md')).toBe(false);
+        });
+
+        it('should list apps widgets only when their files exist', async () => {
+            const widgets = new Map<string, AvailableWidget>([
+                [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, true)],
+                [WIDGET_URIS.ACTOR_RUN, buildAvailableWidget(WIDGET_URIS.ACTOR_RUN, false)],
+            ]);
+            const service = createResourceService({
+                getMode: () => 'apps',
+                getAvailableWidgets: () => widgets,
+            });
+
+            const { resources } = await service.listResources();
+
+            expect(resources.map((resource) => resource.uri)).toEqual([WIDGET_URIS.SEARCH_ACTORS]);
+        });
     });
 
-    it('lists the Skyfire readme only when enabled', async () => {
-        const skyfireService = createResourceService({
-            getMode: () => 'default',
-            paymentProvider: await resolvePaymentProvider('skyfire'),
-            getAvailableWidgets: () => new Map(),
-        });
-        const defaultService = createResourceService({
-            getMode: () => 'default',
-            paymentProvider: undefined,
-            getAvailableWidgets: () => new Map(),
+    describe('readResource', () => {
+        it('should return the Skyfire readme content', async () => {
+            const service = createResourceService({
+                getMode: () => 'default',
+                paymentProvider: await resolvePaymentProvider('skyfire'),
+                getAvailableWidgets: () => new Map(),
+            });
+
+            const result = await service.readResource('file://readme.md');
+
+            expect(result.contents[0].text).toBe(SKYFIRE_README_CONTENT);
+            expect(result.contents[0].mimeType).toBe('text/markdown');
         });
 
-        const skyfireResources = await skyfireService.listResources();
-        const defaultResources = await defaultService.listResources();
+        it('should return a plain-text fallback for an unknown URI', async () => {
+            const service = createResourceService({
+                getMode: () => 'default',
+                getAvailableWidgets: () => new Map(),
+            });
 
-        expect(skyfireResources.resources.some((resource) => resource.uri === 'file://readme.md')).toBe(true);
-        expect(defaultResources.resources.some((resource) => resource.uri === 'file://readme.md')).toBe(false);
+            const result = await service.readResource('file://missing.md');
+
+            expect(result.contents[0].text).toBe('Resource file://missing.md not found');
+            expect(result.contents[0].mimeType).toBe('text/plain');
+        });
+
+        it('should return widget HTML when the widget exists', async () => {
+            const fs = await import('node:fs');
+            const readFileSync = vi.mocked(fs.readFileSync);
+            readFileSync.mockReturnValue('console.log("widget");');
+
+            const widgets = new Map<string, AvailableWidget>([
+                [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, true)],
+            ]);
+            const service = createResourceService({
+                getMode: () => 'apps',
+                getAvailableWidgets: () => widgets,
+            });
+
+            const result = await service.readResource(WIDGET_URIS.SEARCH_ACTORS);
+
+            expect(result.contents[0].mimeType).toBe('text/html;profile=mcp-app');
+            expect(result.contents[0].text).toContain('console.log("widget");');
+            expect(result.contents[0].html).toContain('<script type="module">console.log("widget");</script>');
+        });
+
+        it('should return a plain-text fallback for a widget URI not in the registry', async () => {
+            const service = createResourceService({
+                getMode: () => 'apps',
+                getAvailableWidgets: () => new Map(),
+            });
+
+            const result = await service.readResource('ui://widget/unknown.html');
+
+            expect(result.contents[0].text).toContain('Not found in registry.');
+            expect(result.contents[0].mimeType).toBe('text/plain');
+        });
+
+        it('should return a plain-text fallback when the widget file is missing on disk', async () => {
+            const widgets = new Map<string, AvailableWidget>([
+                [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, false)],
+            ]);
+            const service = createResourceService({
+                getMode: () => 'apps',
+                getAvailableWidgets: () => widgets,
+            });
+
+            const result = await service.readResource(WIDGET_URIS.SEARCH_ACTORS);
+
+            expect(result.contents[0].text).toContain('File not found at');
+            expect(result.contents[0].text).toContain(WIDGET_REGISTRY[WIDGET_URIS.SEARCH_ACTORS].jsFilename);
+            expect(result.contents[0].mimeType).toBe('text/plain');
+        });
     });
 
-    it('does not list the readme when the provider returns no usage guide', async () => {
-        const provider = { getUsageGuide: () => null } as unknown as PaymentProvider;
-        const service = createResourceService({
-            getMode: () => 'default',
-            paymentProvider: provider,
-            getAvailableWidgets: () => new Map(),
+    describe('listResourceTemplates', () => {
+        it('should return an empty list', async () => {
+            const service = createResourceService({
+                getMode: () => 'default',
+                getAvailableWidgets: () => new Map(),
+            });
+
+            const result = await service.listResourceTemplates();
+
+            expect(result).toEqual({ resourceTemplates: [] });
         });
-
-        const { resources } = await service.listResources();
-
-        expect(resources.some((resource) => resource.uri === 'file://readme.md')).toBe(false);
-    });
-
-    it('lists apps widgets only when available', async () => {
-        const widgets = new Map<string, AvailableWidget>([
-            [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, true)],
-            [WIDGET_URIS.ACTOR_RUN, buildAvailableWidget(WIDGET_URIS.ACTOR_RUN, false)],
-        ]);
-        const service = createResourceService({
-            getMode: () => 'apps',
-            getAvailableWidgets: () => widgets,
-        });
-
-        const { resources } = await service.listResources();
-
-        expect(resources.map((resource) => resource.uri)).toEqual([WIDGET_URIS.SEARCH_ACTORS]);
-    });
-
-    it('returns a plain-text message for missing resources', async () => {
-        const service = createResourceService({
-            getMode: () => 'default',
-            getAvailableWidgets: () => new Map(),
-        });
-
-        const result = await service.readResource('file://missing.md');
-
-        expect(result.contents[0].text).toBe('Resource file://missing.md not found');
-        expect(result.contents[0].mimeType).toBe('text/plain');
-    });
-
-    it('returns the Skyfire readme content when requested', async () => {
-        const service = createResourceService({
-            getMode: () => 'default',
-            paymentProvider: await resolvePaymentProvider('skyfire'),
-            getAvailableWidgets: () => new Map(),
-        });
-
-        const result = await service.readResource('file://readme.md');
-
-        expect(result.contents[0].text).toBe(SKYFIRE_README_CONTENT);
-        expect(result.contents[0].mimeType).toBe('text/markdown');
-    });
-
-    it('returns a plain-text message for unknown widgets', async () => {
-        const service = createResourceService({
-            getMode: () => 'apps',
-            getAvailableWidgets: () => new Map(),
-        });
-
-        const result = await service.readResource('ui://widget/unknown.html');
-
-        expect(result.contents[0].text).toContain('Not found in registry.');
-        expect(result.contents[0].mimeType).toBe('text/plain');
-    });
-
-    it('returns a plain-text message when a registered widget file is missing', async () => {
-        const widgets = new Map<string, AvailableWidget>([
-            [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, false)],
-        ]);
-        const service = createResourceService({
-            getMode: () => 'apps',
-            getAvailableWidgets: () => widgets,
-        });
-
-        const result = await service.readResource(WIDGET_URIS.SEARCH_ACTORS);
-
-        expect(result.contents[0].text).toContain('File not found at');
-        expect(result.contents[0].text).toContain(WIDGET_REGISTRY[WIDGET_URIS.SEARCH_ACTORS].jsFilename);
-        expect(result.contents[0].mimeType).toBe('text/plain');
-    });
-
-    it('returns widget HTML when a widget exists', async () => {
-        const fs = await import('node:fs');
-        const readFileSync = vi.mocked(fs.readFileSync);
-        readFileSync.mockReturnValue('console.log("widget");');
-
-        const widgets = new Map<string, AvailableWidget>([
-            [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, true)],
-        ]);
-        const service = createResourceService({
-            getMode: () => 'apps',
-            getAvailableWidgets: () => widgets,
-        });
-
-        const result = await service.readResource(WIDGET_URIS.SEARCH_ACTORS);
-
-        expect(result.contents[0].mimeType).toBe('text/html;profile=mcp-app');
-        expect(result.contents[0].text).toContain('console.log("widget");');
-        expect(result.contents[0].html).toContain('<script type="module">console.log("widget");</script>');
-    });
-
-    it('returns an empty resource templates list', async () => {
-        const service = createResourceService({
-            getMode: () => 'default',
-            getAvailableWidgets: () => new Map(),
-        });
-
-        const result = await service.listResourceTemplates();
-
-        expect(result).toEqual({ resourceTemplates: [] });
     });
 });

--- a/tests/unit/resources.service.test.ts
+++ b/tests/unit/resources.service.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SKYFIRE_README_CONTENT } from '../../src/const.js';
+import { resolvePaymentProvider } from '../../src/payments/index.js';
+import type { PaymentProvider } from '../../src/payments/types.js';
+import { createResourceService } from '../../src/resources/resource_service.js';
+import type { AvailableWidget } from '../../src/resources/widgets.js';
+import { WIDGET_REGISTRY, WIDGET_URIS } from '../../src/resources/widgets.js';
+
+vi.mock('node:fs', () => ({
+    readFileSync: vi.fn(),
+    default: {
+        readFileSync: vi.fn(),
+    },
+}));
+
+describe('MCP resources', () => {
+    const buildAvailableWidget = (uri: string, exists: boolean): AvailableWidget => ({
+        ...WIDGET_REGISTRY[uri],
+        jsPath: `/tmp/${WIDGET_REGISTRY[uri].jsFilename}`,
+        exists,
+    });
+
+    it('lists the Skyfire readme only when enabled', async () => {
+        const skyfireService = createResourceService({
+            getMode: () => 'default',
+            paymentProvider: await resolvePaymentProvider('skyfire'),
+            getAvailableWidgets: () => new Map(),
+        });
+        const defaultService = createResourceService({
+            getMode: () => 'default',
+            paymentProvider: undefined,
+            getAvailableWidgets: () => new Map(),
+        });
+
+        const skyfireResources = await skyfireService.listResources();
+        const defaultResources = await defaultService.listResources();
+
+        expect(skyfireResources.resources.some((resource) => resource.uri === 'file://readme.md')).toBe(true);
+        expect(defaultResources.resources.some((resource) => resource.uri === 'file://readme.md')).toBe(false);
+    });
+
+    it('does not list the readme when the provider returns no usage guide', async () => {
+        const provider = { getUsageGuide: () => null } as unknown as PaymentProvider;
+        const service = createResourceService({
+            getMode: () => 'default',
+            paymentProvider: provider,
+            getAvailableWidgets: () => new Map(),
+        });
+
+        const { resources } = await service.listResources();
+
+        expect(resources.some((resource) => resource.uri === 'file://readme.md')).toBe(false);
+    });
+
+    it('lists apps widgets only when available', async () => {
+        const widgets = new Map<string, AvailableWidget>([
+            [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, true)],
+            [WIDGET_URIS.ACTOR_RUN, buildAvailableWidget(WIDGET_URIS.ACTOR_RUN, false)],
+        ]);
+        const service = createResourceService({
+            getMode: () => 'apps',
+            getAvailableWidgets: () => widgets,
+        });
+
+        const { resources } = await service.listResources();
+
+        expect(resources.map((resource) => resource.uri)).toEqual([WIDGET_URIS.SEARCH_ACTORS]);
+    });
+
+    it('returns a plain-text message for missing resources', async () => {
+        const service = createResourceService({
+            getMode: () => 'default',
+            getAvailableWidgets: () => new Map(),
+        });
+
+        const result = await service.readResource('file://missing.md');
+
+        expect(result.contents[0].text).toBe('Resource file://missing.md not found');
+        expect(result.contents[0].mimeType).toBe('text/plain');
+    });
+
+    it('returns the Skyfire readme content when requested', async () => {
+        const service = createResourceService({
+            getMode: () => 'default',
+            paymentProvider: await resolvePaymentProvider('skyfire'),
+            getAvailableWidgets: () => new Map(),
+        });
+
+        const result = await service.readResource('file://readme.md');
+
+        expect(result.contents[0].text).toBe(SKYFIRE_README_CONTENT);
+        expect(result.contents[0].mimeType).toBe('text/markdown');
+    });
+
+    it('returns a plain-text message for unknown widgets', async () => {
+        const service = createResourceService({
+            getMode: () => 'apps',
+            getAvailableWidgets: () => new Map(),
+        });
+
+        const result = await service.readResource('ui://widget/unknown.html');
+
+        expect(result.contents[0].text).toContain('Not found in registry.');
+        expect(result.contents[0].mimeType).toBe('text/plain');
+    });
+
+    it('returns a plain-text message when a registered widget file is missing', async () => {
+        const widgets = new Map<string, AvailableWidget>([
+            [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, false)],
+        ]);
+        const service = createResourceService({
+            getMode: () => 'apps',
+            getAvailableWidgets: () => widgets,
+        });
+
+        const result = await service.readResource(WIDGET_URIS.SEARCH_ACTORS);
+
+        expect(result.contents[0].text).toContain('File not found at');
+        expect(result.contents[0].text).toContain(WIDGET_REGISTRY[WIDGET_URIS.SEARCH_ACTORS].jsFilename);
+        expect(result.contents[0].mimeType).toBe('text/plain');
+    });
+
+    it('returns widget HTML when a widget exists', async () => {
+        const fs = await import('node:fs');
+        const readFileSync = vi.mocked(fs.readFileSync);
+        readFileSync.mockReturnValue('console.log("widget");');
+
+        const widgets = new Map<string, AvailableWidget>([
+            [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, true)],
+        ]);
+        const service = createResourceService({
+            getMode: () => 'apps',
+            getAvailableWidgets: () => widgets,
+        });
+
+        const result = await service.readResource(WIDGET_URIS.SEARCH_ACTORS);
+
+        expect(result.contents[0].mimeType).toBe('text/html;profile=mcp-app');
+        expect(result.contents[0].text).toContain('console.log("widget");');
+        expect(result.contents[0].html).toContain('<script type="module">console.log("widget");</script>');
+    });
+
+    it('returns an empty resource templates list', async () => {
+        const service = createResourceService({
+            getMode: () => 'default',
+            getAvailableWidgets: () => new Map(),
+        });
+
+        const result = await service.listResourceTemplates();
+
+        expect(result).toEqual({ resourceTemplates: [] });
+    });
+});

--- a/tests/unit/resources.service.test.ts
+++ b/tests/unit/resources.service.test.ts
@@ -20,9 +20,9 @@ const buildAvailableWidget = (uri: string, exists: boolean): AvailableWidget => 
     exists,
 });
 
-describe('createResourceService', () => {
-    describe('listResources', () => {
-        it('should list the Skyfire readme only when enabled', async () => {
+describe('createResourceService()', () => {
+    describe('listResources()', () => {
+        it('lists the Skyfire readme only when enabled', async () => {
             const skyfireService = createResourceService({
                 getMode: () => 'default',
                 paymentProvider: await resolvePaymentProvider('skyfire'),
@@ -41,7 +41,7 @@ describe('createResourceService', () => {
             expect(defaultResources.resources.some((resource) => resource.uri === 'file://readme.md')).toBe(false);
         });
 
-        it('should not list the readme when the provider returns no usage guide', async () => {
+        it('does not list the readme when the provider returns no usage guide', async () => {
             const provider = { getUsageGuide: () => null } as unknown as PaymentProvider;
             const service = createResourceService({
                 getMode: () => 'default',
@@ -54,7 +54,7 @@ describe('createResourceService', () => {
             expect(resources.some((resource) => resource.uri === 'file://readme.md')).toBe(false);
         });
 
-        it('should list apps widgets only when their files exist', async () => {
+        it('lists apps widgets only when their files exist', async () => {
             const widgets = new Map<string, AvailableWidget>([
                 [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, true)],
                 [WIDGET_URIS.ACTOR_RUN, buildAvailableWidget(WIDGET_URIS.ACTOR_RUN, false)],
@@ -70,8 +70,8 @@ describe('createResourceService', () => {
         });
     });
 
-    describe('readResource', () => {
-        it('should return the Skyfire readme content', async () => {
+    describe('readResource()', () => {
+        it('returns the Skyfire readme content', async () => {
             const service = createResourceService({
                 getMode: () => 'default',
                 paymentProvider: await resolvePaymentProvider('skyfire'),
@@ -84,7 +84,7 @@ describe('createResourceService', () => {
             expect(result.contents[0].mimeType).toBe('text/markdown');
         });
 
-        it('should return a plain-text fallback for an unknown URI', async () => {
+        it('returns a plain-text fallback for an unknown URI', async () => {
             const service = createResourceService({
                 getMode: () => 'default',
                 getAvailableWidgets: () => new Map(),
@@ -96,7 +96,7 @@ describe('createResourceService', () => {
             expect(result.contents[0].mimeType).toBe('text/plain');
         });
 
-        it('should return widget HTML when the widget exists', async () => {
+        it('returns widget HTML when the widget exists', async () => {
             const fs = await import('node:fs');
             const readFileSync = vi.mocked(fs.readFileSync);
             readFileSync.mockReturnValue('console.log("widget");');
@@ -116,7 +116,7 @@ describe('createResourceService', () => {
             expect(result.contents[0].html).toContain('<script type="module">console.log("widget");</script>');
         });
 
-        it('should return a plain-text fallback for a widget URI not in the registry', async () => {
+        it('returns a plain-text fallback for a widget URI not in the registry', async () => {
             const service = createResourceService({
                 getMode: () => 'apps',
                 getAvailableWidgets: () => new Map(),
@@ -128,7 +128,7 @@ describe('createResourceService', () => {
             expect(result.contents[0].mimeType).toBe('text/plain');
         });
 
-        it('should return a plain-text fallback when the widget file is missing on disk', async () => {
+        it('returns a plain-text fallback when the widget file is missing on disk', async () => {
             const widgets = new Map<string, AvailableWidget>([
                 [WIDGET_URIS.SEARCH_ACTORS, buildAvailableWidget(WIDGET_URIS.SEARCH_ACTORS, false)],
             ]);
@@ -145,8 +145,8 @@ describe('createResourceService', () => {
         });
     });
 
-    describe('listResourceTemplates', () => {
-        it('should return an empty list', async () => {
+    describe('listResourceTemplates()', () => {
+        it('returns an empty list', async () => {
             const service = createResourceService({
                 getMode: () => 'default',
                 getAvailableWidgets: () => new Map(),


### PR DESCRIPTION
- **Two new tests added during the reorg** — fill coverage gaps for:
  (a) widget URI in registry but `exists === false` (distinct message from "not in registry"),
  (b) provider with `getUsageGuide() => null` (covers x402's branch; distinct path from `paymentProvider: undefined`).
- **Silent bug fixed**: two `it()`s shared the same name (`'should parse enableAddingActors flag'`), one tested `true`, the other `false`.
- **Inline `PaymentProvider` stub instead of `resolvePaymentProvider('x402')`** — its `.create()` makes a real HTTP fetch, would slow unit tests by ~1.4s and add a network dependency.
- **CLAUDE.md addition** locks in the test naming convention applied here.