### PR TITLE
feat: Surface dataset size hints to guide large-output fetches

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -16,6 +16,15 @@ export const ACTOR_MAX_MEMORY_MBYTES = 4_096; // If the Actor requires 8GB of me
  */
 export const KV_RECORD_MAX_INLINE_BYTES = 256 * 1024;
 
+/**
+ * Advisory threshold (uncompressed bytes) above which dataset tools append a size hint steering the
+ * caller to narrow the fetch. A soft hint, not a truncation cap; ~50 KB mirrors the ~25k-token budget.
+ */
+export const DATASET_SIZE_HINT_BYTES = 50000;
+
+/** Shared steer appended to large-output hints so the model narrows instead of refetching everything. */
+export const NARROW_OUTPUT_HINT = 'narrow with fields= or page with offset';
+
 // MCP Server
 /** When `false`, `resolveServerMode('auto', ...)` forces {@link ServerMode.DEFAULT} regardless of client capabilities. */
 export const SERVER_MODE_AUTO_DETECTION_ENABLED = true;

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -41,6 +41,7 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
         Actor runs automatically produce unnamed datasets (set unnamed=true to include them). Users can also create named datasets.
 
         The results will include datasets with itemCount, access settings, and usage stats, sorted by createdAt (ascending by default).
+        Each dataset's stats.inflatedBytes is its approximate uncompressed byte size — use it with itemCount to gauge size before fetching.
         Use limit (max 20), offset, and desc to paginate and sort.
 
         USAGE:

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -7,7 +7,7 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleDatasetUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { normalizeDatasetFields } from '../core/actor_run_response.js';
+import { datasetSizeNextStepHint, normalizeDatasetFields } from '../core/actor_run_response.js';
 import { datasetMetadataOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
 
@@ -25,6 +25,7 @@ export const getDataset: ToolEntry = Object.freeze({
         Get metadata for a dataset (collection of structured data created by an Actor run).
         The results will include dataset details such as itemCount, schema, fields, and stats.
         Use fields to understand structure for filtering with ${HelperTools.DATASET_GET_ITEMS}.
+        stats.inflatedBytes (when present) is the approximate uncompressed byte size — use it with itemCount to pick a safe limit and fields before fetching.
         Note: itemCount updates may be delayed by up to ~5 seconds.
 
         USAGE:
@@ -62,8 +63,11 @@ export const getDataset: ToolEntry = Object.freeze({
         // the structured `storages.datasets.default.fields` shape.
         const normalized = dataset.fields ? { ...dataset, fields: normalizeDatasetFields(dataset.fields) } : dataset;
         const fieldCount = Array.isArray(normalized.fields) ? normalized.fields.length : undefined;
+        // `inflatedBytes` is undeclared on the apify-client `DatasetStats` type and absent from the GET
+        // response today (only the dataset-list endpoint returns it), so read it defensively.
+        const inflatedBytes = (dataset.stats as { inflatedBytes?: number } | undefined)?.inflatedBytes;
         const summary = `Dataset '${normalized.name ?? datasetId}' has ${normalized.itemCount ?? 0} items${fieldCount !== undefined ? `, ${fieldCount} fields` : ''}.`;
-        const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to fetch items.`;
+        const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to fetch items.${datasetSizeNextStepHint(inflatedBytes)}`;
         return buildStorageResponse({
             structuredContent: normalized as unknown as Record<string, unknown>,
             summary,

--- a/src/tools/core/actor_run_response.ts
+++ b/src/tools/core/actor_run_response.ts
@@ -3,7 +3,13 @@ import type { ActorRun, Dataset, KeyValueClientListKeysResult } from 'apify-clie
 import log from '@apify/log';
 
 import type { ApifyClient } from '../../apify_client.js';
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
+import {
+    DATASET_SIZE_HINT_BYTES,
+    FAILURE_CATEGORY,
+    HelperTools,
+    NARROW_OUTPUT_HINT,
+    TOOL_STATUS,
+} from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { ConsoleLinkContext } from '../../types.js';
 import {
@@ -78,6 +84,12 @@ export type RunDataset = {
     title?: string;
     itemCount?: number;
     cleanItemCount?: number;
+    /**
+     * Uncompressed size of the dataset in bytes (Apify `stats.inflatedBytes`). Items are stored as BSON,
+     * so this approximates — not exactly equals — the JSON size fetched into context. The single-dataset
+     * GET response does not return it (only the dataset-list endpoint does), so it is normally absent.
+     */
+    inflatedBytes?: number;
     /**
      * Dot-notation field paths. Pure-numeric segments (array indices) are stripped and the
      * list is deduped at build time, so callers receive a flat unique projection-valid list
@@ -214,6 +226,9 @@ function buildRunDataset(
         title: datasetMeta.title,
         itemCount: resolvedItemCount ?? datasetMeta.itemCount,
         cleanItemCount: datasetMeta.cleanItemCount,
+        // Undeclared on the apify-client `DatasetStats` type (and absent from the GET response today),
+        // so read it defensively; `cleanEmptyProperties` drops it when absent.
+        inflatedBytes: (datasetMeta.stats as { inflatedBytes?: number } | undefined)?.inflatedBytes,
         fields: datasetMeta.fields ? normalizeDatasetFields(datasetMeta.fields) : undefined,
     }) as RunDataset;
 }
@@ -395,6 +410,18 @@ function fieldsProjectionHint(fields: string[] | undefined): string {
     return ` Available fields (dot notation): ${fields.join(', ')} — pass via fields="..." to project.`;
 }
 
+/**
+ * nextStep suffix reporting dataset size. The byte size is always shown when known; the steer to
+ * narrow is appended only when it exceeds DATASET_SIZE_HINT_BYTES. `inflatedBytes` is the
+ * whole-dataset uncompressed size; shared by get-actor-run and get-dataset.
+ */
+export function datasetSizeNextStepHint(inflatedBytes: number | undefined): string {
+    if (inflatedBytes === undefined || inflatedBytes <= 0) return '';
+    const size = ` Full output is ~${inflatedBytes} bytes.`;
+    if (inflatedBytes <= DATASET_SIZE_HINT_BYTES) return size;
+    return `${size} Fetching all may exceed context; ${NARROW_OUTPUT_HINT}.`;
+}
+
 function buildSucceededSummaryNextStep(
     runTimeSecs: number,
     statusMessage: string | null | undefined,
@@ -411,7 +438,7 @@ function buildSucceededSummaryNextStep(
         const fields = dataset?.fields ?? [];
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. ${itemCount} ${itemCount === 1 ? 'item' : 'items'}; ${fields.length} fields available.${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to fetch items (${itemCount} total).${fieldsProjectionHint(fields)}`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to fetch items (${itemCount} total).${datasetSizeNextStepHint(dataset?.inflatedBytes)}${fieldsProjectionHint(fields)}`,
         };
     }
 

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -381,6 +381,11 @@ export const getActorRunOutputSchema = {
                                 title: { type: 'string' },
                                 itemCount: { type: 'number' },
                                 cleanItemCount: { type: 'number' },
+                                inflatedBytes: {
+                                    type: 'number',
+                                    description:
+                                        'Approximate uncompressed byte size of the dataset. Use with itemCount to pick limit/fields before fetching.',
+                                },
                                 fields: {
                                     type: 'array' as const,
                                     items: { type: 'string' },
@@ -594,7 +599,8 @@ export const datasetSchemaOutputSchema = {
 
 /**
  * Schema for storage collection listings (get-dataset-list, get-key-value-store-list).
- * Mirrors the Apify paginated-list response shape plus the narrative fields.
+ * Mirrors the Apify paginated-list response shape plus the narrative fields. `items` is an opaque
+ * object since item shape varies by storage type; per-item fields pass through from the API.
  */
 export const storageListOutputSchema = {
     type: 'object' as const,

--- a/tests/unit/tools.dataset_collection.test.ts
+++ b/tests/unit/tools.dataset_collection.test.ts
@@ -48,6 +48,25 @@ describe('get-dataset-list', () => {
         expect(content[1].text).toBe(`${summary}\n${nextStep}`);
     });
 
+    it('preserves each dataset stats.inflatedBytes in structuredContent', async () => {
+        const listSpy = vi.fn().mockResolvedValue({
+            ...MOCK_LIST,
+            items: [
+                { id: 'ds-1', name: 'a', itemCount: 5, stats: { inflatedBytes: 54385 } },
+                { id: 'ds-2', name: 'b', itemCount: 0, stats: { inflatedBytes: 0 } },
+            ],
+        });
+
+        const result = await (getUserDatasetsList as HelperTool).call(
+            stubToolCallContext({}, stubApifyClient(listSpy)),
+        );
+        const { structuredContent } = result as {
+            structuredContent: { items: { stats: { inflatedBytes: number } }[] };
+        };
+
+        expect(structuredContent.items[0].stats.inflatedBytes).toBe(54385);
+    });
+
     it('emits a pagination nextStep when more datasets remain', async () => {
         const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 25 });
 

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -128,6 +128,21 @@ describe('get-actor-run default response', () => {
         });
     });
 
+    it('surfaces dataset inflatedBytes from stats in structuredContent', async () => {
+        // The single-dataset GET does not return `inflatedBytes` (only the dataset-list endpoint does);
+        // this stub injects it to verify the wiring.
+        const run = mockSucceededRun();
+        const result = await (defaultGetActorRun as HelperTool).call(
+            stubToolCallContext(
+                { runId: 'run-1', waitSecs: 0 },
+                stubClient({ run, dataset: mockDataset({ stats: { writeCount: 47, inflatedBytes: 1234 } }) }),
+            ),
+        );
+        const { structuredContent } = result as { structuredContent: RunResponse };
+
+        expect(structuredContent.storages.datasets?.default.inflatedBytes).toBe(1234);
+    });
+
     it('fetches dataset metadata for a non-terminal RUNNING run and surfaces progress in the summary', async () => {
         // Dataset metadata is fetched on every poll so the summary can surface partial progress.
         // KV listKeys stays terminal-only — non-terminal summaries don't reference KV records, so
@@ -648,6 +663,28 @@ describe('buildStatusTemplate', () => {
         expect(t.nextStep).toContain('get-dataset-items');
         expect(t.nextStep).toContain('datasetId=ds-1');
         expect(t.nextStep).toContain('metadata.url, markdown');
+    });
+
+    it('SUCCEEDED steers nextStep away from fetching a large dataset', () => {
+        const dataset: RunDataset = { id: 'ds-1', itemCount: 47, fields: ['metadata.url'], inflatedBytes: 2_400_000 };
+        const t = buildStatusSummaryNextStep({ run: makeRun('SUCCEEDED'), dataset });
+        expect(t.summary).toContain('47 items; 1 fields available');
+        expect(t.nextStep).toContain('Full output is ~2400000 bytes');
+        expect(t.nextStep).toContain('page with offset');
+    });
+
+    it('SUCCEEDED reports size but omits the large-output warning below the threshold', () => {
+        const dataset: RunDataset = { id: 'ds-1', itemCount: 2, fields: [], inflatedBytes: 4000 };
+        const t = buildStatusSummaryNextStep({ run: makeRun('SUCCEEDED'), dataset });
+        expect(t.summary).toContain('2 items');
+        expect(t.nextStep).toContain('Full output is ~4000 bytes');
+        expect(t.nextStep).not.toContain('may exceed context');
+    });
+
+    it('SUCCEEDED omits the size hint entirely when the dataset size is unknown', () => {
+        const dataset: RunDataset = { id: 'ds-1', itemCount: 2, fields: [] };
+        const t = buildStatusSummaryNextStep({ run: makeRun('SUCCEEDED'), dataset });
+        expect(t.nextStep).not.toContain('Full output');
     });
 
     it('SUCCEEDED with items but no fields metadata omits the fields hint without a dangling em-dash', () => {

--- a/tests/unit/tools.get_dataset.test.ts
+++ b/tests/unit/tools.get_dataset.test.ts
@@ -56,6 +56,32 @@ describe('get-dataset', () => {
         expect(content[1].text).toBe(`${summary}\n${nextStep}`);
     });
 
+    it('steers nextStep away from fetching when the dataset is large', async () => {
+        const result = await (getDataset as HelperTool).call(
+            stubToolCallContext(
+                { datasetId: 'ds-1' },
+                stubApifyClient({ ...MOCK_DATASET, itemCount: 47, stats: { inflatedBytes: 2_400_000 } }),
+            ),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, string> };
+
+        expect(structuredContent.summary).toContain('has 47 items');
+        expect(structuredContent.nextStep).toContain('Full output is ~2400000 bytes');
+    });
+
+    it('reports size but omits the large-output warning below the threshold', async () => {
+        const result = await (getDataset as HelperTool).call(
+            stubToolCallContext(
+                { datasetId: 'ds-1' },
+                stubApifyClient({ ...MOCK_DATASET, itemCount: 2, stats: { inflatedBytes: 4000 } }),
+            ),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, string> };
+
+        expect(structuredContent.nextStep).toContain('Full output is ~4000 bytes');
+        expect(structuredContent.nextStep).not.toContain('may exceed context');
+    });
+
     it('returns isError with a not-found message when the dataset does not exist', async () => {
         const result = await (getDataset as HelperTool).call(
             stubToolCallContext({ datasetId: 'missing' }, stubApifyClient(undefined)),


### PR DESCRIPTION
Closes #878

Dataset items can be huge, so fetching them blows the LLM's context window. This surfaces a dataset's uncompressed byte size (`stats.inflatedBytes`) on the **pre-fetch** tools so the model can narrow before items land in context. Advisory only — nothing is truncated.

- **`get-actor-run` / `get-dataset`** — append a "fetching all may exceed context — narrow with `fields=`/`offset`" steer to `nextStep` when the dataset is large.
- **`dataset-collection`** — `inflatedBytes` flows through per dataset; the description points the model at it.
- **`get-dataset-items`** — no hint: items and the hint arrive together, so the data is already in context.

### Apify core to ship
`client.dataset(id).get()` returns `storageBytes` (compressed), **not** `inflatedBytes` — only the dataset-**list** endpoint returns `inflatedBytes` today. So the `get-actor-run`/`get-dataset` hints read it defensively and stay **dormant** until the API/client expose `inflatedBytes` (and `storageBytes`) consistently on both endpoints (and drop internal `s3StorageBytes`). They light up with no further MCP change. `dataset-collection` works now (list endpoint).

https://claude.ai/code/session_013sKA6tQ9Y8Ytr859xmrBNv