### PR TITLE
feat: Add task status notifications for long-running tools

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -218,7 +218,3 @@ export const HTTP_NOT_FOUND = 404;
 
 // Modes that allow long running task tool executions
 export const ALLOWED_TASK_TOOL_EXECUTION_MODES = ['optional', 'required'] as const;
-
-// Heartbeat interval for notifications/tasks/status while a task is working.
-// Transport-layer mitigation to keep clients with sub-minute timeouts alive.
-export const TASK_STATUS_HEARTBEAT_INTERVAL_MS = 30_000;

--- a/src/const.ts
+++ b/src/const.ts
@@ -222,3 +222,7 @@ export const ALLOWED_TASK_TOOL_EXECUTION_MODES = ['optional', 'required'] as con
 // MCP _meta key for associating messages with a task.
 // TODO: replace with RELATED_TASK_META_KEY from @modelcontextprotocol/sdk once the installed SDK exports it.
 export const RELATED_TASK_META_KEY = 'io.modelcontextprotocol/related-task';
+
+// Heartbeat interval for notifications/tasks/status while a task is working.
+// Transport-layer mitigation to keep clients with sub-minute timeouts alive.
+export const TASK_STATUS_HEARTBEAT_INTERVAL_MS = 30_000;

--- a/src/const.ts
+++ b/src/const.ts
@@ -219,10 +219,6 @@ export const HTTP_NOT_FOUND = 404;
 // Modes that allow long running task tool executions
 export const ALLOWED_TASK_TOOL_EXECUTION_MODES = ['optional', 'required'] as const;
 
-// MCP _meta key for associating messages with a task.
-// TODO: replace with RELATED_TASK_META_KEY from @modelcontextprotocol/sdk once the installed SDK exports it.
-export const RELATED_TASK_META_KEY = 'io.modelcontextprotocol/related-task';
-
 // Heartbeat interval for notifications/tasks/status while a task is working.
 // Transport-layer mitigation to keep clients with sub-minute timeouts alive.
 export const TASK_STATUS_HEARTBEAT_INTERVAL_MS = 30_000;

--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -262,11 +262,29 @@ export function createExpressApp(): express.Express {
         }
     });
 
-    // Handle GET requests for SSE streams according to spec
-    app.get(Routes.MCP, async (_req: Request, res: Response) => {
-        // We don't support GET requests for this server
-        // The spec requires returning 405 Method Not Allowed in this case
-        res.status(405).set('Allow', 'POST').send('Method Not Allowed');
+    // Handle GET requests for the standalone SSE stream.
+    // Clients open this to receive server-initiated notifications (e.g. notifications/tasks/status)
+    // that are not tied to a specific POST request.  Without this, session-level notifications
+    // are silently dropped by the transport.
+    app.get(Routes.MCP, async (req: Request, res: Response) => {
+        const sessionId = req.headers['mcp-session-id'] as string | undefined;
+        const transport = transports[sessionId || ''] as StreamableHTTPServerTransport | undefined;
+        if (!transport) {
+            log.softFail('Session not found for GET SSE stream', { mcpSessionId: sessionId, statusCode: 404 });
+            res.status(404).send('Not Found: Session not found').end();
+            return;
+        }
+        log.info('MCP API', {
+            mth: req.method,
+            rt: Routes.MCP,
+            tr: TransportType.HTTP,
+            mcpSessionId: sessionId,
+        });
+        try {
+            await transport.handleRequest(req, res);
+        } catch (error) {
+            respondWithError(res, error, 'Error handling GET SSE stream');
+        }
     });
 
     app.delete(Routes.MCP, async (req: Request, res: Response) => {

--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -262,7 +262,7 @@ export function createExpressApp(): express.Express {
         }
     });
 
-    // Handle GET requests for the standalone SSE stream.
+    // Handle GET requests
     // Clients open this to receive server-initiated notifications (e.g. notifications/tasks/status)
     // that are not tied to a specific POST request.  Without this, session-level notifications
     // are silently dropped by the transport.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -49,7 +49,9 @@ import {
     FAILURE_CATEGORY,
     HelperTools,
     HTTP_PAYMENT_REQUIRED,
+    RELATED_TASK_META_KEY,
     SERVER_NAME,
+    TASK_STATUS_HEARTBEAT_INTERVAL_MS,
     TOOL_STATUS,
 } from '../const.js';
 import { prepareToolCallContext } from '../payments/helpers.js';
@@ -116,6 +118,34 @@ function isUiSupportedByClient(request: InitializeRequest | undefined): boolean 
 }
 
 type ToolsChangedHandler = (toolNames: string[]) => void;
+
+/** Send notifications/tasks/status for taskId. Swallows errors — notifications are advisory. */
+export async function emitTaskStatusNotification(
+    taskId: string,
+    mcpSessionId: string | undefined,
+    taskStore: TaskStore,
+    sendNotification: RequestHandlerExtra<Request, Notification>['sendNotification'],
+): Promise<void> {
+    try {
+        const task = await taskStore.getTask(taskId, mcpSessionId);
+        if (!task) return;
+        // Per spec: notifications/tasks/status MUST NOT carry _meta.related-task (task ID is in params)
+        await sendNotification({
+            method: 'notifications/tasks/status',
+            params: {
+                taskId: task.taskId,
+                status: task.status,
+                createdAt: task.createdAt,
+                lastUpdatedAt: task.lastUpdatedAt,
+                ttl: task.ttl,
+                ...(task.statusMessage != null && { statusMessage: task.statusMessage }),
+                ...(task.pollInterval != null && { pollInterval: task.pollInterval }),
+            },
+        } as Notification);
+    } catch {
+        // Silent fail — notifications are advisory
+    }
+}
 
 /**
  * Create Apify MCP server
@@ -700,11 +730,19 @@ export class ActorsMcpServer {
                     `Task "${taskId}" is not completed yet. Current status: ${task.status}`,
                 );
             }
-            return await this.taskStore.getTaskResult(taskId, mcpSessionId);
+            const result = await this.taskStore.getTaskResult(taskId, mcpSessionId);
+            // taskId is not in the result body — _meta.related-task lets clients correlate them
+            return {
+                ...result,
+                _meta: {
+                    ...(result._meta as Record<string, unknown> ?? {}),
+                    [RELATED_TASK_META_KEY]: { taskId },
+                },
+            };
         });
 
         // Cancel task
-        this.server.setRequestHandler(CancelTaskRequestSchema, async (request) => {
+        this.server.setRequestHandler(CancelTaskRequestSchema, async (request, extra) => {
             // mcpSessionId is injected at transport layer for session isolation in task stores
             const params = (request.params || {}) as ApifyRequestParams & { taskId: string };
             const { taskId } = params;
@@ -736,6 +774,7 @@ export class ActorsMcpServer {
             await this.taskStore.updateTaskStatus(taskId, 'cancelled', 'Cancelled by client', mcpSessionId);
             const updatedTask = await this.taskStore.getTask(taskId, mcpSessionId);
             log.debug('[CancelTaskRequestSchema] Task cancelled successfully', { taskId, mcpSessionId });
+            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
             return updatedTask!;
         });
     }
@@ -1263,6 +1302,7 @@ export class ActorsMcpServer {
         // Always populate actor fields so they're tracked on both success and failure paths.
         let callDiagnostics: CallDiagnostics = { ...buildActorFields(actorName, actorId) };
         const startTime = Date.now();
+        let heartbeat: ReturnType<typeof setInterval> | undefined;
 
         log.debug('[executeToolAndUpdateTask] Starting task execution', {
             taskId,
@@ -1308,6 +1348,8 @@ export class ActorsMcpServer {
                 mcpSessionId,
             });
             await this.taskStore.updateTaskStatus(taskId, 'working', undefined, mcpSessionId);
+            let lastEmissionAt = Date.now();
+            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
 
             // Execute the tool and get the result
             let result: Record<string, unknown> = {};
@@ -1323,12 +1365,28 @@ export class ActorsMcpServer {
                 result = paymentRequiredResult;
             }
 
-            // Callback to propagate Actor run statusMessage into the task store.
-            // Clients retrieve it via tasks/get and tasks/list polling.
-            // TODO: Also send notifications/tasks/status so clients get real-time push updates
+            // Callback to propagate Actor run statusMessage into the task store and emit a push notification.
             const onStatusMessage = async (message: string) => {
                 await this.taskStore.updateTaskStatus(taskId, 'working', message, mcpSessionId);
+                lastEmissionAt = Date.now();
+                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
             };
+
+            // Heartbeat: re-emit notifications/tasks/status every ~30 s of silence so clients with
+            // sub-minute tool-call timeouts do not drop the connection.
+            heartbeat = setInterval(async () => {
+                if (Date.now() - lastEmissionAt < TASK_STATUS_HEARTBEAT_INTERVAL_MS) return;
+                const currentTask = await this.taskStore.getTask(taskId, mcpSessionId);
+                if (!currentTask || currentTask.status !== 'working') return;
+                lastEmissionAt = Date.now();
+                await this.taskStore.updateTaskStatus(
+                    taskId,
+                    'working',
+                    currentTask.statusMessage ?? undefined,
+                    mcpSessionId,
+                );
+                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+            }, TASK_STATUS_HEARTBEAT_INTERVAL_MS);
 
             // Handle internal tool execution in task mode
             if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === 'internal') {
@@ -1407,6 +1465,7 @@ export class ActorsMcpServer {
             });
             await this.taskStore.storeTaskResult(taskId, 'completed', result, mcpSessionId);
             log.debug('Task completed successfully', { taskId, toolName: tool.name, mcpSessionId });
+            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
 
             finishTaskTracking(toolStatus, callDiagnostics);
         } catch (error) {
@@ -1415,6 +1474,7 @@ export class ActorsMcpServer {
             if (httpStatus === HTTP_PAYMENT_REQUIRED) {
                 logHttpError(error, 'Payment required while calling tool (task mode)', { toolName: tool.name });
                 await this.taskStore.storeTaskResult(taskId, 'completed', buildPaymentRequiredResponse(error), mcpSessionId);
+                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
                 finishTaskTracking(TOOL_STATUS.SOFT_FAIL, {
                     failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                     failure_http_status: 402,
@@ -1426,6 +1486,7 @@ export class ActorsMcpServer {
             if (isPermissionApprovalError(error)) {
                 logHttpError(error, 'Permission approval required while calling tool (task mode)', { toolName: tool.name });
                 await this.taskStore.storeTaskResult(taskId, 'completed', buildPermissionApprovalResponse(error), mcpSessionId);
+                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
                 finishTaskTracking(TOOL_STATUS.SOFT_FAIL, {
                     failure_category: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
                     failure_http_status: error.statusCode,
@@ -1497,8 +1558,11 @@ export class ActorsMcpServer {
                 isError: true,
                 internalToolStatus: toolStatus,
             }, mcpSessionId);
+            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
 
             finishTaskTracking(toolStatus, callDiagnostics);
+        } finally {
+            clearInterval(heartbeat);
         }
     }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -14,7 +14,13 @@ import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { InitializeRequest, InitializeResult, Notification, Request } from '@modelcontextprotocol/sdk/types.js';
+import type {
+    InitializeRequest,
+    InitializeResult,
+    Notification,
+    Request,
+    TaskStatusNotification,
+} from '@modelcontextprotocol/sdk/types.js';
 import {
     CallToolRequestSchema,
     CallToolResultSchema,
@@ -31,6 +37,7 @@ import {
     ListToolsRequestSchema,
     McpError,
     ReadResourceRequestSchema,
+    RELATED_TASK_META_KEY,
     ServerNotificationSchema,
     SetLevelRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
@@ -49,7 +56,6 @@ import {
     FAILURE_CATEGORY,
     HelperTools,
     HTTP_PAYMENT_REQUIRED,
-    RELATED_TASK_META_KEY,
     SERVER_NAME,
     TASK_STATUS_HEARTBEAT_INTERVAL_MS,
     TOOL_STATUS,
@@ -119,18 +125,21 @@ function isUiSupportedByClient(request: InitializeRequest | undefined): boolean 
 
 type ToolsChangedHandler = (toolNames: string[]) => void;
 
-/** Send notifications/tasks/status for taskId. Swallows errors — notifications are advisory. */
+/** Send notifications/tasks/status for taskId. Routes via session transport (no relatedRequestId).
+ *  Swallows errors — notifications are advisory. */
 export async function emitTaskStatusNotification(
     taskId: string,
     mcpSessionId: string | undefined,
     taskStore: TaskStore,
-    sendNotification: RequestHandlerExtra<Request, Notification>['sendNotification'],
+    server: Server,
 ): Promise<void> {
     try {
         const task = await taskStore.getTask(taskId, mcpSessionId);
         if (!task) return;
-        // Per spec: notifications/tasks/status MUST NOT carry _meta.related-task (task ID is in params)
-        await sendNotification({
+        // Per spec: notifications/tasks/status MUST NOT carry _meta.related-task (task ID is in params).
+        // Called without options so the notification routes through the session transport,
+        // not the request-scoped stream (which closes once the initial { task } response is flushed).
+        await server.notification({
             method: 'notifications/tasks/status',
             params: {
                 taskId: task.taskId,
@@ -141,7 +150,7 @@ export async function emitTaskStatusNotification(
                 ...(task.statusMessage != null && { statusMessage: task.statusMessage }),
                 ...(task.pollInterval != null && { pollInterval: task.pollInterval }),
             },
-        } as Notification);
+        } as TaskStatusNotification);
     } catch {
         // Silent fail — notifications are advisory
     }
@@ -742,7 +751,7 @@ export class ActorsMcpServer {
         });
 
         // Cancel task
-        this.server.setRequestHandler(CancelTaskRequestSchema, async (request, extra) => {
+        this.server.setRequestHandler(CancelTaskRequestSchema, async (request) => {
             // mcpSessionId is injected at transport layer for session isolation in task stores
             const params = (request.params || {}) as ApifyRequestParams & { taskId: string };
             const { taskId } = params;
@@ -774,7 +783,7 @@ export class ActorsMcpServer {
             await this.taskStore.updateTaskStatus(taskId, 'cancelled', 'Cancelled by client', mcpSessionId);
             const updatedTask = await this.taskStore.getTask(taskId, mcpSessionId);
             log.debug('[CancelTaskRequestSchema] Task cancelled successfully', { taskId, mcpSessionId });
-            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
             return updatedTask!;
         });
     }
@@ -954,12 +963,13 @@ export class ActorsMcpServer {
                         },
                         `call-tool-${name}-${randomUUID()}`,
                         request,
+                        mcpSessionId,
                     );
                     log.debug('Created task for tool execution', { taskId: task.taskId, toolName: tool.name, mcpSessionId });
 
                     // Execute the tool asynchronously and update task status
-                    setImmediate(async () => {
-                        await this.executeToolAndUpdateTask({
+                    setImmediate(() => {
+                        this.executeToolAndUpdateTask({
                             taskId: task.taskId,
                             tool,
                             toolArgs: toolArgs!,
@@ -973,7 +983,7 @@ export class ActorsMcpServer {
                             actorName,
                             actorId,
                             userRentedActorIds,
-                        });
+                        }).catch((error) => log.error('executeToolAndUpdateTask failed unexpectedly', { taskId: task.taskId, error }));
                     });
 
                     // Return the task immediately; execution continues asynchronously
@@ -1349,7 +1359,7 @@ export class ActorsMcpServer {
             });
             await this.taskStore.updateTaskStatus(taskId, 'working', undefined, mcpSessionId);
             let lastEmissionAt = Date.now();
-            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
 
             // Execute the tool and get the result
             let result: Record<string, unknown> = {};
@@ -1369,7 +1379,7 @@ export class ActorsMcpServer {
             const onStatusMessage = async (message: string) => {
                 await this.taskStore.updateTaskStatus(taskId, 'working', message, mcpSessionId);
                 lastEmissionAt = Date.now();
-                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
             };
 
             // Heartbeat: re-emit notifications/tasks/status every ~30 s of silence so clients with
@@ -1380,13 +1390,7 @@ export class ActorsMcpServer {
                     const currentTask = await this.taskStore.getTask(taskId, mcpSessionId);
                     if (!currentTask || currentTask.status !== 'working') return;
                     lastEmissionAt = Date.now();
-                    await this.taskStore.updateTaskStatus(
-                        taskId,
-                        'working',
-                        currentTask.statusMessage ?? undefined,
-                        mcpSessionId,
-                    );
-                    await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+                    await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
                 } catch {
                     // Silent fail — heartbeat is advisory
                 }
@@ -1469,7 +1473,7 @@ export class ActorsMcpServer {
             });
             await this.taskStore.storeTaskResult(taskId, 'completed', result, mcpSessionId);
             log.debug('Task completed successfully', { taskId, toolName: tool.name, mcpSessionId });
-            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
 
             finishTaskTracking(toolStatus, callDiagnostics);
         } catch (error) {
@@ -1478,7 +1482,7 @@ export class ActorsMcpServer {
             if (httpStatus === HTTP_PAYMENT_REQUIRED) {
                 logHttpError(error, 'Payment required while calling tool (task mode)', { toolName: tool.name });
                 await this.taskStore.storeTaskResult(taskId, 'completed', buildPaymentRequiredResponse(error), mcpSessionId);
-                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
                 finishTaskTracking(TOOL_STATUS.SOFT_FAIL, {
                     failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                     failure_http_status: 402,
@@ -1490,7 +1494,7 @@ export class ActorsMcpServer {
             if (isPermissionApprovalError(error)) {
                 logHttpError(error, 'Permission approval required while calling tool (task mode)', { toolName: tool.name });
                 await this.taskStore.storeTaskResult(taskId, 'completed', buildPermissionApprovalResponse(error), mcpSessionId);
-                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
                 finishTaskTracking(TOOL_STATUS.SOFT_FAIL, {
                     failure_category: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
                     failure_http_status: error.statusCode,
@@ -1562,7 +1566,7 @@ export class ActorsMcpServer {
                 isError: true,
                 internalToolStatus: toolStatus,
             }, mcpSessionId);
-            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
 
             finishTaskTracking(toolStatus, callDiagnostics);
         } finally {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -57,7 +57,6 @@ import {
     HelperTools,
     HTTP_PAYMENT_REQUIRED,
     SERVER_NAME,
-    TASK_STATUS_HEARTBEAT_INTERVAL_MS,
     TOOL_STATUS,
 } from '../const.js';
 import { prepareToolCallContext } from '../payments/helpers.js';
@@ -1312,7 +1311,6 @@ export class ActorsMcpServer {
         // Always populate actor fields so they're tracked on both success and failure paths.
         let callDiagnostics: CallDiagnostics = { ...buildActorFields(actorName, actorId) };
         const startTime = Date.now();
-        let heartbeat: ReturnType<typeof setInterval> | undefined;
 
         log.debug('[executeToolAndUpdateTask] Starting task execution', {
             taskId,
@@ -1358,7 +1356,6 @@ export class ActorsMcpServer {
                 mcpSessionId,
             });
             await this.taskStore.updateTaskStatus(taskId, 'working', undefined, mcpSessionId);
-            let lastEmissionAt = Date.now();
             await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
 
             // Execute the tool and get the result
@@ -1378,23 +1375,8 @@ export class ActorsMcpServer {
             // Callback to propagate Actor run statusMessage into the task store and emit a push notification.
             const onStatusMessage = async (message: string) => {
                 await this.taskStore.updateTaskStatus(taskId, 'working', message, mcpSessionId);
-                lastEmissionAt = Date.now();
                 await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
             };
-
-            // Heartbeat: re-emit notifications/tasks/status every ~30 s of silence so clients with
-            // sub-minute tool-call timeouts do not drop the connection.
-            heartbeat = setInterval(async () => {
-                try {
-                    if (Date.now() - lastEmissionAt < TASK_STATUS_HEARTBEAT_INTERVAL_MS) return;
-                    const currentTask = await this.taskStore.getTask(taskId, mcpSessionId);
-                    if (!currentTask || currentTask.status !== 'working') return;
-                    lastEmissionAt = Date.now();
-                    await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
-                } catch {
-                    // Silent fail — heartbeat is advisory
-                }
-            }, TASK_STATUS_HEARTBEAT_INTERVAL_MS);
 
             // Handle internal tool execution in task mode
             if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === 'internal') {
@@ -1569,8 +1551,6 @@ export class ActorsMcpServer {
             await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
 
             finishTaskTracking(toolStatus, callDiagnostics);
-        } finally {
-            clearInterval(heartbeat);
         }
     }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -735,7 +735,7 @@ export class ActorsMcpServer {
             return {
                 ...result,
                 _meta: {
-                    ...(result._meta as Record<string, unknown> ?? {}),
+                    ...(result._meta as Record<string, unknown>),
                     [RELATED_TASK_META_KEY]: { taskId },
                 },
             };
@@ -1375,17 +1375,21 @@ export class ActorsMcpServer {
             // Heartbeat: re-emit notifications/tasks/status every ~30 s of silence so clients with
             // sub-minute tool-call timeouts do not drop the connection.
             heartbeat = setInterval(async () => {
-                if (Date.now() - lastEmissionAt < TASK_STATUS_HEARTBEAT_INTERVAL_MS) return;
-                const currentTask = await this.taskStore.getTask(taskId, mcpSessionId);
-                if (!currentTask || currentTask.status !== 'working') return;
-                lastEmissionAt = Date.now();
-                await this.taskStore.updateTaskStatus(
-                    taskId,
-                    'working',
-                    currentTask.statusMessage ?? undefined,
-                    mcpSessionId,
-                );
-                await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+                try {
+                    if (Date.now() - lastEmissionAt < TASK_STATUS_HEARTBEAT_INTERVAL_MS) return;
+                    const currentTask = await this.taskStore.getTask(taskId, mcpSessionId);
+                    if (!currentTask || currentTask.status !== 'working') return;
+                    lastEmissionAt = Date.now();
+                    await this.taskStore.updateTaskStatus(
+                        taskId,
+                        'working',
+                        currentTask.statusMessage ?? undefined,
+                        mcpSessionId,
+                    );
+                    await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, extra.sendNotification);
+                } catch {
+                    // Silent fail — heartbeat is advisory
+                }
             }, TASK_STATUS_HEARTBEAT_INTERVAL_MS);
 
             // Handle internal tool execution in task mode

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,7 +1,8 @@
 import type { ProgressNotification } from '@modelcontextprotocol/sdk/types.js';
+import { RELATED_TASK_META_KEY } from '@modelcontextprotocol/sdk/types.js';
 
 import type { ApifyClient } from '../apify_client.js';
-import { PROGRESS_NOTIFICATION_INTERVAL_MS, RELATED_TASK_META_KEY } from '../const.js';
+import { PROGRESS_NOTIFICATION_INTERVAL_MS } from '../const.js';
 
 const TERMINAL_RUN_STATUSES = new Set(['SUCCEEDED', 'FAILED', 'ABORTED', 'TIMED-OUT']);
 

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2251,6 +2251,7 @@ export function createIntegrationTestsSuite(
             );
 
             let lastStatus = '';
+            let taskStatusCount = 0;
             let resultReceived = false;
             for await (const message of stream) {
                 switch (message.type) {
@@ -2258,9 +2259,7 @@ export function createIntegrationTestsSuite(
                         // Task created successfully with ID: message.task.taskId
                         break;
                     case 'taskStatus':
-                        if (lastStatus !== message.task.status) {
-                            // Task status: message.task.status with optional message.task.statusMessage
-                        }
+                        taskStatusCount++;
                         lastStatus = message.task.status;
                         break;
                     case 'result':
@@ -2278,6 +2277,11 @@ export function createIntegrationTestsSuite(
                 }
             }
             expect(resultReceived).toBe(true);
+            // Regression guard: notifications/tasks/status must reach the client over the
+            // session-level transport (standalone SSE on streamable HTTP). If notifications
+            // are dropped, callToolStream emits no taskStatus events.
+            expect(taskStatusCount).toBeGreaterThan(0);
+            expect(lastStatus).not.toBe('');
         });
 
         it('should be able to call a long running task and list it, get the status and then separately retrieve the result', async () => {

--- a/tests/unit/mcp.task_notifications.test.ts
+++ b/tests/unit/mcp.task_notifications.test.ts
@@ -1,8 +1,9 @@
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
-import type { Notification } from '@modelcontextprotocol/sdk/types.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { RELATED_TASK_META_KEY } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
 
-import { RELATED_TASK_META_KEY, TASK_STATUS_HEARTBEAT_INTERVAL_MS } from '../../src/const.js';
+import { TASK_STATUS_HEARTBEAT_INTERVAL_MS } from '../../src/const.js';
 import { emitTaskStatusNotification } from '../../src/mcp/server.js';
 
 // Helper to create a minimal TaskStore mock
@@ -13,9 +14,13 @@ function makeTaskStore(task: Record<string, unknown> | undefined) {
     };
 }
 
+function makeServer() {
+    return { notification: vi.fn().mockResolvedValue(undefined) } as unknown as Server;
+}
+
 describe('emitTaskStatusNotification', () => {
     it('sends notifications/tasks/status with full Task shape', async () => {
-        const sendNotification = vi.fn<[Notification], Promise<void>>().mockResolvedValue(undefined);
+        const server = makeServer();
         const task = {
             taskId: 'task-1',
             status: 'working',
@@ -26,10 +31,10 @@ describe('emitTaskStatusNotification', () => {
         };
         const store = makeTaskStore(task);
 
-        await emitTaskStatusNotification('task-1', undefined, store as never, sendNotification);
+        await emitTaskStatusNotification('task-1', undefined, store as never, server);
 
-        expect(sendNotification).toHaveBeenCalledOnce();
-        const notification = sendNotification.mock.calls[0][0];
+        expect(server.notification).toHaveBeenCalledOnce();
+        const notification = (server.notification as ReturnType<typeof vi.fn>).mock.calls[0][0];
         expect(notification.method).toBe('notifications/tasks/status');
         expect(notification.params).toMatchObject({
             taskId: 'task-1',
@@ -42,7 +47,7 @@ describe('emitTaskStatusNotification', () => {
     });
 
     it('does NOT include _meta.related-task in notification (SHOULD NOT)', async () => {
-        const sendNotification = vi.fn<[Notification], Promise<void>>().mockResolvedValue(undefined);
+        const server = makeServer();
         const task = {
             taskId: 'task-1',
             status: 'working',
@@ -52,16 +57,16 @@ describe('emitTaskStatusNotification', () => {
         };
         const store = makeTaskStore(task);
 
-        await emitTaskStatusNotification('task-1', undefined, store as never, sendNotification);
+        await emitTaskStatusNotification('task-1', undefined, store as never, server);
 
-        const notification = sendNotification.mock.calls[0][0];
+        const notification = (server.notification as ReturnType<typeof vi.fn>).mock.calls[0][0];
         expect(notification).not.toHaveProperty('_meta');
         expect(notification.params).not.toHaveProperty('_meta');
         expect((notification.params as Record<string, unknown>)?.[RELATED_TASK_META_KEY]).toBeUndefined();
     });
 
     it('omits statusMessage when null', async () => {
-        const sendNotification = vi.fn<[Notification], Promise<void>>().mockResolvedValue(undefined);
+        const server = makeServer();
         const store = makeTaskStore({
             taskId: 'task-1',
             status: 'working',
@@ -71,23 +76,23 @@ describe('emitTaskStatusNotification', () => {
             statusMessage: null,
         });
 
-        await emitTaskStatusNotification('task-1', undefined, store as never, sendNotification);
+        await emitTaskStatusNotification('task-1', undefined, store as never, server);
 
-        const params = sendNotification.mock.calls[0][0].params as Record<string, unknown>;
+        const params = (server.notification as ReturnType<typeof vi.fn>).mock.calls[0][0].params as Record<string, unknown>;
         expect(params).not.toHaveProperty('statusMessage');
     });
 
     it('is silent when task is not found', async () => {
-        const sendNotification = vi.fn<[Notification], Promise<void>>().mockResolvedValue(undefined);
+        const server = makeServer();
         const store = makeTaskStore(undefined);
 
-        await emitTaskStatusNotification('missing', undefined, store as never, sendNotification);
+        await emitTaskStatusNotification('missing', undefined, store as never, server);
 
-        expect(sendNotification).not.toHaveBeenCalled();
+        expect(server.notification).not.toHaveBeenCalled();
     });
 
-    it('is silent when sendNotification throws', async () => {
-        const sendNotification = vi.fn<[Notification], Promise<void>>().mockRejectedValue(new Error('network'));
+    it('is silent when server.notification throws', async () => {
+        const server = { notification: vi.fn().mockRejectedValue(new Error('transport closed')) } as unknown as Server;
         const store = makeTaskStore({
             taskId: 'task-1',
             status: 'working',
@@ -97,7 +102,7 @@ describe('emitTaskStatusNotification', () => {
         });
 
         // Should not throw
-        await expect(emitTaskStatusNotification('task-1', undefined, store as never, sendNotification))
+        await expect(emitTaskStatusNotification('task-1', undefined, store as never, server))
             .resolves.toBeUndefined();
     });
 });

--- a/tests/unit/mcp.task_notifications.test.ts
+++ b/tests/unit/mcp.task_notifications.test.ts
@@ -1,0 +1,170 @@
+import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
+import type { Notification } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RELATED_TASK_META_KEY, TASK_STATUS_HEARTBEAT_INTERVAL_MS } from '../../src/const.js';
+import { emitTaskStatusNotification } from '../../src/mcp/server.js';
+
+// Helper to create a minimal TaskStore mock
+function makeTaskStore(task: Record<string, unknown> | undefined) {
+    return {
+        getTask: vi.fn().mockResolvedValue(task),
+        updateTaskStatus: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+describe('emitTaskStatusNotification', () => {
+    it('sends notifications/tasks/status with full Task shape', async () => {
+        const sendNotification = vi.fn<[Notification], Promise<void>>().mockResolvedValue(undefined);
+        const task = {
+            taskId: 'task-1',
+            status: 'working',
+            createdAt: '2025-01-01T00:00:00.000Z',
+            lastUpdatedAt: '2025-01-01T00:00:01.000Z',
+            ttl: 3600,
+            statusMessage: 'Crawling page 1',
+        };
+        const store = makeTaskStore(task);
+
+        await emitTaskStatusNotification('task-1', undefined, store as never, sendNotification);
+
+        expect(sendNotification).toHaveBeenCalledOnce();
+        const notification = sendNotification.mock.calls[0][0];
+        expect(notification.method).toBe('notifications/tasks/status');
+        expect(notification.params).toMatchObject({
+            taskId: 'task-1',
+            status: 'working',
+            createdAt: '2025-01-01T00:00:00.000Z',
+            lastUpdatedAt: '2025-01-01T00:00:01.000Z',
+            ttl: 3600,
+            statusMessage: 'Crawling page 1',
+        });
+    });
+
+    it('does NOT include _meta.related-task in notification (SHOULD NOT)', async () => {
+        const sendNotification = vi.fn<[Notification], Promise<void>>().mockResolvedValue(undefined);
+        const task = {
+            taskId: 'task-1',
+            status: 'working',
+            createdAt: '2025-01-01T00:00:00.000Z',
+            lastUpdatedAt: '2025-01-01T00:00:01.000Z',
+            ttl: 3600,
+        };
+        const store = makeTaskStore(task);
+
+        await emitTaskStatusNotification('task-1', undefined, store as never, sendNotification);
+
+        const notification = sendNotification.mock.calls[0][0];
+        expect(notification).not.toHaveProperty('_meta');
+        expect(notification.params).not.toHaveProperty('_meta');
+        expect((notification.params as Record<string, unknown>)?.[RELATED_TASK_META_KEY]).toBeUndefined();
+    });
+
+    it('omits statusMessage when null', async () => {
+        const sendNotification = vi.fn<[Notification], Promise<void>>().mockResolvedValue(undefined);
+        const store = makeTaskStore({
+            taskId: 'task-1',
+            status: 'working',
+            createdAt: '2025-01-01T00:00:00.000Z',
+            lastUpdatedAt: '2025-01-01T00:00:01.000Z',
+            ttl: 3600,
+            statusMessage: null,
+        });
+
+        await emitTaskStatusNotification('task-1', undefined, store as never, sendNotification);
+
+        const params = sendNotification.mock.calls[0][0].params as Record<string, unknown>;
+        expect(params).not.toHaveProperty('statusMessage');
+    });
+
+    it('is silent when task is not found', async () => {
+        const sendNotification = vi.fn<[Notification], Promise<void>>().mockResolvedValue(undefined);
+        const store = makeTaskStore(undefined);
+
+        await emitTaskStatusNotification('missing', undefined, store as never, sendNotification);
+
+        expect(sendNotification).not.toHaveBeenCalled();
+    });
+
+    it('is silent when sendNotification throws', async () => {
+        const sendNotification = vi.fn<[Notification], Promise<void>>().mockRejectedValue(new Error('network'));
+        const store = makeTaskStore({
+            taskId: 'task-1',
+            status: 'working',
+            createdAt: '2025-01-01T00:00:00.000Z',
+            lastUpdatedAt: '2025-01-01T00:00:01.000Z',
+            ttl: 3600,
+        });
+
+        // Should not throw
+        await expect(emitTaskStatusNotification('task-1', undefined, store as never, sendNotification))
+            .resolves.toBeUndefined();
+    });
+});
+
+describe('tasks/result _meta.related-task injection', () => {
+    type HandlerFn = (req: Record<string, unknown>, extra: Record<string, unknown>) => Promise<Record<string, unknown>>;
+
+    // Helper to dispatch a handler by method name via the SDK's internal handler map
+    function getHandler(server: unknown, method: string) {
+        // eslint-disable-next-line no-underscore-dangle
+        const handler = (server as { server: { _requestHandlers: Map<string, HandlerFn> } }).server._requestHandlers.get(method);
+        if (!handler) throw new Error(`Handler "${method}" not registered`);
+        return handler;
+    }
+
+    // Minimal fake CallToolRequest required by InMemoryTaskStore.createTask
+    const fakeRequest = { method: 'tools/call', params: { name: 'test-tool', arguments: {} } };
+
+    it('injects _meta.related-task into tasks/result response (MUST)', async () => {
+        const { ActorsMcpServer } = await import('../../src/mcp/server.js');
+        const taskStore = new InMemoryTaskStore();
+        const server = new ActorsMcpServer({ taskStore, setupSigintHandler: false, telemetry: { enabled: false } });
+
+        const task = await taskStore.createTask({ ttl: 60_000 }, 'req-1', fakeRequest as never);
+        await taskStore.storeTaskResult(task.taskId, 'completed', { content: [{ type: 'text', text: 'done' }] }, undefined);
+
+        const handler = getHandler(server as never, 'tasks/result');
+        const result = await handler(
+            { method: 'tasks/result', params: { taskId: task.taskId } },
+            { sendNotification: vi.fn() },
+        );
+
+        expect((result as Record<string, unknown>)._meta).toMatchObject({
+            [RELATED_TASK_META_KEY]: { taskId: task.taskId },
+        });
+
+        await server.close();
+    });
+
+    it('merges _meta.related-task with existing _meta keys', async () => {
+        const { ActorsMcpServer } = await import('../../src/mcp/server.js');
+        const taskStore = new InMemoryTaskStore();
+        const server = new ActorsMcpServer({ taskStore, setupSigintHandler: false, telemetry: { enabled: false } });
+
+        const task = await taskStore.createTask({ ttl: 60_000 }, 'req-2', fakeRequest as never);
+        const existingMeta = { 'com.apify/ActorRun': { runId: 'run-abc' } };
+        await taskStore.storeTaskResult(task.taskId, 'completed', {
+            content: [{ type: 'text', text: 'done' }],
+            _meta: existingMeta,
+        }, undefined);
+
+        const handler = getHandler(server as never, 'tasks/result');
+        const result = await handler(
+            { method: 'tasks/result', params: { taskId: task.taskId } },
+            { sendNotification: vi.fn() },
+        ) as Record<string, unknown>;
+
+        const meta = result._meta as Record<string, unknown>;
+        expect(meta[RELATED_TASK_META_KEY]).toEqual({ taskId: task.taskId });
+        expect(meta['com.apify/ActorRun']).toEqual({ runId: 'run-abc' });
+
+        await server.close();
+    });
+});
+
+describe('heartbeat constant', () => {
+    it('TASK_STATUS_HEARTBEAT_INTERVAL_MS is 30 seconds', () => {
+        expect(TASK_STATUS_HEARTBEAT_INTERVAL_MS).toBe(30_000);
+    });
+});

--- a/tests/unit/mcp.task_notifications.test.ts
+++ b/tests/unit/mcp.task_notifications.test.ts
@@ -3,7 +3,6 @@ import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { RELATED_TASK_META_KEY } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
 
-import { TASK_STATUS_HEARTBEAT_INTERVAL_MS } from '../../src/const.js';
 import { emitTaskStatusNotification } from '../../src/mcp/server.js';
 
 // Helper to create a minimal TaskStore mock
@@ -165,11 +164,5 @@ describe('tasks/result _meta.related-task injection', () => {
         expect(meta['com.apify/ActorRun']).toEqual({ runId: 'run-abc' });
 
         await server.close();
-    });
-});
-
-describe('heartbeat constant', () => {
-    it('TASK_STATUS_HEARTBEAT_INTERVAL_MS is 30 seconds', () => {
-        expect(TASK_STATUS_HEARTBEAT_INTERVAL_MS).toBe(30_000);
     });
 });

--- a/tests/unit/utils.progress.test.ts
+++ b/tests/unit/utils.progress.test.ts
@@ -1,6 +1,7 @@
+import { RELATED_TASK_META_KEY } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
 
-import { PROGRESS_NOTIFICATION_INTERVAL_MS, RELATED_TASK_META_KEY } from '../../src/const.js';
+import { PROGRESS_NOTIFICATION_INTERVAL_MS } from '../../src/const.js';
 import { createProgressTracker, formatRunStatusMessage, ProgressTracker } from '../../src/utils/progress.js';
 
 describe('ProgressTracker', () => {


### PR DESCRIPTION
## What
Wire `notifications/tasks/status` push notifications for task-mode tool calls, and add `_meta.related-task` on `tasks/result` so clients can correlate results to their tasks.

## Non-obvious

- **`server.notification()`
- **dev_server** GET `/` previously returned 405. Now forwarded to `transport.handleRequest`.
- **`notifications/tasks/status` deliberately omits `_meta.related-task`.** Per spec, `taskId` belongs in `params`, not `_meta`. `tasks/result` *does* carry the key — that asymmetry is intentional.
- **`setImmediate(async () => …)` → `setImmediate(() => …).catch(log)`.** The prior form swallowed unhandled rejections from `executeToolAndUpdateTask`.

## Test plan
- [x] `npm run type-check`, `npm run lint`, `npm run test:unit`
- [x] Integration: `should be able to call a long running task tool call` now asserts at least one `taskStatus` event reaches the client — catches a regression where notifications get dropped on streamable HTTP.
- [x] Tested with mcpc and MCPInspector

Closes: #816
