### PR TITLE
ci(integration-tests): run integration tests on PR and master push

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -1,0 +1,33 @@
+name: Integration tests
+
+on:
+    workflow_call:
+        secrets:
+            APIFY_TOKEN:
+                required: true
+
+jobs:
+    integration_tests:
+        name: Integration tests
+        runs-on: ubuntu-latest
+
+        steps:
+            -   uses: actions/checkout@v6
+            -   name: Use Node.js
+                uses: actions/setup-node@v6
+                with:
+                    node-version-file: '.nvmrc'
+                    cache: 'npm'
+                    cache-dependency-path: 'package-lock.json'
+            -   name: Install Dependencies
+                run: npm ci --force
+            # Re-mask in case the token shows up transformed (base64/url-encoded/etc.) in
+            # any downstream log output. Literal value is already masked by GitHub.
+            -   name: Mask token
+                env:
+                    APIFY_TOKEN: ${{ secrets.APIFY_TOKEN }}
+                run: echo "::add-mask::$APIFY_TOKEN"
+            -   name: Integration tests
+                env:
+                    APIFY_TOKEN: ${{ secrets.APIFY_TOKEN }}
+                run: npm run test:integration

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -16,6 +16,12 @@ jobs:
         name: Code checks
         uses: ./.github/workflows/_check_code.yaml
 
+    integration_tests:
+        name: Integration tests
+        uses: ./.github/workflows/_integration_tests.yaml
+        secrets:
+            APIFY_TOKEN: ${{ secrets.APIFY_TOKEN }}
+
     release_metadata:
         # Skip this for "ci", "docs" and "test" commits
         if: "!startsWith(github.event.head_commit.message, 'ci') && !startsWith(github.event.head_commit.message, 'docs') && !startsWith(github.event.head_commit.message, 'test')"

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -20,7 +20,7 @@ jobs:
         name: Integration tests
         uses: ./.github/workflows/_integration_tests.yaml
         secrets:
-            APIFY_TOKEN: ${{ secrets.APIFY_TOKEN }}
+            APIFY_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
 
     release_metadata:
         # Skip this for "ci", "docs" and "test" commits

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -14,7 +14,7 @@ jobs:
         name: Integration tests
         uses: ./.github/workflows/_integration_tests.yaml
         secrets:
-            APIFY_TOKEN: ${{ secrets.APIFY_TOKEN }}
+            APIFY_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
 
     pr_title_check:
         name: PR title check

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -8,6 +8,14 @@ jobs:
         name: Code checks
         uses: ./.github/workflows/_check_code.yaml
 
+    integration_tests:
+        # Fork PRs don't have access to repo secrets — skip rather than fail.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        name: Integration tests
+        uses: ./.github/workflows/_integration_tests.yaml
+        secrets:
+            APIFY_TOKEN: ${{ secrets.APIFY_TOKEN }}
+
     pr_title_check:
         name: PR title check
         runs-on: ubuntu-latest

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -8,9 +8,35 @@ jobs:
         name: Code checks
         uses: ./.github/workflows/_check_code.yaml
 
+    # Whitelist of paths whose changes can affect integration-test behavior.
+    # Anything outside this list (docs, evals, notebooks, research, scripts, ...)
+    # skips the integration suite to save CI time.
+    changes:
+        name: Detect relevant changes
+        runs-on: ubuntu-latest
+        outputs:
+            run_integration: ${{ steps.filter.outputs.code }}
+        steps:
+            -   uses: dorny/paths-filter@v3
+                id: filter
+                with:
+                    filters: |
+                        code:
+                            - 'src/**'
+                            - 'tests/integration/**'
+                            - 'package.json'
+                            - 'package-lock.json'
+                            - 'tsconfig.json'
+                            - '.nvmrc'
+                            - '.github/workflows/_integration_tests.yaml'
+                            - '.github/workflows/on_pull_request.yaml'
+
     integration_tests:
+        needs: changes
         # Fork PRs don't have access to repo secrets — skip rather than fail.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            needs.changes.outputs.run_integration == 'true'
         name: Integration tests
         uses: ./.github/workflows/_integration_tests.yaml
         secrets:


### PR DESCRIPTION
## Context
We have `npm run test:integration` but nothing runs it in CI. This wires it into PR and master-push workflows.

## Solution
New reusable workflow `_integration_tests.yaml` called from `on_pull_request.yaml` and `on_master.yaml`. Reads `APIFY_TOKEN` from the repo secret of the same name.

## Worth your attention
- **Fork PRs are skipped** — `if: github.event.pull_request.head.repo.full_name == github.repository`. Secrets aren't available to forks, so we skip rather than fail.
- **Secret handling** — declared explicitly on the reusable workflow (no `secrets: inherit`), scoped as env to the test step only, and re-masked via `::add-mask::` to cover transformed-leak edge cases (base64/url-encoded).
- **Not a required check** — added as a normal job; promote it in branch protection if/when you want it blocking.

## Follow-up
- Requires a repo (or org) secret named `APIFY_TEST_USER_API_TOKEN` to be created in `apify/apify-mcp-server` settings before the job will pass. :heavy_check_mark: 
