### PR TITLE
fix(docker): repair pnpm deploy and add build smoke test to CI

### DIFF
--- a/.github/workflows/_check_code.yaml
+++ b/.github/workflows/_check_code.yaml
@@ -77,3 +77,44 @@ jobs:
                 uses: apify/actions/pnpm-install@v1.1.2
             -   name: Type checks
                 run: pnpm run type-check
+
+    docker_build_smoke_test:
+        # The Dockerfile is consumed by the external Docker Hub auto-build integration
+        # (see README) but no other CI job builds it, so breakage — like the pnpm v10+
+        # `pnpm deploy` regression — only surfaces post-merge. This job builds the image
+        # on every PR / master push and exercises the entrypoint to keep that surface honest.
+        name: Docker build & smoke test
+        runs-on: ubuntu-latest
+
+        steps:
+            -   uses: actions/checkout@v6
+
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v3
+
+            -   name: Build image
+                uses: docker/build-push-action@v6
+                with:
+                    context: .
+                    load: true
+                    tags: apify-mcp-server:ci
+                    cache-from: type=gha
+                    cache-to: type=gha,mode=max
+
+            -   name: Smoke test — CLI help output
+                # Confirms the entrypoint starts and yargs renders the usage block.
+                run: |
+                    docker run --rm apify-mcp-server:ci --help | grep -F 'Usage: stdio.js'
+
+            -   name: Smoke test — MCP initialize handshake over stdio
+                # Validates the server boots in the runtime image and speaks MCP.
+                # APIFY_TOKEN can be any non-empty string — the initialize handshake
+                # does not hit the Apify API, so no secret is required.
+                run: |
+                    request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"1.0"}}}'
+                    response=$(printf '%s\n' "$request" | docker run --rm -i -e APIFY_TOKEN=apify_api_dummy_for_smoke apify-mcp-server:ci)
+                    echo "--- raw response ---"
+                    echo "$response"
+                    echo "--- assertions ---"
+                    echo "$response" | grep -m1 '"id":1' | jq -e '.result.serverInfo.name == "apify-mcp-server"'
+                    echo "$response" | grep -m1 '"id":1' | jq -e '.result.protocolVersion != null'

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,16 @@ RUN corepack enable
 
 WORKDIR /app
 
-# `pnpm deploy --prod` produces a self-contained, hoisted node_modules (no `.pnpm/`
-# symlinks) with production dependencies only — the pnpm equivalent of
+# `pnpm deploy --legacy --filter` produces a self-contained node_modules for the
+# named package with production dependencies only — the pnpm equivalent of
 # `npm ci --omit=dev`, with no extra registry resolution at runtime.
+# - `--filter` is required from the workspace root so pnpm knows which package to
+#   deploy (workspace contains both the server and the `src/web` widget package).
+# - `--legacy` opts out of pnpm v10+'s `inject-workspace-packages` requirement; the
+#   server doesn't depend on any workspace package at runtime, so the legacy path is
+#   the correct one (see ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE).
 COPY --from=builder /app /build
-RUN cd /build && pnpm deploy --prod /app && rm -rf /build
+RUN cd /build && pnpm deploy --legacy --filter "@apify/actors-mcp-server" --prod /app && rm -rf /build
 COPY --from=builder /app/dist ./dist
 
 ENTRYPOINT ["node", "dist/stdio.js"]


### PR DESCRIPTION
## Context

The Dockerfile broke during the npm → pnpm 11 migration (#869) — `pnpm deploy --prod /app` in the runtime stage fails with `ERR_PNPM_NOTHING_TO_DEPLOY` because the workspace now contains two packages. No CI job builds the Dockerfile, so the regression slipped through; the Docker Hub auto-build integration (which the README directs external users to) is the only place it would have surfaced.

## Solution

Two changes:

1. Fix the runtime-stage `pnpm deploy` invocation.
2. Add a `docker_build_smoke_test` job to `_check_code.yaml` so this doesn't happen again. `_check_code.yaml` is already wired into `on_pull_request.yaml` and `on_master.yaml`, so the job runs on every PR and every push to master with no extra plumbing.

## Worth your attention

- **Why both `--filter` and `--legacy`.** `--filter "@apify/actors-mcp-server"` is mandatory per the [pnpm deploy docs](https://pnpm.io/cli/deploy) — without it pnpm can't pick a package from the workspace root. `--legacy` then opts out of pnpm v10+'s `inject-workspace-packages` requirement; enabling that setting workspace-wide breaks dev tooling (watch builds, VSCode breakpoints — pnpm/pnpm#9386, #8975), and the runtime server doesn't depend on any workspace package, so the legacy path is the right scope. It also produces real file copies instead of symlinks to the global pnpm store (pnpm/pnpm#9883), which matters inside a Docker image where the store isn't present.
- **Smoke test needs no real `APIFY_TOKEN`.** The MCP `initialize` handshake never hits the Apify API, so passing `APIFY_TOKEN=apify_api_dummy_for_smoke` is enough. This lets the job run on fork PRs without secrets.
- **GHA cache for buildx layers.** `cache-from`/`cache-to: type=gha` keeps re-runs under ~30s after the first build.
