### PR TITLE
fix(call-actor): synthesize structuredContent on MCP server pass-through

### DIFF
--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -327,7 +327,25 @@ export async function handleMcpToolCall(params: {
             arguments: input,
         });
 
-        return { content: result.content };
+        // `call-actor` declares `getActorRunOutputSchema`, so MCP SDK ≥ 1.11.4 rejects any response
+        // without `structuredContent` (unless `isError: true`) with -32600. The pass-through has no
+        // Apify run, so synthesize a sentinel `RunResponse` matching the schema's `required` keys;
+        // the remote tool's payload still flows through `content`. Also forward `isError` so a
+        // failing remote tool surfaces as a failure here.
+        const isErrorFromRemote = result.isError === true;
+        return {
+            content: result.content,
+            isError: isErrorFromRemote,
+            structuredContent: {
+                runId: 'mcp-passthrough',
+                actorId: baseActorName,
+                actorName: baseActorName,
+                status: isErrorFromRemote ? 'FAILED' : 'SUCCEEDED',
+                storages: {},
+                summary: `Called MCP tool '${mcpToolName}' on '${baseActorName}'.`,
+                nextStep: 'Response content carries the remote MCP tool result; no Apify run was started.',
+            },
+        };
     } catch (error) {
         logHttpError(error, `Failed to call MCP tool '${mcpToolName}' on Actor '${baseActorName}'`, {
             actorName: baseActorName,

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -804,6 +804,48 @@ export function createIntegrationTestsSuite(
             expect(callContent.some((item) => item.text.includes(`Fetched content from ${DOCS_URL}`))).toBe(true);
         });
 
+        // Regression: `call-actor` declares an `outputSchema` (since #415), but the MCP-server pass-through
+        // path in `handleMcpToolCall` returns `{ content }` only — no `structuredContent`. SDK ≥ 1.11.4
+        // throws -32600 "has an output schema but did not return structured content" once it has cached
+        // the tool validators (which happens on `listTools()` — every real client does this on connect).
+        // The happy-path test above never calls `listTools()`, so the SDK skips validation and the bug stays
+        // invisible at the integration layer. This test surfaces it.
+        it('MCP server actor:tool pass-through returns structuredContent satisfying outputSchema', async () => {
+            client = await createClientFn({ tools: ['actors'] });
+
+            // Populates the SDK's `_cachedToolOutputValidators` map so callTool runs schema validation.
+            await client.listTools();
+
+            const callResult = await client.callTool({
+                name: HelperTools.ACTOR_CALL,
+                arguments: {
+                    actor: `${ACTOR_MCP_SERVER_ACTOR_NAME}:fetch-apify-docs`,
+                    input: { url: 'https://docs.apify.com' },
+                },
+            });
+
+            // structuredContent must be present and carry the keys declared `required` on
+            // `getActorRunOutputSchema`. The pass-through path has no Apify run, so the fix is expected to
+            // synthesize sentinel values (e.g. `runId: 'mcp-passthrough'`) rather than real run identifiers.
+            const sc = (callResult as { structuredContent?: Record<string, unknown> }).structuredContent;
+            expect(sc).toBeDefined();
+            expect(sc).toHaveProperty('runId');
+            expect(sc).toHaveProperty('actorId');
+            expect(sc).toHaveProperty('status');
+            expect(sc).toHaveProperty('storages');
+            expect(sc).toHaveProperty('summary');
+            expect(sc).toHaveProperty('nextStep');
+
+            // The remote MCP tool's actual result must still flow through `content` — the fix must not
+            // lose the payload while satisfying the schema.
+            const content = callResult.content as { text: string }[];
+            expect(content.some((item) => item.text.includes('Fetched content from'))).toBe(true);
+
+            // `isError` must reflect the remote tool's status — false on the happy path. Forwarding this
+            // closes a second drop on the same line: `handleMcpToolCall` currently discards `result.isError`.
+            expect(callResult.isError ?? false).toBe(false);
+        });
+
         it('should search Apify documentation', async () => {
             client = await createClientFn({
                 tools: ['docs'],


### PR DESCRIPTION
## Context
`call-actor` with MCP-server pass-through syntax (`actor: "apify/actors-mcp-server:search-apify-docs"`) fails on master with `MCP error -32600: Tool call-actor has an output schema but did not return structured content`. Repro with `mcpc --json @apify tools-call call-actor actor:='"apify/actors-mcp-server:search-apify-docs"' input:='{"query":"weather"}'`. Regression introduced in #415 (`f9512c4`, 2026-01-29) when `outputSchema` was added to `call-actor`; the MCP-pass-through code in `handleMcpToolCall` has been returning `{ content }` only since #274 (2025-09-18). Both ingredients sat dormant until the SDK on `^1.25.2` (already enforcing since 1.11.4) saw them combined.

## Solution
In `handleMcpToolCall`, synthesize a sentinel `RunResponse` matching `getActorRunOutputSchema.required` (`runId: 'mcp-passthrough'`, `actorId: baseActorName`, `status`, `storages: {}`, `summary`, `nextStep`) and forward `result.isError` from the remote tool. The remote tool's payload still flows through `content`. Stacks on #853.

## Worth your attention
- **Sentinel runId** — `'mcp-passthrough'` is a deliberate non-Apify literal so logs / dashboards never mistake it for a real run id. Open to `mcp-passthrough:${mcpToolName}` for greppability per tool if preferred.
- **Integration coverage** — the existing happy-path test for this code path didn't catch the regression because it never calls `client.listTools()`, so the SDK never builds the validator cache. The new test at `tests/integration/suite.ts:813` calls `listTools()` first to mirror real clients (mcpc, Claude Desktop), which is the only way to surface this class of bug at the integration layer.
- **Not the architectural fix** — `call-actor` doing two unrelated things (Apify run vs. MCP tool pass-through) under one tool name is the root cause; this PR keeps that shape and just makes the response spec-compliant. Follow-up tracked in #860 (see comment).

## Follow-up
- Split `call-actor` MCP pass-through into a dedicated tool, or move to code-mode as the default. Issue: #860
