### PR TITLE
refactor: Extract storage tool helpers

### DIFF
--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -5,6 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { wrapJsonText } from './storage_helpers.js';
 
 const getUserDatasetsListArgs = z.object({
     offset: z
@@ -65,6 +66,6 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(datasets)}\n\`\`\`` }] };
+        return { content: [{ type: 'text', text: wrapJsonText(datasets) }] };
     },
 } as const);

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { wrapJsonText } from './storage_helpers.js';
+import { wrapJsonText } from '../../utils/mcp.js';
 
 const getUserDatasetsListArgs = z.object({
     offset: z

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -5,8 +5,10 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { stripQuoteWrappers } from '../../utils/generic.js';
+import { wrapJsonText } from '../../utils/mcp.js';
 import { normalizeDatasetFields } from '../core/actor_run_response.js';
-import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
+import { buildStorageNotFound } from './storage_helpers.js';
 
 const getDatasetArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
@@ -43,7 +45,7 @@ export const getDataset: ToolEntry = Object.freeze({
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = getDatasetArgs.parse(args);
-        const datasetId = normalizeStorageId(parsed.datasetId);
+        const datasetId = stripQuoteWrappers(parsed.datasetId);
         const dataset = await client.dataset(datasetId).get();
         if (!dataset) {
             return buildStorageNotFound(`Dataset '${datasetId}' not found.`);

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -1,11 +1,12 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
+import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
 import { normalizeDatasetFields } from '../core/actor_run_response.js';
+import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
 
 const getDatasetArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
@@ -17,17 +18,18 @@ const getDatasetArgs = z.object({
 export const getDataset: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_GET,
-    description: `Get metadata for a dataset (collection of structured data created by an Actor run).
-The results will include dataset details such as itemCount, schema, fields, and stats.
-Use fields to understand structure for filtering with ${HelperTools.DATASET_GET_ITEMS}.
-Note: itemCount updates may be delayed by up to ~5 seconds.
+    description: dedent`
+        Get metadata for a dataset (collection of structured data created by an Actor run).
+        The results will include dataset details such as itemCount, schema, fields, and stats.
+        Use fields to understand structure for filtering with ${HelperTools.DATASET_GET_ITEMS}.
+        Note: itemCount updates may be delayed by up to ~5 seconds.
 
-USAGE:
-- Use when you need dataset metadata to understand its structure before fetching items.
+        USAGE:
+        - Use when you need dataset metadata to understand its structure before fetching items.
 
-USAGE EXAMPLES:
-- user_input: Show info for dataset xyz123
-- user_input: What fields does username~my-dataset have?`,
+        USAGE EXAMPLES:
+        - user_input: Show info for dataset xyz123
+        - user_input: What fields does username~my-dataset have?`,
     inputSchema: z.toJSONSchema(getDatasetArgs) as ToolInputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getDatasetArgs)),
     paymentRequired: true,
@@ -41,13 +43,10 @@ USAGE EXAMPLES:
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = getDatasetArgs.parse(args);
-        const dataset = await client.dataset(parsed.datasetId).get();
+        const datasetId = normalizeStorageId(parsed.datasetId);
+        const dataset = await client.dataset(datasetId).get();
         if (!dataset) {
-            return buildMCPResponse({
-                texts: [`Dataset '${parsed.datasetId}' not found.`],
-                isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
-            });
+            return buildStorageNotFound(`Dataset '${datasetId}' not found.`);
         }
         // Apify returns `fields` slash-separated AND with array indices expanded
         // (e.g. `latestComments/0/owner/username`). For a real Instagram-scraper
@@ -57,6 +56,6 @@ USAGE EXAMPLES:
         // normalization `buildRunDataset` applies so this tool's `fields` matches
         // the structured `storages.datasets.default.fields` shape.
         const normalized = dataset.fields ? { ...dataset, fields: normalizeDatasetFields(dataset.fields) } : dataset;
-        return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(normalized)}\n\`\`\`` }] };
+        return { content: [{ type: 'text', text: wrapJsonText(normalized) }] };
     },
 } as const);

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -1,13 +1,13 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
+import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { parseCommaSeparatedList } from '../../utils/generic.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
+import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
 
 const DEFAULT_DATASET_ITEMS_LIMIT = 20;
 
@@ -97,25 +97,33 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             parsed.flatten !== undefined ? parseCommaSeparatedList(parsed.flatten) : extractDotPrefixes(fields);
 
         const effectiveLimit = parsed.limit ?? DEFAULT_DATASET_ITEMS_LIMIT;
-        const v = await client.dataset(parsed.datasetId).listItems({
-            clean: parsed.clean,
-            offset: parsed.offset,
-            limit: effectiveLimit,
-            fields,
-            omit,
-            desc: parsed.desc,
-            flatten,
-        });
-        if (!v) {
-            return buildMCPResponse({
-                texts: [`Dataset '${parsed.datasetId}' not found.`],
-                isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
+        const datasetId = normalizeStorageId(parsed.datasetId);
+        // `dataset(id).listItems()` throws ApifyApiError on a missing dataset
+        // instead of returning undefined (only `.get()` and `.getStatistics()`
+        // soft-catch 404 in the SDK), so translate 404 into a soft-fail.
+        const v = await client
+            .dataset(datasetId)
+            .listItems({
+                clean: parsed.clean,
+                offset: parsed.offset,
+                limit: effectiveLimit,
+                fields,
+                omit,
+                desc: parsed.desc,
+                flatten,
+            })
+            .catch((err: unknown) => {
+                if (typeof err === 'object' && err !== null && 'statusCode' in err && err.statusCode === HTTP_NOT_FOUND) {
+                    return null;
+                }
+                throw err;
             });
+        if (!v) {
+            return buildStorageNotFound(`Dataset '${datasetId}' not found.`);
         }
 
         const structuredContent = {
-            datasetId: parsed.datasetId,
+            datasetId,
             items: v.items,
             itemCount: v.items.length,
             totalItemCount: v.total,
@@ -123,6 +131,6 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             limit: effectiveLimit,
         };
 
-        return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(v)}\n\`\`\`` }], structuredContent };
+        return { content: [{ type: 'text', text: wrapJsonText(v) }], structuredContent };
     },
 } as const);

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -6,6 +6,7 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { parseCommaSeparatedList } from '../../utils/generic.js';
+import { getHttpStatusCode } from '../../utils/logging.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
 
@@ -113,7 +114,7 @@ export const getDatasetItems: ToolEntry = Object.freeze({
                 flatten,
             })
             .catch((err: unknown) => {
-                if (typeof err === 'object' && err !== null && 'statusCode' in err && err.statusCode === HTTP_NOT_FOUND) {
+                if (getHttpStatusCode(err) === HTTP_NOT_FOUND) {
                     return null;
                 }
                 throw err;

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -5,10 +5,11 @@ import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { parseCommaSeparatedList } from '../../utils/generic.js';
+import { parseCommaSeparatedList, stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
+import { wrapJsonText } from '../../utils/mcp.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
-import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
+import { buildStorageNotFound } from './storage_helpers.js';
 
 const DEFAULT_DATASET_ITEMS_LIMIT = 20;
 
@@ -98,7 +99,7 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             parsed.flatten !== undefined ? parseCommaSeparatedList(parsed.flatten) : extractDotPrefixes(fields);
 
         const effectiveLimit = parsed.limit ?? DEFAULT_DATASET_ITEMS_LIMIT;
-        const datasetId = normalizeStorageId(parsed.datasetId);
+        const datasetId = stripQuoteWrappers(parsed.datasetId);
         // `dataset(id).listItems()` throws ApifyApiError on a missing dataset
         // instead of returning undefined (only `.get()` and `.getStatistics()`
         // soft-catch 404 in the SDK), so translate 404 into a soft-fail.

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -1,10 +1,11 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, TOOL_STATUS } from '../../const.js';
+import { HelperTools, HTTP_NOT_FOUND, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { getHttpStatusCode } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
 import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
@@ -55,11 +56,17 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
         const parsed = getDatasetSchemaArgs.parse(args);
         const datasetId = normalizeStorageId(parsed.datasetId);
 
-        // Get dataset items
-        const datasetResponse = await client.dataset(datasetId).listItems({
-            clean: parsed.clean,
-            limit: parsed.limit,
-        });
+        // `listItems()` throws ApifyApiError on a missing dataset (the SDK only soft-catches
+        // 404 on `.get()` / `.getStatistics()`), so translate 404 into a soft-fail.
+        const datasetResponse = await client
+            .dataset(datasetId)
+            .listItems({ clean: parsed.clean, limit: parsed.limit })
+            .catch((err: unknown) => {
+                if (getHttpStatusCode(err) === HTTP_NOT_FOUND) {
+                    return null;
+                }
+                throw err;
+            });
 
         if (!datasetResponse) {
             return buildStorageNotFound(`Dataset '${datasetId}' not found.`);

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -5,10 +5,11 @@ import { HelperTools, HTTP_NOT_FOUND, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { buildMCPResponse, wrapJsonText } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
-import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
+import { buildStorageNotFound } from './storage_helpers.js';
 
 const getDatasetSchemaArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
@@ -54,7 +55,7 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = getDatasetSchemaArgs.parse(args);
-        const datasetId = normalizeStorageId(parsed.datasetId);
+        const datasetId = stripQuoteWrappers(parsed.datasetId);
 
         // `listItems()` throws ApifyApiError on a missing dataset (the SDK only soft-catches
         // 404 on `.get()` / `.getStatistics()`), so translate 404 into a soft-fail.

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -1,11 +1,13 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
+import { HelperTools, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
+import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
 
 const getDatasetSchemaArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
@@ -27,16 +29,17 @@ const getDatasetSchemaArgs = z.object({
 export const getDatasetSchema: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_SCHEMA_GET,
-    description: `Generate a JSON schema from a sample of dataset items.
-The schema describes the structure of the data and can be used for validation, documentation, or processing.
-Use this to understand the dataset before fetching many items.
+    description: dedent`
+        Generate a JSON schema from a sample of dataset items.
+        The schema describes the structure of the data and can be used for validation, documentation, or processing.
+        Use this to understand the dataset before fetching many items.
 
-USAGE:
-- Use when you need to infer the structure of dataset items for downstream processing or validation.
+        USAGE:
+        - Use when you need to infer the structure of dataset items for downstream processing or validation.
 
-USAGE EXAMPLES:
-- user_input: Generate schema for dataset 34das2 using 10 items
-- user_input: Show schema of username~my-dataset (clean items only)`,
+        USAGE EXAMPLES:
+        - user_input: Generate schema for dataset 34das2 using 10 items
+        - user_input: Show schema of username~my-dataset (clean items only)`,
     inputSchema: z.toJSONSchema(getDatasetSchemaArgs) as ToolInputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getDatasetSchemaArgs)),
     paymentRequired: true,
@@ -50,25 +53,22 @@ USAGE EXAMPLES:
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = getDatasetSchemaArgs.parse(args);
+        const datasetId = normalizeStorageId(parsed.datasetId);
 
         // Get dataset items
-        const datasetResponse = await client.dataset(parsed.datasetId).listItems({
+        const datasetResponse = await client.dataset(datasetId).listItems({
             clean: parsed.clean,
             limit: parsed.limit,
         });
 
         if (!datasetResponse) {
-            return buildMCPResponse({
-                texts: [`Dataset '${parsed.datasetId}' not found.`],
-                isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
-            });
+            return buildStorageNotFound(`Dataset '${datasetId}' not found.`);
         }
 
         const datasetItems = datasetResponse.items;
 
         if (datasetItems.length === 0) {
-            return { content: [{ type: 'text', text: `Dataset '${parsed.datasetId}' is empty.` }] };
+            return { content: [{ type: 'text', text: `Dataset '${datasetId}' is empty.` }] };
         }
 
         // Generate schema using the shared utility
@@ -80,12 +80,12 @@ USAGE EXAMPLES:
         if (!schema) {
             // Schema generation failure is typically a server/processing error, not a user error
             return buildMCPResponse({
-                texts: [`Failed to generate schema for dataset '${parsed.datasetId}'.`],
+                texts: [`Failed to generate schema for dataset '${datasetId}'.`],
                 isError: true,
                 telemetry: { toolStatus: TOOL_STATUS.FAILED },
             });
         }
 
-        return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(schema)}\n\`\`\`` }] };
+        return { content: [{ type: 'text', text: wrapJsonText(schema) }] };
     },
 } as const);

--- a/src/tools/common/get_key_value_store.ts
+++ b/src/tools/common/get_key_value_store.ts
@@ -1,10 +1,11 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
+import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
 
 const getKeyValueStoreArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -16,15 +17,16 @@ const getKeyValueStoreArgs = z.object({
 export const getKeyValueStore: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_GET,
-    description: `Get details about a key-value store by ID or username~store-name.
-The results will include store metadata (ID, name, owner, access settings) and usage statistics.
+    description: dedent`
+        Get details about a key-value store by ID or username~store-name.
+        The results will include store metadata (ID, name, owner, access settings) and usage statistics.
 
-USAGE:
-- Use when you need to inspect a store to locate records or understand its properties.
+        USAGE:
+        - Use when you need to inspect a store to locate records or understand its properties.
 
-USAGE EXAMPLES:
-- user_input: Show info for key-value store username~my-store
-- user_input: Get details for store adb123`,
+        USAGE EXAMPLES:
+        - user_input: Show info for key-value store username~my-store
+        - user_input: Get details for store adb123`,
     inputSchema: z.toJSONSchema(getKeyValueStoreArgs) as ToolInputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getKeyValueStoreArgs)),
     paymentRequired: true,
@@ -38,14 +40,11 @@ USAGE EXAMPLES:
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = getKeyValueStoreArgs.parse(args);
-        const kvStore = await client.keyValueStore(parsed.keyValueStoreId).get();
+        const keyValueStoreId = normalizeStorageId(parsed.keyValueStoreId);
+        const kvStore = await client.keyValueStore(keyValueStoreId).get();
         if (!kvStore) {
-            return buildMCPResponse({
-                texts: [`Key-value store '${parsed.keyValueStoreId}' not found.`],
-                isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
-            });
+            return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(kvStore)}\n\`\`\`` }] };
+        return { content: [{ type: 'text', text: wrapJsonText(kvStore) }] };
     },
 } as const);

--- a/src/tools/common/get_key_value_store.ts
+++ b/src/tools/common/get_key_value_store.ts
@@ -5,7 +5,9 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
+import { stripQuoteWrappers } from '../../utils/generic.js';
+import { wrapJsonText } from '../../utils/mcp.js';
+import { buildStorageNotFound } from './storage_helpers.js';
 
 const getKeyValueStoreArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -40,7 +42,7 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = getKeyValueStoreArgs.parse(args);
-        const keyValueStoreId = normalizeStorageId(parsed.keyValueStoreId);
+        const keyValueStoreId = stripQuoteWrappers(parsed.keyValueStoreId);
         const kvStore = await client.keyValueStore(keyValueStoreId).get();
         if (!kvStore) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -1,9 +1,11 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { normalizeStorageId, wrapJsonText } from './storage_helpers.js';
 
 const getKeyValueStoreKeysArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -20,16 +22,17 @@ const getKeyValueStoreKeysArgs = z.object({
 export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_KEYS_GET,
-    description: `List keys in a key-value store with optional pagination.
-The results will include keys and basic info about stored values (e.g., size).
-Use exclusiveStartKey and limit to paginate.
+    description: dedent`
+        List keys in a key-value store with optional pagination.
+        The results will include keys and basic info about stored values (e.g., size).
+        Use exclusiveStartKey and limit to paginate.
 
-USAGE:
-- Use when you need to discover what records exist in a store.
+        USAGE:
+        - Use when you need to discover what records exist in a store.
 
-USAGE EXAMPLES:
-- user_input: List first 10 keys in store username~my-store
-- user_input: Continue listing keys in store a123 from key data.json`,
+        USAGE EXAMPLES:
+        - user_input: List first 10 keys in store username~my-store
+        - user_input: Continue listing keys in store a123 from key data.json`,
     inputSchema: z.toJSONSchema(getKeyValueStoreKeysArgs) as ToolInputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getKeyValueStoreKeysArgs)),
     paymentRequired: true,
@@ -43,10 +46,11 @@ USAGE EXAMPLES:
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = getKeyValueStoreKeysArgs.parse(args);
-        const keys = await client.keyValueStore(parsed.keyValueStoreId).listKeys({
+        const keyValueStoreId = normalizeStorageId(parsed.keyValueStoreId);
+        const keys = await client.keyValueStore(keyValueStoreId).listKeys({
             exclusiveStartKey: parsed.exclusiveStartKey,
             limit: parsed.limit,
         });
-        return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(keys)}\n\`\`\`` }] };
+        return { content: [{ type: 'text', text: wrapJsonText(keys) }] };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -5,8 +5,10 @@ import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
+import { wrapJsonText } from '../../utils/mcp.js';
+import { buildStorageNotFound } from './storage_helpers.js';
 
 const getKeyValueStoreKeysArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -47,7 +49,7 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = getKeyValueStoreKeysArgs.parse(args);
-        const keyValueStoreId = normalizeStorageId(parsed.keyValueStoreId);
+        const keyValueStoreId = stripQuoteWrappers(parsed.keyValueStoreId);
         // `listKeys()` throws ApifyApiError on a missing store (the SDK only soft-catches
         // 404 on `.get()` / `.getRecord()`), so translate 404 into a soft-fail.
         const keys = await client

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -1,11 +1,12 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { normalizeStorageId, wrapJsonText } from './storage_helpers.js';
+import { getHttpStatusCode } from '../../utils/logging.js';
+import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
 
 const getKeyValueStoreKeysArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -47,10 +48,20 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         const { args, apifyClient: client } = toolArgs;
         const parsed = getKeyValueStoreKeysArgs.parse(args);
         const keyValueStoreId = normalizeStorageId(parsed.keyValueStoreId);
-        const keys = await client.keyValueStore(keyValueStoreId).listKeys({
-            exclusiveStartKey: parsed.exclusiveStartKey,
-            limit: parsed.limit,
-        });
+        // `listKeys()` throws ApifyApiError on a missing store (the SDK only soft-catches
+        // 404 on `.get()` / `.getRecord()`), so translate 404 into a soft-fail.
+        const keys = await client
+            .keyValueStore(keyValueStoreId)
+            .listKeys({ exclusiveStartKey: parsed.exclusiveStartKey, limit: parsed.limit })
+            .catch((err: unknown) => {
+                if (getHttpStatusCode(err) === HTTP_NOT_FOUND) {
+                    return null;
+                }
+                throw err;
+            });
+        if (!keys) {
+            return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
+        }
         return { content: [{ type: 'text', text: wrapJsonText(keys) }] };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -1,10 +1,11 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
+import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
 
 const getKeyValueStoreRecordArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -17,15 +18,16 @@ const getKeyValueStoreRecordArgs = z.object({
 export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_RECORD_GET,
-    description: `Get a value stored in a key-value store under a specific key.
-The response preserves the original Content-Encoding; most clients handle decompression automatically.
+    description: dedent`
+        Get a value stored in a key-value store under a specific key.
+        The response preserves the original Content-Encoding; most clients handle decompression automatically.
 
-USAGE:
-- Use when you need to retrieve a specific record (JSON, text, or binary) from a store.
+        USAGE:
+        - Use when you need to retrieve a specific record (JSON, text, or binary) from a store.
 
-USAGE EXAMPLES:
-- user_input: Get record INPUT from store abc123
-- user_input: Get record data.json from store username~my-store`,
+        USAGE EXAMPLES:
+        - user_input: Get record INPUT from store abc123
+        - user_input: Get record data.json from store username~my-store`,
     inputSchema: z.toJSONSchema(getKeyValueStoreRecordArgs) as ToolInputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getKeyValueStoreRecordArgs)),
     paymentRequired: true,
@@ -39,20 +41,17 @@ USAGE EXAMPLES:
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = getKeyValueStoreRecordArgs.parse(args);
-        const store = client.keyValueStore(parsed.keyValueStoreId);
+        const keyValueStoreId = normalizeStorageId(parsed.keyValueStoreId);
+        const store = client.keyValueStore(keyValueStoreId);
         const record = await store.getRecord(parsed.recordKey);
         if (record === undefined) {
             // getRecord returns undefined for both missing-store and missing-key; disambiguate.
             const storeInfo = await store.get();
             const text = storeInfo
-                ? `Record '${parsed.recordKey}' not found in key-value store '${parsed.keyValueStoreId}'.`
-                : `Key-value store '${parsed.keyValueStoreId}' not found.`;
-            return buildMCPResponse({
-                texts: [text],
-                isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
-            });
+                ? `Record '${parsed.recordKey}' not found in key-value store '${keyValueStoreId}'.`
+                : `Key-value store '${keyValueStoreId}' not found.`;
+            return buildStorageNotFound(text);
         }
-        return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(record)}\n\`\`\`` }] };
+        return { content: [{ type: 'text', text: wrapJsonText(record) }] };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -5,7 +5,9 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildStorageNotFound, normalizeRecordKey, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
+import { stripQuoteWrappers } from '../../utils/generic.js';
+import { wrapJsonText } from '../../utils/mcp.js';
+import { buildStorageNotFound, normalizeRecordKey } from './storage_helpers.js';
 
 const getKeyValueStoreRecordArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -41,7 +43,7 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = getKeyValueStoreRecordArgs.parse(args);
-        const keyValueStoreId = normalizeStorageId(parsed.keyValueStoreId);
+        const keyValueStoreId = stripQuoteWrappers(parsed.keyValueStoreId);
         const recordKey = normalizeRecordKey(parsed.recordKey);
         const store = client.keyValueStore(keyValueStoreId);
         const record = await store.getRecord(recordKey);

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildStorageNotFound, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
+import { buildStorageNotFound, normalizeRecordKey, normalizeStorageId, wrapJsonText } from './storage_helpers.js';
 
 const getKeyValueStoreRecordArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -42,13 +42,14 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
         const { args, apifyClient: client } = toolArgs;
         const parsed = getKeyValueStoreRecordArgs.parse(args);
         const keyValueStoreId = normalizeStorageId(parsed.keyValueStoreId);
+        const recordKey = normalizeRecordKey(parsed.recordKey);
         const store = client.keyValueStore(keyValueStoreId);
-        const record = await store.getRecord(parsed.recordKey);
+        const record = await store.getRecord(recordKey);
         if (record === undefined) {
             // getRecord returns undefined for both missing-store and missing-key; disambiguate.
             const storeInfo = await store.get();
             const text = storeInfo
-                ? `Record '${parsed.recordKey}' not found in key-value store '${keyValueStoreId}'.`
+                ? `Record '${recordKey}' not found in key-value store '${keyValueStoreId}'.`
                 : `Key-value store '${keyValueStoreId}' not found.`;
             return buildStorageNotFound(text);
         }

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { wrapJsonText } from './storage_helpers.js';
+import { wrapJsonText } from '../../utils/mcp.js';
 
 const getUserKeyValueStoresListArgs = z.object({
     offset: z

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -1,9 +1,11 @@
+import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { wrapJsonText } from './storage_helpers.js';
 
 const getUserKeyValueStoresListArgs = z.object({
     offset: z
@@ -35,18 +37,19 @@ const getUserKeyValueStoresListArgs = z.object({
 export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_LIST_GET,
-    description: `List key-value stores owned by the authenticated user.
-Actor runs automatically produce unnamed stores (set unnamed=true to include them). Users can also create named stores.
+    description: dedent`
+        List key-value stores owned by the authenticated user.
+        Actor runs automatically produce unnamed stores (set unnamed=true to include them). Users can also create named stores.
 
-The results will include basic info for each store, sorted by createdAt (ascending by default).
-Use limit, offset, and desc to paginate and sort.
+        The results will include basic info for each store, sorted by createdAt (ascending by default).
+        Use limit, offset, and desc to paginate and sort.
 
-USAGE:
-- Use when you need to browse available key-value stores (named or unnamed).
+        USAGE:
+        - Use when you need to browse available key-value stores (named or unnamed).
 
-USAGE EXAMPLES:
-- user_input: List my last 10 key-value stores (newest first)
-- user_input: List unnamed key-value stores`,
+        USAGE EXAMPLES:
+        - user_input: List my last 10 key-value stores (newest first)
+        - user_input: List unnamed key-value stores`,
     inputSchema: z.toJSONSchema(getUserKeyValueStoresListArgs) as ToolInputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getUserKeyValueStoresListArgs)),
     annotations: {
@@ -65,6 +68,6 @@ USAGE EXAMPLES:
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: `\`\`\`json\n${JSON.stringify(stores)}\n\`\`\`` }] };
+        return { content: [{ type: 'text', text: wrapJsonText(stores) }] };
     },
 } as const);

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -2,12 +2,20 @@ import { FAILURE_CATEGORY, TOOL_STATUS } from '../../const.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 
+const JSON_FENCE_PREFIX = '```json\n';
+const JSON_FENCE_SUFFIX = '\n```';
+
 /**
  * Wrap a JSON-serializable value in a Markdown ` ```json ` code fence.
  * Used by every storage tool that returns SDK payloads to the LLM.
  */
 export function wrapJsonText(value: unknown): string {
-    return `\`\`\`json\n${JSON.stringify(value)}\n\`\`\``;
+    return `${JSON_FENCE_PREFIX}${JSON.stringify(value)}${JSON_FENCE_SUFFIX}`;
+}
+
+/** Inverse of `wrapJsonText`; shares the fence constants so prod + tests can't drift. */
+export function parseFencedJson(text: string): unknown {
+    return JSON.parse(text.slice(JSON_FENCE_PREFIX.length, -JSON_FENCE_SUFFIX.length));
 }
 
 /**
@@ -32,4 +40,15 @@ export function buildStorageNotFound(text: string) {
  */
 export function normalizeStorageId(id: string): string {
     return stripQuoteWrappers(id);
+}
+
+/**
+ * Normalize a key-value store record key before SDK lookup.
+ *
+ * Mirrors `normalizeStorageId` but omits the apostrophe (`'`) from the wrapper
+ * class — Apify record keys allow `'` as a valid character
+ * (`/^[a-zA-Z0-9!\-_.'()]{1,256}$/`), so stripping it could corrupt a real key.
+ */
+export function normalizeRecordKey(key: string): string {
+    return key.trim().replace(/^[`"“”‘’]+|[`"“”‘’]+$/g, '').trim();
 }

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -1,0 +1,49 @@
+import { FAILURE_CATEGORY, TOOL_STATUS } from '../../const.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
+
+/**
+ * Wrap a JSON-serializable value in a Markdown ` ```json ` code fence.
+ * Used by every storage tool that returns SDK payloads to the LLM.
+ */
+export function wrapJsonText(value: unknown): string {
+    return `\`\`\`json\n${JSON.stringify(value)}\n\`\`\``;
+}
+
+/**
+ * Soft-fail not-found response for storage tools. Centralizes
+ * `isError: true` + SOFT_FAIL/INVALID_INPUT telemetry so call sites
+ * only supply the message.
+ */
+export function buildStorageNotFound(text: string) {
+    return buildMCPResponse({
+        texts: [text],
+        isError: true,
+        telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
+    });
+}
+
+const STORAGE_ID_WRAPPERS: [string, string][] = [
+    ['`', '`'],
+    ['"', '"'],
+    ['“', '”'],
+    ['‘', '’'],
+];
+
+/**
+ * Normalize a dataset / key-value store id before SDK lookup.
+ *
+ * LLMs commonly wrap ids in markdown backticks or smart quotes, which the
+ * Apify API treats as distinct strings and 404s. This mirrors the trim/strip
+ * half of `fixActorNameInput` (no slash-padding — storage ids use `~`).
+ * Valid ids pass through unchanged.
+ */
+export function normalizeStorageId(id: string): string {
+    let s = id.trim();
+    for (const [open, close] of STORAGE_ID_WRAPPERS) {
+        if (s.startsWith(open) && s.endsWith(close) && s.length >= open.length + close.length) {
+            s = s.slice(open.length, -close.length).trim();
+            break;
+        }
+    }
+    return s.replace(/^[`'"“”‘’]+|[`'"“”‘’]+$/g, '').trim();
+}

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -1,22 +1,6 @@
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../const.js';
-import { stripQuoteWrappers } from '../../utils/generic.js';
+import { QUOTE_WRAPPER_CHARS } from '../../utils/generic.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
-
-const JSON_FENCE_PREFIX = '```json\n';
-const JSON_FENCE_SUFFIX = '\n```';
-
-/**
- * Wrap a JSON-serializable value in a Markdown ` ```json ` code fence.
- * Used by every storage tool that returns SDK payloads to the LLM.
- */
-export function wrapJsonText(value: unknown): string {
-    return `${JSON_FENCE_PREFIX}${JSON.stringify(value)}${JSON_FENCE_SUFFIX}`;
-}
-
-/** Inverse of `wrapJsonText`; shares the fence constants so prod + tests can't drift. */
-export function parseFencedJson(text: string): unknown {
-    return JSON.parse(text.slice(JSON_FENCE_PREFIX.length, -JSON_FENCE_SUFFIX.length));
-}
 
 /**
  * Soft-fail not-found response for storage tools. Centralizes
@@ -32,26 +16,14 @@ export function buildStorageNotFound(text: string) {
 }
 
 /**
- * Normalize a dataset / key-value store id before SDK lookup.
- *
- * LLMs commonly wrap ids in markdown backticks or smart quotes, which the
- * Apify API treats as distinct strings and 404s. Mirrors the trim/strip
- * half of `fixActorNameInput` (no slash-padding — storage ids use `~`).
- */
-export function normalizeStorageId(id: string): string {
-    return stripQuoteWrappers(id);
-}
-
-/**
  * Normalize a key-value store record key before SDK lookup.
  *
- * Mirrors `normalizeStorageId` but omits the apostrophe (`'`) from the wrapper
- * class — Apify record keys allow `'` as a valid character
- * (`/^[a-zA-Z0-9!\-_.'()]{1,256}$/`), so stripping it could corrupt a real key.
+ * Strips the same LLM-leaked wrapper chars as `stripQuoteWrappers` (shared
+ * `QUOTE_WRAPPER_CHARS`), but preserves the apostrophe — Apify record keys
+ * allow `'` as a valid character (`/^[a-zA-Z0-9!\-_.'()]{1,256}$/`), so
+ * stripping it could corrupt a real key.
  */
+const NORMALIZE_RECORD_KEY_REGEX = new RegExp(`^[${QUOTE_WRAPPER_CHARS}]+|[${QUOTE_WRAPPER_CHARS}]+$`, 'g');
 export function normalizeRecordKey(key: string): string {
-    return key
-        .trim()
-        .replace(/^[`"“”‘’]+|[`"“”‘’]+$/g, '')
-        .trim();
+    return key.trim().replace(NORMALIZE_RECORD_KEY_REGEX, '').trim();
 }

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -50,5 +50,8 @@ export function normalizeStorageId(id: string): string {
  * (`/^[a-zA-Z0-9!\-_.'()]{1,256}$/`), so stripping it could corrupt a real key.
  */
 export function normalizeRecordKey(key: string): string {
-    return key.trim().replace(/^[`"“”‘’]+|[`"“”‘’]+$/g, '').trim();
+    return key
+        .trim()
+        .replace(/^[`"“”‘’]+|[`"“”‘’]+$/g, '')
+        .trim();
 }

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -1,4 +1,5 @@
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../const.js';
+import { stripQuoteWrappers } from '../../utils/generic.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 
 /**
@@ -22,28 +23,13 @@ export function buildStorageNotFound(text: string) {
     });
 }
 
-const STORAGE_ID_WRAPPERS: [string, string][] = [
-    ['`', '`'],
-    ['"', '"'],
-    ['“', '”'],
-    ['‘', '’'],
-];
-
 /**
  * Normalize a dataset / key-value store id before SDK lookup.
  *
  * LLMs commonly wrap ids in markdown backticks or smart quotes, which the
- * Apify API treats as distinct strings and 404s. This mirrors the trim/strip
+ * Apify API treats as distinct strings and 404s. Mirrors the trim/strip
  * half of `fixActorNameInput` (no slash-padding — storage ids use `~`).
- * Valid ids pass through unchanged.
  */
 export function normalizeStorageId(id: string): string {
-    let s = id.trim();
-    for (const [open, close] of STORAGE_ID_WRAPPERS) {
-        if (s.startsWith(open) && s.endsWith(close) && s.length >= open.length + close.length) {
-            s = s.slice(open.length, -close.length).trim();
-            break;
-        }
-    }
-    return s.replace(/^[`'"“”‘’]+|[`'"“”‘’]+$/g, '').trim();
+    return stripQuoteWrappers(id);
 }

--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -21,6 +21,7 @@ import {
 } from '../../types.js';
 import { getActorDefinitionCached } from '../../utils/actor.js';
 import { ajv } from '../../utils/ajv.js';
+import { stripQuoteWrappers } from '../../utils/generic.js';
 import { logHttpError } from '../../utils/logging.js';
 import { buildEnrichedDirectActorOutputSchema, getActorRunOutputSchema } from '../structured_output_schemas.js';
 import {
@@ -246,14 +247,6 @@ export async function getMCPServersAsTools(
     return actorToolsArrays.flat();
 }
 
-// Quote/backtick pairs that LLMs wrap actor names in (allocated once, not per call).
-const ACTOR_NAME_WRAPPERS: [string, string][] = [
-    ['`', '`'],
-    ['"', '"'],
-    ['\u201c', '\u201d'],
-    ['\u2018', '\u2019'],
-];
-
 /**
  * Fixes an Actor name input from LLM and logs at INFO when the input differed from the fixed version.
  * Single entry point for fix+log — avoids duplicating the pattern at every call site.
@@ -278,16 +271,7 @@ export function fixActorNameInputAndLog(actorName: string, extra?: Record<string
  * and strips common wrappers / spacing noise; valid names pass through unchanged.
  */
 export function fixActorNameInput(actorName: string): string {
-    let s = actorName.trim();
-    for (const [open, close] of ACTOR_NAME_WRAPPERS) {
-        if (s.startsWith(open) && s.endsWith(close) && s.length >= open.length + close.length) {
-            s = s.slice(open.length, -close.length).trim();
-            break;
-        }
-    }
-    // Unpaired markdown / JSON leakage (Mezmo: `apify/rag-web-browser` or `...pr-226"`)
-    s = s.replace(/^[`'"\u201c\u201d\u2018\u2019]+|[`'"\u201c\u201d\u2018\u2019]+$/g, '').trim();
-    s = s.replace(/\s*\/\s*/g, '/');
+    const s = stripQuoteWrappers(actorName).replace(/\s*\/\s*/g, '/');
     return s.replace(/\s+/g, ' ').trim();
 }
 

--- a/src/utils/generic.ts
+++ b/src/utils/generic.ts
@@ -91,6 +91,34 @@ export function getValuesByDotKeys(obj: Record<string, unknown>, keys: string[])
     return result;
 }
 
+// Quote/backtick pairs that LLMs wrap user-facing identifiers in
+// (markdown backticks, straight + smart quotes). Allocated once.
+const QUOTE_WRAPPERS: [string, string][] = [
+    ['`', '`'],
+    ['"', '"'],
+    ['“', '”'],
+    ['‘', '’'],
+];
+
+/**
+ * Strip surrounding quote/backtick wrappers and whitespace from an LLM-supplied id.
+ *
+ * LLMs often paste names wrapped in markdown backticks or smart quotes; the Apify
+ * API treats those as distinct strings and 404s. Trims, strips one matched pair,
+ * then strips any remaining unpaired quote-like chars on either end.
+ */
+export function stripQuoteWrappers(s: string): string {
+    let out = s.trim();
+    for (const [open, close] of QUOTE_WRAPPERS) {
+        if (out.startsWith(open) && out.endsWith(close) && out.length >= open.length + close.length) {
+            out = out.slice(open.length, -close.length).trim();
+            break;
+        }
+    }
+    // Unpaired markdown / JSON leakage (e.g. `apify/rag-web-browser` or `...pr-226"`)
+    return out.replace(/^[`'"“”‘’]+|[`'"“”‘’]+$/g, '').trim();
+}
+
 /**
  * Validates whether a given string is a well-formed URL.
  *

--- a/src/utils/generic.ts
+++ b/src/utils/generic.ts
@@ -92,6 +92,14 @@ export function getValuesByDotKeys(obj: Record<string, unknown>, keys: string[])
 }
 
 /**
+ * Backtick + straight & smart double-quote chars LLMs wrap user inputs in.
+ * Shared between `stripQuoteWrappers` (which also strips apostrophes from ids)
+ * and `normalizeRecordKey` (which preserves apostrophes in KV record keys).
+ * Single source of truth: extend here and both call sites pick it up.
+ */
+export const QUOTE_WRAPPER_CHARS = '`"“”‘’';
+
+/**
  * Strip surrounding quote/backtick wrappers and whitespace from an LLM-supplied id.
  *
  * LLMs paste names wrapped in markdown backticks or smart quotes; the Apify API
@@ -99,11 +107,9 @@ export function getValuesByDotKeys(obj: Record<string, unknown>, keys: string[])
  * `` ` ``, `'`, `"` or smart quotes — handles matched pairs, unpaired leakage,
  * and nested wrappers (`` `"id"` ``) uniformly.
  */
+const STRIP_QUOTE_WRAPPERS_REGEX = new RegExp(`^[${QUOTE_WRAPPER_CHARS}']+|[${QUOTE_WRAPPER_CHARS}']+$`, 'g');
 export function stripQuoteWrappers(s: string): string {
-    return s
-        .trim()
-        .replace(/^[`'"“”‘’]+|[`'"“”‘’]+$/g, '')
-        .trim();
+    return s.trim().replace(STRIP_QUOTE_WRAPPERS_REGEX, '').trim();
 }
 
 /**

--- a/src/utils/generic.ts
+++ b/src/utils/generic.ts
@@ -91,32 +91,16 @@ export function getValuesByDotKeys(obj: Record<string, unknown>, keys: string[])
     return result;
 }
 
-// Quote/backtick pairs that LLMs wrap user-facing identifiers in
-// (markdown backticks, straight + smart quotes). Allocated once.
-const QUOTE_WRAPPERS: [string, string][] = [
-    ['`', '`'],
-    ['"', '"'],
-    ['“', '”'],
-    ['‘', '’'],
-];
-
 /**
  * Strip surrounding quote/backtick wrappers and whitespace from an LLM-supplied id.
  *
- * LLMs often paste names wrapped in markdown backticks or smart quotes; the Apify
- * API treats those as distinct strings and 404s. Trims, strips one matched pair,
- * then strips any remaining unpaired quote-like chars on either end.
+ * LLMs paste names wrapped in markdown backticks or smart quotes; the Apify API
+ * treats those as distinct strings and 404s. Strips any leading/trailing run of
+ * `` ` ``, `'`, `"` or smart quotes — handles matched pairs, unpaired leakage,
+ * and nested wrappers (`` `"id"` ``) uniformly.
  */
 export function stripQuoteWrappers(s: string): string {
-    let out = s.trim();
-    for (const [open, close] of QUOTE_WRAPPERS) {
-        if (out.startsWith(open) && out.endsWith(close) && out.length >= open.length + close.length) {
-            out = out.slice(open.length, -close.length).trim();
-            break;
-        }
-    }
-    // Unpaired markdown / JSON leakage (e.g. `apify/rag-web-browser` or `...pr-226"`)
-    return out.replace(/^[`'"“”‘’]+|[`'"“”‘’]+$/g, '').trim();
+    return s.trim().replace(/^[`'"“”‘’]+|[`'"“”‘’]+$/g, '').trim();
 }
 
 /**

--- a/src/utils/generic.ts
+++ b/src/utils/generic.ts
@@ -100,7 +100,10 @@ export function getValuesByDotKeys(obj: Record<string, unknown>, keys: string[])
  * and nested wrappers (`` `"id"` ``) uniformly.
  */
 export function stripQuoteWrappers(s: string): string {
-    return s.trim().replace(/^[`'"“”‘’]+|[`'"“”‘’]+$/g, '').trim();
+    return s
+        .trim()
+        .replace(/^[`'"“”‘’]+|[`'"“”‘’]+$/g, '')
+        .trim();
 }
 
 /**

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -49,6 +49,19 @@ export function buildMCPResponse(options: {
     };
 }
 
+/** Markdown JSON code-fence prefix used by `wrapJsonText` and the test-side `parseFencedJson`. */
+export const JSON_FENCE_PREFIX = '```json\n';
+/** Markdown JSON code-fence suffix used by `wrapJsonText` and the test-side `parseFencedJson`. */
+export const JSON_FENCE_SUFFIX = '\n```';
+
+/**
+ * Wrap a JSON-serializable value in a Markdown ` ```json ` code fence.
+ * Used by any tool that returns SDK payloads to the LLM.
+ */
+export function wrapJsonText(value: unknown): string {
+    return `${JSON_FENCE_PREFIX}${JSON.stringify(value)}${JSON_FENCE_SUFFIX}`;
+}
+
 /**
  * Computes the byte size of a tool response — sums UTF-8 byte length of every
  * text item in `content[]` plus JSON-stringified `structuredContent` (if present).

--- a/tests/const.ts
+++ b/tests/const.ts
@@ -3,7 +3,11 @@ import { toolCategoriesEnabledByDefault } from '../src/tools/index.js';
 import { actorNameToToolName } from '../src/tools/utils.js';
 import { getExpectedToolNamesByCategories } from '../src/utils/tool_categories_helpers.js';
 
-export const ACTOR_NORMAL_MODE = 'apify/normal-mode-test-actor';
+// TEMP — points at jiri.spilka's deployed copy so #880 storage-tool integration tests
+// (math.factorial.first, RESULT/STATS/LOG/COVER) can run before apify/normal-mode-test-actor
+// is rebuilt with apify/mcp-server-test-actor#6. Revert to 'apify/normal-mode-test-actor'
+// before merging.
+export const ACTOR_NORMAL_MODE = 'jiri.spilka/normal-test-actor';
 export const ACTOR_EXAMPLE_MCP_SERVER = 'apify/example-mcp-server';
 // Function to avoid circular dependency during module initialization
 export const getDefaultToolNames = () => getExpectedToolNamesByCategories(toolCategoriesEnabledByDefault);

--- a/tests/const.ts
+++ b/tests/const.ts
@@ -3,11 +3,7 @@ import { toolCategoriesEnabledByDefault } from '../src/tools/index.js';
 import { actorNameToToolName } from '../src/tools/utils.js';
 import { getExpectedToolNamesByCategories } from '../src/utils/tool_categories_helpers.js';
 
-// TEMP — points at jiri.spilka's deployed copy so #880 storage-tool integration tests
-// (math.factorial.first, RESULT/STATS/LOG/COVER) can run before apify/normal-mode-test-actor
-// is rebuilt with apify/mcp-server-test-actor#6. Revert to 'apify/normal-mode-test-actor'
-// before merging.
-export const ACTOR_NORMAL_MODE = 'jiri.spilka/normal-test-actor';
+export const ACTOR_NORMAL_MODE = 'apify/normal-mode-test-actor';
 export const ACTOR_EXAMPLE_MCP_SERVER = 'apify/example-mcp-server';
 // Function to avoid circular dependency during module initialization
 export const getDefaultToolNames = () => getExpectedToolNamesByCategories(toolCategoriesEnabledByDefault);

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -213,6 +213,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
     }
 
     describe(
+        // eslint-disable-next-line vitest/valid-title -- parametric suite factory; title is the suiteName argument
         suiteName,
         {
             concurrent: false, // Make all tests sequential to prevent state interference
@@ -1773,7 +1774,9 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 async () => {
                     client = await createClientFn();
                     await client.listTools();
-                    await (client.transport as StreamableHTTPClientTransport).terminateSession();
+                    await expect(
+                        (client.transport as StreamableHTTPClientTransport).terminateSession(),
+                    ).resolves.toBeUndefined();
                 },
             );
 

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -4,6 +4,8 @@ import { expect } from 'vitest';
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../../src/const.js';
 import type { InternalToolArgs } from '../../../src/types.js';
 
+export { parseFencedJson } from '../../../src/tools/common/storage_helpers.js';
+
 /**
  * `CallToolResult` narrowed to text-only content. All current internal tools
  * emit text content, so tests cast results to this shape to avoid the
@@ -17,11 +19,6 @@ export type ToolTelemetrySnapshot = {
     toolStatus?: string;
     failureCategory?: string;
 };
-
-/** Parse the ```` ```json … ``` ```` block emitted by internal storage tools. */
-export function parseFencedJson(text: string): unknown {
-    return JSON.parse(text.replace(/^```json\n/, '').replace(/\n```$/, ''));
-}
 
 /** Minimal `InternalToolArgs` stub for unit tests. */
 export function stubToolCallContext(

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -3,8 +3,12 @@ import { expect } from 'vitest';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../../src/const.js';
 import type { InternalToolArgs } from '../../../src/types.js';
+import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from '../../../src/utils/mcp.js';
 
-export { parseFencedJson } from '../../../src/tools/common/storage_helpers.js';
+/** Inverse of `wrapJsonText`; imports prod's fence constants so the two halves can't drift. */
+export function parseFencedJson(text: string): unknown {
+    return JSON.parse(text.slice(JSON_FENCE_PREFIX.length, -JSON_FENCE_SUFFIX.length));
+}
 
 /**
  * `CallToolResult` narrowed to text-only content. All current internal tools

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -45,6 +45,12 @@ function stubApifyClient(
     } as unknown as InternalToolArgs['apifyClient'];
 }
 
+function stubApifyClientThrowing(err: unknown): InternalToolArgs['apifyClient'] {
+    return stubApifyClient(async () => {
+        throw err;
+    });
+}
+
 describe('get-dataset-items', () => {
     it('has the expected tool name', () => {
         expect(getDatasetItems.name).toBe(HelperTools.DATASET_GET_ITEMS);
@@ -81,12 +87,7 @@ describe('get-dataset-items', () => {
     it('returns isError with a not-found message when listItems throws 404', async () => {
         const notFound = Object.assign(new Error('Dataset was not found'), { statusCode: 404 });
         const result = await (getDatasetItems as HelperTool).call(
-            stubToolCallContext(
-                { datasetId: 'missing' },
-                stubApifyClient(async () => {
-                    throw notFound;
-                }),
-            ),
+            stubToolCallContext({ datasetId: 'missing' }, stubApifyClientThrowing(notFound)),
         );
         const { content } = result as TextToolResult;
 
@@ -98,12 +99,7 @@ describe('get-dataset-items', () => {
         const serverError = Object.assign(new Error('Internal server error'), { statusCode: 500 });
         await expect(
             (getDatasetItems as HelperTool).call(
-                stubToolCallContext(
-                    { datasetId: 'ds-1' },
-                    stubApifyClient(async () => {
-                        throw serverError;
-                    }),
-                ),
+                stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClientThrowing(serverError)),
             ),
         ).rejects.toBe(serverError);
     });
@@ -128,5 +124,20 @@ describe('get-dataset-items', () => {
         const tool = getDatasetItems as HelperTool;
         expect(tool.ajvValidate({ datasetId: '' })).toBe(false);
         expect(tool.ajvValidate({ datasetId: 'ds-1' })).toBe(true);
+    });
+
+    it('passes the wrapper-stripped datasetId to client.dataset()', async () => {
+        const datasetSpy = vi
+            .fn()
+            .mockReturnValue({ listItems: async () => ({ items: MOCK_ITEMS, total: 1 }) });
+        const client = { dataset: datasetSpy } as unknown as InternalToolArgs['apifyClient'];
+
+        const result = await (getDatasetItems as HelperTool).call(
+            stubToolCallContext({ datasetId: '`user~my-dataset`' }, client),
+        );
+
+        expect(datasetSpy).toHaveBeenCalledWith('user~my-dataset');
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+        expect(structuredContent.datasetId).toBe('user~my-dataset');
     });
 });

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -127,9 +127,7 @@ describe('get-dataset-items', () => {
     });
 
     it('passes the wrapper-stripped datasetId to client.dataset()', async () => {
-        const datasetSpy = vi
-            .fn()
-            .mockReturnValue({ listItems: async () => ({ items: MOCK_ITEMS, total: 1 }) });
+        const datasetSpy = vi.fn().mockReturnValue({ listItems: async () => ({ items: MOCK_ITEMS, total: 1 }) });
         const client = { dataset: datasetSpy } as unknown as InternalToolArgs['apifyClient'];
 
         const result = await (getDatasetItems as HelperTool).call(

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -78,17 +78,34 @@ describe('get-dataset-items', () => {
         expect(structuredContent).toHaveProperty('limit', 10);
     });
 
-    it('returns isError with a not-found message when listItems returns no response', async () => {
+    it('returns isError with a not-found message when listItems throws 404', async () => {
+        const notFound = Object.assign(new Error('Dataset was not found'), { statusCode: 404 });
         const result = await (getDatasetItems as HelperTool).call(
             stubToolCallContext(
                 { datasetId: 'missing' },
-                stubApifyClient(async () => null),
+                stubApifyClient(async () => {
+                    throw notFound;
+                }),
             ),
         );
         const { content } = result as TextToolResult;
 
         expectSoftFailInvalidInput(result);
         expect(content[0].text).toContain("Dataset 'missing' not found");
+    });
+
+    it('rethrows non-404 errors from listItems', async () => {
+        const serverError = Object.assign(new Error('Internal server error'), { statusCode: 500 });
+        await expect(
+            (getDatasetItems as HelperTool).call(
+                stubToolCallContext(
+                    { datasetId: 'ds-1' },
+                    stubApifyClient(async () => {
+                        throw serverError;
+                    }),
+                ),
+            ),
+        ).rejects.toBe(serverError);
     });
 
     it('auto-derives flatten from dot-notation in fields', async () => {

--- a/tests/unit/tools.get_dataset_schema.test.ts
+++ b/tests/unit/tools.get_dataset_schema.test.ts
@@ -34,6 +34,16 @@ function stubApifyClient(listItemsResponse: unknown): InternalToolArgs['apifyCli
     } as unknown as InternalToolArgs['apifyClient'];
 }
 
+function stubApifyClientThrowing(err: unknown): InternalToolArgs['apifyClient'] {
+    return {
+        dataset: (_id: string) => ({
+            listItems: async () => {
+                throw err;
+            },
+        }),
+    } as unknown as InternalToolArgs['apifyClient'];
+}
+
 describe('get-dataset-schema', () => {
     it('has the expected tool name', () => {
         expect(getDatasetSchema.name).toBe(HelperTools.DATASET_SCHEMA_GET);
@@ -59,14 +69,24 @@ describe('get-dataset-schema', () => {
         expect(content[0].text).toBe("Dataset 'ds-1' is empty.");
     });
 
-    it('returns isError with a not-found message when listItems returns no response', async () => {
+    it('returns isError with a not-found message when listItems throws 404', async () => {
+        const notFound = Object.assign(new Error('Dataset was not found'), { statusCode: 404 });
         const result = await (getDatasetSchema as HelperTool).call(
-            stubToolCallContext({ datasetId: 'missing' }, stubApifyClient(null)),
+            stubToolCallContext({ datasetId: 'missing' }, stubApifyClientThrowing(notFound)),
         );
         const { content } = result as TextToolResult;
 
         expectSoftFailInvalidInput(result);
         expect(content[0].text).toContain("Dataset 'missing' not found");
+    });
+
+    it('rethrows non-404 errors from listItems', async () => {
+        const serverError = Object.assign(new Error('Internal server error'), { statusCode: 500 });
+        await expect(
+            (getDatasetSchema as HelperTool).call(
+                stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClientThrowing(serverError)),
+            ),
+        ).rejects.toBe(serverError);
     });
 
     it('returns isError when schema generation fails (generator returns null)', async () => {

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getKeyValueStoreKeys } from '../../src/tools/common/get_key_value_store_keys.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { parseFencedJson, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import {
+    expectSoftFailInvalidInput,
+    parseFencedJson,
+    stubToolCallContext,
+    type TextToolResult,
+} from './helpers/tool_context.js';
 
 const MOCK_KEYS = {
     items: [
@@ -67,5 +72,29 @@ describe('get-key-value-store-keys', () => {
         const tool = getKeyValueStoreKeys as HelperTool;
         expect(tool.ajvValidate({ keyValueStoreId: 'kv-1', limit: 11 })).toBe(false);
         expect(tool.ajvValidate({ keyValueStoreId: 'kv-1', limit: 10 })).toBe(true);
+    });
+
+    it('returns isError with a not-found message when listKeys throws 404', async () => {
+        const notFound = Object.assign(new Error('Key-value store was not found'), { statusCode: 404 });
+        const listKeysSpy = vi.fn().mockRejectedValue(notFound);
+
+        const result = await (getKeyValueStoreKeys as HelperTool).call(
+            stubToolCallContext({ keyValueStoreId: 'missing' }, stubApifyClient(listKeysSpy)),
+        );
+        const { content } = result as TextToolResult;
+
+        expectSoftFailInvalidInput(result);
+        expect(content[0].text).toContain("Key-value store 'missing' not found");
+    });
+
+    it('rethrows non-404 errors from listKeys', async () => {
+        const serverError = Object.assign(new Error('Internal server error'), { statusCode: 500 });
+        const listKeysSpy = vi.fn().mockRejectedValue(serverError);
+
+        await expect(
+            (getKeyValueStoreKeys as HelperTool).call(
+                stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(listKeysSpy)),
+            ),
+        ).rejects.toBe(serverError);
     });
 });

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -29,6 +29,10 @@ function stubApifyClient(listKeysSpy: ReturnType<typeof vi.fn>): InternalToolArg
     } as unknown as InternalToolArgs['apifyClient'];
 }
 
+function stubApifyClientThrowing(err: unknown): InternalToolArgs['apifyClient'] {
+    return stubApifyClient(vi.fn().mockRejectedValue(err));
+}
+
 describe('get-key-value-store-keys', () => {
     it('has the expected tool name', () => {
         expect(getKeyValueStoreKeys.name).toBe(HelperTools.KEY_VALUE_STORE_KEYS_GET);
@@ -76,10 +80,8 @@ describe('get-key-value-store-keys', () => {
 
     it('returns isError with a not-found message when listKeys throws 404', async () => {
         const notFound = Object.assign(new Error('Key-value store was not found'), { statusCode: 404 });
-        const listKeysSpy = vi.fn().mockRejectedValue(notFound);
-
         const result = await (getKeyValueStoreKeys as HelperTool).call(
-            stubToolCallContext({ keyValueStoreId: 'missing' }, stubApifyClient(listKeysSpy)),
+            stubToolCallContext({ keyValueStoreId: 'missing' }, stubApifyClientThrowing(notFound)),
         );
         const { content } = result as TextToolResult;
 
@@ -89,12 +91,21 @@ describe('get-key-value-store-keys', () => {
 
     it('rethrows non-404 errors from listKeys', async () => {
         const serverError = Object.assign(new Error('Internal server error'), { statusCode: 500 });
-        const listKeysSpy = vi.fn().mockRejectedValue(serverError);
-
         await expect(
             (getKeyValueStoreKeys as HelperTool).call(
-                stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(listKeysSpy)),
+                stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClientThrowing(serverError)),
             ),
         ).rejects.toBe(serverError);
+    });
+
+    it('passes the wrapper-stripped keyValueStoreId to client.keyValueStore()', async () => {
+        const kvStoreSpy = vi.fn().mockReturnValue({ listKeys: async () => MOCK_KEYS });
+        const client = { keyValueStore: kvStoreSpy } as unknown as InternalToolArgs['apifyClient'];
+
+        await (getKeyValueStoreKeys as HelperTool).call(
+            stubToolCallContext({ keyValueStoreId: '`user~my-store`' }, client),
+        );
+
+        expect(kvStoreSpy).toHaveBeenCalledWith('user~my-store');
     });
 });

--- a/tests/unit/tools.get_key_value_store_record.test.ts
+++ b/tests/unit/tools.get_key_value_store_record.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
 import { getKeyValueStoreRecord } from '../../src/tools/common/get_key_value_store_record.js';
@@ -77,5 +77,18 @@ describe('get-key-value-store-record', () => {
         const tool = getKeyValueStoreRecord as HelperTool;
         expect(tool.ajvValidate({ keyValueStoreId: 'kv-1', recordKey: '' })).toBe(false);
         expect(tool.ajvValidate({ keyValueStoreId: 'kv-1', recordKey: 'INPUT' })).toBe(true);
+    });
+
+    it('passes wrapper-stripped keyValueStoreId and recordKey to the SDK', async () => {
+        const getRecordSpy = vi.fn().mockResolvedValue(MOCK_RECORD);
+        const kvStoreSpy = vi.fn().mockReturnValue({ getRecord: getRecordSpy, get: async () => MOCK_STORE });
+        const client = { keyValueStore: kvStoreSpy } as unknown as InternalToolArgs['apifyClient'];
+
+        await (getKeyValueStoreRecord as HelperTool).call(
+            stubToolCallContext({ keyValueStoreId: '`user~my-store`', recordKey: '`INPUT`' }, client),
+        );
+
+        expect(kvStoreSpy).toHaveBeenCalledWith('user~my-store');
+        expect(getRecordSpy).toHaveBeenCalledWith('INPUT');
     });
 });

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -87,13 +87,14 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
         for (const categoryName of CATEGORY_NAMES) {
             const defaultNames = toolNames(defaultCategories[categoryName]);
             const appsNames = toolNames(appsCategories[categoryName]);
+            const bothModesHaveCategory = defaultNames.length > 0 && appsNames.length > 0;
 
-            // Only check categories that exist in both modes
-            if (defaultNames.length > 0 && appsNames.length > 0) {
-                it(`should have identical tool names in ${categoryName} category across modes`, () => {
+            it.runIf(bothModesHaveCategory)(
+                `should have identical tool names in ${categoryName} category across modes`,
+                () => {
                     expect(defaultNames).toEqual(appsNames);
-                });
-            }
+                },
+            );
         }
     });
 

--- a/tests/unit/tools.storage_helpers.test.ts
+++ b/tests/unit/tools.storage_helpers.test.ts
@@ -35,30 +35,8 @@ describe('buildStorageNotFound()', () => {
 });
 
 describe('normalizeStorageId()', () => {
-    it('returns the input unchanged when no wrappers or whitespace are present', () => {
-        expect(normalizeStorageId('ds-1')).toBe('ds-1');
-        expect(normalizeStorageId('user~my-dataset')).toBe('user~my-dataset');
-    });
-
-    it('trims surrounding whitespace', () => {
-        expect(normalizeStorageId('  ds-1  ')).toBe('ds-1');
-    });
-
-    it('strips matched markdown backtick wrappers', () => {
+    // Wrapper-stripping behavior is pinned via `stripQuoteWrappers` in utils.generic.test.ts.
+    it('delegates to stripQuoteWrappers — typical wrapped id is returned canonical', () => {
         expect(normalizeStorageId('`user~my-store`')).toBe('user~my-store');
-    });
-
-    it('strips matched straight double-quote wrappers', () => {
-        expect(normalizeStorageId('"ds-1"')).toBe('ds-1');
-    });
-
-    it('strips matched smart quote wrappers', () => {
-        expect(normalizeStorageId('“ds-1”')).toBe('ds-1');
-        expect(normalizeStorageId('‘ds-1’')).toBe('ds-1');
-    });
-
-    it('strips unpaired trailing quote/backtick noise', () => {
-        expect(normalizeStorageId('ds-1"')).toBe('ds-1');
-        expect(normalizeStorageId('`ds-1')).toBe('ds-1');
     });
 });

--- a/tests/unit/tools.storage_helpers.test.ts
+++ b/tests/unit/tools.storage_helpers.test.ts
@@ -50,7 +50,7 @@ describe('normalizeRecordKey()', () => {
         expect(normalizeRecordKey('“data.json”')).toBe('data.json');
     });
 
-    it('preserves apostrophes — `\'` is a valid record-key character', () => {
+    it("preserves apostrophes — `'` is a valid record-key character", () => {
         expect(normalizeRecordKey("o'reilly.json")).toBe("o'reilly.json");
         expect(normalizeRecordKey("'apostrophe-key'")).toBe("'apostrophe-key'");
     });

--- a/tests/unit/tools.storage_helpers.test.ts
+++ b/tests/unit/tools.storage_helpers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
+import {
+    buildStorageNotFound,
+    normalizeStorageId,
+    wrapJsonText,
+} from '../../src/tools/common/storage_helpers.js';
+
+describe('wrapJsonText()', () => {
+    it('emits a ```json … ``` fenced block', () => {
+        expect(wrapJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
+    });
+
+    it('serializes arrays', () => {
+        expect(wrapJsonText([1, 2])).toBe('```json\n[1,2]\n```');
+    });
+
+    it('serializes primitives', () => {
+        expect(wrapJsonText('x')).toBe('```json\n"x"\n```');
+    });
+});
+
+describe('buildStorageNotFound()', () => {
+    it('returns a SOFT_FAIL / INVALID_INPUT response with the supplied message', () => {
+        const result = buildStorageNotFound("Dataset 'ds-1' not found.");
+
+        expect(result.isError).toBe(true);
+        expect(result.content).toEqual([{ type: 'text', text: "Dataset 'ds-1' not found." }]);
+        expect(result.toolTelemetry).toEqual({
+            toolStatus: TOOL_STATUS.SOFT_FAIL,
+            failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+        });
+    });
+});
+
+describe('normalizeStorageId()', () => {
+    it('returns the input unchanged when no wrappers or whitespace are present', () => {
+        expect(normalizeStorageId('ds-1')).toBe('ds-1');
+        expect(normalizeStorageId('user~my-dataset')).toBe('user~my-dataset');
+    });
+
+    it('trims surrounding whitespace', () => {
+        expect(normalizeStorageId('  ds-1  ')).toBe('ds-1');
+    });
+
+    it('strips matched markdown backtick wrappers', () => {
+        expect(normalizeStorageId('`user~my-store`')).toBe('user~my-store');
+    });
+
+    it('strips matched straight double-quote wrappers', () => {
+        expect(normalizeStorageId('"ds-1"')).toBe('ds-1');
+    });
+
+    it('strips matched smart quote wrappers', () => {
+        expect(normalizeStorageId('“ds-1”')).toBe('ds-1');
+        expect(normalizeStorageId('‘ds-1’')).toBe('ds-1');
+    });
+
+    it('strips unpaired trailing quote/backtick noise', () => {
+        expect(normalizeStorageId('ds-1"')).toBe('ds-1');
+        expect(normalizeStorageId('`ds-1')).toBe('ds-1');
+    });
+});

--- a/tests/unit/tools.storage_helpers.test.ts
+++ b/tests/unit/tools.storage_helpers.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
 import {
     buildStorageNotFound,
+    normalizeRecordKey,
     normalizeStorageId,
+    parseFencedJson,
     wrapJsonText,
 } from '../../src/tools/common/storage_helpers.js';
 
@@ -38,5 +40,30 @@ describe('normalizeStorageId()', () => {
     // Wrapper-stripping behavior is pinned via `stripQuoteWrappers` in utils.generic.test.ts.
     it('delegates to stripQuoteWrappers — typical wrapped id is returned canonical', () => {
         expect(normalizeStorageId('`user~my-store`')).toBe('user~my-store');
+    });
+});
+
+describe('normalizeRecordKey()', () => {
+    it('strips backticks and double / smart quotes', () => {
+        expect(normalizeRecordKey('`INPUT`')).toBe('INPUT');
+        expect(normalizeRecordKey('"data.json"')).toBe('data.json');
+        expect(normalizeRecordKey('“data.json”')).toBe('data.json');
+    });
+
+    it('preserves apostrophes — `\'` is a valid record-key character', () => {
+        expect(normalizeRecordKey("o'reilly.json")).toBe("o'reilly.json");
+        expect(normalizeRecordKey("'apostrophe-key'")).toBe("'apostrophe-key'");
+    });
+
+    it('trims surrounding whitespace', () => {
+        expect(normalizeRecordKey('  INPUT  ')).toBe('INPUT');
+    });
+});
+
+describe('parseFencedJson()', () => {
+    it('round-trips with wrapJsonText for objects, arrays, and primitives', () => {
+        for (const value of [{ a: 1, b: [2, 3] }, [1, 2, 3], 'x', 42, true, null]) {
+            expect(parseFencedJson(wrapJsonText(value))).toEqual(value);
+        }
     });
 });

--- a/tests/unit/tools.storage_helpers.test.ts
+++ b/tests/unit/tools.storage_helpers.test.ts
@@ -1,27 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
-import {
-    buildStorageNotFound,
-    normalizeRecordKey,
-    normalizeStorageId,
-    parseFencedJson,
-    wrapJsonText,
-} from '../../src/tools/common/storage_helpers.js';
-
-describe('wrapJsonText()', () => {
-    it('emits a ```json … ``` fenced block', () => {
-        expect(wrapJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
-    });
-
-    it('serializes arrays', () => {
-        expect(wrapJsonText([1, 2])).toBe('```json\n[1,2]\n```');
-    });
-
-    it('serializes primitives', () => {
-        expect(wrapJsonText('x')).toBe('```json\n"x"\n```');
-    });
-});
+import { buildStorageNotFound, normalizeRecordKey } from '../../src/tools/common/storage_helpers.js';
 
 describe('buildStorageNotFound()', () => {
     it('returns a SOFT_FAIL / INVALID_INPUT response with the supplied message', () => {
@@ -33,13 +13,6 @@ describe('buildStorageNotFound()', () => {
             toolStatus: TOOL_STATUS.SOFT_FAIL,
             failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
         });
-    });
-});
-
-describe('normalizeStorageId()', () => {
-    // Wrapper-stripping behavior is pinned via `stripQuoteWrappers` in utils.generic.test.ts.
-    it('delegates to stripQuoteWrappers — typical wrapped id is returned canonical', () => {
-        expect(normalizeStorageId('`user~my-store`')).toBe('user~my-store');
     });
 });
 
@@ -57,13 +30,5 @@ describe('normalizeRecordKey()', () => {
 
     it('trims surrounding whitespace', () => {
         expect(normalizeRecordKey('  INPUT  ')).toBe('INPUT');
-    });
-});
-
-describe('parseFencedJson()', () => {
-    it('round-trips with wrapJsonText for objects, arrays, and primitives', () => {
-        for (const value of [{ a: 1, b: [2, 3] }, [1, 2, 3], 'x', 42, true, null]) {
-            expect(parseFencedJson(wrapJsonText(value))).toEqual(value);
-        }
     });
 });

--- a/tests/unit/utils.generic.test.ts
+++ b/tests/unit/utils.generic.test.ts
@@ -7,6 +7,7 @@ import {
     isValidHttpUrl,
     parseCommaSeparatedList,
     parseQueryParamList,
+    stripQuoteWrappers,
 } from '../../src/utils/generic.js';
 
 describe('getValuesByDotKeys', () => {
@@ -144,6 +145,39 @@ describe('parseQueryParamList', () => {
     it('should trim whitespace from array items and their comma-separated values', () => {
         const result = parseQueryParamList([' tool1 , tool2 ', ' tool3']);
         expect(result).toEqual(['tool1', 'tool2', 'tool3']);
+    });
+});
+
+describe('stripQuoteWrappers', () => {
+    it('returns the input unchanged when no wrappers or whitespace are present', () => {
+        expect(stripQuoteWrappers('ds-1')).toBe('ds-1');
+        expect(stripQuoteWrappers('user~my-dataset')).toBe('user~my-dataset');
+    });
+
+    it('trims surrounding whitespace', () => {
+        expect(stripQuoteWrappers('  ds-1  ')).toBe('ds-1');
+    });
+
+    it('strips matched markdown backtick wrappers', () => {
+        expect(stripQuoteWrappers('`user~my-store`')).toBe('user~my-store');
+    });
+
+    it('strips matched straight double-quote wrappers', () => {
+        expect(stripQuoteWrappers('"ds-1"')).toBe('ds-1');
+    });
+
+    it('strips matched smart-quote wrappers', () => {
+        expect(stripQuoteWrappers('“ds-1”')).toBe('ds-1');
+        expect(stripQuoteWrappers('‘ds-1’')).toBe('ds-1');
+    });
+
+    it('strips nested wrappers (matched pair + trailing regex)', () => {
+        expect(stripQuoteWrappers('`"ds-1"`')).toBe('ds-1');
+    });
+
+    it('strips unpaired leading/trailing quote noise', () => {
+        expect(stripQuoteWrappers('ds-1"')).toBe('ds-1');
+        expect(stripQuoteWrappers('`ds-1')).toBe('ds-1');
     });
 });
 

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeToolResponseSizeBytes } from '../../src/utils/mcp.js';
+import { computeToolResponseSizeBytes, wrapJsonText } from '../../src/utils/mcp.js';
+
+describe('wrapJsonText()', () => {
+    it('emits a ```json … ``` fenced block', () => {
+        expect(wrapJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
+    });
+
+    it('serializes arrays', () => {
+        expect(wrapJsonText([1, 2])).toBe('```json\n[1,2]\n```');
+    });
+
+    it('serializes primitives', () => {
+        expect(wrapJsonText('x')).toBe('```json\n"x"\n```');
+    });
+});
 
 describe('computeToolResponseSizeBytes()', () => {
     it('returns 0 for null/undefined/non-object input', () => {


### PR DESCRIPTION
Closes #890.

Pure refactor of the 8 storage tool files in `src/tools/common/`, plus two scoped bug fixes that fall out once the not-found path is centralized.

I check all the tools and the way we return tool results is quite messy. 
Follow up issue: https://github.com/apify/apify-mcp-server/pull/929

## New helpers
- `wrapJsonText(value)` — JSON code-fence wrap.
- `normalizeStorageId(id)` / `normalizeRecordKey(key)` — strip LLM-leaked quote/backtick wrappers before SDK lookup.
- `buildStorageNotFound(text)` — storage-domain soft-fail (SOFT_FAIL + INVALID_INPUT).
- `stripQuoteWrappers(s)` in `src/utils/generic.ts` — shared by `fixActorNameInput` and storage normalizers.

## Bug fixes folded in
- **`listItems()` / `listKeys()` 404 handling.** They throw `ApifyApiError`, not return null (only `.get()` / `.getRecord()` soft-catch). The `if (!v)` branches in `get-dataset-items`, `get-dataset-schema`, `get-key-value-store-keys` were dead — now caught and translated to `buildStorageNotFound`. Non-404 rethrows so 500s stay `INTERNAL_ERROR`.
- 6 tool descriptions migrated to `dedent` to match siblings.

## Flag for internal repo
`get-dataset-items` `structuredContent.datasetId` now reflects the **normalized** id, not the raw input. Previously `` "`ds-1`" `` round-tripped verbatim; now it returns `'ds-1'`. No contract pinned echo-verbatim, but per `CLAUDE.md` worth checking the internal contract suite.

## Verification
`type-check`, `lint`, `test:unit` all clean (823 passing, +12 new tests). Integration tests deferred to reviewer (need `APIFY_TOKEN`).