### PR TITLE
fix(ci): migrate bump_dependency_in_internal_repo job to pnpm

### DIFF
--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -138,21 +138,45 @@ jobs:
                 with:
                     repository: apify/apify-mcp-server-internal
                     token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+            -   name: Resolve pnpm version from internal repo
+                # Read the version from the internal repo's devEngines so this job
+                # tracks the source of truth instead of carrying a hardcoded duplicate.
+                # `jq -e` exits non-zero if the key is missing, so a structure change
+                # in the internal repo's package.json fails this step loudly.
+                id: pnpm-version
+                run: |
+                    version=$(jq -er '.devEngines.packageManager.version' package.json)
+                    echo "version=$version" >> "$GITHUB_OUTPUT"
+            -   name: Install pnpm
+                # v6 is the first major running on Node 24 (matches `.nvmrc`).
+                # Exact patch pin (vs. floating `v6`) sidesteps the unmarked
+                # pre-releases in the v6 line (pnpm/action-setup#236) and lets
+                # newer patches age 14 days before adoption.
+                uses: pnpm/action-setup@v6.0.5
+                with:
+                    version: ${{ steps.pnpm-version.outputs.version }}
             -   name: Use Node.js
                 uses: actions/setup-node@v6
                 with:
                     node-version-file: '.nvmrc'
-                    cache: 'npm'
-                    cache-dependency-path: 'package-lock.json'
+                    cache: 'pnpm'
+                    cache-dependency-path: 'pnpm-lock.yaml'
+                # The internal repo pins `devEngines.packageManager` (onFail: error),
+                # so npm refuses to run inside the checkout. setup-node still calls
+                # `npm config get cache` for env diagnostics — NPM_CONFIG_FORCE
+                # (== `--force`) is the only documented bypass (npm/rfcs#830).
+                # Scoped to this step; install work below uses pnpm.
+                env:
+                    NPM_CONFIG_FORCE: 'true'
             -   name: Configure GitHub Packages auth
-                run: npm config set //npm.pkg.github.com/:_authToken ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                run: pnpm config set //npm.pkg.github.com/:_authToken ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
             -   name: Install updated dependency
-                uses: nick-fields/retry@v3 # Retry to compensate for NPM propagation lag
+                uses: nick-fields/retry@v3 # Retry to compensate for npm registry propagation lag
                 with:
                     timeout_minutes: 10
                     max_attempts: 3
                     retry_wait_seconds: 30
-                    command: npm install --save-exact @apify/actors-mcp-server@${{ needs.release_metadata.outputs.version_number }}
+                    command: pnpm add --save-exact @apify/actors-mcp-server@${{ needs.release_metadata.outputs.version_number }}
             -   name: Commit dependency bump
                 id: commit
                 uses: apify/actions/signed-commit@v1.0.0


### PR DESCRIPTION
## Context
[apify-mcp-server-internal#544](https://github.com/apify/apify-mcp-server-internal/pull/544) pinned `devEngines.packageManager` to pnpm with `onFail: "error"`. The `bump_dependency_in_internal_repo` job here checks out that repo and runs `npm install` against it — npm now refuses with `EBADDEVENGINES`, including `setup-node`’s internal `npm config get cache` diagnostic. Last failing run: [#26095570530](https://github.com/apify/apify-mcp-server/actions/runs/26095570530/job/76732557798).

## Solution
Migrate the job to pnpm: `pnpm/action-setup` + `cache: pnpm` + `pnpm add --save-exact`. The pnpm version is read from the internal repo’s `devEngines.packageManager.version` at job time so it never drifts from the source of truth.

## Worth your attention
- **`NPM_CONFIG_FORCE: 'true'` on the setup-node step** — even after swapping to pnpm, `setup-node@v6` still calls `npm config get cache` internally for env diagnostics. Per [npm/rfcs#830](https://github.com/npm/rfcs/issues/830), `--force` is the only documented bypass for the devEngines check. Scoped to that one step; the install work below uses pnpm.
- **`pnpm/action-setup@v6.0.5`, not floating `v6`** — v6 is the first major running on Node 24 (matches `.nvmrc`). Exact patch pin sidesteps the unmarked pre-releases in the v6 line ([pnpm/action-setup#236](https://github.com/pnpm/action-setup/issues/236)) and lets newer patches age 14 days before adoption.
- **`jq -er`** in the version-resolve step — `-e` makes jq exit non-zero on a missing/null result, so a future restructure of the internal `package.json` fails this step loudly instead of silently writing `version=null`.

## Follow-up
- The internal repo’s own CI (`tests_unit_lint.yaml`, `integration_tests.yaml`) hits the same EBADDEVENGINES — needs the same `NPM_CONFIG_FORCE` env on its `setup-node` steps once PR #544 lands.