### PR TITLE
fix: softFail noisy 'Not Acceptable' Accept-header errors from SDK

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -540,8 +540,19 @@ export class ActorsMcpServer {
             //   - "Invalid state: Controller is already closed" (ERR_INVALID_STATE from
             //     WebStandardStreamableHTTPServerTransport.writeSSEEvent when the SSE ReadableStream
             //     controller was closed by client cancellation before a queued event was flushed)
+            //   - "Not Acceptable: Client must accept [both application/json and] text/event-stream"
+            //     (thrown from WebStandardStreamableHTTPServerTransport.handlePost/GetRequest when
+            //     the client sends an Accept header missing one of the required MIME types — pure
+            //     client misconfiguration, not a server fault; HTTP 406 is already returned to caller)
             // All are expected; log as softFail so they don't flood Mezmo error alerts.
-            if (/Not connected|No connection established|Only one SSE stream|Controller is already closed/i.test(error.message ?? '')) {
+            const clientDisconnectPattern = new RegExp([
+                'Not connected',
+                'No connection established',
+                'Only one SSE stream',
+                'Controller is already closed',
+                'Not Acceptable: Client must accept',
+            ].join('|'), 'i');
+            if (clientDisconnectPattern.test(error.message ?? '')) {
                 // Mezmo (logDNA) promotes log entries to errors when the message contains "error".
                 // Use errMessage key and sanitize the string to preserve the soft-fail log level.
                 const errMessage = (error.message ?? '').replace(/ error:/gi, ' failure:');


### PR DESCRIPTION
## Context
`WebStandardStreamableHTTPServerTransport` throws `Not Acceptable: Client must accept ...` from both `handlePostRequest` and `handleGetRequest` when the client's `Accept` header is missing one of the required MIME types (`application/json`, `text/event-stream`). The SDK already responds HTTP 406 to the caller, then forwards the error to `onerror` — where we currently log it as `[MCP Error]` and trip Mezmo alerts. Same class of client-misconfiguration noise we already soft-fail via #787 / #795.

## Solution
Add the SDK error prefix `Not Acceptable: Client must accept` to the existing soft-fail filter in `setupErrorHandling()`. The prefix covers both variants the SDK emits (GET-path "must accept text/event-stream" and POST-path "must accept both application/json and text/event-stream").

## Worth your attention
- **Refactored the regex into an `Array.join('|')` builder** — the previous one-liner was already brushing the 160-char `max-len` cap; a 5th alternation would break it. Each pattern now lives on its own line aligned with the comment block above.
- **No tests added** — follows the precedent from #795 ("Drop the SSE softFail unit test"), the filter is a string-match guard with no behavioral branching worth a unit test.
