### PR TITLE
fix(ci): repair mcpb package build under pnpm 11

### DIFF
--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -56,12 +56,12 @@ jobs:
             -   name: Build module
                 run: pnpm run build
             -   name: Prepare MCPB package
-                # `pnpm deploy --prod mcpb` builds a self-contained deployment dir:
+                # `pnpm --filter=@apify/actors-mcp-server deploy --prod --legacy --node-linker=hoisted mcpb` builds a self-contained deployment dir:
                 # production-only deps, a flat (hoisted) node_modules with no `.pnpm/`
                 # store or symlinks — the MCPB packer requires a portable tree.
                 # Then we copy in the build output and assets the packer expects.
                 run: |
-                    pnpm deploy --prod mcpb
+                    pnpm --filter=@apify/actors-mcp-server deploy --prod --legacy --node-linker=hoisted mcpb
                     cp -r dist mcpb/dist
                     cp -r docs mcpb/docs
                     cp manifest.json mcpb/manifest.json


### PR DESCRIPTION
## Context
The repository migrated from npm to pnpm, causing the `pnpm deploy --prod mcpb` step in the stable release GitHub workflow to fail with `[ERR_PNPM_NOTHING_TO_DEPLOY] No project was selected for deployment`.

## Solution
Specify the target workspace filter and deploy configurations under pnpm 11:
- Add `--filter=@apify/actors-mcp-server` to select the root project for deployment.
- Add `--legacy` to bypass the missing `inject-workspace-packages` setting in workspaces.
- Add `--node-linker=hoisted` to build a flat/hoisted `node_modules` without `.pnpm/` store or symlinks (as required for the MCPB packer).

## Worth your attention
- `--node-linker=hoisted` is critical to match the flat structure expected by the MCPB packer.