### PR TITLE
feat: Truncate inputFields in search-actors structured output

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -75,7 +75,7 @@ export const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
 /** API rejects `includeInputSchema=true` above this; mirrors apify-core `MAX_LIMIT_WITH_INPUT_SCHEMA`. */
 export const MAX_LIMIT_WITH_INPUT_SCHEMA = 10;
 /** Max input fields shown inline in text and structured Actor cards. */
-export const MAX_INPUT_FIELDS_IN_TEXT_CARD = 20;
+export const MAX_INPUT_FIELDS_IN_ACTOR_CARD = 20;
 
 export const ACTOR_PRICING_MODEL = {
     /** Rental Actors */

--- a/src/const.ts
+++ b/src/const.ts
@@ -74,7 +74,7 @@ export const USER_CACHE_MAX_SIZE = 200;
 export const USER_CACHE_TTL_SECS = 60 * 60; // 1 hour
 /** API rejects `includeInputSchema=true` above this; mirrors apify-core `MAX_LIMIT_WITH_INPUT_SCHEMA`. */
 export const MAX_LIMIT_WITH_INPUT_SCHEMA = 10;
-/** Max input fields shown inline in the text Actor card; structured output keeps the full schema. */
+/** Max input fields shown inline in text and structured Actor cards. */
 export const MAX_INPUT_FIELDS_IN_TEXT_CARD = 20;
 
 export const ACTOR_PRICING_MODEL = {

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -171,6 +171,16 @@ export const actorInfoSchema = {
             },
             required: ['type', 'properties'],
         },
+        inputFieldsTruncated: {
+            type: 'boolean',
+            description:
+                'Present and `true` when `inputFields` was truncated; fetch the full schema via `fetch-actor-details`.',
+        },
+        inputFieldsTotalCount: {
+            type: 'number',
+            description:
+                'Total number of input fields before truncation; present only when `inputFields` was truncated.',
+        },
     },
     required: ['url', 'id', 'fullName', 'developer', 'description', 'categories', 'isDeprecated'],
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -645,6 +645,8 @@ export type StructuredActorCard = {
     modifiedAt?: string;
     isDeprecated: boolean;
     inputFields?: ActorStoreInputSchema;
+    inputFieldsTruncated?: boolean;
+    inputFieldsTotalCount?: number;
 };
 
 /**

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -1,4 +1,4 @@
-import { APIFY_STORE_URL, MAX_INPUT_FIELDS_IN_TEXT_CARD } from '../const.js';
+import { APIFY_STORE_URL, MAX_INPUT_FIELDS_IN_ACTOR_CARD } from '../const.js';
 import type { Actor, ActorCardOptions, ActorStoreInputSchema, ActorStoreList, StructuredActorCard } from '../types.js';
 import {
     getCurrentPricingInfo,
@@ -15,29 +15,12 @@ function getInputSchema(actor: Actor | ActorStoreList): ActorStoreInputSchema | 
     return 'inputSchema' in actor ? actor.inputSchema : undefined;
 }
 
-function inputFieldsToString(inputSchema: ActorStoreInputSchema): string | null {
-    const entries = Object.entries(inputSchema.properties);
-    if (entries.length === 0) return null;
-
-    const requiredSet = new Set(inputSchema.required ?? []);
-    const shown = entries.slice(0, MAX_INPUT_FIELDS_IN_TEXT_CARD);
-    const fields = shown
-        .map(
-            ([name, prop]) =>
-                `${name}${requiredSet.has(name) ? '' : '?'}: ${Array.isArray(prop.type) ? prop.type.join('|') : prop.type}`,
-        )
-        .join(', ');
-    const overflow = entries.length - shown.length;
-    const suffix = overflow > 0 ? ` ... (+${overflow} more)` : '';
-
-    return `- **Input fields:** ${fields}${suffix}`;
-}
-
+/** Caps an Actor input schema at {@link MAX_INPUT_FIELDS_IN_ACTOR_CARD} fields — single truncation point for both the text and structured Actor cards. */
 function truncateInputSchema(inputSchema: ActorStoreInputSchema): ActorStoreInputSchema {
     const entries = Object.entries(inputSchema.properties);
-    if (entries.length <= MAX_INPUT_FIELDS_IN_TEXT_CARD) return inputSchema;
+    if (entries.length <= MAX_INPUT_FIELDS_IN_ACTOR_CARD) return inputSchema;
 
-    const shownEntries = entries.slice(0, MAX_INPUT_FIELDS_IN_TEXT_CARD);
+    const shownEntries = entries.slice(0, MAX_INPUT_FIELDS_IN_ACTOR_CARD);
     const shownPropertyNames = new Set(shownEntries.map(([name]) => name));
 
     return {
@@ -45,6 +28,24 @@ function truncateInputSchema(inputSchema: ActorStoreInputSchema): ActorStoreInpu
         properties: Object.fromEntries(shownEntries) as ActorStoreInputSchema['properties'],
         required: inputSchema.required?.filter((name) => shownPropertyNames.has(name)),
     };
+}
+
+function inputFieldsToString(inputSchema: ActorStoreInputSchema): string | null {
+    const truncated = truncateInputSchema(inputSchema);
+    const entries = Object.entries(truncated.properties);
+    if (entries.length === 0) return null;
+
+    const requiredSet = new Set(truncated.required ?? []);
+    const fields = entries
+        .map(
+            ([name, prop]) =>
+                `${name}${requiredSet.has(name) ? '' : '?'}: ${Array.isArray(prop.type) ? prop.type.join('|') : prop.type}`,
+        )
+        .join(', ');
+    const overflow = Object.keys(inputSchema.properties).length - entries.length;
+    const suffix = overflow > 0 ? ` ... (+${overflow} more)` : '';
+
+    return `- **Input fields:** ${fields}${suffix}`;
 }
 
 // Helper function to format categories from uppercase with underscores to a proper case
@@ -278,7 +279,7 @@ export function formatActorToStructuredCard(
         : pricingInfoToStructured(data.pricingInfo, userTier);
     const inputSchema = getInputSchema(actor);
     const inputFieldsTotalCount = inputSchema ? Object.keys(inputSchema.properties).length : 0;
-    const isInputFieldsTruncated = inputFieldsTotalCount > MAX_INPUT_FIELDS_IN_TEXT_CARD;
+    const isInputFieldsTruncated = inputFieldsTotalCount > MAX_INPUT_FIELDS_IN_ACTOR_CARD;
 
     return {
         title: data.title,

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -33,6 +33,20 @@ function inputFieldsToString(inputSchema: ActorStoreInputSchema): string | null 
     return `- **Input fields:** ${fields}${suffix}`;
 }
 
+function truncateInputSchema(inputSchema: ActorStoreInputSchema): ActorStoreInputSchema {
+    const entries = Object.entries(inputSchema.properties);
+    if (entries.length <= MAX_INPUT_FIELDS_IN_TEXT_CARD) return inputSchema;
+
+    const shownEntries = entries.slice(0, MAX_INPUT_FIELDS_IN_TEXT_CARD);
+    const shownPropertyNames = new Set(shownEntries.map(([name]) => name));
+
+    return {
+        ...inputSchema,
+        properties: Object.fromEntries(shownEntries) as ActorStoreInputSchema['properties'],
+        required: inputSchema.required?.filter((name) => shownPropertyNames.has(name)),
+    };
+}
+
 // Helper function to format categories from uppercase with underscores to a proper case
 function formatCategories(categories?: string[]): string[] {
     if (!categories) return [];
@@ -262,6 +276,9 @@ export function formatActorToStructuredCard(
     const pricing = options.simplifyPricingForUserTier
         ? pricingInfoToSimplifiedStructured(data.pricingInfo, userTier)
         : pricingInfoToStructured(data.pricingInfo, userTier);
+    const inputSchema = getInputSchema(actor);
+    const inputFieldsTotalCount = inputSchema ? Object.keys(inputSchema.properties).length : 0;
+    const isInputFieldsTruncated = inputFieldsTotalCount > MAX_INPUT_FIELDS_IN_TEXT_CARD;
 
     return {
         title: data.title,
@@ -277,7 +294,11 @@ export function formatActorToStructuredCard(
         rating: data.rating,
         modifiedAt: data.modifiedAt,
         isDeprecated: data.isDeprecated,
-        inputFields: getInputSchema(actor),
+        inputFields: inputSchema ? truncateInputSchema(inputSchema) : undefined,
+        ...(isInputFieldsTruncated && {
+            inputFieldsTruncated: true,
+            inputFieldsTotalCount,
+        }),
     };
 }
 

--- a/tests/unit/tools.search_actors.default.response.test.ts
+++ b/tests/unit/tools.search_actors.default.response.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { APIFY_STORE_URL, HelperTools, MAX_INPUT_FIELDS_IN_TEXT_CARD } from '../../src/const.js';
+import { APIFY_STORE_URL, HelperTools, MAX_INPUT_FIELDS_IN_ACTOR_CARD } from '../../src/const.js';
 import { defaultSearchActors } from '../../src/tools/default/search_actors.js';
 import type { ActorStoreInputSchema, ActorStoreList, HelperTool } from '../../src/types.js';
 import {
@@ -89,7 +89,7 @@ describe('search-actors without widget (defaultSearchActors)', () => {
     });
 
     it('truncates structured inputFields for every Actor and keeps text cards unchanged', async () => {
-        const total = MAX_INPUT_FIELDS_IN_TEXT_CARD + 5;
+        const total = MAX_INPUT_FIELDS_IN_ACTOR_CARD + 5;
         const actors = [
             { ...MOCK_STORE_ACTOR, inputSchema: buildInputSchema(total) },
             {
@@ -119,8 +119,8 @@ describe('search-actors without widget (defaultSearchActors)', () => {
 
         expect(structuredContent.actors).toHaveLength(2);
         for (const actor of structuredContent.actors) {
-            expect(Object.keys(actor.inputFields?.properties ?? {})).toHaveLength(MAX_INPUT_FIELDS_IN_TEXT_CARD);
-            expect(actor.inputFields?.properties[`field${MAX_INPUT_FIELDS_IN_TEXT_CARD}`]).toBeUndefined();
+            expect(Object.keys(actor.inputFields?.properties ?? {})).toHaveLength(MAX_INPUT_FIELDS_IN_ACTOR_CARD);
+            expect(actor.inputFields?.properties[`field${MAX_INPUT_FIELDS_IN_ACTOR_CARD}`]).toBeUndefined();
             expect(actor.inputFieldsTruncated).toBe(true);
             expect(actor.inputFieldsTotalCount).toBe(total);
         }

--- a/tests/unit/tools.search_actors.default.response.test.ts
+++ b/tests/unit/tools.search_actors.default.response.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { APIFY_STORE_URL, HelperTools } from '../../src/const.js';
+import { APIFY_STORE_URL, HelperTools, MAX_INPUT_FIELDS_IN_TEXT_CARD } from '../../src/const.js';
 import { defaultSearchActors } from '../../src/tools/default/search_actors.js';
-import type { HelperTool } from '../../src/types.js';
-import { formatActorToStructuredCard } from '../../src/utils/actor_card.js';
+import type { ActorStoreInputSchema, ActorStoreList, HelperTool } from '../../src/types.js';
+import {
+    DEFAULT_CARD_OPTIONS,
+    formatActorToActorCard,
+    formatActorToStructuredCard,
+} from '../../src/utils/actor_card.js';
 import { searchAgentSafeActors } from '../../src/utils/actor_search.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import { MOCK_STORE_ACTOR, SEARCH_KEYWORDS, stubInternalToolArgs } from './tools.search_actors.fixtures.js';
@@ -19,6 +23,19 @@ vi.mock('../../src/utils/actor_search.js', () => ({
 vi.mock('../../src/utils/userid_cache.js', () => ({
     getUserInfoCached: vi.fn(),
 }));
+
+function buildInputSchema(fieldCount: number): ActorStoreInputSchema {
+    const properties: ActorStoreInputSchema['properties'] = {};
+    for (let i = 0; i < fieldCount; i++) {
+        properties[`field${i}`] = { type: 'string' };
+    }
+
+    return {
+        type: 'object',
+        properties,
+        required: Object.keys(properties),
+    };
+}
 
 describe('search-actors without widget (defaultSearchActors)', () => {
     beforeEach(() => {
@@ -69,6 +86,55 @@ describe('search-actors without widget (defaultSearchActors)', () => {
         expect(text).toContain(`## [${MOCK_STORE_ACTOR.title}](${APIFY_STORE_URL}/apify/web-scraper)`);
         expect(text).toContain('`apify/web-scraper`');
         expect(text).not.toContain('do NOT print or summarize');
+    });
+
+    it('truncates structured inputFields for every Actor and keeps text cards unchanged', async () => {
+        const total = MAX_INPUT_FIELDS_IN_TEXT_CARD + 5;
+        const actors = [
+            { ...MOCK_STORE_ACTOR, inputSchema: buildInputSchema(total) },
+            {
+                ...MOCK_STORE_ACTOR,
+                id: 'actor-id-2',
+                name: 'web-scraper-2',
+                title: 'Web Scraper 2',
+                inputSchema: buildInputSchema(total),
+            },
+        ] as ActorStoreList[];
+        vi.mocked(searchAgentSafeActors).mockResolvedValue(actors);
+
+        const result = await (defaultSearchActors as HelperTool).call(
+            stubInternalToolArgs({
+                keywords: SEARCH_KEYWORDS,
+                limit: 5,
+                offset: 0,
+            }),
+        );
+
+        const { structuredContent, content } = result as {
+            structuredContent: {
+                actors: ReturnType<typeof formatActorToStructuredCard>[];
+            };
+            content: { type: string; text: string }[];
+        };
+
+        expect(structuredContent.actors).toHaveLength(2);
+        for (const actor of structuredContent.actors) {
+            expect(Object.keys(actor.inputFields?.properties ?? {})).toHaveLength(MAX_INPUT_FIELDS_IN_TEXT_CARD);
+            expect(actor.inputFields?.properties[`field${MAX_INPUT_FIELDS_IN_TEXT_CARD}`]).toBeUndefined();
+            expect(actor.inputFieldsTruncated).toBe(true);
+            expect(actor.inputFieldsTotalCount).toBe(total);
+        }
+
+        const expectedActorText = actors
+            .map((actor) =>
+                formatActorToActorCard(actor, {
+                    ...DEFAULT_CARD_OPTIONS,
+                    userTier: 'FREE',
+                    simplifyPricingForUserTier: true,
+                }),
+            )
+            .join('\n\n');
+        expect(content[0].text).toContain(expectedActorText);
     });
 
     it('returns empty structured content and retry instructions when no actors match', async () => {

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -1,7 +1,7 @@
 import type { Actor } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
-import { MAX_INPUT_FIELDS_IN_TEXT_CARD } from '../../src/const.js';
+import { MAX_INPUT_FIELDS_IN_ACTOR_CARD } from '../../src/const.js';
 import type { ActorStoreInputSchema, ActorStoreList } from '../../src/types.js';
 import { formatActorToActorCard, formatActorToStructuredCard } from '../../src/utils/actor_card.js';
 
@@ -591,17 +591,17 @@ describe('formatActorToStructuredCard', () => {
 
 describe('formatActorToStructuredCard inputSchema truncation', () => {
     it('truncates inputFields and marks incomplete schemas', () => {
-        const total = MAX_INPUT_FIELDS_IN_TEXT_CARD + 5;
+        const total = MAX_INPUT_FIELDS_IN_ACTOR_CARD + 5;
         const actor = { ...mockActorStoreList, inputSchema: buildInputSchema(total) } as ActorStoreList;
         const result = formatActorToStructuredCard(actor);
 
-        expect(Object.keys(result.inputFields?.properties ?? {})).toHaveLength(MAX_INPUT_FIELDS_IN_TEXT_CARD);
-        expect(result.inputFields?.properties[`field${MAX_INPUT_FIELDS_IN_TEXT_CARD - 1}`]).toStrictEqual({
+        expect(Object.keys(result.inputFields?.properties ?? {})).toHaveLength(MAX_INPUT_FIELDS_IN_ACTOR_CARD);
+        expect(result.inputFields?.properties[`field${MAX_INPUT_FIELDS_IN_ACTOR_CARD - 1}`]).toStrictEqual({
             type: 'string',
         });
-        expect(result.inputFields?.properties[`field${MAX_INPUT_FIELDS_IN_TEXT_CARD}`]).toBeUndefined();
+        expect(result.inputFields?.properties[`field${MAX_INPUT_FIELDS_IN_ACTOR_CARD}`]).toBeUndefined();
         expect(result.inputFields?.required).toEqual(
-            Array.from({ length: MAX_INPUT_FIELDS_IN_TEXT_CARD }, (_, index) => `field${index}`),
+            Array.from({ length: MAX_INPUT_FIELDS_IN_ACTOR_CARD }, (_, index) => `field${index}`),
         );
         expect(result.inputFieldsTruncated).toBe(true);
         expect(result.inputFieldsTotalCount).toBe(total);
@@ -642,15 +642,15 @@ describe('formatActorToActorCard inputSchema rendering', () => {
         expect(result).not.toMatch(/\(\+\d+ more\)/);
     });
 
-    it(`truncates to MAX_INPUT_FIELDS_IN_TEXT_CARD and appends "... (+N more)" when count exceeds the cap`, () => {
+    it(`truncates to MAX_INPUT_FIELDS_IN_ACTOR_CARD and appends "... (+N more)" when count exceeds the cap`, () => {
         const overflow = 5;
-        const total = MAX_INPUT_FIELDS_IN_TEXT_CARD + overflow;
+        const total = MAX_INPUT_FIELDS_IN_ACTOR_CARD + overflow;
         const properties: Record<string, { type: string }> = {};
         for (let i = 0; i < total; i++) properties[`field${i}`] = { type: 'string' };
         const actor = { ...mockActorStoreList, inputSchema: { type: 'object' as const, properties } } as ActorStoreList;
         const result = formatActorToActorCard(actor);
-        expect(result).toContain(`field${MAX_INPUT_FIELDS_IN_TEXT_CARD - 1}?: string`);
-        expect(result).not.toContain(`field${MAX_INPUT_FIELDS_IN_TEXT_CARD}?: string`);
+        expect(result).toContain(`field${MAX_INPUT_FIELDS_IN_ACTOR_CARD - 1}?: string`);
+        expect(result).not.toContain(`field${MAX_INPUT_FIELDS_IN_ACTOR_CARD}?: string`);
         expect(result).toContain(` ... (+${overflow} more)`);
     });
 

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -2,7 +2,7 @@ import type { Actor } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
 import { MAX_INPUT_FIELDS_IN_TEXT_CARD } from '../../src/const.js';
-import type { ActorStoreList } from '../../src/types.js';
+import type { ActorStoreInputSchema, ActorStoreList } from '../../src/types.js';
 import { formatActorToActorCard, formatActorToStructuredCard } from '../../src/utils/actor_card.js';
 
 // Mock Actor data for testing (based on real apify/rag-web-browser Actor)
@@ -83,6 +83,19 @@ const mockDeprecatedActor: Actor = {
     title: 'Deprecated RAG Browser',
     isDeprecated: true,
 } as unknown as Actor;
+
+function buildInputSchema(fieldCount: number): ActorStoreInputSchema {
+    const properties: ActorStoreInputSchema['properties'] = {};
+    for (let i = 0; i < fieldCount; i++) {
+        properties[`field${i}`] = { type: 'string' };
+    }
+
+    return {
+        type: 'object',
+        properties,
+        required: Object.keys(properties),
+    };
+}
 
 describe('formatActorToActorCard', () => {
     describe('backwards compatibility (no options)', () => {
@@ -573,6 +586,42 @@ describe('formatActorToStructuredCard', () => {
             expect(result.developer.username).toBe('');
             expect(result.modifiedAt).toBeUndefined();
         });
+    });
+});
+
+describe('formatActorToStructuredCard inputSchema truncation', () => {
+    it('truncates inputFields and marks incomplete schemas', () => {
+        const total = MAX_INPUT_FIELDS_IN_TEXT_CARD + 5;
+        const actor = { ...mockActorStoreList, inputSchema: buildInputSchema(total) } as ActorStoreList;
+        const result = formatActorToStructuredCard(actor);
+
+        expect(Object.keys(result.inputFields?.properties ?? {})).toHaveLength(MAX_INPUT_FIELDS_IN_TEXT_CARD);
+        expect(result.inputFields?.properties[`field${MAX_INPUT_FIELDS_IN_TEXT_CARD - 1}`]).toStrictEqual({
+            type: 'string',
+        });
+        expect(result.inputFields?.properties[`field${MAX_INPUT_FIELDS_IN_TEXT_CARD}`]).toBeUndefined();
+        expect(result.inputFields?.required).toEqual(
+            Array.from({ length: MAX_INPUT_FIELDS_IN_TEXT_CARD }, (_, index) => `field${index}`),
+        );
+        expect(result.inputFieldsTruncated).toBe(true);
+        expect(result.inputFieldsTotalCount).toBe(total);
+    });
+
+    it('leaves inputFields unchanged when schema fits under the cap', () => {
+        const inputSchema: ActorStoreInputSchema = {
+            type: 'object',
+            properties: {
+                url: { type: 'string' },
+                maxResults: { type: 'number' },
+            },
+            required: ['url'],
+        };
+        const actor = { ...mockActorStoreList, inputSchema } as ActorStoreList;
+        const result = formatActorToStructuredCard(actor);
+
+        expect(result.inputFields).toStrictEqual(inputSchema);
+        expect(result.inputFieldsTruncated).toBeUndefined();
+        expect(result.inputFieldsTotalCount).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
## Summary

Truncate the `inputFields` object in `search-actors` structured output to the same cap the text card already uses (`MAX_INPUT_FIELDS_IN_TEXT_CARD`, 20), and attach a completeness marker when truncation happens.

`formatActorToStructuredCard` now:
- trims `inputFields.properties` to the first 20 entries and prunes any `required` names that point at dropped properties, preserving the original `getInputSchema` shape for what remains;
- emits `inputFieldsTruncated: true` and `inputFieldsTotalCount` only when the schema exceeded the cap (both absent for schemas that fit);
- declares the two new marker fields in `actorInfoSchema` so the advertised MCP output schema stays in sync.

`fetch-actor-details` is unchanged as the drill-down path — it still returns the complete input schema via its dedicated `inputSchema` field, so no capability is lost.

## Why this matters

Per issue #888, `search-actors` returned the full, untruncated input schema for every Actor in `structuredOutput`. The text card was already truncated via `MAX_INPUT_FIELDS_IN_TEXT_CARD`, but the structured payload was not, so multi-Actor results bloated the LLM context with complete schemas. As discussed in the thread, the structured output should be truncated the same way as text, with a marker noting the list is incomplete so a consuming agent knows to fetch full details via `fetch-actor-details`.

## Testing

- `tests/unit/utils.actor_card.test.ts`: an Actor with more than the cap number of properties truncates to exactly the cap, sets the marker and total count, and drops `required` entries for removed properties; an Actor under the cap is unchanged with no marker.
- `tests/unit/tools.search_actors.default.response.test.ts`: a multi-Actor search response has every structured `inputFields` truncated and marked, while the text card output is unchanged.
- `pnpm run type-check`, `pnpm run lint`, and `pnpm run test:unit` all pass (827 unit tests).

Fixes #888
