### PR TITLE
feat: Track tool response size in telemetry

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -83,7 +83,7 @@ import type {
 } from '../types.js';
 import { ServerMode } from '../types.js';
 import { getHttpStatusCode, logHttpError } from '../utils/logging.js';
-import { buildMCPResponse, getToolCallErrorUserText } from '../utils/mcp.js';
+import { buildMCPResponse, computeToolResponseSizeBytes, getToolCallErrorUserText } from '../utils/mcp.js';
 import { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
 import { parseServerMode, resolveServerMode } from '../utils/server_mode.js';
@@ -826,6 +826,12 @@ export class ActorsMcpServer {
             let callDiagnostics: CallDiagnostics = {};
             let shouldTrackTelemetry = true;
             let resolvedToolName = name;
+            // Captured by `captureResult` so the `finally` block can measure response size for telemetry.
+            let toolResult: unknown = null;
+            const captureResult = <T>(r: T): T => {
+                toolResult = r;
+                return r;
+            };
             const failInvalidParams = async (
                 message: string,
                 details: CallDiagnostics,
@@ -998,7 +1004,7 @@ export class ActorsMcpServer {
                         failure_http_status: 402,
                         ...buildActorFields(actorName, actorId),
                     };
-                    return paymentRequiredResult;
+                    return captureResult(paymentRequiredResult);
                 }
 
                 // Handle internal tool
@@ -1029,7 +1035,7 @@ export class ActorsMcpServer {
                         const diag = extractToolTelemetry(res, actorName, actorId);
                         toolStatus = diag.toolStatus;
                         callDiagnostics = { ...callDiagnostics, ...diag.callDiagnostics };
-                        return res;
+                        return captureResult(res);
                     } finally {
                         progressTracker?.stop();
                     }
@@ -1048,7 +1054,7 @@ export class ActorsMcpServer {
                             await this.server.sendLoggingMessage({ level: 'error', data: msg });
                             toolStatus = TOOL_STATUS.SOFT_FAIL;
                             callDiagnostics = { ...callDiagnostics, failure_category: FAILURE_CATEGORY.INTERNAL_ERROR };
-                            return buildMCPResponse({ texts: [msg], isError: true });
+                            return captureResult(buildMCPResponse({ texts: [msg], isError: true }));
                         }
 
                         // Only set up notification handlers if progressToken is provided by the client
@@ -1092,7 +1098,7 @@ export class ActorsMcpServer {
                             callDiagnostics = { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR, ...buildActorFields(actorName, actorId) };
                         }
 
-                        return { ...res };
+                        return captureResult({ ...res });
                     } catch (error) {
                         toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
                         const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
@@ -1106,10 +1112,10 @@ export class ActorsMcpServer {
                             toolName: tool.originToolName,
                             failureCategory: callDiagnostics.failure_category,
                         });
-                        return buildMCPResponse({
+                        return captureResult(buildMCPResponse({
                             texts: [`Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}': ${error instanceof Error ? error.message : String(error)}. The MCP server may be temporarily unavailable.`],
                             isError: true,
-                        });
+                        }));
                     } finally {
                         if (client) await client.close();
                     }
@@ -1136,10 +1142,10 @@ export class ActorsMcpServer {
                             toolStatus = TOOL_STATUS.ABORTED;
                             // Receivers of cancellation notifications SHOULD NOT send a response for the cancelled request
                             // https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/cancellation#behavior-requirements
-                            return {};
+                            return captureResult({});
                         }
 
-                        return executorResult;
+                        return captureResult(executorResult);
                     } finally {
                         if (progressTracker) {
                             progressTracker.stop();
@@ -1160,7 +1166,7 @@ export class ActorsMcpServer {
                         failure_http_status: 402,
                         ...buildActorFields(actorName, actorId),
                     };
-                    return buildPaymentRequiredResponse(error);
+                    return captureResult(buildPaymentRequiredResponse(error));
                 }
 
                 if (isPermissionApprovalError(error)) {
@@ -1171,7 +1177,7 @@ export class ActorsMcpServer {
                         ...buildActorFields(actorName, actorId),
                     };
                     logHttpError(error, 'Permission approval required while calling tool', { toolName: name, mcpSessionId });
-                    return buildPermissionApprovalResponse(error);
+                    return captureResult(buildPermissionApprovalResponse(error));
                 }
 
                 // Re-throw MCP protocol errors (e.g. from failInvalidParams) so the SDK
@@ -1205,11 +1211,11 @@ export class ActorsMcpServer {
                     validationMissingProperty: callDiagnostics.validation_missing_property,
                     validationAdditionalProperty: callDiagnostics.validation_additional_property,
                 });
-                return buildMCPResponse({
+                return captureResult(buildMCPResponse({
                     texts: [getToolCallErrorUserText(name, error)],
                     isError: true,
                     telemetry: { toolStatus },
-                });
+                }));
             } finally {
                 if (shouldTrackTelemetry) {
                     this.logToolCallAndTelemetry({
@@ -1220,6 +1226,7 @@ export class ActorsMcpServer {
                         telemetryData,
                         userId,
                         callDiagnostics,
+                        responseSizeBytes: computeToolResponseSizeBytes(toolResult),
                     });
                 }
             }
@@ -1255,6 +1262,7 @@ export class ActorsMcpServer {
         telemetryData: ToolCallTelemetryProperties | null;
         userId: string | null;
         callDiagnostics?: CallDiagnostics;
+        responseSizeBytes?: number;
     }): void {
         const durationMs = Date.now() - params.startTime;
 
@@ -1263,6 +1271,7 @@ export class ActorsMcpServer {
             mcpSessionId: params.mcpSessionId,
             toolStatus: params.toolStatus,
             durationMs,
+            ...(params.responseSizeBytes !== undefined && { responseSizeBytes: params.responseSizeBytes }),
             ...(params.taskId !== undefined && { taskId: params.taskId }),
         });
 
@@ -1271,6 +1280,7 @@ export class ActorsMcpServer {
                 ...params.telemetryData,
                 tool_status: params.toolStatus,
                 tool_exec_time_ms: durationMs,
+                ...(params.responseSizeBytes !== undefined && { tool_response_size_bytes: params.responseSizeBytes }),
                 // Always include actor_name/actor_id; failure-specific fields are only present when callDiagnostics has them.
                 ...params.callDiagnostics,
             };
@@ -1326,7 +1336,7 @@ export class ActorsMcpServer {
         // This avoids re-fetching user data in the error handler.
         const { telemetryData, userId } = await this.prepareTelemetryData(getToolFullName(tool), mcpSessionId, apifyToken);
 
-        const finishTaskTracking = (status: ToolStatus, diagnostics?: CallDiagnostics) => {
+        const finishTaskTracking = (status: ToolStatus, diagnostics?: CallDiagnostics, responseSizeBytes?: number) => {
             this.logToolCallAndTelemetry({
                 toolName: tool.name,
                 mcpSessionId,
@@ -1336,6 +1346,7 @@ export class ActorsMcpServer {
                 telemetryData,
                 userId,
                 callDiagnostics: diagnostics,
+                responseSizeBytes,
             });
         };
 
@@ -1485,7 +1496,7 @@ export class ActorsMcpServer {
             log.debug('Task completed successfully', { taskId, toolName: tool.name, mcpSessionId });
             await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
 
-            finishTaskTracking(toolStatus, callDiagnostics);
+            finishTaskTracking(toolStatus, callDiagnostics, computeToolResponseSizeBytes(result));
         } catch (error) {
             // Handle 402 Payment Required — return structured x402 result so clients can auto-pay
             const httpStatus = getHttpStatusCode(error);
@@ -1498,13 +1509,14 @@ export class ActorsMcpServer {
                     TOOL_STATUS.ABORTED,
                     { ...buildActorFields(actorName, actorId) },
                 )) return;
-                await this.taskStore.storeTaskResult(taskId, 'completed', buildPaymentRequiredResponse(error), mcpSessionId);
+                const paymentResponse = buildPaymentRequiredResponse(error);
+                await this.taskStore.storeTaskResult(taskId, 'completed', paymentResponse, mcpSessionId);
                 await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
                 finishTaskTracking(TOOL_STATUS.SOFT_FAIL, {
                     failure_category: FAILURE_CATEGORY.INVALID_INPUT,
                     failure_http_status: 402,
                     ...buildActorFields(actorName, actorId),
-                });
+                }, computeToolResponseSizeBytes(paymentResponse));
                 return;
             }
 
@@ -1517,13 +1529,14 @@ export class ActorsMcpServer {
                     TOOL_STATUS.ABORTED,
                     { ...buildActorFields(actorName, actorId) },
                 )) return;
-                await this.taskStore.storeTaskResult(taskId, 'completed', buildPermissionApprovalResponse(error), mcpSessionId);
+                const approvalResponse = buildPermissionApprovalResponse(error);
+                await this.taskStore.storeTaskResult(taskId, 'completed', approvalResponse, mcpSessionId);
                 await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
                 finishTaskTracking(TOOL_STATUS.SOFT_FAIL, {
                     failure_category: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
                     failure_http_status: error.statusCode,
                     ...buildActorFields(actorName, actorId),
-                });
+                }, computeToolResponseSizeBytes(approvalResponse));
                 return;
             }
 
@@ -1573,17 +1586,18 @@ export class ActorsMcpServer {
                 taskId,
                 mcpSessionId,
             });
-            await this.taskStore.storeTaskResult(taskId, 'failed', {
+            const failedResult = {
                 content: [{
                     type: 'text' as const,
                     text: userText,
                 }],
                 isError: true,
                 internalToolStatus: toolStatus,
-            }, mcpSessionId);
+            };
+            await this.taskStore.storeTaskResult(taskId, 'failed', failedResult, mcpSessionId);
             await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
 
-            finishTaskTracking(toolStatus, callDiagnostics);
+            finishTaskTracking(toolStatus, callDiagnostics, computeToolResponseSizeBytes(failedResult));
         } finally {
             cancelWatcher.dispose();
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -353,6 +353,8 @@ export type ToolCallTelemetryProperties = {
     tool_name: string;
     tool_status: ToolStatus;
     tool_exec_time_ms: number;
+    /** Byte size of the tool response (text content + JSON-stringified structured content). */
+    tool_response_size_bytes?: number;
     failure_category?: FailureCategory;
     failure_http_status?: number;
     failure_detail?: string;

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -66,9 +66,10 @@ export function computeToolResponseSizeBytes(result: unknown): number {
             }
         }
     }
-    if (res.structuredContent !== undefined) {
+    if (res.structuredContent != null) {
         try {
-            bytes += Buffer.byteLength(JSON.stringify(res.structuredContent) ?? '', 'utf8');
+            const json = JSON.stringify(res.structuredContent);
+            if (json) bytes += Buffer.byteLength(json, 'utf8');
         } catch {
             // Non-serialisable structured content (e.g. circular) — skip.
         }

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -49,6 +49,33 @@ export function buildMCPResponse(options: {
     };
 }
 
+/**
+ * Computes the byte size of a tool response — sums UTF-8 byte length of every
+ * text item in `content[]` plus JSON-stringified `structuredContent` (if present).
+ * Other fields (`isError`, `_meta`, etc.) are not counted.
+ */
+export function computeToolResponseSizeBytes(result: unknown): number {
+    if (!result || typeof result !== 'object') return 0;
+    const res = result as { content?: unknown; structuredContent?: unknown };
+    let bytes = 0;
+    if (Array.isArray(res.content)) {
+        for (const item of res.content) {
+            const text = (item as { text?: unknown })?.text;
+            if (typeof text === 'string') {
+                bytes += Buffer.byteLength(text, 'utf8');
+            }
+        }
+    }
+    if (res.structuredContent !== undefined) {
+        try {
+            bytes += Buffer.byteLength(JSON.stringify(res.structuredContent) ?? '', 'utf8');
+        } catch {
+            // Non-serialisable structured content (e.g. circular) — skip.
+        }
+    }
+    return bytes;
+}
+
 /** User-facing error text for tool execution failures with HTTP-aware hints. */
 export function getToolCallErrorUserText(toolName: string, error: unknown): string {
     const msg = error instanceof Error ? error.message : String(error);

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeToolResponseSizeBytes } from '../../src/utils/mcp.js';
+
+describe('computeToolResponseSizeBytes()', () => {
+    it('returns 0 for null/undefined/non-object input', () => {
+        expect(computeToolResponseSizeBytes(null)).toBe(0);
+        expect(computeToolResponseSizeBytes(undefined)).toBe(0);
+        expect(computeToolResponseSizeBytes('text')).toBe(0);
+        expect(computeToolResponseSizeBytes(42)).toBe(0);
+    });
+
+    it('returns 0 for empty result object', () => {
+        expect(computeToolResponseSizeBytes({})).toBe(0);
+    });
+
+    it('sums UTF-8 byte length of every text item in content[]', () => {
+        const result = {
+            content: [
+                { type: 'text', text: 'hello' },
+                { type: 'text', text: 'world' },
+            ],
+        };
+        // "hello" = 5 bytes, "world" = 5 bytes -> 10
+        expect(computeToolResponseSizeBytes(result)).toBe(10);
+    });
+
+    it('counts multi-byte UTF-8 characters correctly', () => {
+        const result = {
+            content: [{ type: 'text', text: 'café' }], // c=1 a=1 f=1 é=2 → 5 bytes
+        };
+        expect(computeToolResponseSizeBytes(result)).toBe(5);
+    });
+
+    it('adds JSON-stringified structuredContent bytes', () => {
+        const result = {
+            content: [{ type: 'text', text: 'ok' }],
+            structuredContent: { url: 'https://x' },
+        };
+        const expected = Buffer.byteLength('ok', 'utf8')
+            + Buffer.byteLength(JSON.stringify({ url: 'https://x' }), 'utf8');
+        expect(computeToolResponseSizeBytes(result)).toBe(expected);
+    });
+
+    it('ignores non-text items in content[]', () => {
+        const result = {
+            content: [
+                { type: 'image', data: 'base64...' },
+                { type: 'text', text: 'hi' },
+            ],
+        };
+        expect(computeToolResponseSizeBytes(result)).toBe(2);
+    });
+
+    it('handles structuredContent without content[]', () => {
+        const result = { structuredContent: { a: 1 } };
+        expect(computeToolResponseSizeBytes(result)).toBe(
+            Buffer.byteLength(JSON.stringify({ a: 1 }), 'utf8'),
+        );
+    });
+
+    it('returns 0 when structuredContent is not JSON-serialisable', () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        const result = { structuredContent: circular };
+        expect(computeToolResponseSizeBytes(result)).toBe(0);
+    });
+});


### PR DESCRIPTION
## Context
We want to track tool-response payload size in Segment telemetry to spot outliers, estimate egress / storage cost, and correlate response size with tool status and latency. Closes #838.

## Solution
Add a `tool_response_size_bytes` field to `ToolCallTelemetryProperties` and compute UTF-8 byte length of the response (`content[]` text items + JSON-stringified `structuredContent`) in the call-tool `finally` block. A `captureResult()` closure stashes the return value so the `finally` can read it after the handler has already returned. The task-mode async executor passes the size in directly via `finishTaskTracking`.

## Worth your attention
- **Bytes, not characters** — `bytes / 4` is the standard token-count heuristic ([LangWatch `estimateTokens`](https://langwatch.ai/scenario/reference/javascript/scenario/functions/estimateTokens.html) uses it, justified as: *"accounts for multi-byte characters (emojis, CJK, etc.) that typically consume more tokens than ASCII text"*). Pure character heuristics are documented to break on CJK by 3-4× and on emoji by 4-5× ([hive#3546](https://github.com/aden-hq/hive/issues/3546), [openviking 6471868](https://github.com/LinQiang391/OpenViking/commit/6471868c90e66e2e783355808e13acec188a23a6)) because each CJK char is ~1-2 tokens. JS `String.length` also counts UTF-16 code units, so it under-counts astral-plane chars by 2× — bytes sidestep that entirely. Cross-language *tokens-per-unit* spread is ~2× for bytes vs ~8× for chars.
- **`captureResult()` is declared inside the handler scope** — each concurrent request gets its own closure, so the per-request `toolResult` cannot race. Must not be hoisted to a class field.
- **Field is optional** (`responseSizeBytes?: number` + conditional spreads) — telemetry payload shape stays unchanged for the few paths that throw before reaching any `return` (e.g. early `failInvalidParams`).

## Follow-up
- If dashboards show we actually need token counts (not transport bytes), swap `Buffer.byteLength(text, 'utf8')` for `encoder.encode(text).length` from [`gpt-tokenizer`](https://www.npmjs.com/package/gpt-tokenizer) at the same call sites — accuracy goes from ~2× heuristic to ~95% on cl100k_base.
