### PR TITLE
feat(task-store): shorten task ID by aligning in-memory store with Redis

### DIFF
--- a/res/mcp_task_reference.md
+++ b/res/mcp_task_reference.md
@@ -42,7 +42,7 @@ Tools declare task support via `execution.taskSupport`:
 ```typescript
 // Task object
 interface Task {
-    taskId: string;            // 32 hex chars
+    taskId: string;            // Format: "<tool-name>-<12 base64url chars>"
     status: TaskStatus;        // "working" | "input_required" | "completed" | "failed" | "cancelled"
     ttl: number | null;
     createdAt: string;         // ISO 8601

--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -5,7 +5,6 @@
 import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
-import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
@@ -17,6 +16,7 @@ import { parseBooleanOrNull } from '@apify/utilities';
 
 import { ApifyClient } from './apify_client.js';
 import { ActorsMcpServer } from './mcp/server.js';
+import { ApifyInMemoryTaskStore } from './mcp/task_store.js';
 import { resolvePaymentProvider } from './payments/index.js';
 import type { ApifyRequestParams } from './types.js';
 import { parseServerMode } from './utils/server_mode.js';
@@ -37,7 +37,7 @@ export function createExpressApp(): express.Express {
     const mcpServers: { [sessionId: string]: ActorsMcpServer } = {};
     const transportsSSE: { [sessionId: string]: SSEServerTransport } = {};
     const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
-    const taskStore = new InMemoryTaskStore();
+    const taskStore = new ApifyInMemoryTaskStore();
 
     function respondWithError(res: Response, error: unknown, logMessage: string, statusCode = 500) {
         if (statusCode >= 500) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,7 +2,7 @@
  * Model Context Protocol (MCP) server for Apify Actors
  */
 
-import { randomUUID } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 
 // The ext-apps package exposes `./server` via conditional exports only (no `./server/index.js`
 // wildcard), so we can't satisfy the `import/extensions` rule on this subpath.
@@ -10,7 +10,6 @@ import { randomUUID } from 'node:crypto';
 import { getUiCapability, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
-import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
@@ -94,6 +93,7 @@ import { getUserInfoCached } from '../utils/userid_cache.js';
 import { getPackageVersion } from '../utils/version.js';
 import { connectMCPClient } from './client.js';
 import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC, LOG_LEVEL_MAP } from './const.js';
+import { ApifyInMemoryTaskStore } from './task_store.js';
 import { isTaskCancelled, parseInputParamsFromUrl } from './utils.js';
 
 /** Mode → actor executor. Add new modes here. */
@@ -168,7 +168,7 @@ export class ActorsMcpServer {
 
         // for stdio use in memory task store if not provided, otherwise use provided task store
         if (this.options.transportType === 'stdio' && !this.options.taskStore) {
-            this.taskStore = new InMemoryTaskStore();
+            this.taskStore = new ApifyInMemoryTaskStore();
         } else if (this.options.taskStore) {
             this.taskStore = this.options.taskStore;
         } else {
@@ -909,11 +909,16 @@ export class ActorsMcpServer {
                 // TODO: we should split this huge method into smaller parts as it is slowly getting out of hand
                 // Handle long-running task request
                 if (request.params.task) {
+                    // Short, human-readable taskId: `<tool-name>-<12 base64url chars>` (~35 chars).
+                    // Both task stores (ApifyInMemoryTaskStore for stdio, RedisTaskStore for hosted)
+                    // use String(requestId) as the taskId, so this string surfaces unchanged.
+                    // 9 bytes → 12 base64url chars, 72 bits of entropy; combined with session scope
+                    // (mcpSessionId in taskStore) this is well above any practical collision risk.
                     const task = await this.taskStore.createTask(
                         {
                             ttl: request.params.task.ttl,
                         },
-                        `call-tool-${name}-${randomUUID()}`,
+                        `${tool.name}-${randomBytes(9).toString('base64url')}`,
                         request,
                     );
                     log.debug('Created task for tool execution', { taskId: task.taskId, toolName: tool.name, mcpSessionId });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -909,11 +909,7 @@ export class ActorsMcpServer {
                 // TODO: we should split this huge method into smaller parts as it is slowly getting out of hand
                 // Handle long-running task request
                 if (request.params.task) {
-                    // Short, human-readable taskId: `<tool-name>-<12 base64url chars>` (~35 chars).
-                    // Both task stores (ApifyInMemoryTaskStore for stdio, RedisTaskStore for hosted)
-                    // use String(requestId) as the taskId, so this string surfaces unchanged.
-                    // 9 bytes → 12 base64url chars, 72 bits of entropy; combined with session scope
-                    // (mcpSessionId in taskStore) this is well above any practical collision risk.
+                    // 9 bytes → 12 base64url chars (72 bits of entropy), session-scoped in the task store.
                     const task = await this.taskStore.createTask(
                         {
                             ttl: request.params.task.ttl,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -909,12 +909,12 @@ export class ActorsMcpServer {
                 // TODO: we should split this huge method into smaller parts as it is slowly getting out of hand
                 // Handle long-running task request
                 if (request.params.task) {
-                    // 9 bytes → 12 base64url chars (72 bits of entropy), session-scoped in the task store.
+                    // 12 bytes → 16 base64url chars → strip `-`/`_` → slice(0,8): always ≥14 alphanum available.
                     const task = await this.taskStore.createTask(
                         {
                             ttl: request.params.task.ttl,
                         },
-                        `${tool.name}-${randomBytes(9).toString('base64url')}`,
+                        `${tool.name}-${randomBytes(12).toString('base64url').replace(/[^A-Za-z0-9]/g, '').slice(0, 8)}`,
                         request,
                     );
                     log.debug('Created task for tool execution', { taskId: task.taskId, toolName: tool.name, mcpSessionId });

--- a/src/mcp/task_store.ts
+++ b/src/mcp/task_store.ts
@@ -1,0 +1,67 @@
+import type { CreateTaskOptions } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
+import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
+import type { Request, RequestId, Task } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * In-memory task store that uses the `requestId` argument as the task ID,
+ * matching the contract of `RedisTaskStore` in `apify-mcp-server-internal`
+ * (which does `String(requestId)`).
+ *
+ * The SDK's `InMemoryTaskStore.createTask` ignores `requestId` and generates
+ * its own 32-char hex ID via a private `generateTaskId` method. That divergence
+ * meant the same call site produced different task ID formats on stdio and on
+ * hosted HTTP/SSE — and is what made #725 (request-id only) and #743 (private
+ * method override only) each fix one path while breaking the other.
+ *
+ * Aligning both stores on `requestId` lets `server.ts` generate the short,
+ * tool-prefixed ID once and have it surface unchanged on every transport.
+ *
+ * Implementation note: we override `createTask` rather than reusing super.
+ * Calling super and rekeying after the fact does not work, because the SDK's
+ * TTL setTimeout closes over the SDK-generated ID — once we move the entry to
+ * a new key, the timer's `tasks.delete` no longer matches and the task leaks.
+ * `getTask`, `storeTaskResult`, `updateTaskStatus`, `getTaskResult`,
+ * `listTasks`, and `cleanup` are inherited unchanged — they all read from
+ * `this.tasks` keyed by whatever ID we wrote, so they Just Work.
+ */
+type Internal = {
+    tasks: Map<string, { task: Task; request: Request; requestId: RequestId; result?: unknown }>;
+    cleanupTimers: Map<string, ReturnType<typeof setTimeout>>;
+};
+
+export class ApifyInMemoryTaskStore extends InMemoryTaskStore {
+    override async createTask(
+        taskParams: CreateTaskOptions,
+        requestId: RequestId,
+        _request: Request,
+        _sessionId?: string,
+    ): Promise<Task> {
+        const taskId = String(requestId);
+        if (!taskId) {
+            throw new Error('ApifyInMemoryTaskStore.createTask: requestId must be a non-empty string');
+        }
+        const internal = this as unknown as Internal;
+        if (internal.tasks.has(taskId)) {
+            throw new Error(`Task with ID ${taskId} already exists`);
+        }
+        const actualTtl = taskParams.ttl ?? null;
+        const createdAt = new Date().toISOString();
+        const task: Task = {
+            taskId,
+            status: 'working',
+            ttl: actualTtl,
+            createdAt,
+            lastUpdatedAt: createdAt,
+            pollInterval: taskParams.pollInterval ?? 1000,
+        };
+        internal.tasks.set(taskId, { task, request: _request, requestId });
+        if (actualTtl) {
+            const timer = setTimeout(() => {
+                internal.tasks.delete(taskId);
+                internal.cleanupTimers.delete(taskId);
+            }, actualTtl);
+            internal.cleanupTimers.set(taskId, timer);
+        }
+        return task;
+    }
+}

--- a/src/mcp/task_store.ts
+++ b/src/mcp/task_store.ts
@@ -3,26 +3,9 @@ import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/
 import type { Request, RequestId, Task } from '@modelcontextprotocol/sdk/types.js';
 
 /**
- * In-memory task store that uses the `requestId` argument as the task ID,
- * matching the contract of `RedisTaskStore` in `apify-mcp-server-internal`
- * (which does `String(requestId)`).
- *
- * The SDK's `InMemoryTaskStore.createTask` ignores `requestId` and generates
- * its own 32-char hex ID via a private `generateTaskId` method. That divergence
- * meant the same call site produced different task ID formats on stdio and on
- * hosted HTTP/SSE — and is what made #725 (request-id only) and #743 (private
- * method override only) each fix one path while breaking the other.
- *
- * Aligning both stores on `requestId` lets `server.ts` generate the short,
- * tool-prefixed ID once and have it surface unchanged on every transport.
- *
- * Implementation note: we override `createTask` rather than reusing super.
- * Calling super and rekeying after the fact does not work, because the SDK's
- * TTL setTimeout closes over the SDK-generated ID — once we move the entry to
- * a new key, the timer's `tasks.delete` no longer matches and the task leaks.
- * `getTask`, `storeTaskResult`, `updateTaskStatus`, `getTaskResult`,
- * `listTasks`, and `cleanup` are inherited unchanged — they all read from
- * `this.tasks` keyed by whatever ID we wrote, so they Just Work.
+ * Uses `requestId` as the task ID. We override (rather than call super and rekey) because
+ * the inherited TTL `setTimeout` closes over the SDK-generated ID — rekeying after the fact
+ * would leave the timer pointing at a stale key, leaking the task on TTL expiry.
  */
 type Internal = {
     tasks: Map<string, { task: Task; request: Request; requestId: RequestId; result?: unknown }>;
@@ -33,33 +16,32 @@ export class ApifyInMemoryTaskStore extends InMemoryTaskStore {
     override async createTask(
         taskParams: CreateTaskOptions,
         requestId: RequestId,
-        _request: Request,
-        _sessionId?: string,
+        request: Request,
     ): Promise<Task> {
         const taskId = String(requestId);
         if (!taskId) {
-            throw new Error('ApifyInMemoryTaskStore.createTask: requestId must be a non-empty string');
+            throw new Error('requestId must be a non-empty string');
         }
         const internal = this as unknown as Internal;
         if (internal.tasks.has(taskId)) {
             throw new Error(`Task with ID ${taskId} already exists`);
         }
-        const actualTtl = taskParams.ttl ?? null;
+        const ttl = taskParams.ttl ?? null;
         const createdAt = new Date().toISOString();
         const task: Task = {
             taskId,
             status: 'working',
-            ttl: actualTtl,
+            ttl,
             createdAt,
             lastUpdatedAt: createdAt,
             pollInterval: taskParams.pollInterval ?? 1000,
         };
-        internal.tasks.set(taskId, { task, request: _request, requestId });
-        if (actualTtl) {
+        internal.tasks.set(taskId, { task, request, requestId });
+        if (ttl) {
             const timer = setTimeout(() => {
                 internal.tasks.delete(taskId);
                 internal.cleanupTimers.delete(taskId);
-            }, actualTtl);
+            }, ttl);
             internal.cleanupTimers.set(taskId, timer);
         }
         return task;

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2303,6 +2303,8 @@ export function createIntegrationTestsSuite(
             for await (const message of stream) {
                 if (message.type === 'taskCreated') {
                     taskId = message.task.taskId;
+                    // Format: "<tool-name>-<12 base64url chars>" — see src/mcp/server.ts (issue #705)
+                    expect(taskId).toMatch(new RegExp(`^${actorNameToToolName(ACTOR_PYTHON_EXAMPLE)}-[A-Za-z0-9_-]{12}$`));
 
                     // Now we can get the task status
                     const taskStatus = await client.experimental.tasks.getTask(taskId);

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2303,7 +2303,7 @@ export function createIntegrationTestsSuite(
             for await (const message of stream) {
                 if (message.type === 'taskCreated') {
                     taskId = message.task.taskId;
-                    expect(taskId).toMatch(new RegExp(`^${actorNameToToolName(ACTOR_PYTHON_EXAMPLE)}-[A-Za-z0-9_-]{12}$`));
+                    expect(taskId).toMatch(new RegExp(`^${actorNameToToolName(ACTOR_PYTHON_EXAMPLE)}-[A-Za-z0-9]{8}$`));
 
                     // Now we can get the task status
                     const taskStatus = await client.experimental.tasks.getTask(taskId);

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2303,7 +2303,6 @@ export function createIntegrationTestsSuite(
             for await (const message of stream) {
                 if (message.type === 'taskCreated') {
                     taskId = message.task.taskId;
-                    // Format: "<tool-name>-<12 base64url chars>" — see src/mcp/server.ts (issue #705)
                     expect(taskId).toMatch(new RegExp(`^${actorNameToToolName(ACTOR_PYTHON_EXAMPLE)}-[A-Za-z0-9_-]{12}$`));
 
                     // Now we can get the task status

--- a/tests/unit/mcp.task_store.test.ts
+++ b/tests/unit/mcp.task_store.test.ts
@@ -1,0 +1,61 @@
+import type { Request } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it } from 'vitest';
+
+import { ApifyInMemoryTaskStore } from '../../src/mcp/task_store.js';
+
+const fakeRequest: Request = {
+    method: 'tools/call',
+    params: { name: 'apify-slash-rag-web-browser', arguments: {} },
+};
+
+describe('ApifyInMemoryTaskStore', () => {
+    it('uses requestId as the taskId (matches RedisTaskStore semantics)', async () => {
+        const store = new ApifyInMemoryTaskStore();
+        const desiredId = 'apify--rag-web-browser-x7kQ9mZpA1bC';
+
+        const task = await store.createTask({ ttl: 60_000 }, desiredId, fakeRequest);
+
+        expect(task.taskId).toBe(desiredId);
+
+        // Round-trip: the task is retrievable under the chosen id.
+        const fetched = await store.getTask(desiredId);
+        expect(fetched).not.toBeNull();
+        expect(fetched?.taskId).toBe(desiredId);
+        expect(fetched?.status).toBe('working');
+
+        // ListTasks surfaces the same id.
+        const { tasks } = await store.listTasks();
+        expect(tasks.map((t) => t.taskId)).toEqual([desiredId]);
+
+        store.cleanup();
+    });
+
+    it('rejects empty requestId', async () => {
+        const store = new ApifyInMemoryTaskStore();
+        await expect(store.createTask({ ttl: null }, '', fakeRequest)).rejects.toThrow(/non-empty/);
+        store.cleanup();
+    });
+
+    it('rejects duplicate taskIds without leaving rolled-back entries behind', async () => {
+        const store = new ApifyInMemoryTaskStore();
+        await store.createTask({ ttl: 60_000 }, 'dup-id-aaaaaaaaaaaa', fakeRequest);
+        await expect(store.createTask({ ttl: 60_000 }, 'dup-id-aaaaaaaaaaaa', fakeRequest))
+            .rejects.toThrow(/already exists/);
+
+        const { tasks } = await store.listTasks();
+        expect(tasks).toHaveLength(1);
+        store.cleanup();
+    });
+
+    it('honors TTL cleanup after rekeying', async () => {
+        const store = new ApifyInMemoryTaskStore();
+        const id = 'ttl-test-aaaaaaaaaaaa';
+        await store.createTask({ ttl: 10 }, id, fakeRequest);
+
+        await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+        const fetched = await store.getTask(id);
+        expect(fetched).toBeNull();
+        store.cleanup();
+    });
+});


### PR DESCRIPTION
Closes #705. Companion (internal): apify/apify-mcp-server-internal#515. Supersedes #725, #743.

## What
Replace `call-tool-${name}-${randomUUID()}` (~70 chars) with `${tool.name}-${randomBytes(9).toString('base64url')}` (~35 chars, 72 bits entropy). New `ApifyInMemoryTaskStore` keys tasks by `String(requestId)` — same contract as `RedisTaskStore`.

## Why
SDK's `InMemoryTaskStore` ignores `requestId` and generates its own ID, so stdio and hosted Redis transports produced different task ID formats for the same call. #725 fixed only Redis; #743 fixed only stdio. Aligning both stores on `String(requestId)` lets `server.ts` mint the short ID once and have it surface unchanged on every transport.

## How
- `src/mcp/task_store.ts` — new `ApifyInMemoryTaskStore extends InMemoryTaskStore`. `createTask` is reimplemented (not rekeyed after `super`) because the SDK's TTL `setTimeout` closes over the SDK-generated ID; a post-hoc rename leaks tasks past their TTL.
- `src/mcp/server.ts` — generate `${tool.name}-${randomBytes(9).toString('base64url')}` and pass as `requestId`; wire stdio to `ApifyInMemoryTaskStore`.
- `tests/unit/mcp.task_store.test.ts` — ID usage, validation, duplicates, TTL cleanup.
- `tests/integration/suite.ts` — taskId format assertion.
- `res/mcp_task_reference.md` — refreshed.

## Risk
Internal `RedisTaskStore` already uses `String(requestId)` — companion PR #515 locks the contract in a comment so the stores can't drift again.

## MCPC
| mcpc @stdio tasks-list

Tasks (1):
* `apify--rag-web-browser-TNF3Lyol`  ⊘ cancelled - Cancelled by client

## Inspector with internal repositroy

<img width="516" height="268" alt="image" src="https://github.com/user-attachments/assets/bc1f4e63-66f5-471a-8cb6-918dec21050f" />
