### PR TITLE
chore: make vscode oxlint typeAware

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     },
     "[typescript]": {
         "editor.defaultFormatter": "oxc.oxc-vscode"
-    }
+    },
+    "oxc.typeAware": true
 }


### PR DESCRIPTION
Enables oxlint type-aware mode in the VS Code extension, mirroring https://github.com/apify/apify-core/pull/28183.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKCfbwxMjFjgbas3NJtJVy)_