### PR TITLE
fix(ci): switch pkg-pr-new to pnpm pack; restore Node 22 minimum

### DIFF
--- a/.github/workflows/_check_code.yaml
+++ b/.github/workflows/_check_code.yaml
@@ -48,9 +48,9 @@ jobs:
         name: Test (Node.js ${{ matrix.node-version }})
         strategy:
             matrix:
-                # 20 = minimum supported (matches package.json#engines.node).
+                # 22 = minimum supported (matches package.json#engines.node).
                 # 22/24 = active LTS lines. 26 = current.
-                node-version: [20, 22, 24, 26]
+                node-version: [22, 24, 26]
             fail-fast: false
         runs-on: ubuntu-latest
 

--- a/.github/workflows/_publish_to_pkg_pr_new.yaml
+++ b/.github/workflows/_publish_to_pkg_pr_new.yaml
@@ -28,7 +28,9 @@ jobs:
             -   name: Build
                 run: pnpm run build
 
-                # `pnpm dlx` instead of `npx` because devEngines.packageManager is
-                # pinned to pnpm with onFail: error, and any invocation of npm at the
-                # repo root (including by `npx`) is rejected with EBADDEVENGINES.
-            -   run: pnpm dlx pkg-pr-new publish
+                # `pnpm dlx` instead of `npx` (which invokes npm — rejected at the repo
+                # root by devEngines.packageManager.onFail: error).
+                # `--pnpm` switches pkg-pr-new's internal packer from `npm pack` to
+                # `pnpm pack`; without it the tool would still shell out to npm pack
+                # inside the checkout and trigger EBADDEVENGINES (see pkg.pr.new README).
+            -   run: pnpm dlx pkg-pr-new publish --pnpm

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Apify MCP Server",
   "mcpName": "com.apify/apify-mcp-server",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "devEngines": {
     "packageManager": {


### PR DESCRIPTION
## Context

After #871 merged, the `Push to pkg.pr.new` job kept failing with `EBADDEVENGINES`:

```
Run pnpm dlx pkg-pr-new publish
…
Error: npm pack --pack-destination … exited with a status of 1.
npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
```

`pnpm dlx` doesn't help here — `pkg-pr-new` shells out to `npm pack --json` internally, and that invocation is rejected by `devEngines.packageManager.onFail: error` at the repo root.

Separately, the team decided to walk back the Node 20 engine relaxation from #871 (Node 20 has been EOL since 2026-03-24). #873 already reverts the docs; this PR aligns `package.json#engines` and the CI matrix.

## Solution

Two independent commits:

- **`fix(ci):`** — add `--pnpm` to `pkg-pr-new publish`. Per the [pkg.pr.new README](https://github.com/stackblitz-labs/pkg.pr.new), this switches the internal packer from `npm pack` to `pnpm pack`, sidestepping the npm invocation entirely. No `NPM_CONFIG_FORCE` hack needed.
- **`revert:`** — restore `engines.node: ">=22.0.0"` and CI matrix `[22, 24, 26]`. Complements #873.

## Worth your attention

- **`--pnpm` is a switch flag, not a glob argument.** Other repos (e.g. `unocss`, `wxt`) pass it with a glob (`--pnpm './packages/*'`), but the bare flag is the documented way to flip the packer when you don't need to filter packages — which is our case (single-package repo).
- **No lockfile change.** Only workflow + package.json + one comment line in `_check_code.yaml`.
