### PR TITLE
fix(ci): replace npx with pnpm dlx; lower node engine to 20

### DIFF
--- a/.github/workflows/_check_code.yaml
+++ b/.github/workflows/_check_code.yaml
@@ -48,7 +48,9 @@ jobs:
         name: Test (Node.js ${{ matrix.node-version }})
         strategy:
             matrix:
-                node-version: [22, 24, 26]
+                # 20 = minimum supported (matches package.json#engines.node).
+                # 22/24 = active LTS lines. 26 = current.
+                node-version: [20, 22, 24, 26]
             fail-fast: false
         runs-on: ubuntu-latest
 

--- a/.github/workflows/_publish_to_pkg_pr_new.yaml
+++ b/.github/workflows/_publish_to_pkg_pr_new.yaml
@@ -28,4 +28,7 @@ jobs:
             -   name: Build
                 run: pnpm run build
 
-            -   run: npx -y pkg-pr-new publish
+                # `pnpm dlx` instead of `npx` because devEngines.packageManager is
+                # pinned to pnpm with onFail: error, and any invocation of npm at the
+                # repo root (including by `npx`) is rejected with EBADDEVENGINES.
+            -   run: pnpm dlx pkg-pr-new publish

--- a/.github/workflows/manual_publish_to_npm.yaml
+++ b/.github/workflows/manual_publish_to_npm.yaml
@@ -44,9 +44,13 @@ jobs:
                 if: ${{ inputs.tag == 'latest' }}
                 env:
                       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                # `pnpm exec` instead of `npx` because devEngines.packageManager is
+                # pinned to pnpm with onFail: error (npx invokes npm, which refuses to
+                # run with EBADDEVENGINES). `@sentry/cli` is already in devDependencies,
+                # so `pnpm exec` runs the locally-installed binary — no extra download.
                 run: |
-                      npx sentry-cli sourcemaps inject ./dist
-                      npx sentry-cli sourcemaps upload --release "$(jq -r '.version' package.json)" ./dist
+                      pnpm exec sentry-cli sourcemaps inject ./dist
+                      pnpm exec sentry-cli sourcemaps upload --release "$(jq -r '.version' package.json)" ./dist
             -   name: Publish to NPM
                 # `pnpm publish` honours the dist-tag flag and is safe under our
                 # devEngines `onFail: error` pin (`npm publish` would be rejected).

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -66,13 +66,16 @@ jobs:
                     cp -r docs mcpb/docs
                     cp manifest.json mcpb/manifest.json
                     cp docs/apify-logo-claude-desktop.png mcpb/icon.png
+                # `pnpm dlx` instead of `npx` because devEngines.packageManager is
+                # pinned to pnpm with onFail: error — npx invokes npm, which is rejected
+                # with EBADDEVENGINES at the repo root. Pinned mcpb version preserved
+                # for reproducible builds.
             -   name: Validate MCPB manifest
-                run: npx -y @anthropic-ai/mcpb@2.1.2 validate mcpb/manifest.json
+                run: pnpm dlx @anthropic-ai/mcpb@2.1.2 validate mcpb/manifest.json
             -   name: Create MCPB package
-                # fix version of anthropic-ai/mcpb to 2.1.2 so that we have a reproducible build
-                run: npx -y @anthropic-ai/mcpb@2.1.2 pack mcpb/ apify-mcp-server.mcpb
+                run: pnpm dlx @anthropic-ai/mcpb@2.1.2 pack mcpb/ apify-mcp-server.mcpb
             -   name: Clean MCPB package
-                run: npx -y @anthropic-ai/mcpb@2.1.2 clean apify-mcp-server.mcpb
+                run: pnpm dlx @anthropic-ai/mcpb@2.1.2 clean apify-mcp-server.mcpb
             -   name: Upload MCPB artifacts
                 uses: actions/upload-artifact@v4
                 with:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Apify MCP Server",
   "mcpName": "com.apify/apify-mcp-server",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20.0.0"
   },
   "devEngines": {
     "packageManager": {


### PR DESCRIPTION
## Context

Three post-migration cleanups that surfaced after #869 (npm → pnpm 11) merged to master:

1. `_publish_to_pkg_pr_new.yaml` / `_smoke_test_npm_package.yaml` / the manual release workflows started failing with `EBADDEVENGINES` — `npx` invokes `npm` under the hood, and `devEngines.packageManager.onFail: error` rejects every npm invocation at the repo root.
2. Downstream consumers asked for Node 20 compatibility for the published package.
3. CI's Node matrix didn't include the new minimum.

## Solution

Three independent commits, each on its own scope:

- **`fix(ci):`** — replace `npx` with `pnpm dlx` for one-shot tools (`pkg-pr-new`, `@anthropic-ai/mcpb`) and `pnpm exec` for `sentry-cli` (already in devDependencies, no extra download). Fixes the failing `Push to pkg.pr.new` job on every master push and unblocks the manual NPM/stable-release workflows.
- **`chore:`** — lower `engines.node` from `>=22.0.0` to `>=20.0.0`. No Node 22+ exclusive APIs in `src/`, and the runtime/build images stay on `node:24-alpine`.
- **`ci:`** — add Node 20 to the CI test matrix so the lowered engine claim is actually validated.

## Worth your attention

- **Node 20 is technically EOL** (2026-03-24 per [nodejs.org/en/eol](https://nodejs.org/en/eol)). We still declare support because downstream consumers commonly run EOL Node lines for months, but newer LTS lines (22 / 24) should be preferred for new deployments.
- **`.nvmrc` (24) deliberately unchanged.** It pins the dev / canary environment, not the minimum supported version.
- **`_smoke_test_npm_package.yaml` keeps its `npx mcpc …` calls.** Those run inside a `smoke-test/` subdir created by `npm init -y`, which has its own fresh `package.json` with no `devEngines` pin — so `npx` works there. Validated by the green PR run.

## Follow-up

#872 — supply-chain `minimumReleaseAge` 1d → 3d bump is split into a separate PR (`chore/raise-minimum-release-age`) because the new policy would reject the current lockfile until ~2026-05-21 13:00 UTC.
