### PR TITLE
feat: Enable MCP Apps auto-detection from client capabilities

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -18,7 +18,7 @@ export const TOOL_MAX_OUTPUT_CHARS = 50000;
 
 // MCP Server
 /** When `false`, `resolveServerMode('auto', ...)` forces {@link ServerMode.DEFAULT} regardless of client capabilities. */
-export const SERVER_MODE_AUTO_DETECTION_ENABLED = false;
+export const SERVER_MODE_AUTO_DETECTION_ENABLED = true;
 
 export const SERVER_NAME = 'apify-mcp-server';
 export const SERVER_TITLE = 'Apify MCP Server';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -293,7 +293,7 @@ export class ActorsMcpServer {
 
             (this.options as Record<string, unknown>).initializeRequestData = request;
 
-            log.info('Resolved server mode for client', {
+            log.info('Resolved server mode for client capabilities', {
                 serverMode: this.serverMode,
                 serverModeOption: this.serverModeOption,
                 clientSupportsUi: this.clientSupportsUi,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -293,10 +293,11 @@ export class ActorsMcpServer {
 
             (this.options as Record<string, unknown>).initializeRequestData = request;
 
-            log.info('Resolved server mode for connection', {
+            log.info('Resolved server mode for client', {
                 serverMode: this.serverMode,
                 serverModeOption: this.serverModeOption,
                 clientSupportsUi: this.clientSupportsUi,
+                capabilities: request?.params?.capabilities,
             });
 
             this.updateToolsAfterServerModeResolved();


### PR DESCRIPTION
Flips `SERVER_MODE_AUTO_DETECTION_ENABLED` in `src/const.ts` from `false` to `true`. The switch stays in place.

After this change, `resolveServerMode('auto', clientSupportsUi)` returns `ServerMode.APPS` for clients advertising `io.modelcontextprotocol/ui` and `ServerMode.DEFAULT` otherwise. Clients passing an explicit `?ui=` / `UI_MODE` value are unaffected.

The two integration tests gated by `it.runIf(SERVER_MODE_AUTO_DETECTION_ENABLED)` (`tests/integration/suite.ts:2542`, and the matching unit test in `tests/unit/utils.server_mode.resolve.test.ts`) become active.

Closes #771

---
_Generated by [Claude Code](https://claude.ai/code/session_018PvFJCJuELZ4RoWTctqhF7)_