### PR TITLE
chore: Use custom action to commit changes in CI instead of `git commit`

### DIFF
--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -56,7 +56,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
 
         steps:
             -   name: Checkout repository
@@ -85,20 +85,9 @@ jobs:
                     write-mode: overwrite
                     contents: ${{ needs.release_metadata.outputs.changelog }}
 
-            -   name: Stage changes
-                id: stage
-                run: |
-                    git add -A
-                    if git diff --cached --quiet; then
-                      echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                    else
-                      echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                    fi
-
             -   name: Commit changes
                 id: commit
-                if: steps.stage.outputs.has-changes == 'true'
-                uses: apify/workflows/commit@v0.44.0
+                uses: apify/actions/signed-commit@v1.0.0
                 with:
-                    commit-message: "chore(release): Update changelog, package.json, manifest.json and server.json versions [skip ci]"
+                    message: "chore(release): Update changelog, package.json, manifest.json and server.json versions [skip ci]"
                     github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -56,7 +56,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
 
         steps:
             -   name: Checkout repository

--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -56,7 +56,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
 
         steps:
             -   name: Checkout repository
@@ -85,10 +85,20 @@ jobs:
                     write-mode: overwrite
                     contents: ${{ needs.release_metadata.outputs.changelog }}
 
+            -   name: Stage changes
+                id: stage
+                run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                    else
+                      echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                    fi
+
             -   name: Commit changes
                 id: commit
-                uses: EndBug/add-and-commit@v9
+                if: steps.stage.outputs.has-changes == 'true'
+                uses: apify/workflows/commit@v0.44.0
                 with:
-                    author_name: Apify Release Bot
-                    author_email: noreply@apify.com
-                    message: "chore(release): Update changelog, package.json, manifest.json and server.json versions [skip ci]"
+                    commit-message: "chore(release): Update changelog, package.json, manifest.json and server.json versions [skip ci]"
+                    github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -153,21 +153,43 @@ jobs:
                     max_attempts: 3
                     retry_wait_seconds: 30
                     command: npm install --save-exact @apify/actors-mcp-server@${{ needs.release_metadata.outputs.version_number }}
-            -   name: Create pull request
-                uses: peter-evans/create-pull-request@v8
+            -   name: Stage dependency bump
+                id: stage
+                run: |
+                    git add -A
+                    if git diff --cached --quiet; then
+                      echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                    else
+                      echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                    fi
+
+            -   name: Commit dependency bump
+                if: steps.stage.outputs.has-changes == 'true'
+                uses: apify/workflows/commit@v0.44.0
                 with:
-                    token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                     commit-message: "chore: bump @apify/actors-mcp-server to ${{ needs.release_metadata.outputs.version_number }}"
+                    github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                    repository: apify/apify-mcp-server-internal
                     branch: "release/${{ needs.release_metadata.outputs.tag_name }}"
-                    title: "chore: bump @apify/actors-mcp-server to ${{ needs.release_metadata.outputs.version_number }}"
-                    body: |
+                    create-branch: 'true'
+
+            -   name: Create pull request
+                if: steps.stage.outputs.has-changes == 'true'
+                run: |
+                    gh pr create \
+                      --repo apify/apify-mcp-server-internal \
+                      --head "release/${{ needs.release_metadata.outputs.tag_name }}" \
+                      --title "chore: bump @apify/actors-mcp-server to ${{ needs.release_metadata.outputs.version_number }}" \
+                      --body "$BODY" \
+                      --reviewer "${{ github.actor }}"
+                env:
+                    GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                    BODY: |
                         Automated PR to bump `@apify/actors-mcp-server` to `${{ needs.release_metadata.outputs.version_number }}`.
 
                         ## Release notes
 
                         ${{ needs.release_metadata.outputs.release_notes }}
-                    reviewers: ${{ github.actor }}
-                    author: Apify Release Bot <noreply@apify.com>
 
     publish_to_mcp_registry:
         name: Publish to MCP Registry

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -153,28 +153,18 @@ jobs:
                     max_attempts: 3
                     retry_wait_seconds: 30
                     command: npm install --save-exact @apify/actors-mcp-server@${{ needs.release_metadata.outputs.version_number }}
-            -   name: Stage dependency bump
-                id: stage
-                run: |
-                    git add -A
-                    if git diff --cached --quiet; then
-                      echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                    else
-                      echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                    fi
-
             -   name: Commit dependency bump
-                if: steps.stage.outputs.has-changes == 'true'
-                uses: apify/workflows/commit@v0.44.0
+                id: commit
+                uses: apify/actions/signed-commit@v1.0.0
                 with:
-                    commit-message: "chore: bump @apify/actors-mcp-server to ${{ needs.release_metadata.outputs.version_number }}"
+                    message: "chore: bump @apify/actors-mcp-server to ${{ needs.release_metadata.outputs.version_number }}"
                     github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                     repository: apify/apify-mcp-server-internal
                     branch: "release/${{ needs.release_metadata.outputs.tag_name }}"
                     create-branch: 'true'
 
             -   name: Create pull request
-                if: steps.stage.outputs.has-changes == 'true'
+                if: steps.commit.outputs.committed == 'true'
                 run: |
                     gh pr create \
                       --repo apify/apify-mcp-server-internal \


### PR DESCRIPTION
We want to enforce commit signing for all commits in our repositories.
To do that, we need to make sure even commits created by CI workflows are signed.

It would be possible to sign using GPG keys, but that would require a lot of maintenance.

Instead, we can commit using the GitHub GraphQL API, which automatically signs commits.

This PR replaces direct `git commit` / `git push` usage (and third-party commit actions like `EndBug/add-and-commit`)
with the `apify/actions/signed-commit` action, which uses the GraphQL API under the hood.