### PR TITLE
chore: migrate get-actor-output eval refs to get-dataset-items

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -77,7 +77,7 @@ pnpm run evals:run -- --dataset-name mcp_server_dataset_v1.3
   - search-actors: Emphasizes finding/discovering what tools exist (informational intent)
   - apify--rag-web-browser: Emphasizes getting/retrieving actual data (data retrieval intent)
 
-Test categories: `fetch-actor-details`, `search-actors`, `apify--rag-web-browser`, `search-apify-docs`, `call-actor`, `get-actor-output`, `fetch-apify-docs`
+Test categories: `fetch-actor-details`, `search-actors`, `apify--rag-web-browser`, `search-apify-docs`, `call-actor`, `get-dataset-items`, `fetch-apify-docs`
 
 ## Output
 

--- a/evals/config.ts
+++ b/evals/config.ts
@@ -114,7 +114,7 @@ You must judge whether this agent made the correct selection.
 - Searches across all documentation to find relevant pages
 - Example: "How to create an Apify Actor?" or "What is Apify Proxy?"
 
-**get-actor-output**: Retrieves the output data (results) from a completed Actor run using its datasetId.
+**get-dataset-items**: Retrieves the output data (results) from a completed Actor run using its datasetId.
 - Use when query asks to get/fetch/retrieve data from a previous Actor execution
 - Returns the actual scraped data, not Actor documentation
 - Example: "Get the data from my last Actor run" or "Show me the results from dataset abc123"

--- a/evals/test_cases.json
+++ b/evals/test_cases.json
@@ -348,34 +348,34 @@
       "expectedTools": ["call-actor"]
     },
     {
-      "id": "get-actor-output-1",
-      "category": "get-actor-output",
+      "id": "get-dataset-items-1",
+      "category": "get-dataset-items",
       "query": "Get output from my latest actor with datasetId des32s",
-      "expectedTools": ["get-actor-output"]
+      "expectedTools": ["get-dataset-items"]
     },
     {
-      "id": "get-actor-output-2",
-      "category": "get-actor-output",
+      "id": "get-dataset-items-2",
+      "category": "get-dataset-items",
       "query": "Retrieve results from dataset abc123",
-      "expectedTools": ["get-actor-output"]
+      "expectedTools": ["get-dataset-items"]
     },
     {
-      "id": "get-actor-output-3",
-      "category": "get-actor-output",
+      "id": "get-dataset-items-3",
+      "category": "get-dataset-items",
       "query": "Show me the data from my Instagram scraper run with datasetId d23d2, ",
-      "expectedTools": ["get-actor-output"]
+      "expectedTools": ["get-dataset-items"]
     },
     {
-      "id": "get-actor-output-4",
-      "category": "get-actor-output",
+      "id": "get-dataset-items-4",
+      "category": "get-dataset-items",
       "query": "Get the first 50 items from my datasetId abc123",
-      "expectedTools": ["get-actor-output"]
+      "expectedTools": ["get-dataset-items"]
     },
     {
-      "id": "get-actor-output-5",
-      "category": "get-actor-output",
+      "id": "get-dataset-items-5",
+      "category": "get-dataset-items",
       "query": "Retrieve all results from my web scraper with datasetID abc123",
-      "expectedTools": ["get-actor-output"]
+      "expectedTools": ["get-dataset-items"]
     },
     {
       "id": "fetch-apify-docs-1",
@@ -384,10 +384,10 @@
       "expectedTools": ["fetch-apify-docs"]
     },
     {
-      "id": "get-actor-output-basic-2",
-      "category": "get-actor-output",
+      "id": "get-dataset-items-basic-2",
+      "category": "get-dataset-items",
       "query": "Get query and markdown fields from dataset UvsU",
-      "expectedTools": ["get-actor-output"]
+      "expectedTools": ["get-dataset-items"]
     },
     {
       "id": "fetch-apify-docs-edge-1",

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -6,7 +6,7 @@
  * search/discover → get details → execute → check status → get results
  *
  * The final tool ordering presented to MCP clients is determined by tools-loader.ts,
- * which also auto-injects get-actor-run right after call-actor.
+ * which also auto-injects run/storage tools (AUTO_INJECTED_TOOLS) right after call-actor.
  *
  * Each tool entry can be:
  * - A plain ToolEntry — mode-independent, always included


### PR DESCRIPTION
Stacked on #939 (`chore/remove-get-actor-output-v2`). Merge into that branch so #939 ships complete.

PR #939 removes the `get-actor-output` tool from the shipped server but leaves the eval harness pointing at it. The eval suite is git-tracked and runs on PR **merge** and via **label** (`on_pull_request_merged.yaml`, `on_pull_request_label.yaml`), so those cases would become permanently unmatchable once #939 lands — the model can't call a tool that no longer exists.

## Changes
- `evals/test_cases.json` — 6 cases (`get-actor-output-1..5`, `-basic-2`) repointed to `get-dataset-items` (`id`, `category`, `expectedTools`).
- `evals/config.ts` — judge-prompt tool header → `get-dataset-items`.
- `evals/README.md` — current "Test categories" list → `get-dataset-items`. Historical changelog entry (line 75) left as-is.
- `src/tools/categories.ts` — auto-injection doc comment now references `AUTO_INJECTED_TOOLS` instead of a hand-listed tool name, so it can't drift again.

## Verification
- `pnpm run type-check` — clean
- `pnpm run lint` — 0 errors (3 pre-existing warnings in `tests/integration/suite.ts`, unrelated)
- `test_cases.json` re-validated as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)