### PR TITLE
ci(release): Drop --legacy from MCPB deploy to fix exotic-subdep crash

### DIFF
--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -56,15 +56,15 @@ jobs:
             -   name: Build module
                 run: pnpm run build
             -   name: Prepare MCPB package
-                # `pnpm --filter=@apify/actors-mcp-server deploy --prod --legacy --node-linker=hoisted mcpb` builds a self-contained deployment dir:
-                # production-only deps, a flat (hoisted) node_modules with no `.pnpm/`
-                # store or symlinks — the MCPB packer requires a portable tree.
-                # Then we copy in the build output and assets the packer expects.
+                # `pnpm deploy` (modern, non-`--legacy`) builds a self-contained deployment dir:
+                # production-only deps, a flat (hoisted) node_modules. Modern deploy also derives
+                # a dedicated lockfile from the workspace lockfile, which keeps the supply-chain
+                # check (blockExoticSubdeps) from re-resolving and tripping on transitive deps.
+                # `dist`, `manifest.json`, README/LICENSE land via the npm `files` field — only
+                # `docs/` and the icon copy still need an explicit cp.
                 run: |
-                    pnpm --filter=@apify/actors-mcp-server deploy --prod --legacy --node-linker=hoisted mcpb
-                    cp -r dist mcpb/dist
+                    pnpm --filter=@apify/actors-mcp-server deploy --prod --node-linker=hoisted mcpb
                     cp -r docs mcpb/docs
-                    cp manifest.json mcpb/manifest.json
                     cp docs/apify-logo-claude-desktop.png mcpb/icon.png
                 # `pnpm dlx` instead of `npx` because devEngines.packageManager is
                 # pinned to pnpm with onFail: error — npx invokes npm, which is rejected

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,7 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
 
 overrides:
   '@modelcontextprotocol/sdk': 1.29.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,3 +33,8 @@ strictDepBuilds: false
 # Dependency version overrides. pnpm 11 reads these from the workspace manifest, not package.json.
 overrides:
   "@modelcontextprotocol/sdk": "1.29.0"
+
+# Required by pnpm v10+ modern `pnpm deploy`: workspace deps get copied ("injected")
+# into consumers' node_modules instead of symlinked, so deploy output is portable.
+# No effect on installs in this repo today — the root package has no `workspace:*` deps.
+injectWorkspacePackages: true


### PR DESCRIPTION
## Context

The MCPB packaging step in `manual_release_stable.yaml` started failing with
`ERR_PNPM_EXOTIC_SUBDEP` for `ox` (resolved via URL), pulled in transitively
through `viem` → `@apify/mcpc@0.2.6`. `mcpc` is a devDependency, so under
`--prod` it should never have entered the deploy graph in the first place —
but `pnpm deploy --legacy --prod` doesn't filter devDeps correctly.

## Solution

Drop `--legacy` so modern `pnpm deploy` runs, which:
- derives a dedicated lockfile from the workspace lockfile (lockfile-sourced
  packages are exempt from the `blockExoticSubdeps` check — verified in
  pnpm 11 source: `isExoticDep` is skipped when `pkgResponse.body.resolvedVia`
  comes from the lockfile),
- correctly excludes devDeps under `--prod` (so `mcpc` / `viem` / `ox` never
  enter the graph at all),
- still produces a hoisted, portable `node_modules` for the MCPB packer.

`injectWorkspacePackages: true` is required by pnpm v10+ modern deploy as a
workspace-wide opt-in. No behavioural effect on installs in this repo — the
root package declares no `workspace:*` deps; the `src/web` package is consumed
via a `postbuild` file-copy, not via pnpm linking.

## Worth your attention

- **The `cp -r dist mcpb/dist` line is removed.** Modern deploy honors the
  npm `files` field, so `dist/`, `manifest.json`, `LICENSE.md`, `README.md`,
  `server.json` already land in the deploy dir. Keeping the `cp` would create
  a nested `mcpb/dist/dist`. `cp -r docs mcpb/docs` and the icon copy stay —
  those paths are NOT in `files`.
- **Locally verified end-to-end.** Ran the exact CI command sequence against
  master + this patch: deploy exit 0, supply-chain check passes, 0 leaked
  `ox`/`viem`, `@apify/mcpc` correctly excluded, `dist/` lands at the right
  level with 440 files, no nested directories.
- **`injectWorkspacePackages: true` is a dormant flag here.** It only changes
  behaviour the day a `workspace:*` runtime dep is added to root — at which
  point that dep gets copied instead of symlinked at install time (trade-off:
  portable deploy artifact in exchange for re-install needed to pick up live
  edits in workspace deps).
