### PR TITLE
fix(mcp): Validate webServerMcpPath stays within Actor standby origin

### DIFF
--- a/src/mcp/actors.ts
+++ b/src/mcp/actors.ts
@@ -35,6 +35,12 @@ export function getActorMCPServerPath(actorDefinition: ActorDefinition | ActorDe
 
 /**
  * Returns the MCP server URL for the given Actor ID.
+ *
+ * `mcpServerPath` comes from an Actor's `webServerMcpPath` field, i.e. it is
+ * controlled by whoever published the Actor. Resolve it against the standby
+ * origin and reject anything that escapes that origin so a crafted path
+ * (`@host/...`, `.host/...`, `//host/...`, `https://host/...`) cannot redirect
+ * the MCP client — and the caller's Apify token — to a third-party host.
  */
 export async function getActorMCPServerURL(realActorId: string, mcpServerPath: string): Promise<string> {
     // TODO: get from API instead
@@ -42,8 +48,19 @@ export async function getActorMCPServerURL(realActorId: string, mcpServerPath: s
         process.env.HOSTNAME === 'mcp-securitybyobscurity.apify.com'
             ? 'securitybyobscurity.apify.actor'
             : 'apify.actor';
-    const standbyUrl = await getActorStandbyURL(realActorId, standbyBaseUrl);
-    return `${standbyUrl}${mcpServerPath}`;
+    // Parse the standby URL up front so the origin comparison below is between two
+    // values normalised by the same parser — WHATWG lowercases hostnames, and Apify
+    // Actor IDs are mixed-case, so a raw-string comparison would reject legitimate URLs.
+    const standby = new URL(`${await getActorStandbyURL(realActorId, standbyBaseUrl)}/`);
+
+    const resolved = new URL(mcpServerPath, standby);
+    if (resolved.origin !== standby.origin) {
+        throw new Error(`Actor ${realActorId} declares a webServerMcpPath that resolves outside its standby origin`);
+    }
+    // Strip any userinfo that survived parsing; we never want credentials in the URL we hand to the MCP client.
+    resolved.username = '';
+    resolved.password = '';
+    return resolved.toString();
 }
 
 /**

--- a/tests/unit/mcp.actors.test.ts
+++ b/tests/unit/mcp.actors.test.ts
@@ -1,7 +1,7 @@
 import type { ActorDefinition } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
-import { getActorMCPServerPath } from '../../src/mcp/actors.js';
+import { getActorMCPServerPath, getActorMCPServerURL } from '../../src/mcp/actors.js';
 import { MCP_STREAMABLE_ENDPOINT } from '../../src/mcp/const.js';
 
 // Helper to create a valid ActorDefinition and allow webServerMcpPath for testing
@@ -55,5 +55,57 @@ describe('getActorMCPServerPath', () => {
         const actorDefinition = makeActorDefinitionWithPath(` /foo ,   ${MCP_STREAMABLE_ENDPOINT}  , /bar `);
         const result = getActorMCPServerPath(actorDefinition);
         expect(result).toBe(MCP_STREAMABLE_ENDPOINT);
+    });
+});
+
+describe('getActorMCPServerURL', () => {
+    const ACTOR_ID = 'abc123';
+    const STANDBY = `https://${ACTOR_ID}.apify.actor`;
+
+    it('returns URL on the standby origin for a normal path', async () => {
+        const url = await getActorMCPServerURL(ACTOR_ID, '/mcp');
+        expect(url).toBe(`${STANDBY}/mcp`);
+    });
+
+    it('returns URL on the standby origin for a path with query and fragment', async () => {
+        const url = await getActorMCPServerURL(ACTOR_ID, '/mcp?x=1#frag');
+        expect(url).toBe(`${STANDBY}/mcp?x=1#frag`);
+    });
+
+    // Apify Actor IDs are mixed-case; WHATWG URL parsing lowercases hostnames.
+    // The origin check must compare two parser-normalised values, not raw strings.
+    it('accepts a normal path for a mixed-case Actor ID', async () => {
+        const url = await getActorMCPServerURL('Iei3c51WbI7eKwgSg', '/mcp');
+        expect(url).toBe('https://iei3c51wbi7ekwgsg.apify.actor/mcp');
+    });
+
+    // Inputs that, under the buggy `${standby}${path}` concat, would produce a URL
+    // whose hostname is NOT *.apify.actor and would leak the caller's Apify token
+    // to a third party. The fix uses `new URL(path, base)` which resolves these as
+    // either same-origin path components or rejects them outright — either way no
+    // request leaves the standby origin.
+    it.each([
+        // Original CVE PoC — userinfo authority injection (`@host`).
+        '@evil.example/mcp',
+        // Subdomain concatenation — fetch-clean variant that worked against production.
+        '.evil.example/mcp',
+        // Protocol-relative authority hijack.
+        '//evil.example/mcp',
+        // Absolute URL pointing elsewhere.
+        'https://evil.example/mcp',
+        // Backslash variant of protocol-relative (some URL parsers normalize \ → /).
+        '\\\\evil.example/mcp',
+    ])('never resolves outside the standby origin for malicious input: %s', async (path) => {
+        let url: string | undefined;
+        try {
+            url = await getActorMCPServerURL(ACTOR_ID, path);
+        } catch (err) {
+            expect((err as Error).message).toMatch(/resolves outside its standby origin/);
+            return;
+        }
+        const parsed = new URL(url);
+        expect(parsed.origin).toBe(STANDBY);
+        expect(parsed.username).toBe('');
+        expect(parsed.password).toBe('');
     });
 });


### PR DESCRIPTION
Fixes https://github.com/apify/apify-mcp-server/security/advisories/GHSA-6gr2-qh89-hxwm

## Context

`getActorMCPServerURL()` built the Actor standby MCP URL by string-concatenating
`https://<id>.apify.actor` with `webServerMcpPath` from the Actor definition.
Because that field is controlled by whoever publishes the Actor, a crafted
value could redirect the MCP client — and the caller's Apify token — to a
third-party host via URL-authority confusion (e.g. a path like
`.attacker.tld/mcp` resolves to `https://<id>.apify.actor.attacker.tld/mcp`).

## Solution

Resolve `webServerMcpPath` against the standby URL with `new URL(path, base)`
and reject anything whose `origin` doesn't equal the standby origin. Any
userinfo that survives parsing is stripped before the URL is handed to
`connectMCPClient`.

## Worth your attention

- **Some malicious forms are normalised rather than rejected.** `@host`,
  `.host` and `\\host` all resolve to *same-origin path components* under
  `new URL(path, base)`, so the test asserts the invariant ("never leaves the
  standby origin") instead of over-specifying "must throw". `//host` and
  `https://host` do throw.
- **Plain `Error`, not `ActorLoadError`.** This is a low-level utility wrapped
  by `getActorMcpUrlCached`, which already propagates non-404 errors; the bulk
  loader `getMCPServersAsTools` catches and skips the offending Actor. Matches
  the existing `throw new Error('Actor … not found')` pattern in the same file.
- **No defence-in-depth check in `client.ts`.** Source-side validation is
  sufficient; duplicating the guard in the transport layer would couple it to
  the Apify-actor domain without a concrete future call-site needing it.
