### PR TITLE
refactor: introduce TOOL_TYPE constant for tool discriminator

### DIFF
--- a/src/index_internals.ts
+++ b/src/index_internals.ts
@@ -19,7 +19,6 @@ import {
 } from './tools/index.js';
 import { actorNameToToolName } from './tools/utils.js';
 import type { ActorStore, ServerCard, ToolCategory } from './types.js';
-import { ToolType } from './types.js';
 import { parseCommaSeparatedList, parseQueryParamList, readJsonFile } from './utils/generic.js';
 import { redactSkyfirePayId } from './utils/logging.js';
 import { getExpectedToolNamesByCategories } from './utils/tool_categories_helpers.js';
@@ -44,7 +43,6 @@ export {
     type ActorStore,
     type ServerCard,
     type ToolCategory,
-    ToolType,
     processParamsGetTools,
     getActorsAsTools,
     getToolPublicFieldOnly,

--- a/src/index_internals.ts
+++ b/src/index_internals.ts
@@ -19,6 +19,7 @@ import {
 } from './tools/index.js';
 import { actorNameToToolName } from './tools/utils.js';
 import type { ActorStore, ServerCard, ToolCategory } from './types.js';
+import { ToolType } from './types.js';
 import { parseCommaSeparatedList, parseQueryParamList, readJsonFile } from './utils/generic.js';
 import { redactSkyfirePayId } from './utils/logging.js';
 import { getExpectedToolNamesByCategories } from './utils/tool_categories_helpers.js';
@@ -43,6 +44,7 @@ export {
     type ActorStore,
     type ServerCard,
     type ToolCategory,
+    ToolType,
     processParamsGetTools,
     getActorsAsTools,
     getToolPublicFieldOnly,

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -4,7 +4,7 @@ import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
 import { fixedAjvCompile } from '../tools/utils.js';
 import type { ActorMcpTool, ToolEntry } from '../types.js';
-import { ToolType } from '../types.js';
+import { TOOL_TYPE } from '../types.js';
 import { ajv } from '../utils/ajv.js';
 import { MAX_TOOL_NAME_LENGTH, SERVER_ID_LENGTH } from './const.js';
 
@@ -40,7 +40,7 @@ export async function getMCPServerTools(actorID: string, client: Client, serverU
 
     return tools.map(
         (tool): ActorMcpTool => ({
-            type: ToolType.ACTOR_MCP,
+            type: TOOL_TYPE.ACTOR_MCP,
             actorId: actorID,
             serverId: getMCPServerID(serverUrl),
             serverUrl,

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -4,6 +4,7 @@ import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
 import { fixedAjvCompile } from '../tools/utils.js';
 import type { ActorMcpTool, ToolEntry } from '../types.js';
+import { ToolType } from '../types.js';
 import { ajv } from '../utils/ajv.js';
 import { MAX_TOOL_NAME_LENGTH, SERVER_ID_LENGTH } from './const.js';
 
@@ -39,7 +40,7 @@ export async function getMCPServerTools(actorID: string, client: Client, serverU
 
     return tools.map(
         (tool): ActorMcpTool => ({
-            type: 'actor-mcp',
+            type: ToolType.ACTOR_MCP,
             actorId: actorID,
             serverId: getMCPServerID(serverUrl),
             serverUrl,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -86,7 +86,7 @@ import type {
     ToolEntry,
     ToolStatus,
 } from '../types.js';
-import { ServerMode } from '../types.js';
+import { ServerMode, ToolType } from '../types.js';
 import { getHttpStatusCode, logHttpError } from '../utils/logging.js';
 import { buildMCPResponse, computeToolResponseSizeBytes, getToolCallErrorUserText } from '../utils/mcp.js';
 import { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
@@ -406,7 +406,7 @@ export class ActorsMcpServer {
      */
     private listInternalToolNames(): string[] {
         return Array.from(this.tools.values())
-            .filter((tool) => tool.type === 'internal')
+            .filter((tool) => tool.type === ToolType.INTERNAL)
             .map((tool) => tool.name);
     }
 
@@ -416,7 +416,7 @@ export class ActorsMcpServer {
      */
     public listActorToolNames(): string[] {
         return Array.from(this.tools.values())
-            .filter((tool) => tool.type === 'actor')
+            .filter((tool) => tool.type === ToolType.ACTOR)
             .map((tool) => tool.actorFullName);
     }
 
@@ -426,7 +426,7 @@ export class ActorsMcpServer {
      */
     private listActorMcpServerToolIds(): string[] {
         const ids = Array.from(this.tools.values())
-            .filter((tool: ToolEntry) => tool.type === 'actor-mcp')
+            .filter((tool: ToolEntry) => tool.type === ToolType.ACTOR_MCP)
             .map((tool) => tool.actorId);
         // Ensure uniqueness
         return Array.from(new Set(ids));
@@ -1104,7 +1104,7 @@ export class ActorsMcpServer {
                 }
 
                 // Handle internal tool
-                if (tool.type === 'internal') {
+                if (tool.type === ToolType.INTERNAL) {
                     // Tools that may emit notifications/progress during a sync wait must be opted in here.
                     // call-actor: emits during start+waitForFinish. get-actor-run: emits when waitSecs > 0.
                     const progressTrackerOptIn =
@@ -1137,7 +1137,7 @@ export class ActorsMcpServer {
                     }
                 }
 
-                if (tool.type === 'actor-mcp') {
+                if (tool.type === ToolType.ACTOR_MCP) {
                     let client: Client | null = null;
                     try {
                         client = await connectMCPClient(tool.serverUrl, apifyToken, mcpSessionId);
@@ -1234,7 +1234,7 @@ export class ActorsMcpServer {
                 }
 
                 // Handle actor tool
-                if (tool.type === 'actor') {
+                if (tool.type === ToolType.ACTOR) {
                     const progressTracker = createProgressTracker(progressToken, extra.sendNotification);
 
                     try {
@@ -1568,7 +1568,7 @@ export class ActorsMcpServer {
             };
 
             // Handle internal tool execution in task mode
-            if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === 'internal') {
+            if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === ToolType.INTERNAL) {
                 const progressTracker = createProgressTracker(
                     progressToken,
                     extra.sendNotification,
@@ -1608,7 +1608,7 @@ export class ActorsMcpServer {
             }
 
             // Handle actor tool execution in task mode
-            if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === 'actor') {
+            if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === ToolType.ACTOR) {
                 const progressTracker = createProgressTracker(
                     progressToken,
                     extra.sendNotification,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -86,7 +86,7 @@ import type {
     ToolEntry,
     ToolStatus,
 } from '../types.js';
-import { ServerMode, ToolType } from '../types.js';
+import { ServerMode, TOOL_TYPE } from '../types.js';
 import { getHttpStatusCode, logHttpError } from '../utils/logging.js';
 import { buildMCPResponse, computeToolResponseSizeBytes, getToolCallErrorUserText } from '../utils/mcp.js';
 import { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
@@ -406,7 +406,7 @@ export class ActorsMcpServer {
      */
     private listInternalToolNames(): string[] {
         return Array.from(this.tools.values())
-            .filter((tool) => tool.type === ToolType.INTERNAL)
+            .filter((tool) => tool.type === TOOL_TYPE.INTERNAL)
             .map((tool) => tool.name);
     }
 
@@ -416,7 +416,7 @@ export class ActorsMcpServer {
      */
     public listActorToolNames(): string[] {
         return Array.from(this.tools.values())
-            .filter((tool) => tool.type === ToolType.ACTOR)
+            .filter((tool) => tool.type === TOOL_TYPE.ACTOR)
             .map((tool) => tool.actorFullName);
     }
 
@@ -426,7 +426,7 @@ export class ActorsMcpServer {
      */
     private listActorMcpServerToolIds(): string[] {
         const ids = Array.from(this.tools.values())
-            .filter((tool: ToolEntry) => tool.type === ToolType.ACTOR_MCP)
+            .filter((tool: ToolEntry) => tool.type === TOOL_TYPE.ACTOR_MCP)
             .map((tool) => tool.actorId);
         // Ensure uniqueness
         return Array.from(new Set(ids));
@@ -1104,7 +1104,7 @@ export class ActorsMcpServer {
                 }
 
                 // Handle internal tool
-                if (tool.type === ToolType.INTERNAL) {
+                if (tool.type === TOOL_TYPE.INTERNAL) {
                     // Tools that may emit notifications/progress during a sync wait must be opted in here.
                     // call-actor: emits during start+waitForFinish. get-actor-run: emits when waitSecs > 0.
                     const progressTrackerOptIn =
@@ -1137,7 +1137,7 @@ export class ActorsMcpServer {
                     }
                 }
 
-                if (tool.type === ToolType.ACTOR_MCP) {
+                if (tool.type === TOOL_TYPE.ACTOR_MCP) {
                     let client: Client | null = null;
                     try {
                         client = await connectMCPClient(tool.serverUrl, apifyToken, mcpSessionId);
@@ -1234,7 +1234,7 @@ export class ActorsMcpServer {
                 }
 
                 // Handle actor tool
-                if (tool.type === ToolType.ACTOR) {
+                if (tool.type === TOOL_TYPE.ACTOR) {
                     const progressTracker = createProgressTracker(progressToken, extra.sendNotification);
 
                     try {
@@ -1568,7 +1568,7 @@ export class ActorsMcpServer {
             };
 
             // Handle internal tool execution in task mode
-            if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === ToolType.INTERNAL) {
+            if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === TOOL_TYPE.INTERNAL) {
                 const progressTracker = createProgressTracker(
                     progressToken,
                     extra.sendNotification,
@@ -1608,7 +1608,7 @@ export class ActorsMcpServer {
             }
 
             // Handle actor tool execution in task mode
-            if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === ToolType.ACTOR) {
+            if (toolStatus === TOOL_STATUS.SUCCEEDED && tool.type === TOOL_TYPE.ACTOR) {
                 const progressTracker = createProgressTracker(
                     progressToken,
                     extra.sendNotification,

--- a/src/tools/apps/call_actor.ts
+++ b/src/tools/apps/call_actor.ts
@@ -1,6 +1,6 @@
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import {
     buildCallActorAppsDescription,
     callActorAjvValidate,
@@ -16,7 +16,7 @@ const CALL_ACTOR_APPS_DESCRIPTION = buildCallActorAppsDescription();
  * Renders no widget; for a live progress UI, use the call-actor-widget sibling.
  */
 export const appsCallActor: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_CALL,
     description: CALL_ACTOR_APPS_DESCRIPTION,
     inputSchema: callActorInputSchema,

--- a/src/tools/apps/call_actor.ts
+++ b/src/tools/apps/call_actor.ts
@@ -1,5 +1,6 @@
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
+import { ToolType } from '../../types.js';
 import {
     buildCallActorAppsDescription,
     callActorAjvValidate,
@@ -15,7 +16,7 @@ const CALL_ACTOR_APPS_DESCRIPTION = buildCallActorAppsDescription();
  * Renders no widget; for a live progress UI, use the call-actor-widget sibling.
  */
 export const appsCallActor: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_CALL,
     description: CALL_ACTOR_APPS_DESCRIPTION,
     inputSchema: callActorInputSchema,

--- a/src/tools/apps/call_actor_widget.ts
+++ b/src/tools/apps/call_actor_widget.ts
@@ -6,6 +6,7 @@ import log from '@apify/log';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { extractActorId } from '../../utils/tools.js';
@@ -64,7 +65,7 @@ const CALL_ACTOR_WIDGET_DESCRIPTION = dedent`
 `;
 
 export const appsCallActorWidget: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_CALL_WIDGET,
     description: CALL_ACTOR_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(callActorWidgetArgsSchema) as ToolInputSchema,

--- a/src/tools/apps/call_actor_widget.ts
+++ b/src/tools/apps/call_actor_widget.ts
@@ -6,7 +6,7 @@ import log from '@apify/log';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { extractActorId } from '../../utils/tools.js';
@@ -65,7 +65,7 @@ const CALL_ACTOR_WIDGET_DESCRIPTION = dedent`
 `;
 
 export const appsCallActorWidget: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_CALL_WIDGET,
     description: CALL_ACTOR_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(callActorWidgetArgsSchema) as ToolInputSchema,

--- a/src/tools/apps/fetch_actor_details_widget.ts
+++ b/src/tools/apps/fetch_actor_details_widget.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { buildActorDetailsForWidget, buildCardOptions, fetchActorDetails } from '../../utils/actor_details.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -45,7 +45,7 @@ const FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION = dedent`
 `;
 
 export const fetchActorDetailsWidgetTool: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_GET_DETAILS_WIDGET,
     description: FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(fetchActorDetailsWidgetArgsSchema) as ToolInputSchema,

--- a/src/tools/apps/fetch_actor_details_widget.ts
+++ b/src/tools/apps/fetch_actor_details_widget.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { buildActorDetailsForWidget, buildCardOptions, fetchActorDetails } from '../../utils/actor_details.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -44,7 +45,7 @@ const FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION = dedent`
 `;
 
 export const fetchActorDetailsWidgetTool: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_GET_DETAILS_WIDGET,
     description: FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(fetchActorDetailsWidgetArgsSchema) as ToolInputSchema,

--- a/src/tools/apps/get_actor_run_widget.ts
+++ b/src/tools/apps/get_actor_run_widget.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { fetchActorRunData } from '../core/actor_run_response.js';
@@ -36,7 +36,7 @@ const GET_ACTOR_RUN_WIDGET_DESCRIPTION = dedent`
 `;
 
 export const getActorRunWidgetTool: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUNS_GET_WIDGET,
     description: GET_ACTOR_RUN_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(getActorRunWidgetArgsSchema) as ToolInputSchema,

--- a/src/tools/apps/get_actor_run_widget.ts
+++ b/src/tools/apps/get_actor_run_widget.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { fetchActorRunData } from '../core/actor_run_response.js';
@@ -35,7 +36,7 @@ const GET_ACTOR_RUN_WIDGET_DESCRIPTION = dedent`
 `;
 
 export const getActorRunWidgetTool: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_RUNS_GET_WIDGET,
     description: GET_ACTOR_RUN_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(getActorRunWidgetArgsSchema) as ToolInputSchema,

--- a/src/tools/apps/search_actors_widget.ts
+++ b/src/tools/apps/search_actors_widget.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { formatActorForWidget } from '../../utils/actor_card.js';
 import { searchAgentSafeActors } from '../../utils/actor_search.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -36,7 +36,7 @@ const SEARCH_ACTORS_WIDGET_DESCRIPTION = dedent`
 `;
 
 export const searchActorsWidgetTool: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.STORE_SEARCH_WIDGET,
     description: SEARCH_ACTORS_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(searchActorsWidgetArgsSchema) as ToolInputSchema,

--- a/src/tools/apps/search_actors_widget.ts
+++ b/src/tools/apps/search_actors_widget.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { formatActorForWidget } from '../../utils/actor_card.js';
 import { searchAgentSafeActors } from '../../utils/actor_search.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -35,7 +36,7 @@ const SEARCH_ACTORS_WIDGET_DESCRIPTION = dedent`
 `;
 
 export const searchActorsWidgetTool: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.STORE_SEARCH_WIDGET,
     description: SEARCH_ACTORS_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(searchActorsWidgetArgsSchema) as ToolInputSchema,

--- a/src/tools/common/abort_actor_run.ts
+++ b/src/tools/common/abort_actor_run.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 
 const abortRunArgs = z.object({
@@ -17,7 +17,7 @@ const abortRunArgs = z.object({
  * https://docs.apify.com/api/v2/actor-run-abort-post
  */
 export const abortActorRun: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUNS_ABORT,
     description: `Abort an Actor run that is currently starting or running.
 For runs with status FINISHED, FAILED, ABORTING, or TIMED-OUT, this call has no effect.

--- a/src/tools/common/abort_actor_run.ts
+++ b/src/tools/common/abort_actor_run.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 
 const abortRunArgs = z.object({
@@ -16,7 +17,7 @@ const abortRunArgs = z.object({
  * https://docs.apify.com/api/v2/actor-run-abort-post
  */
 export const abortActorRun: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_RUNS_ABORT,
     description: `Abort an Actor run that is currently starting or running.
 For runs with status FINISHED, FAILED, ABORTING, or TIMED-OUT, this call has no effect.

--- a/src/tools/common/add_actor.ts
+++ b/src/tools/common/add_actor.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ApifyClient } from '../../apify_client.js';
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 
@@ -14,7 +14,7 @@ export const addToolArgsSchema = z.object({
         .describe(`Actor ID or full name in the format "username/name", e.g., "apify/rag-web-browser".`),
 });
 export const addTool: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_ADD,
     description: `Add an Actor or MCP server to the Apify MCP Server as an available tool.
 This does not execute the Actor; it only registers it so it can be called later.

--- a/src/tools/common/add_actor.ts
+++ b/src/tools/common/add_actor.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ApifyClient } from '../../apify_client.js';
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 
@@ -13,7 +14,7 @@ export const addToolArgsSchema = z.object({
         .describe(`Actor ID or full name in the format "username/name", e.g., "apify/rag-web-browser".`),
 });
 export const addTool: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_ADD,
     description: `Add an Actor or MCP server to the Apify MCP Server as an available tool.
 This does not execute the Actor; it only registers it so it can be called later.

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 
 const getUserDatasetsListArgs = z.object({
@@ -31,7 +32,7 @@ const getUserDatasetsListArgs = z.object({
  * https://docs.apify.com/api/v2/datasets-get
  */
 export const getUserDatasetsList: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.DATASET_LIST_GET,
     description: dedent`
         List datasets (collections of Actor run data) for the authenticated user.

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 
 const getUserDatasetsListArgs = z.object({
@@ -32,7 +32,7 @@ const getUserDatasetsListArgs = z.object({
  * https://docs.apify.com/api/v2/datasets-get
  */
 export const getUserDatasetsList: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_LIST_GET,
     description: dedent`
         List datasets (collections of Actor run data) for the authenticated user.

--- a/src/tools/common/fetch_apify_docs.ts
+++ b/src/tools/common/fetch_apify_docs.ts
@@ -5,7 +5,7 @@ import log from '@apify/log';
 import { ALLOWED_DOC_DOMAINS, FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import { fetchApifyDocsCache } from '../../state.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -58,7 +58,7 @@ You can search for available documentation pages using the ${HelperTools.DOCS_SE
 }
 
 export const fetchApifyDocsTool: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DOCS_FETCH,
     description: `Fetch the full content of an Apify or Crawlee documentation page by its URL.
 Use this after finding a relevant page with the ${HelperTools.DOCS_SEARCH} tool.

--- a/src/tools/common/fetch_apify_docs.ts
+++ b/src/tools/common/fetch_apify_docs.ts
@@ -5,6 +5,7 @@ import log from '@apify/log';
 import { ALLOWED_DOC_DOMAINS, FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import { fetchApifyDocsCache } from '../../state.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -57,7 +58,7 @@ You can search for available documentation pages using the ${HelperTools.DOCS_SE
 }
 
 export const fetchApifyDocsTool: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.DOCS_FETCH,
     description: `Fetch the full content of an Apify or Crawlee documentation page by its URL.
 Use this after finding a relevant page with the ${HelperTools.DOCS_SEARCH} tool.

--- a/src/tools/common/get_actor_output.ts
+++ b/src/tools/common/get_actor_output.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_MAX_OUTPUT_CHARS, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { getValuesByDotKeys, parseCommaSeparatedList } from '../../utils/generic.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -30,7 +30,7 @@ const getActorOutputArgs = z.object({
  * It is a simplified version of the get-dataset-items tool.
  */
 export const getActorOutput: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_OUTPUT_GET,
     description: dedent`
         DEPRECATED: Use \`${HelperTools.DATASET_GET_ITEMS}\` instead.

--- a/src/tools/common/get_actor_output.ts
+++ b/src/tools/common/get_actor_output.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_MAX_OUTPUT_CHARS, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { getValuesByDotKeys, parseCommaSeparatedList } from '../../utils/generic.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -29,7 +30,7 @@ const getActorOutputArgs = z.object({
  * It is a simplified version of the get-dataset-items tool.
  */
 export const getActorOutput: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_OUTPUT_GET,
     description: dedent`
         DEPRECATED: Use \`${HelperTools.DATASET_GET_ITEMS}\` instead.

--- a/src/tools/common/get_actor_run_log.ts
+++ b/src/tools/common/get_actor_run_log.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 
 const GetRunLogArgs = z.object({
@@ -14,7 +15,7 @@ const GetRunLogArgs = z.object({
  *  /v2/actor-runs/{runId}/log{?token}
  */
 export const getActorRunLog: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_RUNS_LOG,
     description: `Retrieve recent log lines for a specific Actor run.
 The results will include the last N lines of the run's log output (plain text).

--- a/src/tools/common/get_actor_run_log.ts
+++ b/src/tools/common/get_actor_run_log.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 
 const GetRunLogArgs = z.object({
@@ -15,7 +15,7 @@ const GetRunLogArgs = z.object({
  *  /v2/actor-runs/{runId}/log{?token}
  */
 export const getActorRunLog: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUNS_LOG,
     description: `Retrieve recent log lines for a specific Actor run.
 The results will include the last N lines of the run's log output (plain text).

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { normalizeDatasetFields } from '../core/actor_run_response.js';
@@ -14,7 +15,7 @@ const getDatasetArgs = z.object({
  * https://docs.apify.com/api/v2/dataset-get
  */
 export const getDataset: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.DATASET_GET,
     description: `Get metadata for a dataset (collection of structured data created by an Actor run).
 The results will include dataset details such as itemCount, schema, fields, and stats.

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { normalizeDatasetFields } from '../core/actor_run_response.js';
@@ -15,7 +15,7 @@ const getDatasetArgs = z.object({
  * https://docs.apify.com/api/v2/dataset-get
  */
 export const getDataset: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_GET,
     description: `Get metadata for a dataset (collection of structured data created by an Actor run).
 The results will include dataset details such as itemCount, schema, fields, and stats.

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { parseCommaSeparatedList } from '../../utils/generic.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -61,7 +61,7 @@ const getDatasetItemsArgs = z.object({
  * https://docs.apify.com/api/v2/dataset-items-get
  */
 export const getDatasetItems: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_GET_ITEMS,
     description: dedent`
         Retrieve dataset items with pagination, sorting, and field selection.

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { parseCommaSeparatedList } from '../../utils/generic.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -60,7 +61,7 @@ const getDatasetItemsArgs = z.object({
  * https://docs.apify.com/api/v2/dataset-items-get
  */
 export const getDatasetItems: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.DATASET_GET_ITEMS,
     description: dedent`
         Retrieve dataset items with pagination, sorting, and field selection.

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
@@ -25,7 +25,7 @@ const getDatasetSchemaArgs = z.object({
  * Generates a JSON schema from dataset items
  */
 export const getDatasetSchema: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_SCHEMA_GET,
     description: `Generate a JSON schema from a sample of dataset items.
 The schema describes the structure of the data and can be used for validation, documentation, or processing.

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
@@ -24,7 +25,7 @@ const getDatasetSchemaArgs = z.object({
  * Generates a JSON schema from dataset items
  */
 export const getDatasetSchema: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.DATASET_SCHEMA_GET,
     description: `Generate a JSON schema from a sample of dataset items.
 The schema describes the structure of the data and can be used for validation, documentation, or processing.

--- a/src/tools/common/get_key_value_store.ts
+++ b/src/tools/common/get_key_value_store.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 
@@ -14,7 +14,7 @@ const getKeyValueStoreArgs = z.object({
  * https://docs.apify.com/api/v2/key-value-store-get
  */
 export const getKeyValueStore: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_GET,
     description: `Get details about a key-value store by ID or username~store-name.
 The results will include store metadata (ID, name, owner, access settings) and usage statistics.

--- a/src/tools/common/get_key_value_store.ts
+++ b/src/tools/common/get_key_value_store.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 
@@ -13,7 +14,7 @@ const getKeyValueStoreArgs = z.object({
  * https://docs.apify.com/api/v2/key-value-store-get
  */
 export const getKeyValueStore: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_GET,
     description: `Get details about a key-value store by ID or username~store-name.
 The results will include store metadata (ID, name, owner, access settings) and usage statistics.

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 
 const getKeyValueStoreKeysArgs = z.object({
@@ -17,7 +18,7 @@ const getKeyValueStoreKeysArgs = z.object({
  * https://docs.apify.com/api/v2/key-value-store-keys-get
  */
 export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_KEYS_GET,
     description: `List keys in a key-value store with optional pagination.
 The results will include keys and basic info about stored values (e.g., size).

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 
 const getKeyValueStoreKeysArgs = z.object({
@@ -18,7 +18,7 @@ const getKeyValueStoreKeysArgs = z.object({
  * https://docs.apify.com/api/v2/key-value-store-keys-get
  */
 export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_KEYS_GET,
     description: `List keys in a key-value store with optional pagination.
 The results will include keys and basic info about stored values (e.g., size).

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 
@@ -15,7 +15,7 @@ const getKeyValueStoreRecordArgs = z.object({
  * https://docs.apify.com/api/v2/key-value-store-record-get
  */
 export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_RECORD_GET,
     description: `Get a value stored in a key-value store under a specific key.
 The response preserves the original Content-Encoding; most clients handle decompression automatically.

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 
@@ -14,7 +15,7 @@ const getKeyValueStoreRecordArgs = z.object({
  * https://docs.apify.com/api/v2/key-value-store-record-get
  */
 export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_RECORD_GET,
     description: `Get a value stored in a key-value store under a specific key.
 The response preserves the original Content-Encoding; most clients handle decompression automatically.

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 
 const getUserKeyValueStoresListArgs = z.object({
@@ -32,7 +33,7 @@ const getUserKeyValueStoresListArgs = z.object({
  * https://docs.apify.com/api/v2/key-value-stores-get
  */
 export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_LIST_GET,
     description: `List key-value stores owned by the authenticated user.
 Actor runs automatically produce unnamed stores (set unnamed=true to include them). Users can also create named stores.

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 
 const getUserKeyValueStoresListArgs = z.object({
@@ -33,7 +33,7 @@ const getUserKeyValueStoresListArgs = z.object({
  * https://docs.apify.com/api/v2/key-value-stores-get
  */
 export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_LIST_GET,
     description: `List key-value stores owned by the authenticated user.
 Actor runs automatically produce unnamed stores (set unnamed=true to include them). Users can also create named stores.

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ApifyClient } from '../../apify_client.js';
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 
@@ -32,7 +33,7 @@ const getUserRunsListArgs = z.object({
  * https://docs.apify.com/api/v2/act-runs-get
  */
 export const getUserRunsList: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_RUN_LIST_GET,
     description: `List Actor runs for the authenticated user with optional filtering and sorting.
 The results will include run details (including datasetId and keyValueStoreId) and can be filtered by status.

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ApifyClient } from '../../apify_client.js';
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 
@@ -33,7 +33,7 @@ const getUserRunsListArgs = z.object({
  * https://docs.apify.com/api/v2/act-runs-get
  */
 export const getUserRunsList: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUN_LIST_GET,
     description: `List Actor runs for the authenticated user with optional filtering and sorting.
 The results will include run details (including datasetId and keyValueStoreId) and can be filtered by status.

--- a/src/tools/common/search_apify_docs.ts
+++ b/src/tools/common/search_apify_docs.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { DOCS_SOURCES, HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { searchDocsBySourceCached } from '../../utils/apify_docs.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -68,7 +69,7 @@ Use this to paginate through the search results. For example, if you want to get
 const searchApifyDocsToolInputSchema = z.toJSONSchema(searchApifyDocsToolArgsSchema) as ToolInputSchema;
 
 export const searchApifyDocsTool: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.DOCS_SEARCH,
     description: buildToolDescription(),
     inputSchema: searchApifyDocsToolInputSchema,

--- a/src/tools/common/search_apify_docs.ts
+++ b/src/tools/common/search_apify_docs.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { DOCS_SOURCES, HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { searchDocsBySourceCached } from '../../utils/apify_docs.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -69,7 +69,7 @@ Use this to paginate through the search results. For example, if you want to get
 const searchApifyDocsToolInputSchema = z.toJSONSchema(searchApifyDocsToolArgsSchema) as ToolInputSchema;
 
 export const searchApifyDocsTool: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DOCS_SEARCH,
     description: buildToolDescription(),
     inputSchema: searchApifyDocsToolInputSchema,

--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -9,14 +9,15 @@ import { getActorMCPServerPath, getActorMCPServerURL } from '../../mcp/actors.js
 import { connectMCPClient } from '../../mcp/client.js';
 import { getMCPServerTools } from '../../mcp/proxy.js';
 import type { PaymentProvider } from '../../payments/types.js';
-import type {
-    ActorDefinitionWithInfo,
-    ActorInfo,
-    ActorStore,
-    ActorTool,
-    ApifyToken,
-    ToolEntry,
-    ToolInputSchema,
+import {
+    type ActorDefinitionWithInfo,
+    type ActorInfo,
+    type ActorStore,
+    type ActorTool,
+    type ApifyToken,
+    type ToolEntry,
+    type ToolInputSchema,
+    ToolType,
 } from '../../types.js';
 import { getActorDefinitionCached } from '../../utils/actor.js';
 import { ajv } from '../../utils/ajv.js';
@@ -58,7 +59,7 @@ const WAIT_SECS_INPUT_PROPERTY = {
  */
 export async function enrichActorToolOutputSchemas(tools: ToolEntry[], actorStore: ActorStore): Promise<void> {
     const enrichPromises = tools
-        .filter((tool): tool is ActorTool => tool.type === 'actor')
+        .filter((tool): tool is ActorTool => tool.type === ToolType.ACTOR)
         .map(async (tool) => {
             try {
                 const itemProperties = await actorStore.getActorOutputSchema(tool.actorFullName);
@@ -152,7 +153,7 @@ Actor description: ${definition.description}`;
         }
 
         tools.push({
-            type: 'actor',
+            type: ToolType.ACTOR,
             name: actorNameToToolName(definition.actorFullName),
             actorId: definition.id,
             actorFullName: definition.actorFullName,

--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -17,7 +17,7 @@ import {
     type ApifyToken,
     type ToolEntry,
     type ToolInputSchema,
-    ToolType,
+    TOOL_TYPE,
 } from '../../types.js';
 import { getActorDefinitionCached } from '../../utils/actor.js';
 import { ajv } from '../../utils/ajv.js';
@@ -59,7 +59,7 @@ const WAIT_SECS_INPUT_PROPERTY = {
  */
 export async function enrichActorToolOutputSchemas(tools: ToolEntry[], actorStore: ActorStore): Promise<void> {
     const enrichPromises = tools
-        .filter((tool): tool is ActorTool => tool.type === ToolType.ACTOR)
+        .filter((tool): tool is ActorTool => tool.type === TOOL_TYPE.ACTOR)
         .map(async (tool) => {
             try {
                 const itemProperties = await actorStore.getActorOutputSchema(tool.actorFullName);
@@ -153,7 +153,7 @@ Actor description: ${definition.description}`;
         }
 
         tools.push({
-            type: ToolType.ACTOR,
+            type: TOOL_TYPE.ACTOR,
             name: actorNameToToolName(definition.actorFullName),
             actorId: definition.id,
             actorFullName: definition.actorFullName,

--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { HelperTool, InternalToolArgs, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import {
     type ActorDetailsResult,
     buildCardOptions,
@@ -120,7 +121,7 @@ EXAMPLES:
  * carries its own widget metadata.
  */
 export const fetchActorDetailsMetadata: Omit<HelperTool, 'call'> = {
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_GET_DETAILS,
     description: FETCH_ACTOR_DETAILS_DESCRIPTION,
     inputSchema: z.toJSONSchema(fetchActorDetailsToolArgsSchema) as ToolInputSchema,

--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
 import type { HelperTool, InternalToolArgs, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import {
     type ActorDetailsResult,
     buildCardOptions,
@@ -121,7 +121,7 @@ EXAMPLES:
  * carries its own widget metadata.
  */
 export const fetchActorDetailsMetadata: Omit<HelperTool, 'call'> = {
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_GET_DETAILS,
     description: FETCH_ACTOR_DETAILS_DESCRIPTION,
     inputSchema: z.toJSONSchema(fetchActorDetailsToolArgsSchema) as ToolInputSchema,

--- a/src/tools/core/get_actor_run_common.ts
+++ b/src/tools/core/get_actor_run_common.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { HelperTools, TOOL_STATUS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { HelperTool, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { compileSchema, fixZodSchemaRequired } from '../../utils/ajv.js';
 import { buildMCPResponse, buildUsageMeta } from '../../utils/mcp.js';
 import { getActorRunOutputSchema } from '../structured_output_schemas.js';
@@ -44,7 +45,7 @@ USAGE EXAMPLES:
  * Mode-independent. Widget `_meta` lives in the widget variant.
  */
 export const getActorRunMetadata: Omit<HelperTool, 'call'> = {
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_RUNS_GET,
     description: GET_ACTOR_RUN_DESCRIPTION,
     // `fixZodSchemaRequired` strips fields with a real `default` from `required` so MCP clients

--- a/src/tools/core/get_actor_run_common.ts
+++ b/src/tools/core/get_actor_run_common.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { HelperTools, TOOL_STATUS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { HelperTool, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { compileSchema, fixZodSchemaRequired } from '../../utils/ajv.js';
 import { buildMCPResponse, buildUsageMeta } from '../../utils/mcp.js';
 import { getActorRunOutputSchema } from '../structured_output_schemas.js';
@@ -45,7 +45,7 @@ USAGE EXAMPLES:
  * Mode-independent. Widget `_meta` lives in the widget variant.
  */
 export const getActorRunMetadata: Omit<HelperTool, 'call'> = {
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUNS_GET,
     description: GET_ACTOR_RUN_DESCRIPTION,
     // `fixZodSchemaRequired` strips fields with a real `default` from `required` so MCP clients

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { HelperTools, MAX_LIMIT_WITH_INPUT_SCHEMA } from '../../const.js';
 import type { ActorStoreList, HelperTool, StructuredActorCard, ToolInputSchema } from '../../types.js';
+import { ToolType } from '../../types.js';
 import { DEFAULT_CARD_OPTIONS, formatActorToActorCard, formatActorToStructuredCard } from '../../utils/actor_card.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -94,7 +95,7 @@ Returns list of Actor cards with the following info:
  * Used by `defaultSearchActors` in both default and apps modes.
  */
 export const searchActorsMetadata: Omit<HelperTool, 'call'> = {
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.STORE_SEARCH,
     description: SEARCH_ACTORS_DESCRIPTION,
     inputSchema: z.toJSONSchema(searchActorsBaseArgsSchema) as ToolInputSchema,

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { HelperTools, MAX_LIMIT_WITH_INPUT_SCHEMA } from '../../const.js';
 import type { ActorStoreList, HelperTool, StructuredActorCard, ToolInputSchema } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import { DEFAULT_CARD_OPTIONS, formatActorToActorCard, formatActorToStructuredCard } from '../../utils/actor_card.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
@@ -95,7 +95,7 @@ Returns list of Actor cards with the following info:
  * Used by `defaultSearchActors` in both default and apps modes.
  */
 export const searchActorsMetadata: Omit<HelperTool, 'call'> = {
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.STORE_SEARCH,
     description: SEARCH_ACTORS_DESCRIPTION,
     inputSchema: z.toJSONSchema(searchActorsBaseArgsSchema) as ToolInputSchema,

--- a/src/tools/default/call_actor.ts
+++ b/src/tools/default/call_actor.ts
@@ -1,5 +1,6 @@
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
+import { ToolType } from '../../types.js';
 import {
     buildCallActorDescription,
     callActorAjvValidate,
@@ -14,7 +15,7 @@ const CALL_ACTOR_DEFAULT_DESCRIPTION = buildCallActorDescription();
  * Default mode call-actor tool.
  */
 export const defaultCallActor: ToolEntry = Object.freeze({
-    type: 'internal',
+    type: ToolType.INTERNAL,
     name: HelperTools.ACTOR_CALL,
     description: CALL_ACTOR_DEFAULT_DESCRIPTION,
     inputSchema: callActorInputSchema,

--- a/src/tools/default/call_actor.ts
+++ b/src/tools/default/call_actor.ts
@@ -1,6 +1,6 @@
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
-import { ToolType } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
 import {
     buildCallActorDescription,
     callActorAjvValidate,
@@ -15,7 +15,7 @@ const CALL_ACTOR_DEFAULT_DESCRIPTION = buildCallActorDescription();
  * Default mode call-actor tool.
  */
 export const defaultCallActor: ToolEntry = Object.freeze({
-    type: ToolType.INTERNAL,
+    type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_CALL,
     description: CALL_ACTOR_DEFAULT_DESCRIPTION,
     inputSchema: callActorInputSchema,

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export type ToolInputSchema = z.infer<typeof ToolSchema>['inputSchema'];
  * Tool type discriminator values.
  * Use these constants instead of string literals for better type safety and maintainability.
  */
-export const ToolType = {
+export const TOOL_TYPE = {
     INTERNAL: 'internal',
     ACTOR: 'actor',
     ACTOR_MCP: 'actor-mcp',
@@ -116,15 +116,15 @@ export const ToolType = {
 /**
  * Union of all tool type discriminator values.
  */
-export type ToolType = (typeof ToolType)[keyof typeof ToolType];
+export type TOOL_TYPE = (typeof TOOL_TYPE)[keyof typeof TOOL_TYPE];
 
 /**
  * Type for Actor-based tools - tools that wrap Apify Actors.
- * Type discriminator: {@link ToolType.ACTOR}
+ * Type discriminator: {@link TOOL_TYPE.ACTOR}
  */
 export type ActorTool = ToolBase & {
     /** Type discriminator for actor tools */
-    type: typeof ToolType.ACTOR;
+    type: typeof TOOL_TYPE.ACTOR;
     /** Stable Apify Actor ID (e.g. "JxcaGGqy7TwBdHxMz") — does not change on rename */
     actorId: string;
     /** Full name of the Apify Actor (username/name) */
@@ -176,11 +176,11 @@ export type InternalToolArgs = {
 
 /**
  * Helper tool - tools implemented directly in the MCP server.
- * Type discriminator: {@link ToolType.INTERNAL}
+ * Type discriminator: {@link TOOL_TYPE.INTERNAL}
  */
 export type HelperTool = ToolBase & {
     /** Type discriminator for helper/internal tools */
-    type: typeof ToolType.INTERNAL;
+    type: typeof TOOL_TYPE.INTERNAL;
     /**
      * Executes the tool with the given arguments
      * @param toolArgs - Arguments and server references
@@ -191,11 +191,11 @@ export type HelperTool = ToolBase & {
 
 /**
  * Actor MCP tool - tools from Actorized MCP servers that this server proxies.
- * Type discriminator: {@link ToolType.ACTOR_MCP}
+ * Type discriminator: {@link TOOL_TYPE.ACTOR_MCP}
  */
 export type ActorMcpTool = ToolBase & {
     /** Type discriminator for actor MCP tools */
-    type: typeof ToolType.ACTOR_MCP;
+    type: typeof TOOL_TYPE.ACTOR_MCP;
     /** Origin MCP server tool name is needed for the tool call */
     originToolName: string;
     /** ID of the Actorized MCP server - for example, apify/actors-mcp-server */
@@ -445,7 +445,7 @@ export const SERVER_MODES: readonly ServerMode[] = Object.values(ServerMode);
 export type ServerModeOption = ServerMode | 'auto';
 
 /**
- * Parameters for executing a direct actor tool ({@link ToolType.ACTOR}).
+ * Parameters for executing a direct actor tool ({@link TOOL_TYPE.ACTOR}).
  * Used by ActorExecutor implementations.
  */
 export type ActorExecutionParams = {
@@ -493,7 +493,7 @@ export type ActorExecutionResult = {
 } | null;
 
 /**
- * Executor for direct actor tools ({@link ToolType.ACTOR}).
+ * Executor for direct actor tools ({@link TOOL_TYPE.ACTOR}).
  * Selected at server construction time based on serverMode.
  * Default mode runs synchronously; apps mode runs async with widget metadata.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,12 +104,27 @@ export type ToolBase = z.infer<typeof ToolSchema> & {
 export type ToolInputSchema = z.infer<typeof ToolSchema>['inputSchema'];
 
 /**
+ * Tool type discriminator values.
+ * Use these constants instead of string literals for better type safety and maintainability.
+ */
+export const ToolType = {
+    INTERNAL: 'internal',
+    ACTOR: 'actor',
+    ACTOR_MCP: 'actor-mcp',
+} as const;
+
+/**
+ * Union of all tool type discriminator values.
+ */
+export type ToolType = (typeof ToolType)[keyof typeof ToolType];
+
+/**
  * Type for Actor-based tools - tools that wrap Apify Actors.
- * Type discriminator: 'actor'
+ * Type discriminator: {@link ToolType.ACTOR}
  */
 export type ActorTool = ToolBase & {
     /** Type discriminator for actor tools */
-    type: 'actor';
+    type: typeof ToolType.ACTOR;
     /** Stable Apify Actor ID (e.g. "JxcaGGqy7TwBdHxMz") — does not change on rename */
     actorId: string;
     /** Full name of the Apify Actor (username/name) */
@@ -161,11 +176,11 @@ export type InternalToolArgs = {
 
 /**
  * Helper tool - tools implemented directly in the MCP server.
- * Type discriminator: 'internal'
+ * Type discriminator: {@link ToolType.INTERNAL}
  */
 export type HelperTool = ToolBase & {
     /** Type discriminator for helper/internal tools */
-    type: 'internal';
+    type: typeof ToolType.INTERNAL;
     /**
      * Executes the tool with the given arguments
      * @param toolArgs - Arguments and server references
@@ -176,11 +191,11 @@ export type HelperTool = ToolBase & {
 
 /**
  * Actor MCP tool - tools from Actorized MCP servers that this server proxies.
- * Type discriminator: 'actor-mcp'
+ * Type discriminator: {@link ToolType.ACTOR_MCP}
  */
 export type ActorMcpTool = ToolBase & {
     /** Type discriminator for actor MCP tools */
-    type: 'actor-mcp';
+    type: typeof ToolType.ACTOR_MCP;
     /** Origin MCP server tool name is needed for the tool call */
     originToolName: string;
     /** ID of the Actorized MCP server - for example, apify/actors-mcp-server */
@@ -430,7 +445,7 @@ export const SERVER_MODES: readonly ServerMode[] = Object.values(ServerMode);
 export type ServerModeOption = ServerMode | 'auto';
 
 /**
- * Parameters for executing a direct actor tool (`type: 'actor'`).
+ * Parameters for executing a direct actor tool ({@link ToolType.ACTOR}).
  * Used by ActorExecutor implementations.
  */
 export type ActorExecutionParams = {
@@ -478,7 +493,7 @@ export type ActorExecutionResult = {
 } | null;
 
 /**
- * Executor for direct actor tools (`type: 'actor'`).
+ * Executor for direct actor tools ({@link ToolType.ACTOR}).
  * Selected at server construction time based on serverMode.
  * Default mode runs synchronously; apps mode runs async with widget metadata.
  */

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -5,7 +5,7 @@ import {
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../payments/const.js';
 import type { CallDiagnostics, HelperTool, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
-import { ServerMode } from '../types.js';
+import { ServerMode, ToolType } from '../types.js';
 import { fixZodSchemaRequired } from './ajv.js';
 
 /**
@@ -15,10 +15,10 @@ import { fixZodSchemaRequired } from './ajv.js';
  */
 export function getToolFullName(tool: ToolEntry): string {
     switch (tool.type) {
-        case 'actor':
+        case ToolType.ACTOR:
             return tool.actorFullName;
-        case 'internal':
-        case 'actor-mcp':
+        case ToolType.INTERNAL:
+        case ToolType.ACTOR_MCP:
             return tool.name;
         default:
             return (tool satisfies never as ToolEntry).name;
@@ -30,7 +30,7 @@ export function getToolFullName(tool: ToolEntry): string {
  * Available for actor and actor-mcp tools; undefined for internal tools.
  */
 export function extractActorId(tool: ToolEntry): string | undefined {
-    if (tool.type === 'actor' || tool.type === 'actor-mcp') return tool.actorId;
+    if (tool.type === ToolType.ACTOR || tool.type === ToolType.ACTOR_MCP) return tool.actorId;
     return undefined;
 }
 
@@ -53,8 +53,8 @@ export function buildActorFields(
  * Returns undefined for other internal tools or when the arg is missing/invalid.
  */
 export function extractActorName(tool: ToolEntry, args?: Record<string, unknown>): string | undefined {
-    if (tool.type === 'actor') return tool.actorFullName;
-    if (tool.type === 'actor-mcp') return tool.actorId;
+    if (tool.type === ToolType.ACTOR) return tool.actorFullName;
+    if (tool.type === ToolType.ACTOR_MCP) return tool.actorId;
 
     // For call-actor, the actor name is in `args.actor`.
     // The format can be "username/name" or "username/name:toolName" (MCP server Actors).
@@ -122,7 +122,7 @@ export function getToolPublicFieldOnly(tool: ToolBase, options: ToolPublicFieldO
 export function cloneToolEntry(toolEntry: ToolEntry): ToolEntry {
     // Store the original functions
     const originalAjvValidate = toolEntry.ajvValidate;
-    const originalCall = toolEntry.type === 'internal' ? toolEntry.call : undefined;
+    const originalCall = toolEntry.type === ToolType.INTERNAL ? toolEntry.call : undefined;
 
     // Create a deep copy using JSON serialization (excluding functions)
     const cloned = JSON.parse(
@@ -134,7 +134,7 @@ export function cloneToolEntry(toolEntry: ToolEntry): ToolEntry {
 
     // Restore the original functions
     cloned.ajvValidate = originalAjvValidate;
-    if (toolEntry.type === 'internal' && originalCall) {
+    if (toolEntry.type === ToolType.INTERNAL && originalCall) {
         (cloned as HelperTool).call = originalCall;
     }
 
@@ -143,7 +143,10 @@ export function cloneToolEntry(toolEntry: ToolEntry): ToolEntry {
 
 /** Returns true if the tool is eligible for Skyfire augmentation. */
 function isSkyfireEligible(tool: ToolEntry): boolean {
-    return tool.type === 'actor' || (tool.type === 'internal' && SKYFIRE_ENABLED_TOOLS.has(tool.name as HelperTools));
+    return (
+        tool.type === ToolType.ACTOR ||
+        (tool.type === ToolType.INTERNAL && SKYFIRE_ENABLED_TOOLS.has(tool.name as HelperTools))
+    );
 }
 
 /**

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -5,7 +5,7 @@ import {
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../payments/const.js';
 import type { CallDiagnostics, HelperTool, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
-import { ServerMode, ToolType } from '../types.js';
+import { ServerMode, TOOL_TYPE } from '../types.js';
 import { fixZodSchemaRequired } from './ajv.js';
 
 /**
@@ -15,10 +15,10 @@ import { fixZodSchemaRequired } from './ajv.js';
  */
 export function getToolFullName(tool: ToolEntry): string {
     switch (tool.type) {
-        case ToolType.ACTOR:
+        case TOOL_TYPE.ACTOR:
             return tool.actorFullName;
-        case ToolType.INTERNAL:
-        case ToolType.ACTOR_MCP:
+        case TOOL_TYPE.INTERNAL:
+        case TOOL_TYPE.ACTOR_MCP:
             return tool.name;
         default:
             return (tool satisfies never as ToolEntry).name;
@@ -30,7 +30,7 @@ export function getToolFullName(tool: ToolEntry): string {
  * Available for actor and actor-mcp tools; undefined for internal tools.
  */
 export function extractActorId(tool: ToolEntry): string | undefined {
-    if (tool.type === ToolType.ACTOR || tool.type === ToolType.ACTOR_MCP) return tool.actorId;
+    if (tool.type === TOOL_TYPE.ACTOR || tool.type === TOOL_TYPE.ACTOR_MCP) return tool.actorId;
     return undefined;
 }
 
@@ -53,8 +53,8 @@ export function buildActorFields(
  * Returns undefined for other internal tools or when the arg is missing/invalid.
  */
 export function extractActorName(tool: ToolEntry, args?: Record<string, unknown>): string | undefined {
-    if (tool.type === ToolType.ACTOR) return tool.actorFullName;
-    if (tool.type === ToolType.ACTOR_MCP) return tool.actorId;
+    if (tool.type === TOOL_TYPE.ACTOR) return tool.actorFullName;
+    if (tool.type === TOOL_TYPE.ACTOR_MCP) return tool.actorId;
 
     // For call-actor, the actor name is in `args.actor`.
     // The format can be "username/name" or "username/name:toolName" (MCP server Actors).
@@ -122,7 +122,7 @@ export function getToolPublicFieldOnly(tool: ToolBase, options: ToolPublicFieldO
 export function cloneToolEntry(toolEntry: ToolEntry): ToolEntry {
     // Store the original functions
     const originalAjvValidate = toolEntry.ajvValidate;
-    const originalCall = toolEntry.type === ToolType.INTERNAL ? toolEntry.call : undefined;
+    const originalCall = toolEntry.type === TOOL_TYPE.INTERNAL ? toolEntry.call : undefined;
 
     // Create a deep copy using JSON serialization (excluding functions)
     const cloned = JSON.parse(
@@ -134,7 +134,7 @@ export function cloneToolEntry(toolEntry: ToolEntry): ToolEntry {
 
     // Restore the original functions
     cloned.ajvValidate = originalAjvValidate;
-    if (toolEntry.type === ToolType.INTERNAL && originalCall) {
+    if (toolEntry.type === TOOL_TYPE.INTERNAL && originalCall) {
         (cloned as HelperTool).call = originalCall;
     }
 
@@ -144,8 +144,8 @@ export function cloneToolEntry(toolEntry: ToolEntry): ToolEntry {
 /** Returns true if the tool is eligible for Skyfire augmentation. */
 function isSkyfireEligible(tool: ToolEntry): boolean {
     return (
-        tool.type === ToolType.ACTOR ||
-        (tool.type === ToolType.INTERNAL && SKYFIRE_ENABLED_TOOLS.has(tool.name as HelperTools))
+        tool.type === TOOL_TYPE.ACTOR ||
+        (tool.type === TOOL_TYPE.INTERNAL && SKYFIRE_ENABLED_TOOLS.has(tool.name as HelperTools))
     );
 }
 

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -23,7 +23,7 @@ import { getKeyValueStoreRecord } from '../tools/common/get_key_value_store_reco
 import { defaultGetActorRun } from '../tools/default/get_actor_run.js';
 import { getActorsAsTools } from '../tools/index.js';
 import type { ActorStore, Input, ToolCategory, ToolEntry } from '../types.js';
-import { SERVER_MODES, ServerMode } from '../types.js';
+import { SERVER_MODES, ServerMode, ToolType } from '../types.js';
 
 /**
  * Tools auto-injected alongside any actor-running tool (call-actor / direct
@@ -269,7 +269,7 @@ export function getToolsForServerMode(
      * via category before `actors`, the de-dup pass below preserves their selector order.
      */
     const hasCallActor = result.some((entry) => entry.name === HelperTools.ACTOR_CALL);
-    const hasActorTools = result.some((entry) => entry.type === 'actor');
+    const hasActorTools = result.some((entry) => entry.type === ToolType.ACTOR);
     const hasAddActorTool = result.some((entry) => entry.name === HelperTools.ACTOR_ADD);
     // `get-actor-run`'s nextStep templates point at `get-dataset-items` / `get-key-value-store-record`,
     // and the apps-mode widget calls `get-dataset-items` to fetch its preview. A runs-only session

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -23,7 +23,7 @@ import { getKeyValueStoreRecord } from '../tools/common/get_key_value_store_reco
 import { defaultGetActorRun } from '../tools/default/get_actor_run.js';
 import { getActorsAsTools } from '../tools/index.js';
 import type { ActorStore, Input, ToolCategory, ToolEntry } from '../types.js';
-import { SERVER_MODES, ServerMode, ToolType } from '../types.js';
+import { SERVER_MODES, ServerMode, TOOL_TYPE } from '../types.js';
 
 /**
  * Tools auto-injected alongside any actor-running tool (call-actor / direct
@@ -269,7 +269,7 @@ export function getToolsForServerMode(
      * via category before `actors`, the de-dup pass below preserves their selector order.
      */
     const hasCallActor = result.some((entry) => entry.name === HelperTools.ACTOR_CALL);
-    const hasActorTools = result.some((entry) => entry.type === ToolType.ACTOR);
+    const hasActorTools = result.some((entry) => entry.type === TOOL_TYPE.ACTOR);
     const hasAddActorTool = result.some((entry) => entry.name === HelperTools.ACTOR_ADD);
     // `get-actor-run`'s nextStep templates point at `get-dataset-items` / `get-key-value-store-record`,
     // and the apps-mode widget calls `get-dataset-items` to fetch its preview. A runs-only session

--- a/tests/unit/mcp.server.progress_wiring.test.ts
+++ b/tests/unit/mcp.server.progress_wiring.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import type { ActorsMcpServer } from '../../src/mcp/server.js';
 import type { InternalToolArgs, ToolEntry } from '../../src/types.js';
+import { ToolType } from '../../src/types.js';
 import { ProgressTracker } from '../../src/utils/progress.js';
 
 /**
@@ -37,7 +38,7 @@ function makeRecorderTool(name: string): {
         progressTracker: undefined,
     };
     const tool: ToolEntry = {
-        type: 'internal',
+        type: ToolType.INTERNAL,
         name,
         description: 'recorder tool for progress wiring tests',
         inputSchema: { type: 'object', properties: {}, additionalProperties: true },

--- a/tests/unit/mcp.server.progress_wiring.test.ts
+++ b/tests/unit/mcp.server.progress_wiring.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import type { ActorsMcpServer } from '../../src/mcp/server.js';
 import type { InternalToolArgs, ToolEntry } from '../../src/types.js';
-import { ToolType } from '../../src/types.js';
+import { TOOL_TYPE } from '../../src/types.js';
 import { ProgressTracker } from '../../src/utils/progress.js';
 
 /**
@@ -38,7 +38,7 @@ function makeRecorderTool(name: string): {
         progressTracker: undefined,
     };
     const tool: ToolEntry = {
-        type: ToolType.INTERNAL,
+        type: TOOL_TYPE.INTERNAL,
         name,
         description: 'recorder tool for progress wiring tests',
         inputSchema: { type: 'object', properties: {}, additionalProperties: true },

--- a/tests/unit/payments.helpers.test.ts
+++ b/tests/unit/payments.helpers.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { prepareToolCallContext } from '../../src/payments/helpers.js';
 import type { PaymentProvider } from '../../src/payments/types.js';
 import type { HelperTool } from '../../src/types.js';
+import { ToolType } from '../../src/types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -25,7 +26,7 @@ function makeTool(paymentRequired = true): HelperTool {
     return {
         name: 'call-actor',
         description: 'Call an Actor',
-        type: 'internal',
+        type: ToolType.INTERNAL,
         paymentRequired,
         inputSchema: { type: 'object', properties: { actor: { type: 'string' } } },
         ajvValidate: vi.fn(() => true) as never,

--- a/tests/unit/payments.helpers.test.ts
+++ b/tests/unit/payments.helpers.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { prepareToolCallContext } from '../../src/payments/helpers.js';
 import type { PaymentProvider } from '../../src/payments/types.js';
 import type { HelperTool } from '../../src/types.js';
-import { ToolType } from '../../src/types.js';
+import { TOOL_TYPE } from '../../src/types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -26,7 +26,7 @@ function makeTool(paymentRequired = true): HelperTool {
     return {
         name: 'call-actor',
         description: 'Call an Actor',
-        type: ToolType.INTERNAL,
+        type: TOOL_TYPE.INTERNAL,
         paymentRequired,
         inputSchema: { type: 'object', properties: { actor: { type: 'string' } } },
         ajvValidate: vi.fn(() => true) as never,

--- a/tests/unit/tools.call_actor_widget.response.test.ts
+++ b/tests/unit/tools.call_actor_widget.response.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WIDGET_URIS } from '../../src/resources/widgets.js';
 import { appsCallActorWidget } from '../../src/tools/apps/call_actor_widget.js';
 import type { HelperTool, InternalToolArgs, ToolEntry } from '../../src/types.js';
+import { ToolType } from '../../src/types.js';
 import { getActorMcpUrlCached } from '../../src/utils/actor.js';
 import { stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
@@ -26,7 +27,7 @@ vi.mock('../../src/tools/core/actor_tools_factory.js', async () => {
 const { getActorsAsTools } = await import('../../src/tools/core/actor_tools_factory.js');
 
 const MOCK_ACTOR_TOOL: ToolEntry = {
-    type: 'actor',
+    type: ToolType.ACTOR,
     name: 'apify--rag-web-browser',
     actorId: 'actor-id-rag',
     actorFullName: 'apify/rag-web-browser',

--- a/tests/unit/tools.call_actor_widget.response.test.ts
+++ b/tests/unit/tools.call_actor_widget.response.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WIDGET_URIS } from '../../src/resources/widgets.js';
 import { appsCallActorWidget } from '../../src/tools/apps/call_actor_widget.js';
 import type { HelperTool, InternalToolArgs, ToolEntry } from '../../src/types.js';
-import { ToolType } from '../../src/types.js';
+import { TOOL_TYPE } from '../../src/types.js';
 import { getActorMcpUrlCached } from '../../src/utils/actor.js';
 import { stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
@@ -27,7 +27,7 @@ vi.mock('../../src/tools/core/actor_tools_factory.js', async () => {
 const { getActorsAsTools } = await import('../../src/tools/core/actor_tools_factory.js');
 
 const MOCK_ACTOR_TOOL: ToolEntry = {
-    type: ToolType.ACTOR,
+    type: TOOL_TYPE.ACTOR,
     name: 'apify--rag-web-browser',
     actorId: 'actor-id-rag',
     actorFullName: 'apify/rag-web-browser',

--- a/tests/unit/tools.skyfire.test.ts
+++ b/tests/unit/tools.skyfire.test.ts
@@ -17,6 +17,7 @@ import {
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../../src/payments/const.js';
 import type { ActorMcpTool, ActorTool, HelperTool, ToolEntry } from '../../src/types.js';
+import { ToolType } from '../../src/types.js';
 import { applySkyfireAugmentation, cloneToolEntry } from '../../src/utils/tools.js';
 
 // ---------------------------------------------------------------------------
@@ -29,7 +30,7 @@ function makeInternalTool(overrides: Partial<HelperTool> = {}): HelperTool {
     return {
         name: HelperTools.ACTOR_CALL,
         description: 'Call an Actor',
-        type: 'internal',
+        type: ToolType.INTERNAL,
         inputSchema: {
             type: 'object' as const,
             properties: { actor: { type: 'string' } },
@@ -44,7 +45,7 @@ function makeActorTool(overrides: Partial<ActorTool> = {}): ActorTool {
     return {
         name: 'apify--web-scraper',
         description: 'Web scraper tool',
-        type: 'actor',
+        type: ToolType.ACTOR,
         actorId: 'abc123',
         actorFullName: 'apify/web-scraper',
         inputSchema: {
@@ -60,7 +61,7 @@ function makeActorMcpTool(overrides: Partial<ActorMcpTool> = {}): ActorMcpTool {
     return {
         name: 'some-mcp-tool',
         description: 'A proxied MCP tool',
-        type: 'actor-mcp',
+        type: ToolType.ACTOR_MCP,
         originToolName: 'some-tool',
         actorId: 'apify/some-actor',
         serverId: 'server-123',

--- a/tests/unit/tools.skyfire.test.ts
+++ b/tests/unit/tools.skyfire.test.ts
@@ -17,7 +17,7 @@ import {
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../../src/payments/const.js';
 import type { ActorMcpTool, ActorTool, HelperTool, ToolEntry } from '../../src/types.js';
-import { ToolType } from '../../src/types.js';
+import { TOOL_TYPE } from '../../src/types.js';
 import { applySkyfireAugmentation, cloneToolEntry } from '../../src/utils/tools.js';
 
 // ---------------------------------------------------------------------------
@@ -30,7 +30,7 @@ function makeInternalTool(overrides: Partial<HelperTool> = {}): HelperTool {
     return {
         name: HelperTools.ACTOR_CALL,
         description: 'Call an Actor',
-        type: ToolType.INTERNAL,
+        type: TOOL_TYPE.INTERNAL,
         inputSchema: {
             type: 'object' as const,
             properties: { actor: { type: 'string' } },
@@ -45,7 +45,7 @@ function makeActorTool(overrides: Partial<ActorTool> = {}): ActorTool {
     return {
         name: 'apify--web-scraper',
         description: 'Web scraper tool',
-        type: ToolType.ACTOR,
+        type: TOOL_TYPE.ACTOR,
         actorId: 'abc123',
         actorFullName: 'apify/web-scraper',
         inputSchema: {
@@ -61,7 +61,7 @@ function makeActorMcpTool(overrides: Partial<ActorMcpTool> = {}): ActorMcpTool {
     return {
         name: 'some-mcp-tool',
         description: 'A proxied MCP tool',
-        type: ToolType.ACTOR_MCP,
+        type: TOOL_TYPE.ACTOR_MCP,
         originToolName: 'some-tool',
         actorId: 'apify/some-actor',
         serverId: 'server-123',

--- a/tests/unit/tools.utils.test.ts
+++ b/tests/unit/tools.utils.test.ts
@@ -15,6 +15,7 @@ import {
     transformActorInputSchemaProperties,
 } from '../../src/tools/utils.js';
 import type { ActorInfo, ActorInputSchema, SchemaProperties, ToolBase, ToolEntry } from '../../src/types.js';
+import { ToolType } from '../../src/types.js';
 import { extractActorName, getToolFullName, getToolPublicFieldOnly } from '../../src/utils/tools.js';
 
 describe('buildApifySpecificProperties', () => {
@@ -932,7 +933,7 @@ describe('filterAndShortenEnum', () => {
 describe('getToolFullName', () => {
     it('returns actorFullName for actor tools', () => {
         const tool = {
-            type: 'actor',
+            type: ToolType.ACTOR,
             name: 'actor-web-scraper-by-apify',
             actorFullName: 'apify/web-scraper',
         } as unknown as ToolEntry;
@@ -940,13 +941,13 @@ describe('getToolFullName', () => {
     });
 
     it('returns name for internal tools', () => {
-        const tool = { type: 'internal', name: 'store-search' } as unknown as ToolEntry;
+        const tool = { type: ToolType.INTERNAL, name: 'store-search' } as unknown as ToolEntry;
         expect(getToolFullName(tool)).toBe('store-search');
     });
 
     it('returns name for actor-mcp tools', () => {
         const tool = {
-            type: 'actor-mcp',
+            type: ToolType.ACTOR_MCP,
             name: 'mcp-tool-search',
             actorId: 'apify/actors-mcp-server',
         } as unknown as ToolEntry;
@@ -956,27 +957,27 @@ describe('getToolFullName', () => {
 
 describe('extractActorName', () => {
     it('returns actorFullName for actor tools', () => {
-        const tool = { type: 'actor', actorFullName: 'apify/web-scraper' } as unknown as ToolEntry;
+        const tool = { type: ToolType.ACTOR, actorFullName: 'apify/web-scraper' } as unknown as ToolEntry;
         expect(extractActorName(tool)).toBe('apify/web-scraper');
     });
 
     it('returns actorId for actor-mcp tools', () => {
-        const tool = { type: 'actor-mcp', actorId: 'apify/actors-mcp-server' } as unknown as ToolEntry;
+        const tool = { type: ToolType.ACTOR_MCP, actorId: 'apify/actors-mcp-server' } as unknown as ToolEntry;
         expect(extractActorName(tool)).toBe('apify/actors-mcp-server');
     });
 
     it('parses actor name from call-actor args', () => {
-        const tool = { type: 'internal', name: 'call-actor' } as unknown as ToolEntry;
+        const tool = { type: ToolType.INTERNAL, name: 'call-actor' } as unknown as ToolEntry;
         expect(extractActorName(tool, { actor: 'apify/web-scraper' })).toBe('apify/web-scraper');
     });
 
     it('strips :toolName suffix from call-actor args', () => {
-        const tool = { type: 'internal', name: 'call-actor' } as unknown as ToolEntry;
+        const tool = { type: ToolType.INTERNAL, name: 'call-actor' } as unknown as ToolEntry;
         expect(extractActorName(tool, { actor: 'apify/actors-mcp-server:search' })).toBe('apify/actors-mcp-server');
     });
 
     it('returns undefined for internal tools without actor arg', () => {
-        const tool = { type: 'internal', name: 'store-search' } as unknown as ToolEntry;
+        const tool = { type: ToolType.INTERNAL, name: 'store-search' } as unknown as ToolEntry;
         expect(extractActorName(tool)).toBeUndefined();
     });
 });

--- a/tests/unit/tools.utils.test.ts
+++ b/tests/unit/tools.utils.test.ts
@@ -15,7 +15,7 @@ import {
     transformActorInputSchemaProperties,
 } from '../../src/tools/utils.js';
 import type { ActorInfo, ActorInputSchema, SchemaProperties, ToolBase, ToolEntry } from '../../src/types.js';
-import { ToolType } from '../../src/types.js';
+import { TOOL_TYPE } from '../../src/types.js';
 import { extractActorName, getToolFullName, getToolPublicFieldOnly } from '../../src/utils/tools.js';
 
 describe('buildApifySpecificProperties', () => {
@@ -933,7 +933,7 @@ describe('filterAndShortenEnum', () => {
 describe('getToolFullName', () => {
     it('returns actorFullName for actor tools', () => {
         const tool = {
-            type: ToolType.ACTOR,
+            type: TOOL_TYPE.ACTOR,
             name: 'actor-web-scraper-by-apify',
             actorFullName: 'apify/web-scraper',
         } as unknown as ToolEntry;
@@ -941,13 +941,13 @@ describe('getToolFullName', () => {
     });
 
     it('returns name for internal tools', () => {
-        const tool = { type: ToolType.INTERNAL, name: 'store-search' } as unknown as ToolEntry;
+        const tool = { type: TOOL_TYPE.INTERNAL, name: 'store-search' } as unknown as ToolEntry;
         expect(getToolFullName(tool)).toBe('store-search');
     });
 
     it('returns name for actor-mcp tools', () => {
         const tool = {
-            type: ToolType.ACTOR_MCP,
+            type: TOOL_TYPE.ACTOR_MCP,
             name: 'mcp-tool-search',
             actorId: 'apify/actors-mcp-server',
         } as unknown as ToolEntry;
@@ -957,27 +957,27 @@ describe('getToolFullName', () => {
 
 describe('extractActorName', () => {
     it('returns actorFullName for actor tools', () => {
-        const tool = { type: ToolType.ACTOR, actorFullName: 'apify/web-scraper' } as unknown as ToolEntry;
+        const tool = { type: TOOL_TYPE.ACTOR, actorFullName: 'apify/web-scraper' } as unknown as ToolEntry;
         expect(extractActorName(tool)).toBe('apify/web-scraper');
     });
 
     it('returns actorId for actor-mcp tools', () => {
-        const tool = { type: ToolType.ACTOR_MCP, actorId: 'apify/actors-mcp-server' } as unknown as ToolEntry;
+        const tool = { type: TOOL_TYPE.ACTOR_MCP, actorId: 'apify/actors-mcp-server' } as unknown as ToolEntry;
         expect(extractActorName(tool)).toBe('apify/actors-mcp-server');
     });
 
     it('parses actor name from call-actor args', () => {
-        const tool = { type: ToolType.INTERNAL, name: 'call-actor' } as unknown as ToolEntry;
+        const tool = { type: TOOL_TYPE.INTERNAL, name: 'call-actor' } as unknown as ToolEntry;
         expect(extractActorName(tool, { actor: 'apify/web-scraper' })).toBe('apify/web-scraper');
     });
 
     it('strips :toolName suffix from call-actor args', () => {
-        const tool = { type: ToolType.INTERNAL, name: 'call-actor' } as unknown as ToolEntry;
+        const tool = { type: TOOL_TYPE.INTERNAL, name: 'call-actor' } as unknown as ToolEntry;
         expect(extractActorName(tool, { actor: 'apify/actors-mcp-server:search' })).toBe('apify/actors-mcp-server');
     });
 
     it('returns undefined for internal tools without actor arg', () => {
-        const tool = { type: ToolType.INTERNAL, name: 'store-search' } as unknown as ToolEntry;
+        const tool = { type: TOOL_TYPE.INTERNAL, name: 'store-search' } as unknown as ToolEntry;
         expect(extractActorName(tool)).toBeUndefined();
     });
 });

--- a/tests/unit/tools.x402.test.ts
+++ b/tests/unit/tools.x402.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PaymentMeta, RequestHeaders } from '../../src/payments/types.js';
 import { X402PaymentProvider, type X402PaymentRequirements } from '../../src/payments/x402.js';
 import type { HelperTool } from '../../src/types.js';
+import { ToolType } from '../../src/types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -39,7 +40,7 @@ function makePaidTool(overrides: Partial<HelperTool> = {}): HelperTool {
     return {
         name: 'paid-tool',
         description: 'Paid tool',
-        type: 'internal',
+        type: ToolType.INTERNAL,
         paymentRequired: true,
         inputSchema: { type: 'object' as const, properties: {} },
         ajvValidate: vi.fn(() => true) as never,

--- a/tests/unit/tools.x402.test.ts
+++ b/tests/unit/tools.x402.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PaymentMeta, RequestHeaders } from '../../src/payments/types.js';
 import { X402PaymentProvider, type X402PaymentRequirements } from '../../src/payments/x402.js';
 import type { HelperTool } from '../../src/types.js';
-import { ToolType } from '../../src/types.js';
+import { TOOL_TYPE } from '../../src/types.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -40,7 +40,7 @@ function makePaidTool(overrides: Partial<HelperTool> = {}): HelperTool {
     return {
         name: 'paid-tool',
         description: 'Paid tool',
-        type: ToolType.INTERNAL,
+        type: TOOL_TYPE.INTERNAL,
         paymentRequired: true,
         inputSchema: { type: 'object' as const, properties: {} },
         ajvValidate: vi.fn(() => true) as never,

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
 import type { ToolEntry } from '../../src/types.js';
-import { ToolType } from '../../src/types.js';
+import { TOOL_TYPE } from '../../src/types.js';
 import {
     AUTO_INJECTED_TOOLS,
     getToolsForServerMode,
@@ -134,7 +134,7 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
         'auto-injects get-actor-run when only direct actor tools are present (%s mode)',
         (mode) => {
             const actorTool = {
-                type: ToolType.ACTOR,
+                type: TOOL_TYPE.ACTOR,
                 name: 'apify--rag-web-browser',
                 actorFullName: 'apify/rag-web-browser',
             } as unknown as ToolEntry;

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
 import type { ToolEntry } from '../../src/types.js';
+import { ToolType } from '../../src/types.js';
 import {
     AUTO_INJECTED_TOOLS,
     getToolsForServerMode,
@@ -133,7 +134,7 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
         'auto-injects get-actor-run when only direct actor tools are present (%s mode)',
         (mode) => {
             const actorTool = {
-                type: 'actor',
+                type: ToolType.ACTOR,
                 name: 'apify--rag-web-browser',
                 actorFullName: 'apify/rag-web-browser',
             } as unknown as ToolEntry;


### PR DESCRIPTION
## What
Replace string literals (`'internal'`, `'actor'`, `'actor-mcp'`) used as the `ToolEntry` discriminator with a `TOOL_TYPE` const object + derived type union.

```ts
export const TOOL_TYPE = {
    INTERNAL: 'internal',
    ACTOR: 'actor',
    ACTOR_MCP: 'actor-mcp',
} as const;
export type TOOL_TYPE = (typeof TOOL_TYPE)[keyof typeof TOOL_TYPE];
```

## Why
- Single rename target instead of ~30 scattered string literals.
- Proper IDE go-to-definition / find-references on the discriminator.
- Typos become compile errors instead of silent dead branches.
- Matches the existing repo convention for `as const` enums (`TOOL_STATUS`, `FAILURE_CATEGORY`, `ACTOR_LOAD_ERROR_KIND`) — see `CONTRIBUTING.md:194-206`. `TOOL_TYPE.ACTOR` reads as a constant lookup, not as a static method on a class.

Closes #339. Broader cleanup (`ServerMode` rename to match the convention, `CONTRIBUTING.md` fixes) tracked in follow-up #924.

## How
- `src/types.ts`: define `TOOL_TYPE` const + derived type union; switch the 3 union members (`HelperTool`, `ActorTool`, `ActorMcpTool`) from literal types to `typeof TOOL_TYPE.X`.
- Replace every raw discriminator literal in `src/` and `tests/unit/` with the corresponding `TOOL_TYPE.*` constant — switch cases, `.filter(... === ...)`, `if (... === ...)`, and tool-definition `type:` fields.
- `src/index_internals.ts`: **not** re-exported. `apify-mcp-server-internal` does not consume this discriminator today; keeping the surface minimal. Trivial to add back later if needed.

## Compatibility
- Wire/runtime values are unchanged — the const resolves to the same strings, so JSON serialization, persisted state and external consumers are unaffected.
- The discriminated union shape is identical (`typeof TOOL_TYPE.ACTOR` is `'actor'` as a TS literal type).

## Diff stats
38 files, +108 / −110. Mechanical 1-for-1 replacement; the only net additions are the ~8-line `TOOL_TYPE` const block in `src/types.ts`.

## Verification
- ✅ `pnpm run type-check`
- ✅ `pnpm run lint` (0 errors; 3 pre-existing warnings unrelated to this change)
- ✅ `pnpm run test:unit` — 800 passed / 1 skipped
- ✅ `pnpm format:check`

## Follow-up
Add the `beta` label to publish a `pkg.pr.new` canary so the internal repo (`apify-mcp-server-internal`) can pin and validate against it before this lands.
