### PR TITLE
docs(dev): Document bearer-token auth for the local dev HTTP server

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,12 +103,19 @@ Builds the core TypeScript project and `src/web/` widgets, then copies widgets i
 ### Hot-reload development
 
 ```bash
-APIFY_TOKEN='your-apify-token' pnpm run dev
+pnpm run dev
 ```
 
-Starts the web widgets builder in watch mode and the MCP server in standby mode on port `3001`. Editing `src/web/src/widgets/*.tsx` triggers a hot-reload — the next widget render uses updated code without restarting the server. Adding new widget filenames requires reconnecting the MCP client to pick them up.
+Starts the web widgets builder in watch mode and the MCP server in standby mode on port `3001`. The dev server mirrors production auth — it does **not** read `APIFY_TOKEN` from its environment. Every request must carry the token via one of (in priority order):
 
-- Get your `APIFY_TOKEN` from [Apify Console](https://console.apify.com/settings/integrations)
+1. `Authorization: Bearer <token>` header
+2. `x-apify-authorization: Bearer <token>` header
+3. `?token=<token>` query parameter (handy for quick browser-based widget previews)
+
+Editing `src/web/src/widgets/*.tsx` triggers a hot-reload — the next widget render uses updated code without restarting the server. Adding new widget filenames requires reconnecting the MCP client to pick them up.
+
+- The repo's [`.mcp.json`](./.mcp.json) ships a `dev` entry wired with `Authorization: Bearer ${APIFY_TOKEN}` — `${APIFY_TOKEN}` is populated via [Claude Code setup](#configuring-apify_token-for-claude-code) below.
+- Get your Apify API token from [Apify Console](https://console.apify.com/settings/integrations)
 - Preview widgets via the local esbuild dev server at `http://localhost:3226/index.html`
 
 The MCP server listens on port `3001`. The HTTP server implementation is in `src/dev_server.ts`. The hosted production server behind [mcp.apify.com](https://mcp.apify.com) is located in the internal Apify repository.


### PR DESCRIPTION
## Context

`DEVELOPMENT.md` documents `pnpm run dev` as `APIFY_TOKEN='your-apify-token' pnpm run dev`,
but the local dev HTTP server (`src/dev_server.ts`) no longer reads `APIFY_TOKEN`
from its environment — it mirrors production by requiring the token on each
incoming request. Anyone following the existing instruction hits a 401 with no
hint at what changed.

## Solution

Rewrite the **Hot-reload development** subsection to:
- Drop the `APIFY_TOKEN=…` prefix from the command.
- List the three accepted token sources, in the same priority `extractApiTokenFromRequest`
  uses: `Authorization: Bearer`, `x-apify-authorization: Bearer`, `?token=`.
- Point at the existing `dev` entry in `.mcp.json` (already wired with the correct header).

## Worth your attention

- **Other `APIFY_TOKEN` mentions in the doc are intentionally untouched.** The env var
  is still consumed by `src/stdio.ts` (the CLI/stdio entry point) and by the integration
  tests (`tests/integration/**`, `tests/helpers.ts`). Only the HTTP dev server stopped
  reading it.
- **No code change.** The dev server's auth behaviour has been bearer-only for a while
  — this PR just brings the docs in line.
