### PR TITLE
feat: Accept build, maxItems, maxTotalChargeUsd in callOptions

### DIFF
--- a/res/call_actor_redesign_v4.md
+++ b/res/call_actor_redesign_v4.md
@@ -9,7 +9,7 @@ Audience: PM and tech lead. No prior reading required — this document is self-
 
 V4 defines a single canonical response shape returned by `call-actor` and `get-actor-run` regardless of mode (sync, task, wait-timeout). The shape mirrors Apify's storage API for familiarity, adds a structured `summary` / `nextStep` pair the LLM can act on directly, and is paired with four substantive companion changes:
 
-1. `get-dataset-items` becomes the canonical retrieval tool — auto-flattens dot-notation fields. Storage IDs the agent needs (`datasetId`, `keyValueStoreId`) are surfaced in `storages.*.id` and embedded directly in the response's `nextStep` text, so the agent can act without parsing `structuredContent`.
+1. `get-dataset-items` becomes the canonical retrieval tool — auto-flattens dot-notation fields. Storage IDs the agent needs (`datasetId`, `storeId`) are surfaced in `storages.*.id` and embedded directly in the response's `nextStep` text, so the agent can act without parsing `structuredContent`.
 2. `abort-actor-run` is promoted into the actor workflow.
 3. `get-key-value-store-record` is promoted into the actor workflow; the response surfaces the list of KV store keys so the agent can fetch what it needs.
 4. Task mode gains real push notifications (`notifications/tasks/status` on every state change) and real cancellation (cancel actually aborts the Apify run).
@@ -56,7 +56,7 @@ V4 defines a single canonical response shape returned by `call-actor` and `get-a
 | **Q3** | `get-dataset-items`, `get-key-value-store-record`, and `abort-actor-run` become available in actor-running workflows through loader auto-injection. Default categories stay unchanged. `get-actor-output` remains available for one minor cycle, deprecated, ordered after `get-dataset-items`. |
 | **Q4** | Slash-to-dot translation is handled by the server for `storages.dataset.fields`. `get-dataset-items` auto-flattens any parent referenced in dot-notation `fields`. Explicit `flatten` arg remains as a diagnostic override. The LLM never sees slashes and never has to compute a flatten set. |
 | **Q5** | `isError` is `false` whenever we observe any terminal actor status (`SUCCEEDED`, `FAILED`, `ABORTED`, `TIMED-OUT`). Task mode lands in `status: completed` for observed actor terminal states. Task `status: failed` is reserved for tool-side failures (auth, validation, network, server). |
-| **Q6** | Storage tools stay single-purpose: `get-dataset-items` requires `datasetId`, `get-key-value-store-record` requires `keyValueStoreId`. The canonical response surfaces both IDs under `storages.*.id` and `nextStep` interpolates them verbatim, so text-mode clients still see one self-contained instruction. (Earlier draft accepted `runId` as an alternative; dropped to avoid a two-mode tool surface and a hidden run-fetch round-trip.) |
+| **Q6** | Storage tools stay single-purpose: `get-dataset-items` requires `datasetId`, `get-key-value-store-record` requires `storeId`. The canonical response surfaces both IDs under `storages.*.id` and `nextStep` interpolates them verbatim, so text-mode clients still see one self-contained instruction. (Earlier draft accepted `runId` as an alternative; dropped to avoid a two-mode tool surface and a hidden run-fetch round-trip.) |
 | **Q7** | The response does not inline KV record bodies. Instead `storages.keyValueStore.keys` lists up to 50 key names with `keyCount` reflecting the total. The agent fetches any record it wants via `get-key-value-store-record`. |
 | **Q8** | Status enum is the full Apify set: `READY | RUNNING | TIMING-OUT | TIMED-OUT | ABORTING | ABORTED | SUCCEEDED | FAILED`. `ABORTING` and `TIMING-OUT` pass through with their own `summary` and `nextStep` templates. |
 | **Q9** | `waitSecs` is capped at 0–45 on both `call-actor` and `get-actor-run`. Default 30 on `call-actor`, 0 on `get-actor-run`. The 45 s ceiling stays safely under the 60 s tool-call timeout that several MCP clients impose; longer waits are agent-driven via repeated `get-actor-run` polls. |
@@ -178,7 +178,7 @@ Every status returns a concrete `summary` and one primary `nextStep`. Templates 
 | TIMING-OUT | `"TIMING-OUT after ${elapsedSecs}s. ${statusMessage \|\| 'Run-time limit reached; cleanup in progress'}."` | `"Use get-actor-run with runId=${runId} and waitSecs=10 to observe terminal state."` |
 | ABORTING | `"ABORTING after ${elapsedSecs}s. ${statusMessage \|\| 'Cancellation in progress'}."` | `"Use get-actor-run with runId=${runId} and waitSecs=10 to observe terminal state."` |
 | SUCCEEDED, dataset has items | `"SUCCEEDED in ${runTimeSecs}s. ${itemCount} items; ${fieldCount} fields available."` | `"Use get-dataset-items with datasetId=${storages.dataset.id} and limit=20 to fetch items (${itemCount} total). Available fields (dot notation): ${storages.dataset.fields.join(', ')} — pass via fields=\"...\" to project. Preview with limit=3."` |
-| SUCCEEDED, dataset empty + KV has keys | `"SUCCEEDED in ${runTimeSecs}s. Output written to key-value store (${keyCount} keys)."` | When `keys` includes `OUTPUT`: `"Use get-key-value-store-record with keyValueStoreId=${storages.keyValueStore.id} and recordKey=\"OUTPUT\" to read the main output. Other keys: ${keys.filter(k=>k!=='OUTPUT').join(', ') \|\| 'none'}."` Otherwise: `"Use get-key-value-store-record with keyValueStoreId=${storages.keyValueStore.id} and one of these keys (as recordKey): ${storages.keyValueStore.keys.join(', ')}."` |
+| SUCCEEDED, dataset empty + KV has keys | `"SUCCEEDED in ${runTimeSecs}s. Output written to key-value store (${keyCount} keys)."` | When `keys` includes `OUTPUT`: `"Use get-key-value-store-record with storeId=${storages.keyValueStore.id} and recordKey=\"OUTPUT\" to read the main output. Other keys: ${keys.filter(k=>k!=='OUTPUT').join(', ') \|\| 'none'}."` Otherwise: `"Use get-key-value-store-record with storeId=${storages.keyValueStore.id} and one of these keys (as recordKey): ${storages.keyValueStore.keys.join(', ')}."` |
 | SUCCEEDED, no dataset items, no KV keys | `"SUCCEEDED in ${runTimeSecs}s. No dataset items and no key-value records were found."` | `"Inspect statusMessage and stats in this response; if the missing output was unexpected, re-run call-actor with adjusted input."` |
 | FAILED | `"FAILED after ${runTimeSecs}s${statusMessage ? ': ' + statusMessage : ''}."` | `"Diagnose using statusMessage and exitCode in this response; re-run call-actor with adjusted input if the cause is fixable."` |
 | ABORTED | `"ABORTED after ${runTimeSecs}s${statusMessage ? ': ' + statusMessage : ''}."` | `"Use call-actor again if you want to rerun the actor."` |
@@ -273,7 +273,7 @@ If the listKeys call fails or the run has no default key-value store, both field
 | `run-actor` | Deferred | Not implemented in this PR. Plan as a separate rename migration. |
 | `get-actor-run` | Modified | Adds `waitSecs` (0–45, default 0 to preserve current immediate-poll behavior). Returns the canonical shape. When `waitSecs > 0` and the caller passes `_meta.progressToken`, the server emits `notifications/progress` on each `run.statusMessage` change during the wait — see "Progress notifications during sync waits" below. |
 | `get-dataset-items` | Promoted in actor workflows | Requires `datasetId`. Defaults `limit` to 20. Auto-flattens dot-notation `fields`. Explicit `flatten` remains as a diagnostic override. |
-| `get-key-value-store-record` | Promoted in actor workflows | Requires `keyValueStoreId` and `recordKey`. Parameter name `recordKey` matches the existing tool schema (kept for backward compatibility). |
+| `get-key-value-store-record` | Promoted in actor workflows | Requires `storeId` and `recordKey`. Parameter name `recordKey` matches the existing tool schema (kept for backward compatibility). |
 | `abort-actor-run` | Promoted in actor workflows | Auto-surfaced when actor-running tools are present. |
 | `get-actor-output` | Deprecated | Kept for one minor cycle. Description prefixed `DEPRECATED:`; points to `get-dataset-items` for dataset items and `get-key-value-store-record` for KV records. |
 
@@ -294,11 +294,11 @@ This is the change that lets us deprecate `get-actor-output`: once `get-dataset-
 
 The KV-only-actor case (and any actor that writes auxiliary records) needs a first-class fetch path now that the response no longer inlines record bodies.
 
-- Requires `keyValueStoreId` and `recordKey`. The parameter is named `recordKey` to match the existing tool schema; v4 does not rename it.
-- The agent gets `keyValueStoreId` from `storages.keyValueStore.id` on the canonical response, or interpolated directly into `nextStep` for text-mode clients.
+- Requires `storeId` and `recordKey`. The parameter is named `recordKey` to match the existing tool schema; v4 does not rename it.
+- The agent gets `storeId` from `storages.keyValueStore.id` on the canonical response, or interpolated directly into `nextStep` for text-mode clients.
 - Auto-surfaced in actor workflows so the LLM can act on `nextStep` without the storage tool category being explicitly enabled.
 
-The agent's path for KV-only output is: `call-actor` returns `storages.keyValueStore.{id,keyCount,keys}` → `nextStep` points at `get-key-value-store-record(keyValueStoreId=${storages.keyValueStore.id}, recordKey="OUTPUT")` → agent fetches the body when (and only when) it actually wants it.
+The agent's path for KV-only output is: `call-actor` returns `storages.keyValueStore.{id,keyCount,keys}` → `nextStep` points at `get-key-value-store-record(storeId=${storages.keyValueStore.id}, recordKey="OUTPUT")` → agent fetches the body when (and only when) it actually wants it.
 
 ## `callOptions` accepted keys
 
@@ -464,8 +464,8 @@ End-to-end behavioral assertions, summarised:
 - **No item or record bodies in the response.** `storages.dataset.fields` and `storages.keyValueStore.{keys,keyCount}` are populated; no `sampleItems` and no inlined record bodies appear under any path.
 - **`waitSecs` cap.** Both `call-actor` and `get-actor-run` reject `waitSecs > 45` with a validation error. `waitSecs: 45` is accepted and the call returns within roughly that bound.
 - **`get-dataset-items` with dot-notation `fields`** returns nested values without explicit `flatten` (auto-flatten works).
-- **`get-key-value-store-record` with `keyValueStoreId`** (read from `storages.keyValueStore.id`) returns the requested record body. Auto-injection: the tool is present in the active tool set whenever `call-actor` is, without explicitly enabling the storage category.
-- **KV-only actor**: `storages.keyValueStore.{id,keys}` lists the store ID and keys (including `OUTPUT`); the response carries no record body. The `nextStep` directs the agent at `get-key-value-store-record(keyValueStoreId, recordKey="OUTPUT")` with the store ID interpolated.
+- **`get-key-value-store-record` with `storeId`** (read from `storages.keyValueStore.id`) returns the requested record body. Auto-injection: the tool is present in the active tool set whenever `call-actor` is, without explicitly enabling the storage category.
+- **KV-only actor**: `storages.keyValueStore.{id,keys}` lists the store ID and keys (including `OUTPUT`); the response carries no record body. The `nextStep` directs the agent at `get-key-value-store-record(storeId, recordKey="OUTPUT")` with the store ID interpolated.
 - **Task mode** lands in `completed` for an actor that finishes in any terminal state, including `FAILED`.
 - **Synthetic infra failure** (invalid actor, sandboxed revoked token) lands in task `failed` and populates `task.statusMessage`.
 - **Push notifications**: at least one `notifications/tasks/status` arrives between `tasks/created` and `completed`.

--- a/res/call_actor_redesign_v4.md
+++ b/res/call_actor_redesign_v4.md
@@ -12,7 +12,7 @@ V4 defines a single canonical response shape returned by `call-actor` and `get-a
 1. `get-dataset-items` becomes the canonical retrieval tool — auto-flattens dot-notation fields. Storage IDs the agent needs (`datasetId`, `storeId`) are surfaced in `storages.*.id` and embedded directly in the response's `nextStep` text, so the agent can act without parsing `structuredContent`.
 2. `abort-actor-run` is promoted into the actor workflow.
 3. `get-key-value-store-record` is promoted into the actor workflow; the response surfaces the list of KV store keys so the agent can fetch what it needs.
-4. Task mode gains real push notifications (`notifications/tasks/status` + heartbeat) and real cancellation (cancel actually aborts the Apify run).
+4. Task mode gains real push notifications (`notifications/tasks/status` on every state change) and real cancellation (cancel actually aborts the Apify run).
 
 **The public tool name stays `call-actor`.** The cleaner name `run-actor` is a separate, later migration — this PR already changes too much to add a name change on top.
 
@@ -40,7 +40,7 @@ V4 defines a single canonical response shape returned by `call-actor` and `get-a
 2. **The LLM is a first-class consumer.** `summary` (past) and `nextStep` (one primary action) are part of the contract. Templates per status are locked, not free-form.
 3. **Hide footguns from the LLM.** Server translates Apify slash-notation to dot-notation. `get-dataset-items` auto-flattens parents when fields contain dots. The LLM never sees the Apify-API edge cases that bit it before.
 4. **Run status is observation, not tool failure.** `isError: true` is reserved for tool-side failures (auth, network, Zod validation). `FAILED` / `ABORTED` / `TIMED-OUT` are observed run outcomes, returned with `isError: false`.
-5. **Push, don't poll.** Task mode emits `notifications/tasks/status` on every state change and heartbeats every ~45 s of silence so clients can verify liveness without tripping the common 60 s client-side tool-call timeout.
+5. **Push state changes, fall back to poll.** Task mode emits `notifications/tasks/status` on every state change. Per the MCP spec the notification is `MAY` (clients must not depend on it), so SDK clients also poll `tasks/get` at the task's `pollInterval` — the push is a UX win, not a transport-keepalive mechanism.
 6. **Cancellation is propagation, not bookkeeping.** `tasks/cancel` aborts the in-flight Apify run, not just the task store entry.
 7. **Server returns shape, agent fetches data.** No server-side previews of dataset items or KV record bodies. The response carries identifiers and key/field lists; the agent calls `get-dataset-items` or `get-key-value-store-record` when it needs values. Truncation of the metadata itself (e.g. capped key list) is observable through a count field.
 
@@ -50,7 +50,7 @@ V4 defines a single canonical response shape returned by `call-actor` and `get-a
 |---|---|
 | **T1** | `storages` is a subset of the Apify storage API: same field names as `apify-client.Dataset` and `KeyValueStore`, but timestamps are ISO 8601 strings, and fields that are required upstream are optional here when not yet known. We omit security/identity fields (`userId`, `username`, `urlSigningSecretKey`, `generalAccess`, `*PublicUrl`, `actId`, `actRunId`) plus redundant `accessedAt`. We add two fields: `storages.keyValueStore.keys` (string array, capped at 50 names) and `storages.keyValueStore.keyCount` (total key count). The dataset block carries `fields` (dot notation) but no item samples. |
 | **T2** | `summary` describes the past. `nextStep` prescribes one primary action. Both camelCase to match the rest of the response. |
-| **R1** | Push notifications are required server work. Emit `notifications/tasks/status` on every task state change AND a heartbeat every ~45 s of silence while a task is still working. The interval stays under the common 60 s client-side tool-call timeout so heartbeats actually keep the connection live. `notifications/progress` already emits today on actor state change; only `tasks/status` is missing. |
+| **R1** | Emit `notifications/tasks/status` on every task state change (start → working, on `statusMessage` change, on terminal). No heartbeat: in task mode `tools/call` returns immediately with `CreateTaskResult`, so there is no held-open request to time out, and the SDK client falls back to `tasks/get` polling per spec. `notifications/progress` already emits today on actor state change; only `tasks/status` was missing. |
 | **R4** | Keep `call-actor`; defer the `run-actor` rename. The current name is referenced across the public repo, internal repo tests, UI constants, examples, docs, and the MCP Apps widget wiring; combining identity rename with this contract change would make regressions hard to isolate. Plan rename as a separate migration once this contract is stable. |
 | **Q2** | `get-actor-run` mirrors `call-actor`'s canonical shape, including `storages.dataset.fields` and `storages.keyValueStore.{keys,keyCount}` when available. |
 | **Q3** | `get-dataset-items`, `get-key-value-store-record`, and `abort-actor-run` become available in actor-running workflows through loader auto-injection. Default categories stay unchanged. `get-actor-output` remains available for one minor cycle, deprecated, ordered after `get-dataset-items`. |
@@ -213,7 +213,7 @@ Implementation reuses the existing `ProgressTracker` (`src/utils/progress.ts`) t
 Task mode is selected when the client passes `task: {...}` on `tools/call`. The server returns `CreateTaskResult` immediately and runs the underlying tool in the background until terminal or cancelled.
 
 - `waitSecs` and `async` from the args are **overridden** at the task boundary. The task always waits until terminal — honoring `async: true` would let the task complete the moment the actor started, which is wrong. If the caller sends both `task: {...}` and `async: true`, log a deprecation event but still wait until terminal.
-- Push notifications: `notifications/tasks/status` emits on every state change and heartbeats every ~45 s of silence. The 45 s interval stays under the 60 s tool-call/connection timeout that several MCP clients impose, so heartbeats actually keep the channel live.
+- Push notifications: `notifications/tasks/status` emits on every state change (start → working, on `statusMessage` change, on terminal). No heartbeat — `tools/call` in task mode returns immediately, and per spec `notifications/tasks/status` is `MAY` so clients must not depend on it; the SDK client polls `tasks/get` regardless.
 - `tasks/result` returns the canonical shape (same as sync mode).
 - See **Cancellation** below.
 
@@ -380,7 +380,7 @@ sequenceDiagram
   Client->>Server: tools/call + task:{ttl:600000} + _meta:{progressToken:"p1"}
   Server-->>Client: CreateTaskResult{task:{taskId,status:working,createdAt,lastUpdatedAt,ttl,pollInterval:5000}}
   Server-)Apify: start + waitForFinish
-  Note over Server: state change OR ~45s silence -> emit task status
+  Note over Server: emit task status on each state change
   Apify--)Server: statusMessage: "Crawling page 5/20"
   Server--)Client: notifications/progress{progressToken:p1, progress:N, message:"apify/x: Crawling page 5/20"}
   Server--)Client: notifications/tasks/status{taskId, status:working, statusMessage:"apify/x: Crawling page 5/20"}
@@ -417,7 +417,6 @@ sequenceDiagram
 | `actorId` added; `actorName` becomes optional | Soft (additive). `actorName` was never present on the shipped `call-actor` shape and was already optional on `get-actor-run`. |
 | `statusMessage` and `exitCode` added at top level | Soft. Additive. |
 | `tasks/cancel` now propagates to `run.abort()` | Soft (bug fix). The current behavior — orphaned runs continuing after cancel — is an oversight, not load-bearing semantics. |
-| Task heartbeat every ~45 s of silence | Soft. Additive. Interval picked to stay under the 60 s client-side connection/tool-call timeout. |
 | Task mode forces `waitSecs` to wait-until-terminal and ignores `async: true` | Soft. Additive defensive behavior. |
 | `actor: "name:tool"` MCP-server pass-through is excluded from the canonical shape | No new behavior; the doc just admits the carve-out exists. |
 
@@ -440,7 +439,7 @@ Three apps-mode tools share this canonical shape and must be updated together: t
 
 ## Risks and open questions
 
-- **`waitSecs` and heartbeat at 45 s.** Chosen against the 60 s tool-call/connection timeout common to several MCP clients. Tune downward if a client surfaces a tighter ceiling; tune upward only with telemetry confirming everyone in scope is comfortably above the new value.
+- **`waitSecs` cap at 45 s.** Chosen against the 60 s tool-call timeout common to several MCP clients (this cap applies to sync mode where `tools/call` is held open; task mode is unaffected because `tools/call` returns immediately). Tune downward if a client surfaces a tighter ceiling; tune upward only with telemetry confirming everyone in scope is comfortably above the new value.
 - **Cancellation race window.** Cancel-before-start does create a brief Apify run that is then aborted. We accept this and assert "no un-aborted orphan." If accounting becomes a problem, the alternative is to delay run creation until after a debounce, which adds latency to the common case.
 - **`keys` cap at 50.** Picked as a safe ceiling. Actors that write hundreds of small KV records (rare) will see a truncated list with `keyCount` reflecting the total, and the agent fetches by name. Tune if telemetry shows real actors with 50+ semantically meaningful keys.
 - **Free-form `statusMessage`.** Actor authors set it. Some are useful ("Crawling page 5/20"), some are noise. Templates pass it through verbatim; we accept variability rather than try to normalize.
@@ -452,7 +451,7 @@ Three apps-mode tools share this canonical shape and must be updated together: t
 - Convert direct actor tools (e.g. `apify--rag-web-browser`) to the canonical shape — separate PR.
 - Remove deprecated `async`, `previewOutput`, and `get-actor-output` — next minor cycle.
 - `taskSupport` on `get-actor-run` — revisit after task adoption is measured.
-- `waitSecs` / heartbeat interval tuning — based on real telemetry; 45 s is the conservative starting point.
+- `waitSecs` ceiling tuning — based on real telemetry; 45 s is the conservative starting point.
 - Convert MCP-server pass-through (`actor:tool`) to a uniform shape — orthogonal redesign.
 
 ## MCP spec compliance
@@ -462,7 +461,7 @@ Verified against the live [tasks spec](https://modelcontextprotocol.io/specifica
 - **Statuses:** v4 emits `working`, `completed`, `failed`, `cancelled`. `input_required` is intentionally unused (no elicitation). Any observed Apify terminal → task `completed` with `isError: false`; tool-side failure → task `failed` with `isError: true`.
 - **`CreateTaskResult` is nested:** `{ task: { taskId, status, createdAt, lastUpdatedAt, ttl, pollInterval? } }`. Flat shapes are non-compliant.
 - **`call-actor` declares `Tool.execution.taskSupport: "optional"`** (nested under `execution`). Other v4 tools omit it (default: `forbidden`).
-- **`notifications/tasks/status` payload** is the full `Task` object per `TaskStatusNotificationParams = NotificationParams & Task`. Heartbeats are not no-ops — each emission advances `lastUpdatedAt`, which is itself a state change. The notification is `MAY` per spec; clients must not rely on it.
+- **`notifications/tasks/status` payload** is the full `Task` object per `TaskStatusNotificationParams = NotificationParams & Task`. The notification is `MAY` per spec; clients must not rely on it (SDK clients fall back to `tasks/get` polling).
 - **`io.modelcontextprotocol/related-task` `_meta` key** is a spec MUST on (a) the `CallToolResult` returned via `tasks/result` and (b) progress notifications. (b) is already wired (`src/utils/progress.ts`); (a) is an implementation item this PR adds. Omitted from `tasks/get` / `tasks/list` / `tasks/cancel` and from `notifications/tasks/status` (taskId is in the message structure). Coexists with the namespaced `com.apify/ActorRun` usage block under the same `_meta` record.
 - **`tasks/cancel` MUSTs:** reject terminal-status tasks with `-32602`; transition the task to `cancelled` before sending the response (Apify abort propagates async — see Cancellation above).
 
@@ -478,12 +477,12 @@ End-to-end behavioral assertions, summarised:
 - **KV-only actor**: `storages.keyValueStore.{id,keys}` lists the store ID and keys (including `OUTPUT`); the response carries no record body. The `nextStep` directs the agent at `get-key-value-store-record(storeId, recordKey="OUTPUT")` with the store ID interpolated.
 - **Task mode** lands in `completed` for an actor that finishes in any terminal state, including `FAILED`.
 - **Synthetic infra failure** (invalid actor, sandboxed revoked token) lands in task `failed` and populates `task.statusMessage`.
-- **Push notifications**: at least one `notifications/tasks/status` arrives between `tasks/created` and `completed`. A heartbeat fires after ~45 s of `statusMessage` silence (test-mode override to keep the suite fast).
+- **Push notifications**: at least one `notifications/tasks/status` arrives between `tasks/created` and `completed`.
 - **Progress on `get-actor-run` waits**: when invoked with `waitSecs > 0` and `_meta.progressToken`, the server emits `notifications/progress` carrying that token on each `run.statusMessage` change observed during the wait. No emissions when `progressToken` is absent.
 - **Cancellation**: `tasks/cancel` mid-run results in the underlying Apify run reaching `ABORTED`; task transitions to `cancelled` **before** the cancel response is sent; a `tasks/status: cancelled` notification fires. Cancel-before-start results in an `ABORTED` run (no un-aborted orphan).
 - **Cancel of terminal task** is rejected with JSON-RPC error `-32602`, message naming the current status.
 - **`_meta.related-task` on `tasks/result`**: the `CallToolResult` returned through `tasks/result` includes `_meta: { "io.modelcontextprotocol/related-task": { taskId } }`. (Progress notifications already covered by existing tests.)
-- **`notifications/tasks/status` payload**: every emission contains the full `Task` object (taskId, status, createdAt, lastUpdatedAt, ttl, optional statusMessage/pollInterval). Heartbeats advance `lastUpdatedAt` rather than emitting with stale fields.
+- **`notifications/tasks/status` payload**: every emission contains the full `Task` object (taskId, status, createdAt, lastUpdatedAt, ttl, optional statusMessage/pollInterval).
 - **`CreateTaskResult` shape**: `tools/call` with `task: { ttl }` returns `{ task: { taskId, status: "working", ... } }` — nested, not flat.
 - **`taskSupport` placement**: `tools/list` reports `call-actor.execution.taskSupport === "optional"`; other v4 tools either omit `execution` or set `taskSupport: "forbidden"`.
 - **Task mode override**: `task: {...}` plus deprecated `async: true` does not short-circuit the task; it waits until terminal.
@@ -509,6 +508,6 @@ Notes:
 - The mcpc bridge is established once per workspace; agents do not need to re-run `mcpc connect`.
 - Probes that actually hit the Apify API (everything except validation/auth-failure paths) require a real `APIFY_TOKEN` in the server env; agents must ask the user for one rather than committing or logging it.
 - Use `--json` piped through `jq` to assert on response shape. No inline Python.
-- Notification-stream tests (task heartbeats, `notifications/tasks/status`, progress events) use mcpc's notification capture; the suite-level harness can mirror those assertions for CI.
+- Notification-stream tests (`notifications/tasks/status`, progress events) use mcpc's notification capture; the suite-level harness can mirror those assertions for CI.
 
 The behavioural list above maps 1:1 onto mcpc-driven test cases. Programmatic equivalents land in `tests/integration/suite.ts` — the shared suite used by both stdio and streamable-HTTP transports — and run via `npm run test:integration` with a real token. New cases must go in `suite.ts`, not in standalone files. Integration runs are humans/CI only; agents drive mcpc instead.

--- a/res/call_actor_redesign_v4.md
+++ b/res/call_actor_redesign_v4.md
@@ -300,9 +300,9 @@ The KV-only-actor case (and any actor that writes auxiliary records) needs a fir
 
 The agent's path for KV-only output is: `call-actor` returns `storages.keyValueStore.{id,keyCount,keys}` → `nextStep` points at `get-key-value-store-record(keyValueStoreId=${storages.keyValueStore.id}, recordKey="OUTPUT")` → agent fetches the body when (and only when) it actually wants it.
 
-## `callOptions` allowlist
+## `callOptions` accepted keys
 
-`call-actor` validates `callOptions` strictly. Allowed:
+`call-actor` accepts these `callOptions`:
 
 | Key | Type | Why |
 |---|---|---|
@@ -312,16 +312,7 @@ The agent's path for KV-only output is: `call-actor` returns `storages.keyValueS
 | `maxItems` | number | Charge cap for pay-per-result actors |
 | `maxTotalChargeUsd` | number | Charge cap for pay-per-event actors |
 
-Rejected (with reason):
-
-- `waitForFinish` — use top-level `waitSecs`.
-- `webhooks` — redirects run events to caller-controlled URLs (security).
-- `contentType` — this tool sends JSON object input only.
-- `forcePermissionLevel` — permission escalation should not be exposed here.
-- `restartOnError` — can multiply cost without an explicit client workflow.
-- `proxy` and any other unknown key.
-
-The new behavior is strict rejection, not silent stripping.
+Unknown keys are silently dropped (Zod default object behavior). The earlier draft proposed strict rejection with per-key rationales for SDK-internal options like `waitForFinish` / `webhooks` / `forcePermissionLevel`; this was dropped because the only caller is an LLM, which has no schema for those keys and won't send them. If unknown keys ever surface in telemetry, revisit then.
 
 ## Input compatibility
 
@@ -412,7 +403,7 @@ sequenceDiagram
 | `isError` unified | Soft for tool-call semantics, but clients using task `status: failed` to detect actor failure must read inner `status` instead. |
 | `storages.keyValueStore.{keys,keyCount}` added | Soft. Additive. Replaces the inline-OUTPUT path that earlier drafts considered. |
 | `responseVersion: "v4"` added | Soft. Additive. |
-| `callOptions` strict allowlist | Potentially hard. Verify current unknown-key behavior first; reject unsafe keys explicitly. |
+| `callOptions` accepts three new keys (`build`, `maxItems`, `maxTotalChargeUsd`) | Soft. Additive. Unknown keys keep being silently dropped. |
 | Status enum widened to all 8 Apify states | Soft. Additive. |
 | `actorId` added; `actorName` becomes optional | Soft (additive). `actorName` was never present on the shipped `call-actor` shape and was already optional on `get-actor-run`. |
 | `statusMessage` and `exitCode` added at top level | Soft. Additive. |
@@ -487,7 +478,7 @@ End-to-end behavioral assertions, summarised:
 - **`taskSupport` placement**: `tools/list` reports `call-actor.execution.taskSupport === "optional"`; other v4 tools either omit `execution` or set `taskSupport: "forbidden"`.
 - **Task mode override**: `task: {...}` plus deprecated `async: true` does not short-circuit the task; it waits until terminal.
 - **MCP-server pass-through**: `actor: "name:tool"` returns the remote MCP tool result, not the canonical shape; `responseVersion` is absent on this path.
-- **`callOptions` allowlist**: rejects `waitForFinish`, `webhooks`, `contentType`, `forcePermissionLevel`, `restartOnError`, `proxy`, and unknown keys.
+- **`callOptions` accept-path**: each of `memory`, `timeout`, `build`, `maxItems`, `maxTotalChargeUsd` passes Zod parsing; `maxItems` is forwarded to `apifyClient.actor(...).start()` end-to-end against `apify/rag-web-browser`.
 - **`keys` cap**: a KV store with >50 keys returns the first 50 names with `keyCount` reflecting the total.
 - **Apps widget**: reads the new shape and polls with `waitSecs: 0`.
 

--- a/res/call_actor_redesign_v4.md
+++ b/res/call_actor_redesign_v4.md
@@ -9,7 +9,7 @@ Audience: PM and tech lead. No prior reading required — this document is self-
 
 V4 defines a single canonical response shape returned by `call-actor` and `get-actor-run` regardless of mode (sync, task, wait-timeout). The shape mirrors Apify's storage API for familiarity, adds a structured `summary` / `nextStep` pair the LLM can act on directly, and is paired with four substantive companion changes:
 
-1. `get-dataset-items` becomes the canonical retrieval tool — auto-flattens dot-notation fields. Storage IDs the agent needs (`datasetId`, `storeId`) are surfaced in `storages.*.id` and embedded directly in the response's `nextStep` text, so the agent can act without parsing `structuredContent`.
+1. `get-dataset-items` becomes the canonical retrieval tool — auto-flattens dot-notation fields. Storage IDs the agent needs (`datasetId`, `keyValueStoreId`) are surfaced in `storages.*.id` and embedded directly in the response's `nextStep` text, so the agent can act without parsing `structuredContent`.
 2. `abort-actor-run` is promoted into the actor workflow.
 3. `get-key-value-store-record` is promoted into the actor workflow; the response surfaces the list of KV store keys so the agent can fetch what it needs.
 4. Task mode gains real push notifications (`notifications/tasks/status` on every state change) and real cancellation (cancel actually aborts the Apify run).
@@ -56,7 +56,7 @@ V4 defines a single canonical response shape returned by `call-actor` and `get-a
 | **Q3** | `get-dataset-items`, `get-key-value-store-record`, and `abort-actor-run` become available in actor-running workflows through loader auto-injection. Default categories stay unchanged. `get-actor-output` remains available for one minor cycle, deprecated, ordered after `get-dataset-items`. |
 | **Q4** | Slash-to-dot translation is handled by the server for `storages.dataset.fields`. `get-dataset-items` auto-flattens any parent referenced in dot-notation `fields`. Explicit `flatten` arg remains as a diagnostic override. The LLM never sees slashes and never has to compute a flatten set. |
 | **Q5** | `isError` is `false` whenever we observe any terminal actor status (`SUCCEEDED`, `FAILED`, `ABORTED`, `TIMED-OUT`). Task mode lands in `status: completed` for observed actor terminal states. Task `status: failed` is reserved for tool-side failures (auth, validation, network, server). |
-| **Q6** | Storage tools stay single-purpose: `get-dataset-items` requires `datasetId`, `get-key-value-store-record` requires `storeId`. The canonical response surfaces both IDs under `storages.*.id` and `nextStep` interpolates them verbatim, so text-mode clients still see one self-contained instruction. (Earlier draft accepted `runId` as an alternative; dropped to avoid a two-mode tool surface and a hidden run-fetch round-trip.) |
+| **Q6** | Storage tools stay single-purpose: `get-dataset-items` requires `datasetId`, `get-key-value-store-record` requires `keyValueStoreId`. The canonical response surfaces both IDs under `storages.*.id` and `nextStep` interpolates them verbatim, so text-mode clients still see one self-contained instruction. (Earlier draft accepted `runId` as an alternative; dropped to avoid a two-mode tool surface and a hidden run-fetch round-trip.) |
 | **Q7** | The response does not inline KV record bodies. Instead `storages.keyValueStore.keys` lists up to 50 key names with `keyCount` reflecting the total. The agent fetches any record it wants via `get-key-value-store-record`. |
 | **Q8** | Status enum is the full Apify set: `READY | RUNNING | TIMING-OUT | TIMED-OUT | ABORTING | ABORTED | SUCCEEDED | FAILED`. `ABORTING` and `TIMING-OUT` pass through with their own `summary` and `nextStep` templates. |
 | **Q9** | `waitSecs` is capped at 0–45 on both `call-actor` and `get-actor-run`. Default 30 on `call-actor`, 0 on `get-actor-run`. The 45 s ceiling stays safely under the 60 s tool-call timeout that several MCP clients impose; longer waits are agent-driven via repeated `get-actor-run` polls. |
@@ -178,7 +178,7 @@ Every status returns a concrete `summary` and one primary `nextStep`. Templates 
 | TIMING-OUT | `"TIMING-OUT after ${elapsedSecs}s. ${statusMessage \|\| 'Run-time limit reached; cleanup in progress'}."` | `"Use get-actor-run with runId=${runId} and waitSecs=10 to observe terminal state."` |
 | ABORTING | `"ABORTING after ${elapsedSecs}s. ${statusMessage \|\| 'Cancellation in progress'}."` | `"Use get-actor-run with runId=${runId} and waitSecs=10 to observe terminal state."` |
 | SUCCEEDED, dataset has items | `"SUCCEEDED in ${runTimeSecs}s. ${itemCount} items; ${fieldCount} fields available."` | `"Use get-dataset-items with datasetId=${storages.dataset.id} and limit=20 to fetch items (${itemCount} total). Available fields (dot notation): ${storages.dataset.fields.join(', ')} — pass via fields=\"...\" to project. Preview with limit=3."` |
-| SUCCEEDED, dataset empty + KV has keys | `"SUCCEEDED in ${runTimeSecs}s. Output written to key-value store (${keyCount} keys)."` | When `keys` includes `OUTPUT`: `"Use get-key-value-store-record with storeId=${storages.keyValueStore.id} and recordKey=\"OUTPUT\" to read the main output. Other keys: ${keys.filter(k=>k!=='OUTPUT').join(', ') \|\| 'none'}."` Otherwise: `"Use get-key-value-store-record with storeId=${storages.keyValueStore.id} and one of these keys (as recordKey): ${storages.keyValueStore.keys.join(', ')}."` |
+| SUCCEEDED, dataset empty + KV has keys | `"SUCCEEDED in ${runTimeSecs}s. Output written to key-value store (${keyCount} keys)."` | When `keys` includes `OUTPUT`: `"Use get-key-value-store-record with keyValueStoreId=${storages.keyValueStore.id} and recordKey=\"OUTPUT\" to read the main output. Other keys: ${keys.filter(k=>k!=='OUTPUT').join(', ') \|\| 'none'}."` Otherwise: `"Use get-key-value-store-record with keyValueStoreId=${storages.keyValueStore.id} and one of these keys (as recordKey): ${storages.keyValueStore.keys.join(', ')}."` |
 | SUCCEEDED, no dataset items, no KV keys | `"SUCCEEDED in ${runTimeSecs}s. No dataset items and no key-value records were found."` | `"Inspect statusMessage and stats in this response; if the missing output was unexpected, re-run call-actor with adjusted input."` |
 | FAILED | `"FAILED after ${runTimeSecs}s${statusMessage ? ': ' + statusMessage : ''}."` | `"Diagnose using statusMessage and exitCode in this response; re-run call-actor with adjusted input if the cause is fixable."` |
 | ABORTED | `"ABORTED after ${runTimeSecs}s${statusMessage ? ': ' + statusMessage : ''}."` | `"Use call-actor again if you want to rerun the actor."` |
@@ -273,7 +273,7 @@ If the listKeys call fails or the run has no default key-value store, both field
 | `run-actor` | Deferred | Not implemented in this PR. Plan as a separate rename migration. |
 | `get-actor-run` | Modified | Adds `waitSecs` (0–45, default 0 to preserve current immediate-poll behavior). Returns the canonical shape. When `waitSecs > 0` and the caller passes `_meta.progressToken`, the server emits `notifications/progress` on each `run.statusMessage` change during the wait — see "Progress notifications during sync waits" below. |
 | `get-dataset-items` | Promoted in actor workflows | Requires `datasetId`. Defaults `limit` to 20. Auto-flattens dot-notation `fields`. Explicit `flatten` remains as a diagnostic override. |
-| `get-key-value-store-record` | Promoted in actor workflows | Requires `storeId` and `recordKey`. Parameter name `recordKey` matches the existing tool schema (kept for backward compatibility). |
+| `get-key-value-store-record` | Promoted in actor workflows | Requires `keyValueStoreId` and `recordKey`. Parameter name `recordKey` matches the existing tool schema (kept for backward compatibility). |
 | `abort-actor-run` | Promoted in actor workflows | Auto-surfaced when actor-running tools are present. |
 | `get-actor-output` | Deprecated | Kept for one minor cycle. Description prefixed `DEPRECATED:`; points to `get-dataset-items` for dataset items and `get-key-value-store-record` for KV records. |
 
@@ -294,11 +294,11 @@ This is the change that lets us deprecate `get-actor-output`: once `get-dataset-
 
 The KV-only-actor case (and any actor that writes auxiliary records) needs a first-class fetch path now that the response no longer inlines record bodies.
 
-- Requires `storeId` and `recordKey`. The parameter is named `recordKey` to match the existing tool schema; v4 does not rename it.
-- The agent gets `storeId` from `storages.keyValueStore.id` on the canonical response, or interpolated directly into `nextStep` for text-mode clients.
+- Requires `keyValueStoreId` and `recordKey`. The parameter is named `recordKey` to match the existing tool schema; v4 does not rename it.
+- The agent gets `keyValueStoreId` from `storages.keyValueStore.id` on the canonical response, or interpolated directly into `nextStep` for text-mode clients.
 - Auto-surfaced in actor workflows so the LLM can act on `nextStep` without the storage tool category being explicitly enabled.
 
-The agent's path for KV-only output is: `call-actor` returns `storages.keyValueStore.{id,keyCount,keys}` → `nextStep` points at `get-key-value-store-record(storeId=${storages.keyValueStore.id}, recordKey="OUTPUT")` → agent fetches the body when (and only when) it actually wants it.
+The agent's path for KV-only output is: `call-actor` returns `storages.keyValueStore.{id,keyCount,keys}` → `nextStep` points at `get-key-value-store-record(keyValueStoreId=${storages.keyValueStore.id}, recordKey="OUTPUT")` → agent fetches the body when (and only when) it actually wants it.
 
 ## `callOptions` allowlist
 
@@ -473,8 +473,8 @@ End-to-end behavioral assertions, summarised:
 - **No item or record bodies in the response.** `storages.dataset.fields` and `storages.keyValueStore.{keys,keyCount}` are populated; no `sampleItems` and no inlined record bodies appear under any path.
 - **`waitSecs` cap.** Both `call-actor` and `get-actor-run` reject `waitSecs > 45` with a validation error. `waitSecs: 45` is accepted and the call returns within roughly that bound.
 - **`get-dataset-items` with dot-notation `fields`** returns nested values without explicit `flatten` (auto-flatten works).
-- **`get-key-value-store-record` with `storeId`** (read from `storages.keyValueStore.id`) returns the requested record body. Auto-injection: the tool is present in the active tool set whenever `call-actor` is, without explicitly enabling the storage category.
-- **KV-only actor**: `storages.keyValueStore.{id,keys}` lists the store ID and keys (including `OUTPUT`); the response carries no record body. The `nextStep` directs the agent at `get-key-value-store-record(storeId, recordKey="OUTPUT")` with the store ID interpolated.
+- **`get-key-value-store-record` with `keyValueStoreId`** (read from `storages.keyValueStore.id`) returns the requested record body. Auto-injection: the tool is present in the active tool set whenever `call-actor` is, without explicitly enabling the storage category.
+- **KV-only actor**: `storages.keyValueStore.{id,keys}` lists the store ID and keys (including `OUTPUT`); the response carries no record body. The `nextStep` directs the agent at `get-key-value-store-record(keyValueStoreId, recordKey="OUTPUT")` with the store ID interpolated.
 - **Task mode** lands in `completed` for an actor that finishes in any terminal state, including `FAILED`.
 - **Synthetic infra failure** (invalid actor, sandboxed revoked token) lands in task `failed` and populates `task.statusMessage`.
 - **Push notifications**: at least one `notifications/tasks/status` arrives between `tasks/created` and `completed`.

--- a/src/const.ts
+++ b/src/const.ts
@@ -209,6 +209,7 @@ export const FAILURE_CATEGORY = {
 
 // Apify API error types
 export const APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED = 'full-permission-actor-not-approved';
+export const APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED = 'memory-limit-exceeded';
 
 // HTTP status codes
 export const HTTP_UNAUTHORIZED = 401;

--- a/src/tools/apps/call_actor_widget.ts
+++ b/src/tools/apps/call_actor_widget.ts
@@ -38,8 +38,8 @@ const callActorWidgetArgsSchema = z.object({
             .max(32768, 'Memory cannot exceed 32 GB (32768 MB)')
             .optional()
             .describe(dedent`
-                Memory allocation for the Actor in MB. Must be a power of 2 (e.g., 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768).
-                Minimum: 128 MB, Maximum: 32768 MB (32 GB).
+                Memory per run in MB. Power of 2 from 128 to 32768.
+                Apify also caps total memory across all your concurrent runs (account plan limit); if a run is rejected because that quota would be exceeded, retry with a smaller value.
             `),
         timeout: z.number()
             .min(0, 'Timeout must be 0 or greater')
@@ -47,6 +47,26 @@ const callActorWidgetArgsSchema = z.object({
             .describe(dedent`
                 Maximum runtime for the Actor in seconds. After this time elapses, the Actor will be automatically terminated.
                 Use 0 for infinite timeout (no time limit). Minimum: 0 seconds (infinite).
+            `),
+        build: z.string()
+            .optional()
+            .describe('Tag or number of the Actor build to run (e.g., "latest", "beta", "1.2.345"). If omitted, the Actor\'s default build is used.'),
+        maxItems: z.number()
+            .int()
+            .positive()
+            .optional()
+            .describe(dedent`
+                Pay-per-result Actors ONLY — has no effect on any other pricing model (pay-per-event, pay-per-usage, rental, free).
+                Caps the number of dataset items billed for this run; does NOT limit how many items the Actor produces.
+                Most Actors also expose their own input field (e.g. "maxResults", "maxPages", "maxItems") to bound how much work they do — prefer those when limiting actual output, since this option only caps billing.
+            `),
+        maxTotalChargeUsd: z.number()
+            .positive()
+            .optional()
+            .describe(dedent`
+                Pay-per-event Actors ONLY — has no effect on any other pricing model (pay-per-result, pay-per-usage, rental, free).
+                Caps the total USD billed for this run; does NOT limit how much work the Actor does.
+                Most Actors also expose their own input field to bound work — prefer those when limiting actual output, since this option only caps billing.
             `),
     }).optional()
         .describe('Optional call options for the Actor run configuration.'),

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -8,6 +8,7 @@ import log from '@apify/log';
 import { ApifyClient } from '../../apify_client.js';
 import {
     APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED,
+    APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED,
     CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG,
     FAILURE_CATEGORY,
     HelperTools,
@@ -186,6 +187,10 @@ export function isPermissionApprovalError(error: unknown): error is ApifyApiErro
     return error instanceof ApifyApiError && error.type === APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED;
 }
 
+export function isMemoryQuotaError(error: unknown): error is ApifyApiError {
+    return error instanceof ApifyApiError && error.type === APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED;
+}
+
 /** Exported for native actor tool error handling in server.ts — no logging, no telemetry. */
 export function buildPermissionApprovalResponse(error: ApifyApiError): ReturnType<typeof buildMCPResponse> {
     const approvalUrl = typeof error.data?.approvalUrl === 'string' ? error.data.approvalUrl : undefined;
@@ -244,13 +249,21 @@ export function buildCallActorErrorResponse(params: CallActorErrorResponseParams
         failureCategory,
     });
 
-    return buildMCPResponse({
-        texts: [
-            `Failed to call Actor '${actorName}': ${errMsg}.`,
+    const header = `Failed to call Actor '${actorName}': ${errMsg}.`;
+    const texts = isMemoryQuotaError(error)
+        ? [
+            header,
+            `Account memory quota exceeded. Retry with a smaller callOptions.memory, or free capacity via ${HelperTools.ACTOR_RUNS_ABORT}.`,
+        ]
+        : [
+            header,
             `Please verify the Actor name, input parameters, and ensure the Actor exists.`,
             // "if available" — search-actors may not be loaded in apps-mode partial tool selections.
             `If ${HelperTools.STORE_SEARCH} is available in this session, you can use it to search for available Actors, or get Actor details using: ${actorGetDetailsTool}.`,
-        ],
+        ];
+
+    return buildMCPResponse({
+        texts,
         isError: true,
         telemetry: {
             toolStatus: getToolStatusFromError(error, false),
@@ -292,8 +305,8 @@ export const callActorArgs = z.object({
             .max(32768, 'Memory cannot exceed 32 GB (32768 MB)')
             .optional()
             .describe(dedent`
-                Memory allocation for the Actor in MB. Must be a power of 2 (e.g., 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768).
-                Minimum: 128 MB, Maximum: 32768 MB (32 GB).
+                Memory per run in MB. Power of 2 from 128 to 32768.
+                Apify also caps total memory across all your concurrent runs (account plan limit); if a run is rejected because that quota would be exceeded, retry with a smaller value.
             `),
         timeout: z.number()
             .min(0, 'Timeout must be 0 or greater')

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -258,6 +258,8 @@ export function buildCallActorErrorResponse(params: CallActorErrorResponseParams
     };
 
     if (isMemoryQuotaError(error)) {
+        // Deliberately do NOT mention actor-runs-abort as a recovery path — nudging the LLM
+        // toward "free capacity" risks aborting unrelated in-flight runs the user cares about.
         return buildMCPResponse({
             texts: [
                 `Failed to call Actor '${actorName}': ${errMsg}`,

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -260,8 +260,8 @@ export function buildCallActorErrorResponse(params: CallActorErrorResponseParams
     if (isMemoryQuotaError(error)) {
         return buildMCPResponse({
             texts: [
-                `Failed to call Actor '${actorName}': ${errMsg}.`,
-                `Account memory quota exceeded. Retry with a smaller callOptions.memory, or free capacity.`,
+                `Failed to call Actor '${actorName}': ${errMsg}`,
+                `Account memory quota exceeded for your plan. Retry with a smaller callOptions.memory, or wait for current runs to finish before retrying.`,
             ],
             isError: true,
             telemetry,
@@ -270,7 +270,7 @@ export function buildCallActorErrorResponse(params: CallActorErrorResponseParams
 
     return buildMCPResponse({
         texts: [
-            `Failed to call Actor '${actorName}': ${errMsg}.`,
+            `Failed to call Actor '${actorName}': ${errMsg}`,
             `Please verify the Actor name, input parameters, and ensure the Actor exists.`,
             // "if available" — search-actors may not be loaded in apps-mode partial tool selections.
             `If ${HelperTools.STORE_SEARCH} is available in this session, you can use it to search for available Actors, or get Actor details using: ${actorGetDetailsTool}.`,

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -187,7 +187,7 @@ export function isPermissionApprovalError(error: unknown): error is ApifyApiErro
     return error instanceof ApifyApiError && error.type === APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED;
 }
 
-export function isMemoryQuotaError(error: unknown): error is ApifyApiError {
+function isMemoryQuotaError(error: unknown): error is ApifyApiError {
     return error instanceof ApifyApiError && error.type === APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED;
 }
 
@@ -264,7 +264,7 @@ export function buildCallActorErrorResponse(params: CallActorErrorResponseParams
                 `Account memory quota exceeded for your plan. Retry with a smaller callOptions.memory, or wait for current runs to finish before retrying.`,
             ],
             isError: true,
-            telemetry,
+            telemetry: { ...telemetry, failureDetail: APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED },
         });
     }
 

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -302,6 +302,21 @@ export const callActorArgs = z.object({
                 Maximum runtime for the Actor in seconds. After this time elapses, the Actor will be automatically terminated.
                 Use 0 for infinite timeout (no time limit). Minimum: 0 seconds (infinite).
             `),
+        build: z.string()
+            .optional()
+            .describe('Tag or number of the Actor build to run (e.g., "latest", "beta", "1.2.345"). If omitted, the Actor\'s default build is used.'),
+        maxItems: z.number()
+            .int()
+            .positive()
+            .optional()
+            .describe(dedent`
+                Charge cap for pay-per-result Actors. Caps the number of dataset items billed for this run.
+                Does not limit how many items the Actor returns.
+            `),
+        maxTotalChargeUsd: z.number()
+            .positive()
+            .optional()
+            .describe('Charge cap in USD for pay-per-event Actors. Caps the total amount billed for this run.'),
     }).optional()
         .describe('Optional call options for the Actor run configuration.'),
 });

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -249,29 +249,34 @@ export function buildCallActorErrorResponse(params: CallActorErrorResponseParams
         failureCategory,
     });
 
-    const header = `Failed to call Actor '${actorName}': ${errMsg}.`;
-    const texts = isMemoryQuotaError(error)
-        ? [
-            header,
-            `Account memory quota exceeded. Retry with a smaller callOptions.memory, or free capacity via ${HelperTools.ACTOR_RUNS_ABORT}.`,
-        ]
-        : [
-            header,
+    const telemetry = {
+        toolStatus: getToolStatusFromError(error, false),
+        failureCategory,
+        failureHttpStatus: getHttpStatusCode(error),
+        failureDetail: errMsg.slice(0, 200),
+        actorId,
+    };
+
+    if (isMemoryQuotaError(error)) {
+        return buildMCPResponse({
+            texts: [
+                `Failed to call Actor '${actorName}': ${errMsg}.`,
+                `Account memory quota exceeded. Retry with a smaller callOptions.memory, or free capacity.`,
+            ],
+            isError: true,
+            telemetry,
+        });
+    }
+
+    return buildMCPResponse({
+        texts: [
+            `Failed to call Actor '${actorName}': ${errMsg}.`,
             `Please verify the Actor name, input parameters, and ensure the Actor exists.`,
             // "if available" — search-actors may not be loaded in apps-mode partial tool selections.
             `If ${HelperTools.STORE_SEARCH} is available in this session, you can use it to search for available Actors, or get Actor details using: ${actorGetDetailsTool}.`,
-        ];
-
-    return buildMCPResponse({
-        texts,
+        ],
         isError: true,
-        telemetry: {
-            toolStatus: getToolStatusFromError(error, false),
-            failureCategory,
-            failureHttpStatus: getHttpStatusCode(error),
-            failureDetail: errMsg.slice(0, 200),
-            actorId,
-        },
+        telemetry,
     });
 }
 
@@ -323,13 +328,18 @@ export const callActorArgs = z.object({
             .positive()
             .optional()
             .describe(dedent`
-                Charge cap for pay-per-result Actors. Caps the number of dataset items billed for this run.
-                Does not limit how many items the Actor returns.
+                Pay-per-result Actors ONLY — has no effect on any other pricing model (pay-per-event, pay-per-usage, rental, free).
+                Caps the number of dataset items billed for this run; does NOT limit how many items the Actor produces.
+                Most Actors also expose their own input field (e.g. "maxResults", "maxPages", "maxItems") to bound how much work they do — prefer those when limiting actual output, since this option only caps billing.
             `),
         maxTotalChargeUsd: z.number()
             .positive()
             .optional()
-            .describe('Charge cap in USD for pay-per-event Actors. Caps the total amount billed for this run.'),
+            .describe(dedent`
+                Pay-per-event Actors ONLY — has no effect on any other pricing model (pay-per-result, pay-per-usage, rental, free).
+                Caps the total USD billed for this run; does NOT limit how much work the Actor does.
+                Most Actors also expose their own input field to bound work — prefer those when limiting actual output, since this option only caps billing.
+            `),
     }).optional()
         .describe('Optional call options for the Actor run configuration.'),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -425,8 +425,14 @@ export type ActorExecutionParams = {
     input: Record<string, unknown>;
     /** Apify client (may include payment headers) */
     apifyClient: ApifyClient;
-    /** Call options (memory, timeout) */
-    callOptions: { memory?: number; timeout?: number };
+    /** Call options forwarded to apifyClient.actor(...).start(input, callOptions) */
+    callOptions: {
+        memory?: number;
+        timeout?: number;
+        build?: string;
+        maxItems?: number;
+        maxTotalChargeUsd?: number;
+    };
     /** Progress tracker for sending progress notifications */
     progressTracker?: ProgressTracker | null;
     /** Signal for aborting the execution */

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -713,6 +713,24 @@ export function createIntegrationTestsSuite(
             expect(resultWithStructured.structuredContent?.items).toEqual([]);
         });
 
+        it('should accept callOptions.maxItems on call-actor and run successfully', async () => {
+            client = await createClientFn({ tools: ['actors'] });
+
+            const callResult = await client.callTool({
+                name: HelperTools.ACTOR_CALL,
+                arguments: {
+                    actor: RAG_WEB_BROWSER,
+                    input: { query: 'hello', maxResults: 3 },
+                    callOptions: { maxItems: 3 },
+                },
+            });
+
+            expect(callResult.isError).not.toBe(true);
+            const content = callResult.content as { text: string }[];
+            expect(content.some((item) => item.text.includes('completed successfully'))).toBe(true);
+            expect(content.some((item) => item.text.includes('Dataset ID'))).toBe(true);
+        });
+
         it('should return preview items by default in call-actor (previewOutput: true)', async () => {
             client = await createClientFn({ tools: ['actors'] });
 

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -713,7 +713,7 @@ export function createIntegrationTestsSuite(
             expect(resultWithStructured.structuredContent?.items).toEqual([]);
         });
 
-        it('should accept callOptions.maxItems on call-actor and run successfully', async () => {
+        it('accepts callOptions.maxItems on call-actor and runs successfully', async () => {
             client = await createClientFn({ tools: ['actors'] });
 
             const callResult = await client.callTool({

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -173,6 +173,8 @@ describe('call_actor_common', () => {
             expect(allText).toContain('memory limit of 8192MB');
             expect(allText).toContain('Account memory quota exceeded');
             expect(allText).toContain('callOptions.memory');
+            // Regression: must not nudge the LLM toward aborting unrelated runs to free capacity.
+            expect(allText).not.toContain(HelperTools.ACTOR_RUNS_ABORT);
             expect(allText).not.toContain('verify the Actor name');
         });
     });

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -2,7 +2,7 @@ import { ApifyApiError } from 'apify-client';
 import type { AxiosResponse } from 'axios';
 import { describe, expect, it } from 'vitest';
 
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../src/const.js';
+import { APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED, FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../src/const.js';
 import {
     buildCallActorDescription,
     buildCallActorErrorResponse,
@@ -153,7 +153,7 @@ describe('call_actor_common', () => {
             const error = new ApifyApiError({
                 data: {
                     error: {
-                        type: 'memory-limit-exceeded',
+                        type: APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED,
                         message: 'By launching this job you will exceed the memory limit of 8192MB for all your Actor runs and builds.',
                     },
                 },

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -8,6 +8,7 @@ import {
     buildCallActorErrorResponse,
     buildPermissionApprovalResponse,
     buildStartAsyncResponse,
+    callActorArgs,
 } from '../../src/tools/core/call_actor_common.js';
 
 describe('call_actor_common', () => {
@@ -146,6 +147,33 @@ describe('call_actor_common', () => {
                 failureHttpStatus: 403,
                 actorId: 'actor-456',
             }));
+        });
+    });
+
+    describe('callActorArgs.callOptions', () => {
+        const baseArgs = { actor: 'apify/rag-web-browser', input: { query: 'hello' } };
+
+        it.each([
+            ['memory', { memory: 1024 }],
+            ['timeout', { timeout: 60 }],
+            ['build', { build: 'latest' }],
+            ['maxItems', { maxItems: 3 }],
+            ['maxTotalChargeUsd', { maxTotalChargeUsd: 1.5 }],
+            ['memory + build', { memory: 1024, build: 'latest' }],
+        ])('accepts %s', (_name, callOptions) => {
+            const result = callActorArgs.safeParse({ ...baseArgs, callOptions });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.callOptions).toEqual(callOptions);
+            }
+        });
+
+        it('rejects negative maxItems', () => {
+            const result = callActorArgs.safeParse({
+                ...baseArgs,
+                callOptions: { maxItems: -1 },
+            });
+            expect(result.success).toBe(false);
         });
     });
 

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -148,6 +148,34 @@ describe('call_actor_common', () => {
                 actorId: 'actor-456',
             }));
         });
+
+        it('returns memory-quota recovery hint for HTTP 402 memory-limit errors', () => {
+            const error = new ApifyApiError({
+                data: {
+                    error: {
+                        type: 'memory-limit-exceeded',
+                        message: 'By launching this job you will exceed the memory limit of 8192MB for all your Actor runs and builds.',
+                    },
+                },
+                status: 402,
+            } as AxiosResponse, 1);
+
+            const response = buildCallActorErrorResponse({
+                actorName: 'compass/crawler-google-places',
+                error,
+                actorId: 'actor-789',
+                isAsync: true,
+                actorGetDetailsTool: HelperTools.ACTOR_GET_DETAILS,
+            });
+
+            expect(response.isError).toBe(true);
+            const allText = response.content.map((c) => c.text).join('\n');
+            expect(allText).toContain('memory limit of 8192MB');
+            expect(allText).toContain('Account memory quota exceeded');
+            expect(allText).toContain('callOptions.memory');
+            expect(allText).toContain(HelperTools.ACTOR_RUNS_ABORT);
+            expect(allText).not.toContain('verify the Actor name');
+        });
     });
 
     describe('callActorArgs.callOptions', () => {

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -173,7 +173,6 @@ describe('call_actor_common', () => {
             expect(allText).toContain('memory limit of 8192MB');
             expect(allText).toContain('Account memory quota exceeded');
             expect(allText).toContain('callOptions.memory');
-            expect(allText).toContain(HelperTools.ACTOR_RUNS_ABORT);
             expect(allText).not.toContain('verify the Actor name');
         });
     });


### PR DESCRIPTION
Three new keys accepted by `call-actor`'s `callOptions`:

- `maxItems` — charge cap for pay-per-result actors
- `maxTotalChargeUsd` — charge cap for pay-per-event actors
- `build` — pin a specific actor build. I'm not sure if it is needed, mostly for testing I guess

Apify client already accepts these fields.

**Plus a follow-up** : the Apify API's `memory-limit-exceeded` (HTTP 402) error wasn't propagated to the caller at all — `call-actor` just returned the generic "verify the actor name, input parameters, and ensure the Actor exists" hint, which is unrelated and misleading. Now the original error message is surfaced and the caller is pointed at `callOptions.memory` (or asked to wait for current runs to finish).

We deliberately do **not** suggest `actor-runs-abort` as a recovery path — nudging the LLM toward "free capacity" risks it aborting unrelated in-flight runs the user cares about. A regression test asserts the recovery hint never references `actor-runs-abort`.

Example upstream error:

> By launching this job you will exceed the memory limit of 8192MB for all your Actor runs and builds.

Closes #815.