### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -42,7 +42,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            -   uses: apify/workflows/git-cliff-release@main
+            -   uses: apify/actions/git-cliff-release@v1.0.0
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -42,7 +42,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            -   uses: apify/actions/git-cliff-release@v1.1.1
+            -   uses: apify/actions/git-cliff-release@v1.1.2
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -42,7 +42,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            -   uses: apify/actions/git-cliff-release@v1.1.0
+            -   uses: apify/actions/git-cliff-release@v1.1.1
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -42,7 +42,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            -   uses: apify/actions/git-cliff-release@v1.0.0
+            -   uses: apify/actions/git-cliff-release@v1.1.0
                 name: Prepare release metadata
                 id: release_metadata
                 with:

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -110,7 +110,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Execute publish workflow
-                uses: apify/actions/execute-workflow@v1.0.0
+                uses: apify/actions/execute-workflow@v1.1.0
                 with:
                     workflow: manual_publish_to_npm.yaml
                     inputs: >

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -110,7 +110,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Execute publish workflow
-                uses: apify/workflows/execute-workflow@main
+                uses: apify/actions/execute-workflow@v1.0.0
                 with:
                     workflow: manual_publish_to_npm.yaml
                     inputs: >

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -110,7 +110,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Execute publish workflow
-                uses: apify/actions/execute-workflow@v1.1.0
+                uses: apify/actions/execute-workflow@v1.1.1
                 with:
                     workflow: manual_publish_to_npm.yaml
                     inputs: >

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -110,7 +110,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Execute publish workflow
-                uses: apify/actions/execute-workflow@v1.1.1
+                uses: apify/actions/execute-workflow@v1.1.2
                 with:
                     workflow: manual_publish_to_npm.yaml
                     inputs: >

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Execute publish workflow
-                uses: apify/actions/execute-workflow@v1.1.1
+                uses: apify/actions/execute-workflow@v1.1.2
                 with:
                     workflow: manual_publish_to_npm.yaml
                     inputs: >

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Execute publish workflow
-                uses: apify/workflows/execute-workflow@main
+                uses: apify/actions/execute-workflow@v1.0.0
                 with:
                     workflow: manual_publish_to_npm.yaml
                     inputs: >

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Execute publish workflow
-                uses: apify/actions/execute-workflow@v1.0.0
+                uses: apify/actions/execute-workflow@v1.1.0
                 with:
                     workflow: manual_publish_to_npm.yaml
                     inputs: >

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Execute publish workflow
-                uses: apify/actions/execute-workflow@v1.1.0
+                uses: apify/actions/execute-workflow@v1.1.1
                 with:
                     workflow: manual_publish_to_npm.yaml
                     inputs: >


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.