### PR TITLE
feat: Add X-Apify-Request-Origin: MCP header to API requests

### DIFF
--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -30,7 +30,7 @@ function addUserAgent(config: AxiosRequestConfig): AxiosRequestConfig {
 }
 
 /**
- * Adds a MCP orgin header to the request config.
+ * Adds an MCP origin header to the request config.
  * @param config
  * @private
  */

--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -4,7 +4,10 @@ import type { AxiosRequestConfig } from 'axios';
 
 import type { PaymentHeaders } from './payments/types.js';
 
+// User agent headers
 const USER_AGENT_ORIGIN = 'Origin/mcp-server';
+
+// Request origin headers
 const REQUEST_ORIGIN_HEADER = 'X-Apify-Request-Origin';
 const REQUEST_ORIGIN_VALUE = 'MCP';
 
@@ -14,6 +17,11 @@ type ExtendedApifyClientOptions = Omit<ApifyClientOptions, 'token'> & {
     paymentHeaders?: PaymentHeaders;
 };
 
+/**
+ * Adds a User-Agent header to the request config.
+ * @param config
+ * @private
+ */
 function addUserAgent(config: AxiosRequestConfig): AxiosRequestConfig {
     const updatedConfig = { ...config };
     updatedConfig.headers = updatedConfig.headers ?? {};
@@ -21,6 +29,11 @@ function addUserAgent(config: AxiosRequestConfig): AxiosRequestConfig {
     return updatedConfig;
 }
 
+/**
+ * Adds a MCP orgin header to the request config.
+ * @param config
+ * @private
+ */
 function addRequestOrigin(config: AxiosRequestConfig): AxiosRequestConfig {
     const updatedConfig = { ...config };
     updatedConfig.headers = updatedConfig.headers ?? {};

--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -4,8 +4,9 @@ import type { AxiosRequestConfig } from 'axios';
 
 import type { PaymentHeaders } from './payments/types.js';
 
-// User agent headers
 const USER_AGENT_ORIGIN = 'Origin/mcp-server';
+const REQUEST_ORIGIN_HEADER = 'X-Apify-Request-Origin';
+const REQUEST_ORIGIN_VALUE = 'MCP';
 
 type ExtendedApifyClientOptions = Omit<ApifyClientOptions, 'token'> & {
     token?: string | null | undefined;
@@ -13,15 +14,17 @@ type ExtendedApifyClientOptions = Omit<ApifyClientOptions, 'token'> & {
     paymentHeaders?: PaymentHeaders;
 };
 
-/**
- * Adds a User-Agent header to the request config.
- * @param config
- * @private
- */
 function addUserAgent(config: AxiosRequestConfig): AxiosRequestConfig {
     const updatedConfig = { ...config };
     updatedConfig.headers = updatedConfig.headers ?? {};
     updatedConfig.headers['User-Agent'] = `${updatedConfig.headers['User-Agent'] ?? ''}; ${USER_AGENT_ORIGIN}`;
+    return updatedConfig;
+}
+
+function addRequestOrigin(config: AxiosRequestConfig): AxiosRequestConfig {
+    const updatedConfig = { ...config };
+    updatedConfig.headers = updatedConfig.headers ?? {};
+    updatedConfig.headers[REQUEST_ORIGIN_HEADER] = REQUEST_ORIGIN_VALUE;
     return updatedConfig;
 }
 
@@ -45,7 +48,7 @@ export class ApifyClient extends _ApifyClient {
         }
 
         const { paymentHeaders, ...clientOptions } = options;
-        const requestInterceptors = [addUserAgent];
+        const requestInterceptors = [addUserAgent, addRequestOrigin];
         /**
          * Add payment headers if provided by a PaymentProvider.
          */


### PR DESCRIPTION
## Summary
- Adds `X-Apify-Request-Origin: MCP` header to all outbound Apify API requests via a new `addRequestOrigin` interceptor in `ApifyClient`
- Keeps existing `Origin/mcp-server` token in `User-Agent` unchanged
- All 13 `ApifyClient` instantiation sites pick up the new header automatically — no call-site changes needed

## New Request Header
<img width="871" height="227" alt="image" src="https://github.com/user-attachments/assets/c99b6c1e-da9c-44e9-8335-9a1090e71d46" />

I cut out the auth ;)

Closes #832