### PR TITLE
fix(ci): swap npm show for pnpm view in before-beta-release script

### DIFF
--- a/.github/scripts/before-beta-release.js
+++ b/.github/scripts/before-beta-release.js
@@ -18,7 +18,12 @@ pkgJson.version = nextVersion;
 writeFileSync(PKG_JSON_PATH, `${JSON.stringify(pkgJson, null, 2)}\n`);
 
 function addBetaSuffixToVersion(version) {
-    const versionString = execSync(`npm show ${PACKAGE_NAME} versions --json`, { encoding: 'utf8' });
+    // `pnpm view` instead of `npm show` because devEngines.packageManager is
+    // pinned to pnpm with onFail: error, and npm enforces that check for every
+    // subcommand (including read-only registry queries), so `npm show` fails
+    // with EBADDEVENGINES at the repo root. `pnpm view` returns the same JSON
+    // shape and skips the npm devEngines validation.
+    const versionString = execSync(`pnpm view ${PACKAGE_NAME} versions --json`, { encoding: 'utf8' });
     const versions = JSON.parse(versionString);
 
     if (versions.some((v) => v === version)) {


### PR DESCRIPTION
## Context

The `Publish to NPM` workflow has been failing on every master push since the npm → pnpm 11 migration (#869):

```
npm error code EBADDEVENGINES
npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
    at addBetaSuffixToVersion .github/scripts/before-beta-release.js:21
```

5 consecutive failing runs (oldest is the migration squash itself, latest is `7c29ccb7` from ~30 minutes ago).

## Root cause

The script does a read-only registry query:

```js
execSync(`npm show ${PACKAGE_NAME} versions --json`)
```

`devEngines.packageManager` validation in npm fires on **every subcommand**, including read-only registry queries. Earlier audits assumed `npm show` was safe ("not an install/publish") — that turned out to be wrong.

## Solution

One-line swap: `npm show` → `pnpm view`. Same arguments, same JSON shape (verified locally: 326-entry array of version strings, identical to npm), no `devEngines` validation. No env-var bypass needed.

## Worth your attention

- **No env / workflow change.** The fix is in the JS script only; the calling workflow step is unchanged.
- **No new dep.** pnpm is already installed by the `Install pnpm and dependencies` step that runs before this one.
