### PR TITLE
fix: Remove x-apify-authorization header support from dev server

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -109,8 +109,7 @@ pnpm run dev
 Starts the web widgets builder in watch mode and the MCP server in standby mode on port `3001`. The dev server mirrors production auth — it does **not** read `APIFY_TOKEN` from its environment. Every request must carry the token via one of (in priority order):
 
 1. `Authorization: Bearer <token>` header
-2. `x-apify-authorization: Bearer <token>` header
-3. `?token=<token>` query parameter (handy for quick browser-based widget previews)
+2. `?token=<token>` query parameter (handy for quick browser-based widget previews)
 
 Editing `src/web/src/widgets/*.tsx` triggers a hot-reload — the next widget render uses updated code without restarting the server. Adding new widget filenames requires reconnecting the MCP client to pick them up.
 

--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -37,17 +37,15 @@ enum Routes {
  *
  * Mirrors `apify-mcp-server-internal`'s `extractApiTokenFromRequest` so the
  * dev server behaves identically to production for auth/payment routing:
- *   1. `x-apify-authorization: Bearer <token>` header (preferred)
- *   2. `authorization: Bearer <token>` header
- *   3. `?token=<token>` query parameter
+ *   1. `authorization: Bearer <token>` header
+ *   2. `?token=<token>` query parameter
  *
  * Returns `undefined` if no valid token is present. The caller decides whether
  * a missing token is an error (no payment provider) or expected (payment mode).
  */
 function extractApiTokenFromRequest(req: Request): string | undefined {
-    for (const header of ['x-apify-authorization', 'authorization']) {
-        const value = req.headers[header];
-        if (typeof value !== 'string') continue;
+    const value = req.headers.authorization;
+    if (typeof value === 'string') {
         const [schema, token] = value.trim().split(/\s+/);
         if (schema?.toLowerCase() === 'bearer' && token) return token;
     }


### PR DESCRIPTION
- Removed `x-apify-authorization` header from `extractApiTokenFromRequest()` token lookup chain

https://claude.ai/code/session_019X3FxEpYZQM7CXkCfKgqmM