### PR TITLE
feat(x402): expose multi-scheme accepts[] and structuredContent

### DIFF
--- a/src/payments/x402.ts
+++ b/src/payments/x402.ts
@@ -206,7 +206,8 @@ export class X402PaymentProvider implements PaymentProvider {
         }
         const metaRecord = cloned._meta as Record<string, unknown>;
         if (!metaRecord.x402) {
-            const acceptsRaw = this.requirements?.accepts;
+            const reqs = this.requirements ? structuredClone(this.requirements) : undefined;
+            const acceptsRaw = reqs?.accepts;
             const accepts = Array.isArray(acceptsRaw) && acceptsRaw.length > 0 ? acceptsRaw : undefined;
             const preferred = accepts ? this.selectPreferredAcceptEntry(accepts) : undefined;
             metaRecord.x402 = {

--- a/src/payments/x402.ts
+++ b/src/payments/x402.ts
@@ -30,9 +30,9 @@ const X402_TOOL_INSTRUCTIONS = [
  * Preferred scheme order when selecting the flat fields exposed on `_meta.x402`.
  *
  * `exact` first to keep the flat-fields contract back-compatible with clients
- * that don't iterate `accepts[]` — they'll continue to sign `exact` payments
- * just like before this PR. Clients that walk `accepts[]` (post-#876 — the
- * current mcpc, the canary) can opt into `upto` via their scheme preference.
+ * that don't iterate `accepts[]` — they continue to sign `exact` payments as
+ * before this PR. Clients that walk `accepts[]` (post-#876 — the current
+ * mcpc, the canary) can opt into `upto` via their scheme preference.
  */
 const X402_PREFERRED_SCHEMES = ['exact', 'upto'] as const;
 
@@ -184,10 +184,8 @@ export class X402PaymentProvider implements PaymentProvider {
 
     /**
      * Picks the preferred accept entry for flat `_meta.x402` advertising.
-     * Order: `exact`, then `upto`, then the first remaining entry.
-     *
-     * `exact` is the pre-#876 contract — keep it as the flat-fields default so
-     * clients that don't walk `accepts[]` keep signing what they always signed.
+     * Order follows `X402_PREFERRED_SCHEMES`; falls back to the first entry
+     * when no preferred scheme matches.
      */
     private selectPreferredAcceptEntry(accepts: X402PaymentAccept[]): X402PaymentAccept {
         for (const preferred of X402_PREFERRED_SCHEMES) {

--- a/src/payments/x402.ts
+++ b/src/payments/x402.ts
@@ -26,8 +26,15 @@ const X402_TOOL_INSTRUCTIONS = [
     'Your MCP client must support the x402 payment protocol.',
 ].join(' ');
 
-/** Preferred scheme order when selecting the flat fields exposed on `_meta.x402`. */
-const X402_PREFERRED_SCHEMES = ['upto', 'exact'] as const;
+/**
+ * Preferred scheme order when selecting the flat fields exposed on `_meta.x402`.
+ *
+ * `exact` first to keep the flat-fields contract back-compatible with clients
+ * that don't iterate `accepts[]` — they'll continue to sign `exact` payments
+ * just like before this PR. Clients that walk `accepts[]` (post-#876 — the
+ * current mcpc, the canary) can opt into `upto` via their scheme preference.
+ */
+const X402_PREFERRED_SCHEMES = ['exact', 'upto'] as const;
 
 /**
  * One entry in a 402 `accepts` array. Mirrors the public x402 v2 wire shape;
@@ -177,10 +184,10 @@ export class X402PaymentProvider implements PaymentProvider {
 
     /**
      * Picks the preferred accept entry for flat `_meta.x402` advertising.
-     * Order: `upto`, then `exact`, then the first remaining entry.
+     * Order: `exact`, then `upto`, then the first remaining entry.
      *
-     * Clients that read only the flat fields (no `accepts[]` walking) get the
-     * richest payment option by default.
+     * `exact` is the pre-#876 contract — keep it as the flat-fields default so
+     * clients that don't walk `accepts[]` keep signing what they always signed.
      */
     private selectPreferredAcceptEntry(accepts: X402PaymentAccept[]): X402PaymentAccept {
         for (const preferred of X402_PREFERRED_SCHEMES) {

--- a/src/payments/x402.ts
+++ b/src/payments/x402.ts
@@ -26,11 +26,31 @@ const X402_TOOL_INSTRUCTIONS = [
     'Your MCP client must support the x402 payment protocol.',
 ].join(' ');
 
+/** Preferred scheme order when selecting the flat fields exposed on `_meta.x402`. */
+const X402_PREFERRED_SCHEMES = ['upto', 'exact'] as const;
+
 /**
- * x402 payment requirements returned by the Apify API.
- * Decoded from the base64 `payment-required` response header.
+ * One entry in a 402 `accepts` array. Mirrors the public x402 v2 wire shape;
+ * carried verbatim from the Apify API.
  */
-export type X402PaymentRequirements = Record<string, unknown>;
+export type X402PaymentAccept = {
+    scheme?: string;
+    network?: string;
+    amount?: string;
+    asset?: string;
+    payTo?: string;
+    maxTimeoutSeconds?: number;
+    extra?: Record<string, unknown>;
+};
+
+/**
+ * Decoded `payment-required` payload returned by the Apify API.
+ */
+export type X402PaymentRequirements = {
+    x402Version?: number;
+    resource?: Record<string, unknown>;
+    accepts?: X402PaymentAccept[];
+};
 
 // Module-level cache for X402 payment requirements.
 // We cache the Promise itself (rather than just the JSON result) to prevent the "thundering herd"
@@ -156,14 +176,18 @@ export class X402PaymentProvider implements PaymentProvider {
     }
 
     /**
-     * Extracts the first accept entry from the full payment requirements.
-     * This is the flattened payment info that goes into _meta.x402 for tool schemas.
+     * Picks the preferred accept entry for flat `_meta.x402` advertising.
+     * Order: `upto`, then `exact`, then the first remaining entry.
+     *
+     * Clients that read only the flat fields (no `accepts[]` walking) get the
+     * richest payment option by default.
      */
-    private getFirstAcceptEntry(): Record<string, unknown> | undefined {
-        if (!this.requirements) return undefined;
-        const accepts = this.requirements.accepts as unknown[] | undefined;
-        if (!Array.isArray(accepts) || accepts.length === 0) return undefined;
-        return accepts[0] as Record<string, unknown>;
+    private selectPreferredAcceptEntry(accepts: X402PaymentAccept[]): X402PaymentAccept {
+        for (const preferred of X402_PREFERRED_SCHEMES) {
+            const match = accepts.find((entry) => entry.scheme === preferred);
+            if (match) return match;
+        }
+        return accepts[0];
     }
 
     decorateToolSchema(tool: ToolEntry): ToolEntry {
@@ -171,16 +195,20 @@ export class X402PaymentProvider implements PaymentProvider {
 
         const cloned = cloneToolEntry(tool);
 
-        // Add _meta.x402 to signal payment requirement to clients (idempotent)
-        // Only include the first accept entry (scheme, network, amount, asset, payTo, etc.)
-        // matching the demo server format — NOT the full API response
+        // Flat preferred fields stay for back-compat with clients that don't iterate `accepts[]`.
         if (!cloned._meta) {
             cloned._meta = {};
         }
         const metaRecord = cloned._meta as Record<string, unknown>;
         if (!metaRecord.x402) {
-            const acceptEntry = this.getFirstAcceptEntry();
-            metaRecord.x402 = { paymentRequired: true, ...acceptEntry };
+            const acceptsRaw = this.requirements?.accepts;
+            const accepts = Array.isArray(acceptsRaw) && acceptsRaw.length > 0 ? acceptsRaw : undefined;
+            const preferred = accepts ? this.selectPreferredAcceptEntry(accepts) : undefined;
+            metaRecord.x402 = {
+                paymentRequired: true,
+                ...(preferred ?? {}),
+                ...(accepts && { accepts }),
+            };
         }
 
         // Append x402 instructions to description (idempotent)

--- a/src/utils/payment_errors.ts
+++ b/src/utils/payment_errors.ts
@@ -95,15 +95,16 @@ function extractPaymentRequiredData(error: unknown): Record<string, unknown> | u
 
 /**
  * Builds an MCP response for a 402 Payment Required error.
- * Formats the response as a tool result containing the PaymentRequired JSON
- * per the x402 MCP transport spec, which allows clients to automatically handle the payment flow.
+ *
+ * Per the x402 MCP transport spec (coinbase/x402 `specs/transports-v2/mcp.md`), the
+ * PaymentRequired payload is carried in two places with identical data:
+ * `structuredContent` (preferred) and `content[0].text` as JSON (fallback for clients
+ * that can't read structured content).
  */
 export function buildPaymentRequiredResponse(errorOrMessage: unknown, precomputedPaymentData?: unknown) {
     const paymentData = precomputedPaymentData ?? extractPaymentRequiredData(errorOrMessage);
     const message = errorOrMessage instanceof Error ? errorOrMessage.message : String(errorOrMessage);
 
-    // When paymentData exists, return two text entries: JSON payload first (backward-compatible
-    // position for x402 clients that parse content[0].text), then a human-readable explanation.
     const texts = paymentData
         ? [
             JSON.stringify(paymentData),
@@ -111,5 +112,5 @@ export function buildPaymentRequiredResponse(errorOrMessage: unknown, precompute
         ]
         : [message];
 
-    return buildMCPResponse({ texts, isError: true });
+    return buildMCPResponse({ texts, isError: true, structuredContent: paymentData });
 }

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2804,7 +2804,7 @@ export function createIntegrationTestsSuite(
                     const accepts = x402?.accepts as Record<string, unknown>[] | undefined;
                     expect(accepts, `Tool "${toolName}" should advertise x402.accepts[]`).toBeInstanceOf(Array);
                     expect(accepts?.length, `Tool "${toolName}" should advertise at least one accept entry`).toBeGreaterThan(0);
-                    for (const entry of accepts!) {
+                    for (const entry of accepts ?? []) {
                         expect(entry.scheme, `Tool "${toolName}" accepts entry should have a scheme`).toBeTypeOf('string');
                     }
                 }

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2787,7 +2787,8 @@ export function createIntegrationTestsSuite(
 
                 const toolsList = await client.listTools();
 
-                // Positive: paid tools advertise _meta.x402 with the expected fields.
+                // Positive: paid tools advertise _meta.x402 with both shapes —
+                // flat preferred-scheme fields (back-compat) and the full accepts[] array.
                 for (const toolName of paidToolNames) {
                     const tool = toolsList.tools.find((t) => t.name === toolName);
                     expect(tool, `Tool "${toolName}" should exist in the tools list`).toBeDefined();
@@ -2798,6 +2799,13 @@ export function createIntegrationTestsSuite(
 
                     for (const field of ['scheme', 'network', 'asset', 'payTo', 'amount'] as const) {
                         expect(x402?.[field], `Tool "${toolName}" should advertise x402.${field}`).toBeDefined();
+                    }
+
+                    const accepts = x402?.accepts as Record<string, unknown>[] | undefined;
+                    expect(accepts, `Tool "${toolName}" should advertise x402.accepts[]`).toBeInstanceOf(Array);
+                    expect(accepts?.length, `Tool "${toolName}" should advertise at least one accept entry`).toBeGreaterThan(0);
+                    for (const entry of accepts!) {
+                        expect(entry.scheme, `Tool "${toolName}" accepts entry should have a scheme`).toBeTypeOf('string');
                     }
                 }
 
@@ -2830,6 +2838,13 @@ export function createIntegrationTestsSuite(
                 expect(result.isError).toBe(true);
                 const content = result.content as { text: string }[];
                 expect(content[0].text).toContain('x402');
+
+                // x402 MCP transport spec: 402 tool results MUST also expose the PaymentRequired
+                // payload via structuredContent (preferred over content[0].text JSON parsing).
+                const structured = (result as { structuredContent?: Record<string, unknown> }).structuredContent;
+                expect(structured, 'x402 402 tool result should expose structuredContent').toBeDefined();
+                expect(structured?.x402Version, 'structuredContent.x402Version should be set').toBeDefined();
+                expect(structured?.accepts, 'structuredContent.accepts should be an array').toBeInstanceOf(Array);
 
                 await client.close();
             },

--- a/tests/unit/tools.x402.test.ts
+++ b/tests/unit/tools.x402.test.ts
@@ -124,27 +124,28 @@ describe('decorateToolSchema()', () => {
         expect(decorated._meta).toBeUndefined();
     });
 
-    it('selects the upto entry over exact for flat fields and exposes both in accepts[]', () => {
+    it('selects the exact entry over upto for flat fields and exposes both in accepts[]', () => {
+        // Back-compat: clients that read only flat fields keep signing `exact` like before #876.
         const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [EXACT_ACCEPT, UPTO_ACCEPT] };
         const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
 
         const x402 = getX402Meta(decorated);
         expect(x402?.paymentRequired).toBe(true);
-        expect(x402?.scheme).toBe('upto');
-        expect(x402?.amount).toBe(UPTO_ACCEPT.amount);
+        expect(x402?.scheme).toBe('exact');
+        expect(x402?.amount).toBe(EXACT_ACCEPT.amount);
         expect(x402?.accepts).toEqual([EXACT_ACCEPT, UPTO_ACCEPT]);
     });
 
-    it('falls back to exact when upto is not present', () => {
-        const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [EXACT_ACCEPT] };
+    it('falls back to upto when exact is not present', () => {
+        const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [UPTO_ACCEPT] };
         const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
 
         const x402 = getX402Meta(decorated);
-        expect(x402?.scheme).toBe('exact');
-        expect(x402?.accepts).toEqual([EXACT_ACCEPT]);
+        expect(x402?.scheme).toBe('upto');
+        expect(x402?.accepts).toEqual([UPTO_ACCEPT]);
     });
 
-    it('falls back to the first entry when neither upto nor exact is present', () => {
+    it('falls back to the first entry when neither exact nor upto is present', () => {
         const customAccept = { ...EXACT_ACCEPT, scheme: 'custom-scheme' };
         const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [customAccept] };
         const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
@@ -162,7 +163,7 @@ describe('decorateToolSchema()', () => {
 
         const x402 = getX402Meta(decorated);
         expect(x402?.accepts).toEqual([UPTO_ACCEPT, EXACT_ACCEPT]);
-        expect(x402?.scheme).toBe('upto');
+        expect(x402?.scheme).toBe('exact');
     });
 
     it('marks paymentRequired without flat fields or accepts[] when requirements were not fetched', () => {

--- a/tests/unit/tools.x402.test.ts
+++ b/tests/unit/tools.x402.test.ts
@@ -1,11 +1,12 @@
 /**
- * Tests for X402PaymentProvider — focused on the dual-channel payment extraction
- * (_meta["x402/payment"] JSON object vs HTTP PAYMENT-SIGNATURE header fallback).
+ * Tests for X402PaymentProvider — payment extraction (_meta["x402/payment"] vs
+ * HTTP PAYMENT-SIGNATURE header) and tool-schema decoration with multi-scheme `accepts[]`.
  */
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PaymentMeta, RequestHeaders } from '../../src/payments/types.js';
-import { X402PaymentProvider } from '../../src/payments/x402.js';
+import { X402PaymentProvider, type X402PaymentRequirements } from '../../src/payments/x402.js';
+import type { HelperTool } from '../../src/types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -13,6 +14,44 @@ import { X402PaymentProvider } from '../../src/payments/x402.js';
 
 const SAMPLE_PAYMENT = { x402Version: 2, payload: { signature: 'test-sig' } };
 const SAMPLE_PAYMENT_BASE64 = Buffer.from(JSON.stringify(SAMPLE_PAYMENT)).toString('base64');
+
+const EXACT_ACCEPT = {
+    scheme: 'exact',
+    network: 'eip155:8453',
+    amount: '100000',
+    asset: '0xExact',
+    payTo: '0xPayee',
+    maxTimeoutSeconds: 60,
+    extra: { name: 'USDC', version: '2' },
+} as const;
+
+const UPTO_ACCEPT = {
+    scheme: 'upto',
+    network: 'eip155:8453',
+    amount: '500000',
+    asset: '0xUpto',
+    payTo: '0xPayee',
+    maxTimeoutSeconds: 18_000,
+    extra: { name: 'USDC', version: '2', facilitatorAddress: '0xFac' },
+} as const;
+
+function makePaidTool(overrides: Partial<HelperTool> = {}): HelperTool {
+    return {
+        name: 'paid-tool',
+        description: 'Paid tool',
+        type: 'internal',
+        paymentRequired: true,
+        inputSchema: { type: 'object' as const, properties: {} },
+        ajvValidate: vi.fn(() => true) as never,
+        call: vi.fn(async () => ({ content: [] })),
+        ...overrides,
+    };
+}
+
+function getX402Meta(tool: { _meta?: unknown }): Record<string, unknown> | undefined {
+    const meta = tool._meta as { x402?: Record<string, unknown> } | undefined;
+    return meta?.x402;
+}
 
 let provider: X402PaymentProvider;
 
@@ -68,5 +107,94 @@ describe('getPaymentHeaders', () => {
         const result = provider.getPaymentHeaders({}, meta, headers);
 
         expect(result).toEqual({ 'PAYMENT-SIGNATURE': metaBase64, 'x-apify-payment-protocol': 'x402' });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// decorateToolSchema
+// ---------------------------------------------------------------------------
+
+describe('decorateToolSchema()', () => {
+    it('returns the original tool unchanged when paymentRequired is not set', () => {
+        const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [EXACT_ACCEPT] };
+        const freeTool = makePaidTool({ paymentRequired: false });
+        const decorated = new X402PaymentProvider(requirements).decorateToolSchema(freeTool);
+
+        expect(decorated).toBe(freeTool);
+        expect(decorated._meta).toBeUndefined();
+    });
+
+    it('selects the upto entry over exact for flat fields and exposes both in accepts[]', () => {
+        const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [EXACT_ACCEPT, UPTO_ACCEPT] };
+        const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
+
+        const x402 = getX402Meta(decorated);
+        expect(x402?.paymentRequired).toBe(true);
+        expect(x402?.scheme).toBe('upto');
+        expect(x402?.amount).toBe(UPTO_ACCEPT.amount);
+        expect(x402?.accepts).toEqual([EXACT_ACCEPT, UPTO_ACCEPT]);
+    });
+
+    it('falls back to exact when upto is not present', () => {
+        const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [EXACT_ACCEPT] };
+        const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
+
+        const x402 = getX402Meta(decorated);
+        expect(x402?.scheme).toBe('exact');
+        expect(x402?.accepts).toEqual([EXACT_ACCEPT]);
+    });
+
+    it('falls back to the first entry when neither upto nor exact is present', () => {
+        const customAccept = { ...EXACT_ACCEPT, scheme: 'custom-scheme' };
+        const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [customAccept] };
+        const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
+
+        const x402 = getX402Meta(decorated);
+        expect(x402?.scheme).toBe('custom-scheme');
+        expect(x402?.accepts).toEqual([customAccept]);
+    });
+
+    it('preserves the configured order in accepts[] regardless of preference selection', () => {
+        // Server-emitted order may be non-deterministic upstream; whatever we receive is
+        // what we forward. Preference only drives the flat-field selection.
+        const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [UPTO_ACCEPT, EXACT_ACCEPT] };
+        const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
+
+        const x402 = getX402Meta(decorated);
+        expect(x402?.accepts).toEqual([UPTO_ACCEPT, EXACT_ACCEPT]);
+        expect(x402?.scheme).toBe('upto');
+    });
+
+    it('marks paymentRequired without flat fields or accepts[] when requirements were not fetched', () => {
+        const decorated = new X402PaymentProvider(undefined).decorateToolSchema(makePaidTool());
+
+        const x402 = getX402Meta(decorated);
+        expect(x402).toEqual({ paymentRequired: true });
+    });
+
+    it('marks paymentRequired without flat fields or accepts[] when accepts is empty', () => {
+        const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [] };
+        const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
+
+        const x402 = getX402Meta(decorated);
+        expect(x402).toEqual({ paymentRequired: true });
+    });
+
+    it('appends x402 tool instructions to the description', () => {
+        const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [EXACT_ACCEPT] };
+        const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
+
+        expect(decorated.description).toContain('x402 payment');
+    });
+
+    it('is idempotent — second decoration does not change _meta.x402 or duplicate instructions', () => {
+        const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [EXACT_ACCEPT, UPTO_ACCEPT] };
+        const x402Provider = new X402PaymentProvider(requirements);
+        const once = x402Provider.decorateToolSchema(makePaidTool());
+        const twice = x402Provider.decorateToolSchema(once);
+
+        expect(getX402Meta(twice)).toEqual(getX402Meta(once));
+        const instructionsCount = (twice.description ?? '').match(/This tool requires an x402 payment/g)?.length ?? 0;
+        expect(instructionsCount).toBe(1);
     });
 });

--- a/tests/unit/utils.payment_errors.test.ts
+++ b/tests/unit/utils.payment_errors.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for `buildPaymentRequiredResponse` — covers the x402 MCP transport spec
+ * requirement that PaymentRequired payloads land in both `structuredContent`
+ * (preferred) and `content[0].text` as JSON (fallback). See coinbase/x402
+ * `specs/transports-v2/mcp.md`.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildPaymentRequiredResponse } from '../../src/utils/payment_errors.js';
+
+const SAMPLE_PAYMENT_REQUIRED = {
+    x402Version: 2,
+    accepts: [
+        { scheme: 'exact', network: 'eip155:8453', amount: '100000' },
+        { scheme: 'upto', network: 'eip155:8453', amount: '500000' },
+    ],
+} as const;
+
+describe('buildPaymentRequiredResponse()', () => {
+    it('writes paymentData to both structuredContent and content[0].text', () => {
+        const result = buildPaymentRequiredResponse(new Error('Payment required'), SAMPLE_PAYMENT_REQUIRED);
+
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toEqual(SAMPLE_PAYMENT_REQUIRED);
+        expect(result.content[0]).toEqual({
+            type: 'text',
+            text: JSON.stringify(SAMPLE_PAYMENT_REQUIRED),
+        });
+    });
+
+    it('appends a human-readable text entry after the JSON entry when paymentData is present', () => {
+        const result = buildPaymentRequiredResponse(new Error('Payment required'), SAMPLE_PAYMENT_REQUIRED);
+
+        expect(result.content).toHaveLength(2);
+        expect(result.content[1]).toEqual({
+            type: 'text',
+            text: 'Payment required to run this Actor or access this resource.',
+        });
+    });
+
+    it('omits structuredContent and returns only the error message when no paymentData is available', () => {
+        const result = buildPaymentRequiredResponse('plain string error');
+
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toBeUndefined();
+        expect(result.content).toEqual([{ type: 'text', text: 'plain string error' }]);
+    });
+});


### PR DESCRIPTION
closes https://github.com/apify/ai-team/issues/169

## Context

apify-core PR #27039 ships x402 `upto` scheme support alongside `exact`, so the 402 `payment-required` response now carries multiple entries in `accepts[]`. Two gaps surfaced on the MCP-server side:

1. The flat `_meta.x402` advertising on paid tools only included the first entry, hiding the other scheme from clients that don't probe the 402 round-trip.
2. The 402 tool-result response only populated `content[0].text` JSON, missing the `structuredContent` field that the x402 MCP transport spec requires (preferred by spec-compliant clients).

## Solution

- `decorateToolSchema` now writes flat preferred-scheme fields **and** the full `accepts[]` array. Preference order is `exact` → `upto` → first remaining entry, so clients that read only the flat fields stay backwards-compatible and keep the pre-#876 contract intact.
- `buildPaymentRequiredResponse` now also sets `structuredContent` on the 402 tool result, matching coinbase/x402 `specs/transports-v2/mcp.md`.
- Tightened `X402PaymentRequirements` from `Record<string, unknown>` to a concrete `{ x402Version, resource, accepts: X402PaymentAccept[] }` type.

## Worth your attention

- **Back-compat**: existing clients reading `_meta.x402.{scheme,network,asset,payTo,amount}` keep working — those flat fields are still there, just resolved against the preferred entry instead of the first one.
- **Why prefer `exact` for back-compat**: switching their default to `upto` would silently move them onto the Permit2 settlement path and require a one-time on-chain allowance approval they don't know to do. We prefer `exact` for flat fields to keep the pre-#876 contract intact.

## Follow-up

- Companion mcpc PR plumbs the client side (upto signer + scheme selection).
- `_meta["x402/payment-response"]` settlement receipts are still not returned to clients — separate spec gap, design question (Apify settles async).