### PR TITLE
fix: Use long commit SHA in release workflow [internal]

### DIFF
--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -56,7 +56,7 @@ jobs:
         name: Update changelog
         runs-on: ubuntu-latest
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha }}
 
         steps:
             -   name: Checkout repository


### PR DESCRIPTION
`actions/checkout` requires the long commit SHA if we want to check out a specific commit, not the short SHA. This fixes the release workflow to use the long sha.