### PR TITLE
refactor(payments): Drop dead OR in standby-block helper

### DIFF
--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -27,7 +27,13 @@ import type {
 import { ajv } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildEnrichedDirectActorOutputSchema, getActorRunOutputSchema } from '../structured_output_schemas.js';
-import { actorNameToToolName, buildActorInputSchema, fixedAjvCompile, isActorInfoMcpServer } from '../utils.js';
+import {
+    actorNameToToolName,
+    buildActorInputSchema,
+    fixedAjvCompile,
+    isActorBlockedUnderPaymentProvider,
+    isActorInfoMcpServer,
+} from '../utils.js';
 import { CALL_ACTOR_WAIT_SECS_DEFAULT, WAIT_SECS_MAX } from './actor_run_response.js';
 
 /**
@@ -379,8 +385,7 @@ export async function getActorsAsTools(
     const normalActorsInfo: ActorInfo[] = [];
     for (const actorInfo of nonNullActors) {
         const isMcpServer = isActorInfoMcpServer(actorInfo);
-        const isStandby = !!actorInfo.actor.actorStandby?.isEnabled;
-        if (paymentProvider && (isMcpServer || isStandby)) {
+        if (paymentProvider && isActorBlockedUnderPaymentProvider(actorInfo)) {
             errors.push(ActorLoadError.standbyPaymentNotSupported(actorInfo.definition.actorFullName));
             continue;
         }

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -16,14 +16,14 @@ import {
 import { ACTOR_LOAD_ERROR_KIND, ActorLoadError } from '../../errors.js';
 import { connectMCPClient } from '../../mcp/client.js';
 import type { PaymentProvider } from '../../payments/types.js';
-import type { ApifyToken, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import type { ActorInfo, ApifyToken, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { getActorDefinitionCached, getActorMcpUrlCached } from '../../utils/actor.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { getHttpStatusCode, logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { classifyFailureCategory, extractAjvErrorDetails, getToolStatusFromError } from '../../utils/tool_status.js';
 import { extractActorId } from '../../utils/tools.js';
-import { actorNameToToolName } from '../utils.js';
+import { actorNameToToolName, isActorBlockedUnderPaymentProvider } from '../utils.js';
 import { abortRunOnSignal, buildStartRunResponse, CALL_ACTOR_WAIT_SECS_DEFAULT, fetchActorRunData } from './actor_run_response.js';
 import { fixActorNameInputAndLog, getActorsAsTools } from './actor_tools_factory.js';
 import { buildGetActorRunSuccessResponse } from './get_actor_run_common.js';
@@ -277,8 +277,7 @@ export type CallActorParsedArgs = z.infer<typeof callActorArgs>;
  * generic payment-required short-circuit in the tool-call handler so the
  * agent receives the precise reason instead of a generic 402.
  *
- * Uses `actorDefinitionCache` + `getActorMcpUrlCached` — cheap on a
- * warm cache, one definition fetch on a cold cache.
+ * Uses `actorDefinitionCache` — one definition fetch on a cold cache.
  */
 export async function checkPaymentProviderStandbyConflict(params: {
     actorName: string;
@@ -292,13 +291,18 @@ export async function checkPaymentProviderStandbyConflict(params: {
 
     // Token-based client — payment headers are only relevant for actual Actor runs.
     const apifyClientForDefinition = new ApifyClient({ token: apifyToken });
-    const mcpServerUrlOrFalse = await getActorMcpUrlCached(baseActorName, apifyClientForDefinition);
-    const isActorMcpServer = !!mcpServerUrlOrFalse;
-
     const actorDefinitionWithInfo = await getActorDefinitionCached(baseActorName, apifyClientForDefinition);
-    const isStandbyActor = !!actorDefinitionWithInfo?.info?.actorStandby?.isEnabled;
+    if (!actorDefinitionWithInfo) {
+        return null;
+    }
 
-    if (!isStandbyActor && !isActorMcpServer) {
+    const actorInfo: ActorInfo = {
+        definition: actorDefinitionWithInfo.definition,
+        actor: actorDefinitionWithInfo.info,
+        webServerMcpPath: null,
+    };
+
+    if (!isActorBlockedUnderPaymentProvider(actorInfo)) {
         return null;
     }
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -26,6 +26,16 @@ export function isActorInfoMcpServer(actorInfo: ActorInfo): boolean {
     return !!((actorInfo.webServerMcpPath && actorInfo.actor.actorStandby?.isEnabled));
 }
 
+/**
+ * Whether this Actor must be excluded from tool surfaces and rejected on
+ * `call-actor` when the session uses a third-party payment provider (x402, Skyfire).
+ * List-time filtering in `getActorsAsTools` and the call-time guard in
+ * `checkPaymentProviderStandbyConflict` must use this — not MCP URL presence alone.
+ */
+export function isActorBlockedUnderPaymentProvider(actorInfo: ActorInfo): boolean {
+    return !!actorInfo.actor.actorStandby?.isEnabled;
+}
+
 export function actorNameToToolName(actorFullName: string): string {
     const slashIndex = actorFullName.indexOf('/');
     if (slashIndex === -1) {

--- a/tests/unit/tools.utils.test.ts
+++ b/tests/unit/tools.utils.test.ts
@@ -9,11 +9,12 @@ import {
     filterAndShortenEnum,
     inferArrayItemsTypeIfMissing,
     inferArrayItemType,
+    isActorBlockedUnderPaymentProvider,
     markInputPropertiesAsRequired,
     shortenProperties,
     transformActorInputSchemaProperties,
 } from '../../src/tools/utils.js';
-import type { ActorInputSchema, SchemaProperties, ToolBase, ToolEntry } from '../../src/types.js';
+import type { ActorInfo, ActorInputSchema, SchemaProperties, ToolBase, ToolEntry } from '../../src/types.js';
 import { extractActorName, getToolFullName, getToolPublicFieldOnly } from '../../src/utils/tools.js';
 
 describe('buildApifySpecificProperties', () => {
@@ -995,5 +996,25 @@ describe('buildActorInputSchema + getToolPublicFieldOnly pipeline', () => {
         expect(schema.required).toEqual(['query']);
         expect(schema.properties?.query?.description).toMatch(/^\*\*REQUIRED\*\*/);
         expect(schema.properties?.maxResults?.description).not.toMatch(/^\*\*REQUIRED\*\*/);
+    });
+});
+
+describe('isActorBlockedUnderPaymentProvider', () => {
+    const actorInfo = ({ standby, mcpPath = null }: { standby: boolean; mcpPath?: string | null }): ActorInfo => ({
+        definition: { actorFullName: 'user/actor', id: 'act' } as ActorInfo['definition'],
+        actor: { actorStandby: standby ? { isEnabled: true } : undefined } as ActorInfo['actor'],
+        webServerMcpPath: mcpPath,
+    });
+
+    it('blocks standby Actors', () => {
+        expect(isActorBlockedUnderPaymentProvider(actorInfo({ standby: true }))).toBe(true);
+    });
+
+    it('does not block normal Actors', () => {
+        expect(isActorBlockedUnderPaymentProvider(actorInfo({ standby: false }))).toBe(false);
+    });
+
+    it('does not block MCP path without standby (must match list-tools filter)', () => {
+        expect(isActorBlockedUnderPaymentProvider(actorInfo({ standby: false, mcpPath: '/mcp' }))).toBe(false);
     });
 });


### PR DESCRIPTION
`isActorBlockedUnderPaymentProvider` was `standby || (mcpPath && standby)` — collapses to `standby`. Reduce body to the standby check, drop the unused `getActorMCPServerPath` call (and import) in `checkPaymentProviderStandbyConflict`, remove the redundant test case.

Stacks on #893.