### PR TITLE
chore(supply-chain): raise minimumReleaseAge from 1 to 3 days (DO NOT MERGE before 2026-05-21 13:00 UTC)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,11 @@
 packages:
   - "src/web"
 
-# 24-hour quarantine on newly published versions to blunt supply-chain attacks
-# (compromised packages typically get yanked within hours of discovery).
+# 72-hour quarantine on newly published versions to blunt supply-chain attacks
+# (compromised packages typically get yanked within hours of discovery, but the
+# longer window catches slow-detection cases too).
 # Excludes are scopes we publish ourselves and trust on the same release cadence.
-minimumReleaseAge: 1440
+minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - "@apify/*"
   - "@apify-packages/*"


### PR DESCRIPTION
It currently fails, we should rerun the CICD on this PR after the `2026-05-21 13:00 UTC`

## 🚨 Do not merge before `2026-05-21 13:00 UTC`

The new 72-hour quarantine rejects five transitive packages that are currently inside the window (introduced when the lockfile was first generated in #869). The latest of them — `@types/node@25.9.0`, published `2026-05-18 12:44 UTC` — clears 72 hours at `2026-05-21 12:44 UTC`, so this PR's CI will only pass after that moment. **Merge ≥ `2026-05-21 13:00 UTC`** (1-hour buffer).

| Package | Published | Clears 72h at |
|---|---|---|
| `@protobufjs/fetch@1.1.1` | 2026-05-17 12:41 UTC | 2026-05-20 12:41 UTC ✅ |
| `@protobufjs/inquire@1.1.2` | 2026-05-17 15:18 UTC | 2026-05-20 15:18 UTC |
| `protobufjs@7.5.9` | 2026-05-17 16:52 UTC | 2026-05-20 16:52 UTC |
| `pg-protocol@1.14.0` | 2026-05-18 12:00 UTC | 2026-05-21 12:00 UTC |
| `@types/node@25.9.0` | 2026-05-18 12:44 UTC | **2026-05-21 12:44 UTC** ← gate |

All five are deep transitives (pulled via `@arizeai/phoenix-client`, `@sentry/node`, `@apify/mcpc` → opentelemetry / inquirer chains). Nothing in our direct deps.

## Context

Compromised packages occasionally take longer than 24 hours to be identified and yanked from the registry. A 72-hour quarantine catches those slow-detection cases without meaningfully slowing legitimate dependency updates. The Apify-internal scopes we publish ourselves remain excluded via `minimumReleaseAgeExclude`, so this doesn't slow first-party releases.

## Why a separate PR (not bundled with the post-migration fixes)

The lockfile generated by #869 (~24h ago) currently has 5 packages inside the new 72h window. Bumping the policy *and* the urgent CI fixes in one PR would have blocked the urgent fixes for ~26h waiting on the lockfile to naturally turn over. The CI fixes ship in `chore/post-migration-tweaks` (#871).

## Alternatives considered

- **Regenerate the lockfile** — doesn't help. pnpm enforces `minimumReleaseAge` *during* resolve, and the latest-satisfying version of every offending transitive is exactly the one in the window. `rm pnpm-lock.yaml && pnpm install` produces the same `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`.
- **`pnpm-workspace.yaml#overrides` to pin transitives to one-minor-older versions** — surgical but adds "delete these later" tech debt for transitives we don't even use directly. Not worth it given the violators clear naturally inside ~26 hours.
