### PR TITLE
fix: Stabilise flaky rag-web-browser integration tests

### DIFF
--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -24,7 +24,7 @@ import { getExpectedToolNamesByCategories } from '../../src/utils/tool_categorie
 import { AUTO_INJECTED_TOOLS } from '../../src/utils/tools_loader.js';
 import { ACTOR_MCP_SERVER_ACTOR_NAME, ACTOR_PYTHON_EXAMPLE, DEFAULT_ACTOR_NAMES, getDefaultToolNames } from '../const.js';
 import { addActor, type McpClientOptions } from '../helpers.js';
-import { assertStatusMessagePropagated, waitForActorRunAbortStatus } from './utils/task_waits.js';
+import { assertStatusMessagePropagated, captureInflightActorRunId, waitForRunAborted } from './utils/task_waits.js';
 
 const AUTO_INJECTED_TOOL_NAMES = AUTO_INJECTED_TOOLS.map((t) => t.name);
 
@@ -1724,20 +1724,23 @@ export function createIntegrationTestsSuite(
             await (client.transport as StreamableHTTPClientTransport).terminateSession();
         });
 
-        // Cancellation test: start a long-running actor and cancel immediately, then verify it was aborted
-        // Is not possible to run this test in parallel
+        // Cancel an in-flight `tools/call` via `notifications/cancelled` and verify the
+        // underlying Apify run is aborted. The runId isn't reachable through the client (no
+        // response after cancel, no runId in progress notifications), so we race the Apify API
+        // for the just-started run while the call is in flight, then trigger the cancel.
         it.runIf(options.transport === 'streamable-http')('should abort actor run on notifications/cancelled', { retry: 1 }, async () => {
             const ACTOR_NAME = 'apify/rag-web-browser';
             const selectedToolName = actorNameToToolName(ACTOR_NAME);
             client = await createClientFn({ enableAddingActors: true });
-
-            // Add actor as tool
             await addActor(client, ACTOR_NAME);
 
-            // Build request and cancel immediately via AbortController
-            const controller = new AbortController();
+            const api = new ApifyClient({ token: process.env.APIFY_TOKEN as string });
+            const actor = await api.actor(ACTOR_NAME).get();
+            expect(actor).toBeDefined();
+            const actId = actor!.id as string;
 
-            const startedAfter = new Date();
+            const capturingSince = new Date();
+            const controller = new AbortController();
             const requestPromise = client.request({
                 method: 'tools/call' as const,
                 params: {
@@ -1745,34 +1748,27 @@ export function createIntegrationTestsSuite(
                     arguments: { query: 'restaurants in San Francisco', maxResults: 10 },
                 },
             }, CallToolResultSchema, { signal: controller.signal })
-                // Ignores error "AbortError: This operation was aborted"
+                // Swallow "AbortError: This operation was aborted" — expected after cancel.
                 .catch(() => undefined);
 
-            // Abort right away
-            setTimeout(() => controller.abort(), 3000);
-
-            // Ensure the request completes/cancels before proceeding
+            const runId = await captureInflightActorRunId(api, actId, capturingSince);
+            controller.abort();
             await requestPromise;
 
-            // Verify via Apify API that a recent run for this actor was aborted
+            await waitForRunAborted(api, runId);
+        });
+
+        it.runIf(options.transport === 'streamable-http')('should abort call-actor tool on notifications/cancelled', { retry: 1 }, async () => {
+            const ACTOR_NAME = 'apify/rag-web-browser';
+            client = await createClientFn({ tools: ['actors'] });
+
             const api = new ApifyClient({ token: process.env.APIFY_TOKEN as string });
             const actor = await api.actor(ACTOR_NAME).get();
             expect(actor).toBeDefined();
             const actId = actor!.id as string;
 
-            // Poll for the latest run for this actor to reach ABORTED/ABORTING
-            await waitForActorRunAbortStatus(api, actId, startedAfter);
-        });
-
-        // Cancellation test using call-actor tool: start a long-running actor via call-actor and cancel immediately, then verify it was aborted
-        it.runIf(options.transport === 'streamable-http')('should abort call-actor tool on notifications/cancelled', { retry: 1 }, async () => {
-            const ACTOR_NAME = 'apify/rag-web-browser';
-            client = await createClientFn({ tools: ['actors'] });
-
-            // Build request and cancel immediately via AbortController
+            const capturingSince = new Date();
             const controller = new AbortController();
-
-            const startedAfter = new Date();
             const requestPromise = client.request({
                 method: 'tools/call' as const,
                 params: {
@@ -1784,23 +1780,13 @@ export function createIntegrationTestsSuite(
                     },
                 },
             }, CallToolResultSchema, { signal: controller.signal })
-                // Ignores error "AbortError: This operation was aborted"
                 .catch(() => undefined);
 
-            // Abort right away
-            setTimeout(() => controller.abort(), 3000);
-
-            // Ensure the request completes/cancels before proceeding
+            const runId = await captureInflightActorRunId(api, actId, capturingSince);
+            controller.abort();
             await requestPromise;
 
-            // Verify via Apify API that a recent run for this actor was aborted
-            const api = new ApifyClient({ token: process.env.APIFY_TOKEN as string });
-            const actor = await api.actor(ACTOR_NAME).get();
-            expect(actor).toBeDefined();
-            const actId = actor!.id as string;
-
-            // Poll for the latest run for this actor to reach ABORTED/ABORTING
-            await waitForActorRunAbortStatus(api, actId, startedAfter);
+            await waitForRunAborted(api, runId);
         });
 
         // Environment variable tests - only applicable to stdio transport
@@ -2448,7 +2434,14 @@ export function createIntegrationTestsSuite(
         it('should abort the Apify run when tasks/cancel is sent (direct actor tool)', { retry: 3 }, async () => {
             client = await createClientFn({ tools: [RAG_WEB_BROWSER] });
 
-            const startedAfter = new Date();
+            const api = new ApifyClient({ token: process.env.APIFY_TOKEN as string });
+            const actor = await api.actor(RAG_WEB_BROWSER).get();
+            expect(actor).toBeDefined();
+            const actId = actor!.id as string;
+
+            // Discover runId in parallel with the stream so it's ready by the time we verify.
+            const runIdPromise = captureInflightActorRunId(api, actId, new Date());
+
             const stream = client.experimental.tasks.callToolStream(
                 {
                     name: actorNameToToolName(RAG_WEB_BROWSER),
@@ -2471,9 +2464,8 @@ export function createIntegrationTestsSuite(
             }
             expect(cancelled).toBe(true);
 
-            const api = new ApifyClient({ token: process.env.APIFY_TOKEN as string });
-            const actor = await api.actor(RAG_WEB_BROWSER).get();
-            await waitForActorRunAbortStatus(api, actor!.id, startedAfter);
+            const runId = await runIdPromise;
+            await waitForRunAborted(api, runId);
         });
 
         it('should support call-actor tool in task mode (internal tool with taskSupport)', async () => {

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2037,7 +2037,8 @@ export function createIntegrationTestsSuite(
 
             const result = await client.callTool({
                 name: actorNameToToolName('apify/rag-web-browser'),
-                arguments: { query: 'https://apify.com' },
+                // Max wait (45s) so the test does not flake on a slow run.
+                arguments: { query: 'https://apify.com', waitSecs: 45 },
             });
 
             // content[0] mirrors structuredContent as JSON; content[1] is "${summary}\n${nextStep}".

--- a/tests/integration/utils/task_waits.ts
+++ b/tests/integration/utils/task_waits.ts
@@ -2,6 +2,15 @@ import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { ApifyClient } from 'apify-client';
 import { expect, vi } from 'vitest';
 
+import { TERMINAL_RUN_STATUSES } from '../../../src/utils/progress.js';
+
+const RUN_DISCOVERY_TIMEOUT_MS = 8_000;
+const RUN_DISCOVERY_INTERVAL_MS = 250;
+const RUN_ABORT_WAIT_TIMEOUT_MS = 30_000;
+const RUN_ABORT_WAIT_INTERVAL_MS = 500;
+// `startedAt` is server-stamped; `capturingSince` is client-stamped — buffer absorbs skew.
+const CLOCK_SKEW_BUFFER_MS = 2_000;
+
 type TaskStreamMessage = {
     type: string;
     task?: {
@@ -47,24 +56,39 @@ export async function assertStatusMessagePropagated(
     expect(listTasksSawStatusMessage).toBe(true);
 }
 
-export async function waitForActorRunAbortStatus(
+/**
+ * Race the Apify API to find the just-started run for this Actor under the test's token.
+ *
+ * Cancellation tests need the runId to verify the abort side-effect, but the runId
+ * isn't reachable through the MCP client — the response isn't delivered after cancel,
+ * and `notifications/progress` doesn't carry it. The run does appear in the Actor-scoped
+ * run list within a few hundred ms of server-side `start()`.
+ *
+ * Scoped to THIS Actor (not global `runs()`) so concurrent runs of other Actors don't
+ * pollute the page. Non-terminal status filter excludes prior completed runs in the window.
+ */
+export async function captureInflightActorRunId(
     apiClient: ApifyClient,
     actorId: string,
-    startedAfter: Date,
-) {
-    // Apify run state propagation can take >10s under load; budget more time so the
-    // server-side abort has a fair chance of being observed before the test gives up.
-    // `startedAfter` gates the match to runs created during this test — without it
-    // a previously aborted run for the same actor (prior test run, concurrent CI job)
-    // would short-circuit the wait and yield a false positive.
+    capturingSince: Date,
+): Promise<string> {
+    const startedAfter = new Date(capturingSince.getTime() - CLOCK_SKEW_BUFFER_MS);
+    const runId = await vi.waitUntil(async () => {
+        const runs = await apiClient.actor(actorId).runs().list({ limit: 3, desc: true });
+        return runs.items.find((r) => r.startedAt instanceof Date
+            && r.startedAt >= startedAfter
+            && !TERMINAL_RUN_STATUSES.has(r.status))?.id;
+    }, { timeout: RUN_DISCOVERY_TIMEOUT_MS, interval: RUN_DISCOVERY_INTERVAL_MS });
+    return runId as string;
+}
+
+/**
+ * Poll a specific run by ID until it reaches ABORTED or ABORTING.
+ * Pair with `captureInflightActorRunId` for deterministic abort verification.
+ */
+export async function waitForRunAborted(apiClient: ApifyClient, runId: string): Promise<void> {
     await vi.waitUntil(async () => {
-        const runsList = await apiClient.runs().list({ limit: 5, desc: true });
-        const currentRun = runsList.items.find((run) => run.actId === actorId
-            && run.startedAt instanceof Date
-            && run.startedAt >= startedAfter);
-        if (!currentRun) {
-            return false;
-        }
-        return currentRun.status === 'ABORTED' || currentRun.status === 'ABORTING';
-    }, { timeout: 30000, interval: 500 });
+        const run = await apiClient.run(runId).get();
+        return run?.status === 'ABORTED' || run?.status === 'ABORTING';
+    }, { timeout: RUN_ABORT_WAIT_TIMEOUT_MS, interval: RUN_ABORT_WAIT_INTERVAL_MS });
 }


### PR DESCRIPTION
## Context

Two unrelated rag-web-browser integration tests flake in CI:

1. `calls apify/rag-web-browser tool directly and retrieves metadata.title via get-dataset-items` — `items.length > 0` asserts before the run populates the dataset under the implicit 30s `waitSecs` default.
2. The three run-abort tests (notifications/cancelled × 2, tasks/cancel × 1) verify the abort side-effect via `apiClient.runs().list({ limit: 5 })`, which lists runs across **all** Actors. Page 1 is dominated by other tests' Actor starts; the abort-test's run is rarely in the top 5, so the wait silently times out. Empirical probe against the CI token returned 0 of 5 rag-web-browser entries — only 3 distinct Actors in the top 5.

## Solution

1. Set explicit `waitSecs: 45` (= `WAIT_SECS_MAX`) on the direct-call test — matches the other rag-web-browser tests in the file.
2. Replace `waitForActorRunAbortStatus` with `captureInflightActorRunId` + `waitForRunAborted`. The runId isn't reachable through the MCP client (no response after cancel, no runId in `notifications/progress`), so we race the Apify API for this Actor's newest non-terminal run while the call is in flight, then trigger the cancel. Verification becomes an exact-runId lookup.

## Worth your attention

- **Actor-scoped runs list** — `apiClient.actor(actorId).runs().list()` instead of the global `runs()` collection eliminates cross-actor pollution (the empirical root cause).
- **Non-terminal status filter** — excludes prior completed runs that could match the time window on retry.
- **Cancel mechanism untouched** — `notifications/cancelled` / `tasks/cancel` and server-side `onAbort: abortRunOnSignal` are unchanged; only the verification side moves from list heuristic to exact-ID lookup.

https://claude.ai/code/session_01VraSf24soKanDRbtptDJZ6
