### PR TITLE
fix: Include mcpTools in fetch-actor-details structured content

### DIFF
--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -209,6 +209,7 @@ export function buildActorDetailsTextResponse(options: {
         readme: resolvedReadme?.content,
         inputSchema: output.inputSchema ? details.inputSchema : undefined,
         outputSchema: output.outputSchema ? (actorOutputSchema ?? {}) : undefined,
+        mcpTools: output.mcpTools ? (mcpToolsMessage ?? '') : undefined,
     };
 
     return { texts, structuredContent };

--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -209,7 +209,7 @@ export function buildActorDetailsTextResponse(options: {
         readme: resolvedReadme?.content,
         inputSchema: output.inputSchema ? details.inputSchema : undefined,
         outputSchema: output.outputSchema ? (actorOutputSchema ?? {}) : undefined,
-        mcpTools: output.mcpTools ? (mcpToolsMessage ?? '') : undefined,
+        mcpTools: output.mcpTools && mcpToolsMessage ? mcpToolsMessage : undefined,
     };
 
     return { texts, structuredContent };

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -187,6 +187,10 @@ export const actorDetailsOutputSchema = {
         readme: { type: 'string', description: 'Actor README summary when available, otherwise the full README documentation.' },
         inputSchema: { type: 'object' as const, description: 'Actor input schema.' }, // Literal type required for MCP SDK type compatibility
         outputSchema: { type: 'object' as const, description: 'Output schema inferred from successful runs.' },
+        mcpTools: {
+            type: 'string',
+            description: 'Markdown listing of MCP tools exposed by the Actor (only present when `output.mcpTools` is requested).',
+        },
     },
 };
 

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -33,7 +33,7 @@ const MOCK_DETAILS = {
 
 describe('buildActorDetailsTextResponse()', () => {
     it('mirrors mcpToolsMessage into structuredContent.mcpTools when output.mcpTools is requested', () => {
-        const mcpToolsMessage = '# Available MCP Tools\nThis Actor is an MCP server with 1 tools.';
+        const mcpToolsMessage = '# Available MCP Tools\nThis Actor is an MCP server with 1 tool.';
 
         const { texts, structuredContent } = buildActorDetailsTextResponse({
             details: MOCK_DETAILS,

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    actorDetailsOutputDefaults,
+    buildActorDetailsTextResponse,
+} from '../../src/tools/core/fetch_actor_details_common.js';
+import type { ActorDetailsResult } from '../../src/utils/actor_details.js';
+
+const MOCK_DETAILS = {
+    actorInfo: {
+        id: 'actor-id-1',
+        name: 'example-mcp-server',
+        username: 'apify',
+        title: 'Example MCP Server',
+        description: 'An example MCP server actor.',
+        categories: ['MCP Servers'],
+    },
+    actorCard: '# Actor card',
+    actorCardStructured: {
+        id: 'actor-id-1',
+        fullName: 'apify/example-mcp-server',
+        url: 'https://apify.com/apify/example-mcp-server',
+        title: 'Example MCP Server',
+        description: 'An example MCP server actor.',
+        categories: ['MCP Servers'],
+        isDeprecated: false,
+        developer: { username: 'apify', isOfficialApify: true, url: 'https://apify.com/apify' },
+    },
+    inputSchema: { type: 'object', properties: {} },
+    readme: '# Example MCP Server',
+    readmeSummary: 'Short summary.',
+} as unknown as ActorDetailsResult;
+
+describe('buildActorDetailsTextResponse()', () => {
+    it('mirrors mcpToolsMessage into structuredContent.mcpTools when output.mcpTools is requested', () => {
+        const mcpToolsMessage = '# Available MCP Tools\nThis Actor is an MCP server with 1 tools.';
+
+        const { texts, structuredContent } = buildActorDetailsTextResponse({
+            details: MOCK_DETAILS,
+            output: {
+                ...actorDetailsOutputDefaults,
+                description: false,
+                stats: false,
+                pricing: false,
+                rating: false,
+                metadata: false,
+                inputSchema: false,
+                readme: false,
+                outputSchema: false,
+                mcpTools: true,
+            },
+            mcpToolsMessage,
+        });
+
+        // Text channel: MCP tools message is the only text emitted.
+        expect(texts).toEqual([mcpToolsMessage]);
+
+        // Structured channel: the same information must be present so that
+        // schema-aware MCP clients (which prefer structuredContent over texts)
+        // do not see an empty `{}` response.
+        expect(structuredContent.mcpTools).toBe(mcpToolsMessage);
+    });
+
+    it('omits structuredContent.mcpTools when output.mcpTools is not requested', () => {
+        const { structuredContent } = buildActorDetailsTextResponse({
+            details: MOCK_DETAILS,
+            output: { ...actorDetailsOutputDefaults, mcpTools: false },
+        });
+
+        expect(structuredContent.mcpTools).toBeUndefined();
+    });
+});

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -69,4 +69,25 @@ describe('buildActorDetailsTextResponse()', () => {
 
         expect(structuredContent.mcpTools).toBeUndefined();
     });
+
+    it('omits structuredContent.mcpTools when output.mcpTools is requested but no message is available', () => {
+        const { texts, structuredContent } = buildActorDetailsTextResponse({
+            details: MOCK_DETAILS,
+            output: {
+                ...actorDetailsOutputDefaults,
+                description: false,
+                stats: false,
+                pricing: false,
+                rating: false,
+                metadata: false,
+                inputSchema: false,
+                readme: false,
+                outputSchema: false,
+                mcpTools: true,
+            },
+        });
+
+        expect(texts).toEqual([]);
+        expect(structuredContent.mcpTools).toBeUndefined();
+    });
 });


### PR DESCRIPTION
## Summary

`fetch-actor-details` returned an empty `{}` to schema-aware MCP clients when called with `output: { mcpTools: true }`.

### **Cause** 
`buildActorDetailsTextResponse` pushed the MCP tools listing only into `texts[]`, and `actorDetailsOutputSchema` declared no `mcpTools` field. Per MCP spec 2025-11-25, clients prefer `structuredContent` when an `outputSchema` is declared — so the markdown lived only in the text channel and never reached the structured one.

### **Fix**
Mirror `mcpToolsMessage` into `structuredContent.mcpTools` (gated on `output.mcpTools`) and declare the field on `actorDetailsOutputSchema`. Follows the file's existing "data duplication between texts and structuredContent is intentional" pattern.

## Test plan

- [x] New unit tests in `tests/unit/tools.fetch_actor_details.response.test.ts` — failing pre-fix, passing post-fix
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm run test:unit` — 661 passed, 1 skipped
- [x] End-to-end verified against hosted MCP after redeploy: `fetch-actor-details(actor: "apify/example-mcp-server", output: { mcpTools: true })` now returns the full tool listing in `structuredContent.mcpTools` instead of `{}`