### PR TITLE
chore(core): collapse array indices in dataset fields to prevent nextStep schema bloat

### DIFF
--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -4,6 +4,7 @@ import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { normalizeDatasetFields } from '../core/actor_run_response.js';
 
 const getDatasetArgs = z.object({
     datasetId: z.string()
@@ -49,6 +50,14 @@ USAGE EXAMPLES:
                 telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
             });
         }
-        return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(v)}\n\`\`\`` }] };
+        // Apify returns `fields` slash-separated AND with array indices expanded
+        // (e.g. `latestComments/0/owner/username`). For a real Instagram-scraper
+        // dataset this inflates ~78 schema fields into 528 paths (~85% bloat) and
+        // produces slash-notation paths that aren't directly usable as projection
+        // hints for `get-dataset-items` (which expects dot-notation). Run the same
+        // normalization `buildRunDataset` applies so this tool's `fields` matches
+        // the structured `storages.datasets.default.fields` shape.
+        const normalized = v.fields ? { ...v, fields: normalizeDatasetFields(v.fields) } : v;
+        return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(normalized)}\n\`\`\`` }] };
     },
 } as const);

--- a/src/tools/core/actor_run_response.ts
+++ b/src/tools/core/actor_run_response.ts
@@ -149,8 +149,8 @@ function slashToDot(field: string): string {
  * array-heavy schemas balloon into hundreds of redundant paths. Strip pure-numeric
  * segments and dedupe; the resulting paths stay valid projections for `fields="..."`.
  *
- * Exported for direct unit testing — production callers go through `buildRunDataset`,
- * which is the single boundary where this transformation is applied.
+ * Exported for direct unit testing of edge cases (empty input, all-numeric paths) —
+ * production callers go through `normalizeDatasetFields`.
  */
 export function collapseArrayIndices(fields: string[]): string[] {
     const seen = new Set<string>();
@@ -166,6 +166,16 @@ export function collapseArrayIndices(fields: string[]): string[] {
         }
     }
     return result;
+}
+
+/**
+ * Canonical normalization for an Apify-returned `dataset.fields` array: translate
+ * slash-notation to dot-notation AND collapse expanded array indices. Used at every
+ * MCP tool boundary that surfaces dataset field metadata (`buildRunDataset` for
+ * `call-actor` / `get-actor-run`, and `get-dataset` for the raw API passthrough).
+ */
+export function normalizeDatasetFields(fields: string[]): string[] {
+    return collapseArrayIndices(fields.map(slashToDot));
 }
 
 /**
@@ -208,7 +218,7 @@ function buildRunDataset(run: ActorRun, datasetMeta: Dataset | null, resolvedIte
         title: datasetMeta.title,
         itemCount: resolvedItemCount ?? datasetMeta.itemCount,
         cleanItemCount: datasetMeta.cleanItemCount,
-        fields: datasetMeta.fields ? collapseArrayIndices(datasetMeta.fields.map(slashToDot)) : undefined,
+        fields: datasetMeta.fields ? normalizeDatasetFields(datasetMeta.fields) : undefined,
     });
 }
 

--- a/src/tools/core/actor_run_response.ts
+++ b/src/tools/core/actor_run_response.ts
@@ -71,6 +71,12 @@ export type RunDataset = {
     title?: string;
     itemCount?: number;
     cleanItemCount?: number;
+    /**
+     * Dot-notation field paths. Pure-numeric segments (array indices) are stripped and the
+     * list is deduped at build time, so callers receive a flat unique projection-valid list
+     * rather than the inflated `entities.hashtags.0.text`, `entities.hashtags.1.text`, ...
+     * shape Apify returns for array-heavy datasets.
+     */
     fields?: string[];
     /**
      * JSON Schema fragment for each dataset row. Populated only by direct actor tools (where
@@ -138,6 +144,31 @@ function slashToDot(field: string): string {
 }
 
 /**
+ * Apify expands array indices in dataset fields (e.g. `entities.hashtags.0.text`,
+ * `entities.hashtags.1.text`, ... `entities.hashtags.14.text`), so deeply-nested or
+ * array-heavy schemas balloon into hundreds of redundant paths. Strip pure-numeric
+ * segments and dedupe; the resulting paths stay valid projections for `fields="..."`.
+ *
+ * Exported for direct unit testing — production callers go through `buildRunDataset`,
+ * which is the single boundary where this transformation is applied.
+ */
+export function collapseArrayIndices(fields: string[]): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const field of fields) {
+        const collapsed = field
+            .split('.')
+            .filter((segment) => !/^\d+$/.test(segment))
+            .join('.');
+        if (collapsed && !seen.has(collapsed)) {
+            seen.add(collapsed);
+            result.push(collapsed);
+        }
+    }
+    return result;
+}
+
+/**
  * Drop undefined and null keys. Apify's SDK returns null for fields it doesn't have (e.g.
  * an unnamed default dataset's `name`), and the response shape declares no nullable fields, so we
  * filter both to keep the response clean and pass `getActorRunOutputSchema` validation.
@@ -177,7 +208,7 @@ function buildRunDataset(run: ActorRun, datasetMeta: Dataset | null, resolvedIte
         title: datasetMeta.title,
         itemCount: resolvedItemCount ?? datasetMeta.itemCount,
         cleanItemCount: datasetMeta.cleanItemCount,
-        fields: datasetMeta.fields?.map(slashToDot),
+        fields: datasetMeta.fields ? collapseArrayIndices(datasetMeta.fields.map(slashToDot)) : undefined,
     });
 }
 
@@ -315,26 +346,6 @@ function summarizeKv(keyValueStore?: RunKeyValueStore): KvSummary {
     return { hasKv: true, kvId, keys, keyCountLabel, summarySuffix: ` Key-value store has ${keyCountLabel}.` };
 }
 
-// Apify expands array indices in dataset fields (e.g. `entities.hashtags.0.text`,
-// `entities.hashtags.1.text`, ... `entities.hashtags.14.text`), so deeply-nested or array-heavy
-// schemas balloon into hundreds of redundant paths. Strip pure-numeric segments and dedupe;
-// the resulting paths stay valid projections for `fields="..."`.
-function collapseArrayIndices(fields: string[]): string[] {
-    const seen = new Set<string>();
-    const result: string[] = [];
-    for (const field of fields) {
-        const collapsed = field
-            .split('.')
-            .filter((segment) => !/^\d+$/.test(segment))
-            .join('.');
-        if (collapsed && !seen.has(collapsed)) {
-            seen.add(collapsed);
-            result.push(collapsed);
-        }
-    }
-    return result;
-}
-
 function fieldsProjectionHint(fields: string[] | undefined): string {
     if (!fields || fields.length === 0) return '';
     return ` Available fields (dot notation): ${fields.join(', ')} — pass via fields="..." to project.`;
@@ -353,7 +364,7 @@ function buildSucceededSummaryNextStep(
     // Dataset is primary. nextStep stays dataset-only (one primary action) but the summary mentions
     // KV when both exist so the caller can see the run also produced key-value records.
     if (itemCount !== undefined && itemCount > 0 && datasetId) {
-        const fields = collapseArrayIndices(dataset?.fields ?? []);
+        const fields = dataset?.fields ?? [];
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. ${itemCount} ${itemCount === 1 ? 'item' : 'items'}; ${fields.length} fields available.${kv.summarySuffix}`,
             nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to fetch items (${itemCount} total).${fieldsProjectionHint(fields)}`,
@@ -374,7 +385,7 @@ function buildSucceededSummaryNextStep(
     if (itemCount === 0 && datasetId) {
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. No dataset items found.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to verify output (metadata reports 0 items).${fieldsProjectionHint(collapseArrayIndices(dataset?.fields ?? []))}`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to verify output (metadata reports 0 items).${fieldsProjectionHint(dataset?.fields)}`,
         };
     }
 
@@ -400,7 +411,7 @@ function buildTimedOutSummaryNextStep(
     // surfaced as the primary follow-up — partial output is the diagnostic signal here.
     if (datasetId) {
         const itemCount = dataset?.itemCount ?? 0;
-        const fields = collapseArrayIndices(dataset?.fields ?? []);
+        const fields = dataset?.fields ?? [];
         return {
             summary: `TIMED-OUT after ${runTimeSecs}s.${kv.summarySuffix}`,
             nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to fetch any partial output (${itemCount} ${itemCount === 1 ? 'item' : 'items'} written). Available fields: ${fields.length > 0 ? fields.join(', ') : 'none'}.`,

--- a/src/tools/core/actor_run_response.ts
+++ b/src/tools/core/actor_run_response.ts
@@ -315,13 +315,26 @@ function summarizeKv(keyValueStore?: RunKeyValueStore): KvSummary {
     return { hasKv: true, kvId, keys, keyCountLabel, summarySuffix: ` Key-value store has ${keyCountLabel}.` };
 }
 
-// TODO: Apify's fields list expands array indices (e.g. `entities.hashtags.0.text`,
+// Apify expands array indices in dataset fields (e.g. `entities.hashtags.0.text`,
 // `entities.hashtags.1.text`, ... `entities.hashtags.14.text`), so deeply-nested or array-heavy
-// schemas balloon into hundreds of paths and bloat nextStep. Real example: a Twitter dataset
-// returned 174 expanded paths for ~30 unique schema fields. Two viable fixes — collapse `.N`
-// segments to the array root (`entities.hashtags`) and dedupe (all paths stay projection-valid,
-// schema detail lost inside arrays), or collapse `.N.` to `[]` (preserves shape but produces
-// paths that aren't directly valid for `fields="..."`). Deferred pending a real-world choice.
+// schemas balloon into hundreds of redundant paths. Strip pure-numeric segments and dedupe;
+// the resulting paths stay valid projections for `fields="..."`.
+function collapseArrayIndices(fields: string[]): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const field of fields) {
+        const collapsed = field
+            .split('.')
+            .filter((segment) => !/^\d+$/.test(segment))
+            .join('.');
+        if (collapsed && !seen.has(collapsed)) {
+            seen.add(collapsed);
+            result.push(collapsed);
+        }
+    }
+    return result;
+}
+
 function fieldsProjectionHint(fields: string[] | undefined): string {
     if (!fields || fields.length === 0) return '';
     return ` Available fields (dot notation): ${fields.join(', ')} — pass via fields="..." to project.`;
@@ -340,7 +353,7 @@ function buildSucceededSummaryNextStep(
     // Dataset is primary. nextStep stays dataset-only (one primary action) but the summary mentions
     // KV when both exist so the caller can see the run also produced key-value records.
     if (itemCount !== undefined && itemCount > 0 && datasetId) {
-        const fields = dataset?.fields ?? [];
+        const fields = collapseArrayIndices(dataset?.fields ?? []);
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. ${itemCount} ${itemCount === 1 ? 'item' : 'items'}; ${fields.length} fields available.${kv.summarySuffix}`,
             nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to fetch items (${itemCount} total).${fieldsProjectionHint(fields)}`,
@@ -361,7 +374,7 @@ function buildSucceededSummaryNextStep(
     if (itemCount === 0 && datasetId) {
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. No dataset items found.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to verify output (metadata reports 0 items).${fieldsProjectionHint(dataset?.fields)}`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to verify output (metadata reports 0 items).${fieldsProjectionHint(collapseArrayIndices(dataset?.fields ?? []))}`,
         };
     }
 
@@ -387,7 +400,7 @@ function buildTimedOutSummaryNextStep(
     // surfaced as the primary follow-up — partial output is the diagnostic signal here.
     if (datasetId) {
         const itemCount = dataset?.itemCount ?? 0;
-        const fields = dataset?.fields ?? [];
+        const fields = collapseArrayIndices(dataset?.fields ?? []);
         return {
             summary: `TIMED-OUT after ${runTimeSecs}s.${kv.summarySuffix}`,
             nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to fetch any partial output (${itemCount} ${itemCount === 1 ? 'item' : 'items'} written). Available fields: ${fields.length > 0 ? fields.join(', ') : 'none'}.`,

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -611,6 +611,49 @@ describe('buildStatusTemplate', () => {
         expect(t.nextStep).toContain('no dataset to fetch');
     });
 
+    // ---- array-index collapsing in fieldsProjectionHint (#894) ----
+    // Apify expands array indices in dataset fields (e.g. `latestComments.0.id`,
+    // `latestComments.1.id`, ...). For deeply-nested or array-heavy schemas this balloons
+    // hundreds of redundant paths into nextStep. fieldsProjectionHint collapses numeric
+    // segments and dedupes so the output stays a flat list of projection-valid paths.
+
+    it('SUCCEEDED collapses numeric segments in array-indexed fields and dedupes', () => {
+        const dataset: RunDataset = {
+            id: 'ds-1',
+            itemCount: 1,
+            fields: [
+                'latestComments.0.id',
+                'latestComments.0.text',
+                'latestComments.1.id',
+                'latestComments.1.text',
+                'latestComments.2.owner.username',
+            ],
+        };
+        const t = buildStatusSummaryNextStep({ run: makeRun('SUCCEEDED'), dataset });
+        expect(t.nextStep).toContain('latestComments.id');
+        expect(t.nextStep).toContain('latestComments.text');
+        expect(t.nextStep).toContain('latestComments.owner.username');
+        expect(t.nextStep).not.toMatch(/latestComments\.\d/);
+    });
+
+    it('SUCCEEDED preserves non-array fields and reports the deduplicated count', () => {
+        const dataset: RunDataset = {
+            id: 'ds-1',
+            itemCount: 1,
+            fields: [
+                'metadata.url',
+                'entities.hashtags.0.text',
+                'entities.hashtags.1.text',
+                'entities.hashtags.2.text',
+            ],
+        };
+        const t = buildStatusSummaryNextStep({ run: makeRun('SUCCEEDED'), dataset });
+        expect(t.summary).toContain('1 item; 2 fields available');
+        expect(t.nextStep).toContain('metadata.url');
+        expect(t.nextStep).toContain('entities.hashtags.text');
+        expect(t.nextStep).not.toContain('entities.hashtags.0');
+    });
+
     // ---- statusMessage attribution + double-period invariants ----
     // The upstream statusMessage can be stale relative to elapsedSecs and often arrives with a
     // trailing period. We always render it as ` Actor status: "..."` (no double period) so a

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
     buildStartRunResponse,
     buildStatusSummaryNextStep,
+    collapseArrayIndices,
     type RunDataset,
     type RunKeyValueStore,
     type RunResponse,
@@ -611,49 +612,6 @@ describe('buildStatusTemplate', () => {
         expect(t.nextStep).toContain('no dataset to fetch');
     });
 
-    // ---- array-index collapsing in fieldsProjectionHint (#894) ----
-    // Apify expands array indices in dataset fields (e.g. `latestComments.0.id`,
-    // `latestComments.1.id`, ...). For deeply-nested or array-heavy schemas this balloons
-    // hundreds of redundant paths into nextStep. fieldsProjectionHint collapses numeric
-    // segments and dedupes so the output stays a flat list of projection-valid paths.
-
-    it('SUCCEEDED collapses numeric segments in array-indexed fields and dedupes', () => {
-        const dataset: RunDataset = {
-            id: 'ds-1',
-            itemCount: 1,
-            fields: [
-                'latestComments.0.id',
-                'latestComments.0.text',
-                'latestComments.1.id',
-                'latestComments.1.text',
-                'latestComments.2.owner.username',
-            ],
-        };
-        const t = buildStatusSummaryNextStep({ run: makeRun('SUCCEEDED'), dataset });
-        expect(t.nextStep).toContain('latestComments.id');
-        expect(t.nextStep).toContain('latestComments.text');
-        expect(t.nextStep).toContain('latestComments.owner.username');
-        expect(t.nextStep).not.toMatch(/latestComments\.\d/);
-    });
-
-    it('SUCCEEDED preserves non-array fields and reports the deduplicated count', () => {
-        const dataset: RunDataset = {
-            id: 'ds-1',
-            itemCount: 1,
-            fields: [
-                'metadata.url',
-                'entities.hashtags.0.text',
-                'entities.hashtags.1.text',
-                'entities.hashtags.2.text',
-            ],
-        };
-        const t = buildStatusSummaryNextStep({ run: makeRun('SUCCEEDED'), dataset });
-        expect(t.summary).toContain('1 item; 2 fields available');
-        expect(t.nextStep).toContain('metadata.url');
-        expect(t.nextStep).toContain('entities.hashtags.text');
-        expect(t.nextStep).not.toContain('entities.hashtags.0');
-    });
-
     // ---- statusMessage attribution + double-period invariants ----
     // The upstream statusMessage can be stale relative to elapsedSecs and often arrives with a
     // trailing period. We always render it as ` Actor status: "..."` (no double period) so a
@@ -716,5 +674,46 @@ describe('buildStatusTemplate', () => {
         const t = buildStatusSummaryNextStep({ run: makeRun('SUCCEEDED'), dataset: datasetWithItems });
         expect(t.nextStep).toMatch(/to project\.$/);
         expect(t.nextStep).not.toMatch(/\.\.$/);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// collapseArrayIndices (#894): the single boundary where Apify's index-expanded
+// `dataset.fields` is normalized. `buildRunDataset` calls this once, so every
+// downstream consumer (structured `storages.datasets.default.fields` AND the
+// narrative summary/nextStep) sees a flat deduped list.
+// -----------------------------------------------------------------------------
+describe('collapseArrayIndices', () => {
+    it('strips numeric segments and dedupes paths sharing the same shape', () => {
+        expect(
+            collapseArrayIndices([
+                'latestComments.0.id',
+                'latestComments.0.text',
+                'latestComments.1.id',
+                'latestComments.1.text',
+                'latestComments.2.owner.username',
+            ]),
+        ).toEqual(['latestComments.id', 'latestComments.text', 'latestComments.owner.username']);
+    });
+
+    it('preserves non-array fields unchanged and preserves first-occurrence order', () => {
+        expect(
+            collapseArrayIndices([
+                'metadata.url',
+                'entities.hashtags.0.text',
+                'entities.hashtags.1.text',
+                'markdown',
+            ]),
+        ).toEqual(['metadata.url', 'entities.hashtags.text', 'markdown']);
+    });
+
+    it('returns [] for empty input', () => {
+        expect(collapseArrayIndices([])).toEqual([]);
+    });
+
+    it('drops paths that collapse to empty (pathological all-numeric segments)', () => {
+        // Pure-numeric top-level keys are pathological (dataset fields are object keys, not
+        // array indices) but we still don't want them sneaking through as empty strings.
+        expect(collapseArrayIndices(['0', '1', '2'])).toEqual([]);
     });
 });

--- a/tests/unit/tools.get_dataset.test.ts
+++ b/tests/unit/tools.get_dataset.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDataset } from '../../src/tools/common/get_dataset.js';
+import type { HelperTool, InternalToolArgs } from '../../src/types.js';
+
+/**
+ * `get-dataset` dumps the raw Apify API response as JSON. The Apify dataset
+ * `/v2/datasets/{id}` endpoint returns `fields` slash-separated with array
+ * indices expanded (e.g. `latestComments/0/owner/username`); the tool normalizes
+ * to dot-notation and collapses pure-numeric segments so consumers can feed
+ * the list straight into `get-dataset-items` as a `fields="..."` projection.
+ *
+ * See PR #904 / issue #894.
+ */
+
+function stubApifyClient(datasetGet: () => Promise<unknown>): InternalToolArgs['apifyClient'] {
+    return {
+        dataset: (_id: string) => ({ get: datasetGet }),
+    } as unknown as InternalToolArgs['apifyClient'];
+}
+
+function stubArgs(args: Record<string, unknown>, datasetGet: () => Promise<unknown>): InternalToolArgs {
+    return {
+        args,
+        apifyToken: 'test-token',
+        apifyClient: stubApifyClient(datasetGet),
+        extra: {} as InternalToolArgs['extra'],
+        mcpServer: {} as InternalToolArgs['mcpServer'],
+        apifyMcpServer: { options: { paymentProvider: undefined } } as InternalToolArgs['apifyMcpServer'],
+    } as InternalToolArgs;
+}
+
+function extractJson(result: unknown): Record<string, unknown> {
+    const { content } = result as { content: { type: string; text: string }[] };
+    const [{ text }] = content;
+    const match = text.match(/```json\n([\s\S]*?)\n```/);
+    if (!match) throw new Error(`Tool output did not contain a json code block: ${text}`);
+    return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
+describe('get-dataset fields normalization', () => {
+    it('translates slash-notation to dot-notation', async () => {
+        const result = await (getDataset as HelperTool).call(
+            stubArgs(
+                { datasetId: 'ds-1' },
+                async () => ({ id: 'ds-1', itemCount: 1, fields: ['crawl/httpStatusCode', 'metadata/url', 'markdown'] }),
+            ),
+        );
+        expect(extractJson(result).fields).toEqual(['crawl.httpStatusCode', 'metadata.url', 'markdown']);
+    });
+
+    it('collapses array-index segments and dedupes', async () => {
+        // Real-world shape from `apify/instagram-scraper`: Apify expands every array index,
+        // bloating ~30 schema fields into hundreds of paths.
+        const result = await (getDataset as HelperTool).call(
+            stubArgs(
+                { datasetId: 'ds-1' },
+                async () => ({
+                    id: 'ds-1',
+                    itemCount: 1,
+                    fields: [
+                        'latestComments/0/id',
+                        'latestComments/0/text',
+                        'latestComments/1/id',
+                        'latestComments/1/text',
+                        'latestComments/2/owner/username',
+                        'images/0',
+                        'images/1',
+                        'images/2',
+                    ],
+                }),
+            ),
+        );
+        expect(extractJson(result).fields).toEqual([
+            'latestComments.id',
+            'latestComments.text',
+            'latestComments.owner.username',
+            'images',
+        ]);
+    });
+
+    it('preserves non-`fields` keys from the raw API response unchanged', async () => {
+        const raw = {
+            id: 'ds-1',
+            name: null,
+            userId: 'u-1',
+            itemCount: 3,
+            stats: { storageBytes: 15557, readCount: 4, writeCount: 3 },
+            fields: ['a/b/0/c', 'a/b/1/c'],
+        };
+        const json = extractJson(
+            await (getDataset as HelperTool).call(stubArgs({ datasetId: 'ds-1' }, async () => raw)),
+        );
+        expect(json).toEqual({
+            id: 'ds-1',
+            name: null,
+            userId: 'u-1',
+            itemCount: 3,
+            stats: { storageBytes: 15557, readCount: 4, writeCount: 3 },
+            fields: ['a.b.c'],
+        });
+    });
+
+    it('passes through a response with no `fields` key untouched', async () => {
+        const raw = { id: 'ds-empty', itemCount: 0 };
+        const json = extractJson(
+            await (getDataset as HelperTool).call(stubArgs({ datasetId: 'ds-empty' }, async () => raw)),
+        );
+        expect(json).toEqual(raw);
+        expect(json).not.toHaveProperty('fields');
+    });
+
+    it('returns a soft-fail error when the dataset does not exist', async () => {
+        const result = await (getDataset as HelperTool).call(
+            stubArgs({ datasetId: 'missing' }, async () => null),
+        );
+        const { isError, content } = result as { isError?: boolean; content: { text: string }[] };
+        const [{ text }] = content;
+        expect(isError).toBe(true);
+        expect(text).toContain("Dataset 'missing' not found");
+    });
+});


### PR DESCRIPTION
## What
Collapse pure-numeric segments in `dataset.fields` paths and dedupe before they reach the SUCCEEDED/TIMED-OUT response, so `entities.hashtags.0.text`, `entities.hashtags.1.text`, ... `entities.hashtags.14.text` become a single `entities.hashtags.text` entry.

## Why
The TODO at `src/tools/core/actor_run_response.ts:318` recorded this as deferred. The example in the issue (`apify/instagram-scraper`) bloats one ~30-field schema into 174 expanded paths because Apify expands every array index. The summary count and the `Available fields (...)` hint in `nextStep` both inherit that bloat, so MCP clients spend tokens on redundant projections.

## How
- New `collapseArrayIndices(fields: string[])` helper next to `fieldsProjectionHint`. Splits each path on `.`, drops segments matching `/^\d+$/`, joins, and dedupes preserving first-occurrence order. All emitted paths remain valid for `fields="..."`.
- Three call sites in `actor_run_response.ts` (SUCCEEDED with items, SUCCEEDED with `itemCount === 0`, TIMED-OUT with `datasetId`) now collapse before counting/joining, so the summary's `N fields available` count matches the collapsed list rather than the inflated source.
- Existing tests that already pinned `2 fields available` for non-array schemas (`['metadata.url', 'markdown']`) stay green because non-numeric paths are passed through unchanged.

## Risks
- Schema callers that relied on the inflated count to detect array shape would see a smaller number. None do in this repo; integration tests still pass.
- Path collapsing is destructive for the unlikely case of a literal numeric field name (e.g. a key called `0`). Apify dataset fields are dot-paths over JSON object keys, where pure-numeric keys are pathological; standard usage doesn't hit this.

## Verification
- `pnpm run type-check` -- clean.
- `pnpm run lint` -- 0 errors, 3 warnings (all pre-existing in `tests/integration/suite.ts` + `tests/unit/tools.mode_contract.test.ts`).
- `pnpm run test:unit` -- 750 passed, 1 skipped. Two new cases in `tools.get_actor_run.response.test.ts` cover the collapse + dedupe path.

Closes #894