### PR TITLE
feat: Add tool call reason middleware for telemetry

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -89,6 +89,7 @@ import { createProgressTracker } from '../utils/progress.js';
 import { parseServerMode, resolveServerMode } from '../utils/server_mode.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
 import { classifyFailureCategory, extractAjvErrorDetails, extractToolTelemetry, getToolStatusFromError } from '../utils/tool_status.js';
+import { extractAndStripReason } from '../utils/tool_call_reason.js';
 import { buildActorFields, extractActorId, extractActorName, getToolFullName, getToolPublicFieldOnly } from '../utils/tools.js';
 import {
     getActors,
@@ -913,6 +914,13 @@ export class ActorsMcpServer {
                 // since validation expects the original, non-encoded property names.
                 args = decodeDotPropertyNames(args as Record<string, unknown>) as Record<string, unknown>;
 
+                // Extract and strip the LLM-provided `reason` for telemetry. Must run before payment
+                // processing and AJV validation so downstream code never observes the field.
+                const reason = extractAndStripReason(args as Record<string, unknown>);
+                if (telemetryData && reason) {
+                    telemetryData.reason = reason;
+                }
+
                 // Centralize all payment processing: validate, strip payment fields, create client.
                 // Must run before AJV validation so toolArgsWithoutPayment doesn't contain provider-specific fields.
                 const { toolArgsWithoutPayment: toolArgs, toolArgsRedacted: logSafeArgs, apifyClient, paymentRequiredResult } = prepareToolCallContext({
@@ -982,6 +990,7 @@ export class ActorsMcpServer {
                             actorName,
                             actorId,
                             userRentedActorIds,
+                            reason,
                         }).catch((error) => log.error('executeToolAndUpdateTask failed unexpectedly', { taskId: task.taskId, error }));
                     });
 
@@ -1306,10 +1315,11 @@ export class ActorsMcpServer {
         actorName?: string;
         actorId?: string;
         userRentedActorIds?: string[];
+        reason?: string;
     }): Promise<void> {
         const {
             taskId, tool, toolArgs, logSafeArgs, paymentRequiredResult,
-            apifyClient, apifyToken, progressToken, extra, mcpSessionId, actorName, actorId, userRentedActorIds,
+            apifyClient, apifyToken, progressToken, extra, mcpSessionId, actorName, actorId, userRentedActorIds, reason,
         } = params;
         let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
         // Always populate actor fields so they're tracked on both success and failure paths.
@@ -1325,6 +1335,9 @@ export class ActorsMcpServer {
         // Prepare telemetry before try-catch so it's accessible to both paths.
         // This avoids re-fetching user data in the error handler.
         const { telemetryData, userId } = await this.prepareTelemetryData(getToolFullName(tool), mcpSessionId, apifyToken);
+        if (telemetryData && reason) {
+            telemetryData.reason = reason;
+        }
 
         const finishTaskTracking = (status: ToolStatus, diagnostics?: CallDiagnostics) => {
             this.logToolCallAndTelemetry({

--- a/src/types.ts
+++ b/src/types.ts
@@ -353,6 +353,8 @@ export type ToolCallTelemetryProperties = {
     tool_name: string;
     tool_status: ToolStatus;
     tool_exec_time_ms: number;
+    /** LLM-provided one-liner explaining why this tool call was made (use-case only, no other context). */
+    reason?: string;
     failure_category?: FailureCategory;
     failure_http_status?: number;
     failure_detail?: string;

--- a/src/utils/tool_call_reason.ts
+++ b/src/utils/tool_call_reason.ts
@@ -1,0 +1,84 @@
+/**
+ * MCP tool call `reason` middleware.
+ *
+ * Injects a `reason` property into every tool's public input schema (tools/list)
+ * and extracts it from incoming arguments at call time so it can be forwarded to
+ * telemetry. The field is stripped from arguments before AJV validation and tool
+ * execution so downstream code (Actor input, payment processing, proxied MCP
+ * calls) never observes it.
+ */
+
+import type { ToolInputSchema } from '../types.js';
+
+/** Name of the property injected into every tool's input schema. */
+export const TOOL_CALL_REASON_PROPERTY = 'reason';
+
+/**
+ * Description shown to the LLM in tools/list. It must be explicit about scope so
+ * the model writes a short, use-case-only sentence and never leaks unrelated
+ * conversation content, identifiers, secrets, or personal data.
+ */
+export const TOOL_CALL_REASON_DESCRIPTION = [
+    'One or two short sentences describing why this tool is being called for this request.',
+    'Scope: explain only the immediate use case of this tool call (what you intend to accomplish with it).',
+    'MUST NOT include any other context from the conversation, prior turns, user messages, file contents, or task background.',
+    'MUST NOT include any personal data, personally identifiable information (PII), names, emails, phone numbers, addresses, IDs, or other identifiers.',
+    'MUST NOT include any secrets, passwords, API keys, tokens, credentials, or sensitive values.',
+    'MUST NOT quote, paraphrase, or summarize anything the user or the system said outside the immediate intent of this call.',
+    'Write it as a generic, self-contained justification, e.g. "Fetching weather data to answer a forecast question." Keep it under 200 characters.',
+].join(' ');
+
+/** Maximum number of characters retained from a reason value when forwarded to telemetry. */
+export const TOOL_CALL_REASON_MAX_LENGTH = 500;
+
+/**
+ * Returns a new input schema with the `reason` property added.
+ *
+ * Idempotent: if `reason` is already present, the original schema is returned.
+ * The property is added to `required` so MCP clients prompt the LLM to provide
+ * it; the AJV-compiled validator on the tool is unaffected (it operates on a
+ * separate schema instance), so a missing `reason` does not fail validation.
+ */
+export function injectReasonProperty(inputSchema: ToolInputSchema): ToolInputSchema {
+    if (!inputSchema || typeof inputSchema !== 'object') return inputSchema;
+
+    const properties = (inputSchema.properties ?? {}) as Record<string, unknown>;
+    if (properties[TOOL_CALL_REASON_PROPERTY]) return inputSchema;
+
+    const required = Array.isArray(inputSchema.required) ? inputSchema.required : [];
+
+    return {
+        ...inputSchema,
+        properties: {
+            ...properties,
+            [TOOL_CALL_REASON_PROPERTY]: {
+                type: 'string',
+                description: TOOL_CALL_REASON_DESCRIPTION,
+            },
+        },
+        required: required.includes(TOOL_CALL_REASON_PROPERTY)
+            ? required
+            : [...required, TOOL_CALL_REASON_PROPERTY],
+    };
+}
+
+/**
+ * Removes the `reason` property from a mutable args object and returns its
+ * trimmed, length-capped value (or `undefined` if missing/empty/non-string).
+ *
+ * Always strip before AJV validation, payment processing, and tool dispatch —
+ * the field is metadata for telemetry and must not leak to downstream code.
+ */
+export function extractAndStripReason(args: Record<string, unknown> | undefined): string | undefined {
+    if (!args || typeof args !== 'object') return undefined;
+
+    const raw = args[TOOL_CALL_REASON_PROPERTY];
+    delete args[TOOL_CALL_REASON_PROPERTY];
+
+    if (typeof raw !== 'string') return undefined;
+    const trimmed = raw.trim();
+    if (!trimmed) return undefined;
+    return trimmed.length > TOOL_CALL_REASON_MAX_LENGTH
+        ? trimmed.slice(0, TOOL_CALL_REASON_MAX_LENGTH)
+        : trimmed;
+}

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -7,6 +7,7 @@ import {
 import type { CallDiagnostics, HelperTool, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
 import { ServerMode } from '../types.js';
 import { fixZodSchemaRequired } from './ajv.js';
+import { injectReasonProperty } from './tool_call_reason.js';
 
 /**
  * Returns the canonical full name for a tool.
@@ -101,7 +102,7 @@ export function getToolPublicFieldOnly(tool: ToolBase, options: ToolPublicFieldO
         name: tool.name,
         title: tool.title,
         description: tool.description,
-        inputSchema: fixZodInputSchemaRequired(tool.inputSchema),
+        inputSchema: injectReasonProperty(fixZodInputSchemaRequired(tool.inputSchema)),
         outputSchema: tool.outputSchema,
         annotations: tool.annotations,
         icons: tool.icons,

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -357,7 +357,7 @@ describe('getToolPublicFieldOnly inputSchema normalization', () => {
         const { inputSchema } = getToolPublicFieldOnly(searchApifyDocsTool, { filterWidgetMeta: false });
         const schema = inputSchema as { required?: string[]; properties?: Record<string, { default?: unknown }> };
 
-        expect(schema.required).toEqual(['query']);
+        expect(schema.required).toEqual(['query', 'reason']);
         expect(schema.properties?.docSource).toMatchObject({ default: 'apify' });
         expect(schema.properties?.limit).toMatchObject({ default: 5 });
         expect(schema.properties?.offset).toMatchObject({ default: 0 });
@@ -381,7 +381,7 @@ describe('getToolPublicFieldOnly inputSchema normalization', () => {
         const { inputSchema } = getToolPublicFieldOnly(actorShapeTool, { filterWidgetMeta: false });
         const schema = inputSchema as { required?: string[] };
 
-        expect(schema.required).toEqual(['query']);
+        expect(schema.required).toEqual(['query', 'reason']);
     });
 
     // Regression: #637 — phantom `default: undefined` from filterSchemaProperties must not clear required.
@@ -402,6 +402,6 @@ describe('getToolPublicFieldOnly inputSchema normalization', () => {
         const { inputSchema } = getToolPublicFieldOnly(toolWithPhantomDefaults, { filterWidgetMeta: false });
         const schema = inputSchema as { required?: string[] };
 
-        expect(schema.required).toEqual(['query']);
+        expect(schema.required).toEqual(['query', 'reason']);
     });
 });

--- a/tests/unit/tools.utils.test.ts
+++ b/tests/unit/tools.utils.test.ts
@@ -992,7 +992,7 @@ describe('buildActorInputSchema + getToolPublicFieldOnly pipeline', () => {
         const pub = getToolPublicFieldOnly(tool, { filterWidgetMeta: false });
         const schema = pub.inputSchema as { required?: string[]; properties?: Record<string, { description?: string }> };
 
-        expect(schema.required).toEqual(['query']);
+        expect(schema.required).toEqual(['query', 'reason']);
         expect(schema.properties?.query?.description).toMatch(/^\*\*REQUIRED\*\*/);
         expect(schema.properties?.maxResults?.description).not.toMatch(/^\*\*REQUIRED\*\*/);
     });

--- a/tests/unit/utils.tool_call_reason.test.ts
+++ b/tests/unit/utils.tool_call_reason.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the tool call reason middleware.
+ *
+ * Covers:
+ * - `injectReasonProperty`: shape, idempotency, required-list handling, no-op on bad input
+ * - `extractAndStripReason`: extraction, mutation, trimming, type guards, length cap
+ * - `getToolPublicFieldOnly` integration: every tool listed exposes `reason`
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { ToolBase, ToolInputSchema } from '../../src/types.js';
+import {
+    extractAndStripReason,
+    injectReasonProperty,
+    TOOL_CALL_REASON_DESCRIPTION,
+    TOOL_CALL_REASON_MAX_LENGTH,
+    TOOL_CALL_REASON_PROPERTY,
+} from '../../src/utils/tool_call_reason.js';
+import { getToolPublicFieldOnly } from '../../src/utils/tools.js';
+
+describe('injectReasonProperty()', () => {
+    it('adds reason to properties and required', () => {
+        const result = injectReasonProperty({
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+        });
+
+        const props = result.properties as Record<string, { type: string; description: string }>;
+        expect(props[TOOL_CALL_REASON_PROPERTY]).toEqual({
+            type: 'string',
+            description: TOOL_CALL_REASON_DESCRIPTION,
+        });
+        expect(result.required).toEqual(['query', TOOL_CALL_REASON_PROPERTY]);
+    });
+
+    it('warns against leaking conversation context, PII, and secrets in the description', () => {
+        expect(TOOL_CALL_REASON_DESCRIPTION).toMatch(/personal data|PII/i);
+        expect(TOOL_CALL_REASON_DESCRIPTION).toMatch(/secret|password|token/i);
+        expect(TOOL_CALL_REASON_DESCRIPTION).toMatch(/conversation|context/i);
+    });
+
+    it('initializes required when missing', () => {
+        const result = injectReasonProperty({
+            type: 'object',
+            properties: { query: { type: 'string' } },
+        });
+        expect(result.required).toEqual([TOOL_CALL_REASON_PROPERTY]);
+    });
+
+    it('is idempotent — does not duplicate property or required entry', () => {
+        const once = injectReasonProperty({
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+        });
+        const twice = injectReasonProperty(once);
+
+        expect(twice).toBe(once);
+        expect(twice.required).toEqual(['query', TOOL_CALL_REASON_PROPERTY]);
+    });
+
+    it('does not mutate the input schema', () => {
+        const original: ToolInputSchema = {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+        };
+        const snapshot = JSON.stringify(original);
+        injectReasonProperty(original);
+        expect(JSON.stringify(original)).toBe(snapshot);
+    });
+
+    it('returns input unchanged when not an object', () => {
+        const bad = null as unknown as ToolInputSchema;
+        expect(injectReasonProperty(bad)).toBe(bad);
+    });
+});
+
+describe('extractAndStripReason()', () => {
+    it('returns the trimmed reason and removes it from args', () => {
+        const args = { reason: '  fetch weather data  ', query: 'forecast' };
+        const result = extractAndStripReason(args);
+        expect(result).toBe('fetch weather data');
+        expect(args).toEqual({ query: 'forecast' });
+    });
+
+    it('returns undefined and still strips the key when value is empty/whitespace', () => {
+        const args: Record<string, unknown> = { reason: '   ', query: 'x' };
+        expect(extractAndStripReason(args)).toBeUndefined();
+        expect(args).toEqual({ query: 'x' });
+    });
+
+    it('returns undefined and strips the key when value is not a string', () => {
+        const args: Record<string, unknown> = { reason: 42, query: 'x' };
+        expect(extractAndStripReason(args)).toBeUndefined();
+        expect(args).toEqual({ query: 'x' });
+    });
+
+    it('returns undefined when reason is absent (no-op)', () => {
+        const args: Record<string, unknown> = { query: 'x' };
+        expect(extractAndStripReason(args)).toBeUndefined();
+        expect(args).toEqual({ query: 'x' });
+    });
+
+    it('returns undefined when args is undefined', () => {
+        expect(extractAndStripReason(undefined)).toBeUndefined();
+    });
+
+    it('caps reason length at TOOL_CALL_REASON_MAX_LENGTH', () => {
+        const long = 'x'.repeat(TOOL_CALL_REASON_MAX_LENGTH + 100);
+        const args: Record<string, unknown> = { reason: long };
+        const result = extractAndStripReason(args);
+        expect(result).toHaveLength(TOOL_CALL_REASON_MAX_LENGTH);
+    });
+});
+
+describe('getToolPublicFieldOnly() integration', () => {
+    it('injects reason into a listed tool\'s input schema', () => {
+        const tool = {
+            name: 'some-tool',
+            description: 'Test tool',
+            inputSchema: {
+                type: 'object',
+                properties: { query: { type: 'string' } },
+                required: ['query'],
+            },
+        } as unknown as ToolBase;
+
+        const result = getToolPublicFieldOnly(tool, { filterWidgetMeta: false });
+        const schema = result.inputSchema as {
+            required?: string[];
+            properties?: Record<string, { description?: string }>;
+        };
+
+        expect(schema.properties?.[TOOL_CALL_REASON_PROPERTY]?.description).toBe(TOOL_CALL_REASON_DESCRIPTION);
+        expect(schema.required).toContain(TOOL_CALL_REASON_PROPERTY);
+    });
+});


### PR DESCRIPTION
Inject a `reason` property into every tool's input schema so LLMs can explain why they're calling each tool. Extract and forward the reason to telemetry, then strip it before validation and execution so downstream code never observes it.

## Changes

- **New module `src/utils/tool_call_reason.ts`**: Exports `injectReasonProperty()` to add the `reason` field to tool schemas, and `extractAndStripReason()` to extract and remove it from call arguments. Includes strict description guidance to prevent LLMs from leaking conversation context, PII, or secrets.
- **`src/utils/tools.ts`**: Call `injectReasonProperty()` in `getToolPublicFieldOnly()` so every tool listed in `tools/list` includes the reason field.
- **`src/mcp/server.ts`**: Extract reason from tool arguments before payment processing and AJV validation, then forward it to telemetry data.
- **`src/types.ts`**: Add optional `reason` field to `ToolCallTelemetryProperties`.
- **Tests**: Full unit test coverage for injection, extraction, idempotency, edge cases, and integration with `getToolPublicFieldOnly()`. Updated existing tests to expect `reason` in required fields.

## Implementation details

- Injection is idempotent: applying it twice returns the same schema instance.
- Extraction always strips the field from args (even if invalid), preventing it from reaching validation or tool execution.
- Reason is capped at 500 characters before forwarding to telemetry.
- The description is explicit about scope (immediate use case only) and prohibits leaking context, identifiers, or secrets.

https://claude.ai/code/session_01FeiC1otmZnAPxSAVxzRidk