### PR TITLE
fix: Add get-actor-run to auto-injected tools and update related tests

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,7 +5,7 @@ import { getExpectedToolsByCategories } from '../utils/tool_categories_helpers.j
 import { CATEGORY_NAME_SET, CATEGORY_NAMES, getCategoryTools, toolCategories, toolCategoriesEnabledByDefault } from './categories.js';
 import { getActorsAsTools } from './core/actor_tools_factory.js';
 
-// Use string constants instead of importing tool objects to avoid circular dependency
+// Use string constants instead of tool object imports to avoid circular dependencies
 export const unauthEnabledTools: string[] = [
     HelperTools.DOCS_SEARCH,
     HelperTools.DOCS_FETCH,

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -30,6 +30,7 @@ import { SERVER_MODES, ServerMode } from '../types.js';
  * KV record → abort.
  */
 export const AUTO_INJECTED_TOOLS: readonly ToolEntry[] = [
+    defaultGetActorRun,
     getDatasetItems,
     getKeyValueStoreRecord,
     abortActorRun,
@@ -183,7 +184,7 @@ export function getToolsForServerMode(input: Input, actorTools: ToolEntry[], mod
             toolsByName.set(tool.name, tool);
         }
     }
-    // Widgets are apps-only and not in any category; include for direct selection
+    // Widgets are apps-only and not in any category; include it for direct selection
     if (mode === ServerMode.APPS) {
         for (const widget of WIDGET_BY_BASE_TOOL.values()) {
             toolsByName.set(widget.name, widget);
@@ -263,18 +264,10 @@ export function getToolsForServerMode(input: Input, actorTools: ToolEntry[], mod
     // (e.g. `tools: ['runs']`) would otherwise land on an unrecommendable tool / empty widget.
     const hasGetActorRun = result.some((entry) => entry.name === HelperTools.ACTOR_RUNS_GET);
 
-    // No presence guards here — the de-dup pass at the end drops any duplicates.
-    const toolsToInject: ToolEntry[] = [];
-    // `call-actor` and direct actor tools return a RunResponse whose `nextStep` may point at
-    // `get-actor-run` for polling (when the run is non-terminal at waitSecs cap), so the LLM
-    // needs that tool available. `call-actor-widget` returns immediately and the widget UI
-    // polls run status itself — that path doesn't drive the auto-inject decision here.
-    if (hasCallActor || (hasActorTools && mode === ServerMode.APPS)) {
-        toolsToInject.push(defaultGetActorRun);
-    }
-    if (hasCallActor || hasActorTools || hasAddActorTool || hasGetActorRun) {
-        toolsToInject.push(...AUTO_INJECTED_TOOLS);
-    }
+    // Inject run-workflow helpers whenever any actor-running entrypoint is present; de-dup pass below drops repeats.
+    const toolsToInject: ToolEntry[] = (hasCallActor || hasActorTools || hasAddActorTool || hasGetActorRun)
+        ? [...AUTO_INJECTED_TOOLS]
+        : [];
 
     if (toolsToInject.length > 0) {
         const callActorIndex = result.findIndex((entry) => entry.name === HelperTools.ACTOR_CALL);

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -26,8 +26,8 @@ import { SERVER_MODES, ServerMode } from '../types.js';
 
 /**
  * Tools auto-injected alongside any actor-running tool (call-actor / direct
- * actor tools / add-actor). Order matches the workflow: fetch items → fetch
- * KV record → abort.
+ * actor tools / add-actor). Order matches the workflow: fetch run status →
+ * fetch items → fetch KV record → abort.
  */
 export const AUTO_INJECTED_TOOLS: readonly ToolEntry[] = [
     defaultGetActorRun,

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -265,9 +265,10 @@ export function getToolsForServerMode(input: Input, actorTools: ToolEntry[], mod
     const hasGetActorRun = result.some((entry) => entry.name === HelperTools.ACTOR_RUNS_GET);
 
     // Inject run-workflow helpers whenever any actor-running entrypoint is present; de-dup pass below drops repeats.
-    const toolsToInject: ToolEntry[] = (hasCallActor || hasActorTools || hasAddActorTool || hasGetActorRun)
-        ? [...AUTO_INJECTED_TOOLS]
-        : [];
+    const toolsToInject: ToolEntry[] = [];
+    if (hasCallActor || hasActorTools || hasAddActorTool || hasGetActorRun) {
+        toolsToInject.push(...AUTO_INJECTED_TOOLS);
+    }
 
     if (toolsToInject.length > 0) {
         const callActorIndex = result.findIndex((entry) => entry.name === HelperTools.ACTOR_CALL);
@@ -279,7 +280,7 @@ export function getToolsForServerMode(input: Input, actorTools: ToolEntry[], mod
     }
 
     // Apps mode: append a widget tool for each base tool already in the result.
-    // Runs after the get-actor-run auto-inject so an auto-injected base still
+    // Runs after the get-actor-run auto-inject, so an auto-injected base still
     // brings its widget sibling.
     if (mode === ServerMode.APPS) {
         for (const entry of [...result]) {

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -33,10 +33,11 @@ describe('MCP server internals integration tests', () => {
 
         // Store the tool name list
         const names = actorsMcpServer.listAllToolNames();
-        // enableAddingActors=true seeds add-actor + 3 auto-injected helpers (dataset, kv, abort);
+        // enableAddingActors=true seeds add-actor + 4 auto-injected helpers (get-actor-run, dataset, kv, abort);
         // then ACTOR_NORMAL_MODE is added on top.
         const expectedToolNames = [
             addTool.name,
+            'get-actor-run',
             'get-dataset-items',
             'get-key-value-store-record',
             'abort-actor-run',
@@ -57,8 +58,8 @@ describe('MCP server internals integration tests', () => {
 
     it('should notify tools changed handler on tool modifications', async () => {
         let latestTools: string[] = [];
-        // enableAddingActors=true seeds add-actor + 3 auto-injected helpers (dataset, kv, abort)
-        const numberOfTools = 4;
+        // enableAddingActors=true seeds add-actor + 4 auto-injected helpers (get-actor-run, dataset, kv, abort)
+        const numberOfTools = 5;
 
         let toolNotificationCount = 0;
         const onToolsChanged = (tools: string[]) => {
@@ -98,8 +99,8 @@ describe('MCP server internals integration tests', () => {
     it('should stop notifying after unregistering tools changed handler', async () => {
         let latestTools: string[] = [];
         let notificationCount = 0;
-        // enableAddingActors=true seeds add-actor + 3 auto-injected helpers (dataset, kv, abort)
-        const numberOfTools = 4;
+        // enableAddingActors=true seeds add-actor + 4 auto-injected helpers (get-actor-run, dataset, kv, abort)
+        const numberOfTools = 5;
         const onToolsChanged = (tools: string[]) => {
             latestTools = tools;
             notificationCount++;

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -272,7 +272,7 @@ export function createIntegrationTestsSuite(
         it('should auto-inject storage and abort tools when enableAddingActors is true', async () => {
             client = await createClientFn({ enableAddingActors: true });
             const names = getToolNames(await client.listTools());
-            // add-actor triggers storage/abort helpers but NOT get-actor-run (no call-actor; not apps mode).
+            // add-actor triggers auto-injected helpers (get-actor-run, storage, abort).
             expect(names.length).toEqual(1 + AUTO_INJECTED_TOOL_NAMES.length);
             expect(names).toContain('add-actor');
             expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
@@ -313,7 +313,7 @@ export function createIntegrationTestsSuite(
             client = await createClientFn({ enableAddingActors: false, tools: ['experimental'] });
 
             const names = getToolNames(await client.listTools());
-            // experimental category provides add-actor; no call-actor → no get-actor-run.
+            // experimental category provides add-actor + auto-injected helpers (get-actor-run, storage, abort).
             expect(names).toHaveLength(1 + AUTO_INJECTED_TOOL_NAMES.length);
             expect(names).toContain('add-actor');
             expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
@@ -325,7 +325,7 @@ export function createIntegrationTestsSuite(
             const actors = ['apify/python-example', 'apify/rag-web-browser'];
             client = await createClientFn({ actors, enableAddingActors: false, serverMode: 'default' });
             const names = getToolNames(await client.listTools());
-            // Actor tools trigger storage/abort helpers; default mode skips get-actor-run for actor tools.
+            // Actor tools trigger auto-injected helpers (get-actor-run, storage, abort).
             expect(names.length).toEqual(actors.length + AUTO_INJECTED_TOOL_NAMES.length);
             expectToolNamesToContain(names, actors.map((actor) => actorNameToToolName(actor)));
             expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
@@ -480,7 +480,7 @@ export function createIntegrationTestsSuite(
             client = await createClientFn({ tools: [], actors: [ACTOR_NORMAL_MODE] });
 
             const names = getToolNames(await client.listTools());
-            // Actor tool triggers storage/abort helpers; default mode skips get-actor-run for actor tools.
+            // Actor tool triggers auto-injected helpers (get-actor-run, storage, abort).
             expect(names.length).toEqual(1 + AUTO_INJECTED_TOOL_NAMES.length);
             expect(names).toContain(actorNameToToolName(ACTOR_NORMAL_MODE));
             expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
@@ -511,8 +511,8 @@ export function createIntegrationTestsSuite(
             const selectedToolName = actorNameToToolName(ACTOR_NORMAL_MODE);
             client = await createClientFn({ enableAddingActors: true, tools: ['actors'] });
             const names = getToolNames(await client.listTools());
-            // actors category + add-actor + get-actor-run + auto-injected storage/abort helpers
-            const numberOfTools = getCategoryTools('default').actors.length + 2 + AUTO_INJECTED_TOOL_NAMES.length;
+            // actors category + add-actor + auto-injected helpers (get-actor-run, dataset, kv, abort)
+            const numberOfTools = getCategoryTools('default').actors.length + 1 + AUTO_INJECTED_TOOL_NAMES.length;
             expect(names).toHaveLength(numberOfTools);
             // get-actor-run should be automatically included when call-actor is present
             expect(names).toContain(HelperTools.ACTOR_RUNS_GET);

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -2,7 +2,8 @@ import { ApifyClient } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
-import { AUTO_INJECTED_TOOLS, loadToolsFromInput, toolNamesToInput } from '../../src/utils/tools_loader.js';
+import type { ToolEntry } from '../../src/types.js';
+import { AUTO_INJECTED_TOOLS, getToolsForServerMode, loadToolsFromInput, toolNamesToInput } from '../../src/utils/tools_loader.js';
 
 const AUTO_INJECTED_TOOL_NAMES = AUTO_INJECTED_TOOLS.map((t) => t.name);
 
@@ -113,6 +114,19 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
         expect(toolNames).not.toContain(HelperTools.ACTOR_CALL);
         for (const name of AUTO_INJECTED_TOOL_NAMES) expect(toolNames).toContain(name);
     });
+
+    it.each(['default', 'apps'] as const)(
+        'auto-injects get-actor-run when only direct actor tools are present (%s mode)',
+        (mode) => {
+            const actorTool = { type: 'actor', name: 'apify--rag-web-browser', actorFullName: 'apify/rag-web-browser' } as unknown as ToolEntry;
+            const tools = getToolsForServerMode({ actors: ['apify/rag-web-browser'], tools: [] }, [actorTool], mode);
+            const toolNames = tools.map((t) => t.name);
+
+            expect(toolNames).toContain('apify--rag-web-browser');
+            expect(toolNames).toContain(HelperTools.ACTOR_RUNS_GET);
+            for (const name of AUTO_INJECTED_TOOL_NAMES) expect(toolNames).toContain(name);
+        },
+    );
 });
 
 describe('loadToolsFromInput explicit widget selection', () => {


### PR DESCRIPTION
Closes #908.

Auto-inject `get-actor-run` whenever any actor-running entrypoint is present (direct actor tools, `add-actor`, `call-actor`, or `get-actor-run` itself). Previously gated behind `call-actor || apps mode`, so `?actors=<name>` sessions in default MCP mode were told to poll a tool they didn't have.

- Move `defaultGetActorRun` into `AUTO_INJECTED_TOOLS`
- Drop the now-redundant mode-specific guard
- Add regression test (`getToolsForServerMode`, default + apps mode)
- Update integration test counts/comments that hardcoded the old behavior