### PR TITLE
chore: add .git-blame-ignore-revs for oxfmt reformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Revisions listed here are skipped by `git blame` (and GitHub's blame view),
+# so bulk no-op changes don't clutter line history.
+#
+# Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# chore: apply oxfmt formatting [internal] (#919)
+e8aa64589499b8a4575d71c4cea59f7fef8b310b


### PR DESCRIPTION
Adds `.git-blame-ignore-revs` listing the squash SHA of the oxfmt mass-reformat (#919), so `git blame` and GitHub's blame view skip the bulk no-op change.

Final step of the oxfmt rollout for this repo (tooling #915 → reformat #919 → this).

Refs apify/apify-core#28164

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEbAE25XHNNtQLxiXDdfHz)_