### PR TITLE
feat(tools): TOON-encode list responses with structuredContent + outputSchema

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -146,6 +146,15 @@ To trigger the eval workflow on a PR, apply the **`validated`** label.
 The workflow then runs automatically and posts results to Phoenix.
 It also runs automatically on every merge to the `master` branch.
 
+### Test Actors
+
+Integration tests run against two purpose-built Actors defined in [apify/mcp-server-test-actor](https://github.com/apify/mcp-server-test-actor) and referenced from [`tests/const.ts`](./tests/const.ts):
+
+| Actor | Constant | Purpose |
+|---|---|---|
+| `apify/normal-mode-test-actor` | `ACTOR_NORMAL_MODE` | A normal Actor that writes dataset and key-value-store output. Exercises `call-actor`, the canonical run response, and the storage tools (`get-dataset-items`, `get-dataset`, `get-key-value-store-*`). |
+| `apify/example-mcp-server` | `ACTOR_EXAMPLE_MCP_SERVER` | A standby MCP-server Actor. Exercises the MCP-in-MCP proxy path, where the server registers the Actor's own MCP tools as sub-tools. |
+
 ### Test structure
 
 - `tests/unit/` — unit tests for individual modules

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@segment/analytics-node": "^2.3.0",
     "@sentry/node": "^10.38.0",
+    "@toon-format/toon": "2.3.0",
     "ajv": "^8.17.1",
     "algoliasearch": "^5.31.0",
     "apify-client": "^2.22.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       '@sentry/node':
         specifier: ^10.38.0
         version: 10.53.1
+      '@toon-format/toon':
+        specifier: 2.3.0
+        version: 2.3.0
       ajv:
         specifier: ^8.17.1
         version: 8.20.0
@@ -2227,6 +2230,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@toon-format/toon@2.3.0':
+    resolution: {integrity: sha512-/Ew9etdRQKVMnm9fDaCG0JjyAOK/O7T0M97oum1aW4W+UR8ZhVVPBanIV7oWgHBiGlnVxV9M55PWQCHofDV07w==}
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -6111,6 +6117,8 @@ snapshots:
   '@sindresorhus/is@4.6.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@toon-format/toon@2.3.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { encodeToon } from '../../utils/encode_text.js';
 import { datasetListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserDatasetsListArgs = z.object({
@@ -68,6 +68,6 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: wrapJsonText(datasets) }], structuredContent: datasets };
+        return { content: [{ type: 'text', text: encodeToon(datasets) }], structuredContent: datasets };
     },
 } as const);

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -6,6 +6,7 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { wrapJsonText } from '../../utils/mcp.js';
+import { datasetListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserDatasetsListArgs = z.object({
     offset: z
@@ -49,6 +50,7 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
         - user_input: List my last 10 datasets (newest first)
         - user_input: List unnamed datasets`,
     inputSchema: z.toJSONSchema(getUserDatasetsListArgs) as ToolInputSchema,
+    outputSchema: datasetListOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getUserDatasetsListArgs)),
     annotations: {
         title: 'Get user datasets list',
@@ -66,6 +68,6 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: wrapJsonText(datasets) }] };
+        return { content: [{ type: 'text', text: wrapJsonText(datasets) }], structuredContent: datasets };
     },
 } as const);

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -5,8 +5,8 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { wrapJsonText } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { wrapJsonText } from '../../utils/mcp.js';
 import { normalizeDatasetFields } from '../core/actor_run_response.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -5,9 +5,9 @@ import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { encodeToon } from '../../utils/encode_text.js';
 import { parseCommaSeparatedList, stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { wrapJsonText } from '../../utils/mcp.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
@@ -133,6 +133,6 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             limit: effectiveLimit,
         };
 
-        return { content: [{ type: 'text', text: wrapJsonText(v) }], structuredContent };
+        return { content: [{ type: 'text', text: encodeToon(structuredContent) }], structuredContent };
     },
 } as const);

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -5,9 +5,10 @@ import { HelperTools, HTTP_NOT_FOUND, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { wrapJsonText } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { buildMCPResponse, wrapJsonText } from '../../utils/mcp.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 

--- a/src/tools/common/get_key_value_store.ts
+++ b/src/tools/common/get_key_value_store.ts
@@ -5,8 +5,8 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { wrapJsonText } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { wrapJsonText } from '../../utils/mcp.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
 const getKeyValueStoreArgs = z.object({

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -8,6 +8,7 @@ import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
 import { wrapJsonText } from '../../utils/mcp.js';
+import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
 const getKeyValueStoreKeysArgs = z.object({
@@ -37,6 +38,7 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         - user_input: List first 10 keys in store username~my-store
         - user_input: Continue listing keys in store a123 from key data.json`,
     inputSchema: z.toJSONSchema(getKeyValueStoreKeysArgs) as ToolInputSchema,
+    outputSchema: keyValueStoreKeysOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getKeyValueStoreKeysArgs)),
     paymentRequired: true,
     annotations: {
@@ -64,6 +66,6 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         if (!keys) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: wrapJsonText(keys) }] };
+        return { content: [{ type: 'text', text: wrapJsonText(keys) }], structuredContent: keys };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -5,9 +5,9 @@ import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { encodeToon } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { wrapJsonText } from '../../utils/mcp.js';
 import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
@@ -66,6 +66,6 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         if (!keys) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: wrapJsonText(keys) }], structuredContent: keys };
+        return { content: [{ type: 'text', text: encodeToon(keys) }], structuredContent: keys };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -5,8 +5,8 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { wrapJsonText } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { wrapJsonText } from '../../utils/mcp.js';
 import { buildStorageNotFound, normalizeRecordKey } from './storage_helpers.js';
 
 const getKeyValueStoreRecordArgs = z.object({

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { encodeToon } from '../../utils/encode_text.js';
 import { keyValueStoreListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserKeyValueStoresListArgs = z.object({
@@ -70,6 +70,6 @@ export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: wrapJsonText(stores) }], structuredContent: stores };
+        return { content: [{ type: 'text', text: encodeToon(stores) }], structuredContent: stores };
     },
 } as const);

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -6,6 +6,7 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { wrapJsonText } from '../../utils/mcp.js';
+import { keyValueStoreListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserKeyValueStoresListArgs = z.object({
     offset: z
@@ -51,6 +52,7 @@ export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
         - user_input: List my last 10 key-value stores (newest first)
         - user_input: List unnamed key-value stores`,
     inputSchema: z.toJSONSchema(getUserKeyValueStoresListArgs) as ToolInputSchema,
+    outputSchema: keyValueStoreListOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getUserKeyValueStoresListArgs)),
     annotations: {
         title: 'Get user key-value stores list',
@@ -68,6 +70,6 @@ export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: wrapJsonText(stores) }] };
+        return { content: [{ type: 'text', text: wrapJsonText(stores) }], structuredContent: stores };
     },
 } as const);

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -5,7 +5,8 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { buildMCPResponse, wrapJsonText } from '../../utils/mcp.js';
+import { actorRunListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserRunsListArgs = z.object({
     offset: z
@@ -46,6 +47,7 @@ USAGE EXAMPLES:
 - user_input: List my last 10 runs (newest first)
 - user_input: Show only SUCCEEDED runs`,
     inputSchema: z.toJSONSchema(getUserRunsListArgs) as ToolInputSchema,
+    outputSchema: actorRunListOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getUserRunsListArgs)),
     annotations: {
         title: 'Get user runs list',
@@ -62,7 +64,8 @@ USAGE EXAMPLES:
             .runs()
             .list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
         return buildMCPResponse({
-            texts: [`\`\`\`json\n${JSON.stringify(runs)}\n\`\`\``],
+            texts: [wrapJsonText(runs)],
+            structuredContent: runs,
         });
     },
 } as const);

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse, wrapJsonText } from '../../utils/mcp.js';
+import { encodeToon } from '../../utils/encode_text.js';
 import { actorRunListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserRunsListArgs = z.object({
@@ -63,9 +63,6 @@ USAGE EXAMPLES:
         const runs = await client
             .runs()
             .list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
-        return buildMCPResponse({
-            texts: [wrapJsonText(runs)],
-            structuredContent: runs,
-        });
+        return { content: [{ type: 'text', text: encodeToon(runs) }], structuredContent: runs };
     },
 } as const);

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -459,6 +459,163 @@ export function buildEnrichedDirectActorOutputSchema(itemProperties: Record<stri
 }
 
 /**
+ * Builds the Apify `PaginatedList` envelope schema (offset-based pagination) shared by the
+ * run and storage list tools. `itemsSchema` describes one array element; mirrors `PaginatedList`
+ * from apify-client (api.apify.com `*-get` collection endpoints).
+ */
+function paginatedListOutputSchema(itemsSchema: object, itemsDescription: string) {
+    return {
+        type: 'object' as const,
+        properties: {
+            total: { type: 'number', description: 'Total number of items across all pages.' },
+            count: { type: 'number', description: 'Number of items returned in this page.' },
+            offset: { type: 'number', description: 'Number of items skipped from the start.' },
+            limit: { type: 'number', description: 'Maximum number of items requested.' },
+            desc: { type: 'boolean', description: 'Whether items are sorted in descending order.' },
+            items: { type: 'array' as const, items: itemsSchema, description: itemsDescription },
+        },
+        required: ['total', 'offset', 'limit', 'count', 'items'],
+    };
+}
+
+/** Schema for one run in get-actor-run-list (apify-client `ActorRunListItem`). */
+const actorRunListItemSchema = {
+    type: 'object' as const,
+    properties: {
+        id: { type: 'string', description: 'Run ID.' },
+        actId: { type: 'string', description: 'ID of the Actor that produced the run.' },
+        actorTaskId: { type: 'string', description: 'ID of the Actor task, when the run was started from one.' },
+        status: {
+            type: 'string',
+            description:
+                'Run status: READY | RUNNING | SUCCEEDED | FAILED | TIMING-OUT | TIMED-OUT | ABORTING | ABORTED.',
+        },
+        startedAt: { type: ['string', 'null'], description: 'ISO timestamp when the run started.' },
+        finishedAt: {
+            type: ['string', 'null'],
+            description: 'ISO timestamp when the run finished; null while still running.',
+        },
+        buildId: { type: 'string', description: 'ID of the Actor build used for the run.' },
+        buildNumber: { type: 'string', description: 'Build number used for the run.' },
+        defaultDatasetId: { type: 'string', description: "ID of the run's default dataset." },
+        defaultKeyValueStoreId: { type: 'string', description: "ID of the run's default key-value store." },
+        defaultRequestQueueId: { type: 'string', description: "ID of the run's default request queue." },
+        usageTotalUsd: { type: 'number', description: 'Total run cost in USD.' },
+    },
+    required: ['id', 'actId', 'status', 'defaultDatasetId', 'defaultKeyValueStoreId'],
+};
+
+/** Schema for get-actor-run-list output (paginated list of runs). */
+export const actorRunListOutputSchema = paginatedListOutputSchema(actorRunListItemSchema, 'Actor runs.');
+
+/** Schema for one dataset in get-dataset-list (apify-client `Dataset`). */
+const datasetListItemSchema = {
+    type: 'object' as const,
+    properties: {
+        id: { type: 'string', description: 'Dataset ID.' },
+        name: { type: ['string', 'null'], description: 'Dataset name; null for unnamed datasets.' },
+        title: { type: ['string', 'null'], description: 'Human-readable dataset title; null when unset.' },
+        userId: { type: 'string', description: 'ID of the owning user.' },
+        createdAt: { type: 'string', description: 'ISO timestamp when the dataset was created.' },
+        modifiedAt: { type: 'string', description: 'ISO timestamp when the dataset was last modified.' },
+        accessedAt: { type: 'string', description: 'ISO timestamp when the dataset was last accessed.' },
+        itemCount: { type: 'number', description: 'Total number of items in the dataset.' },
+        cleanItemCount: { type: 'number', description: 'Number of non-empty, non-hidden items.' },
+        actId: { type: ['string', 'null'], description: 'ID of the Actor that created the dataset; null otherwise.' },
+        actRunId: {
+            type: ['string', 'null'],
+            description: 'ID of the Actor run that created the dataset; null otherwise.',
+        },
+        fields: { type: 'array' as const, items: { type: 'string' }, description: 'Field names present in items.' },
+        stats: {
+            type: 'object' as const,
+            description: 'Dataset usage statistics.',
+            properties: {
+                readCount: { type: 'number' },
+                writeCount: { type: 'number' },
+                deleteCount: { type: 'number' },
+                storageBytes: { type: 'number' },
+            },
+        },
+    },
+    required: ['id', 'userId', 'itemCount', 'cleanItemCount'],
+};
+
+/** Schema for get-dataset-list output (paginated list of datasets). */
+export const datasetListOutputSchema = paginatedListOutputSchema(datasetListItemSchema, 'Datasets.');
+
+/** Schema for one store in get-key-value-store-list (apify-client `KeyValueStore`). */
+const keyValueStoreListItemSchema = {
+    type: 'object' as const,
+    properties: {
+        id: { type: 'string', description: 'Key-value store ID.' },
+        name: { type: ['string', 'null'], description: 'Store name; null for unnamed stores.' },
+        title: { type: ['string', 'null'], description: 'Human-readable store title; null when unset.' },
+        userId: { type: 'string', description: 'ID of the owning user.' },
+        createdAt: { type: 'string', description: 'ISO timestamp when the store was created.' },
+        modifiedAt: { type: 'string', description: 'ISO timestamp when the store was last modified.' },
+        accessedAt: { type: 'string', description: 'ISO timestamp when the store was last accessed.' },
+        actId: { type: ['string', 'null'], description: 'ID of the Actor that created the store; null otherwise.' },
+        actRunId: {
+            type: ['string', 'null'],
+            description: 'ID of the Actor run that created the store; null otherwise.',
+        },
+        stats: {
+            type: 'object' as const,
+            description: 'Store usage statistics.',
+            properties: {
+                readCount: { type: 'number' },
+                writeCount: { type: 'number' },
+                deleteCount: { type: 'number' },
+                listCount: { type: 'number' },
+                storageBytes: { type: 'number' },
+            },
+        },
+    },
+    required: ['id', 'userId'],
+};
+
+/** Schema for get-key-value-store-list output (paginated list of stores). */
+export const keyValueStoreListOutputSchema = paginatedListOutputSchema(
+    keyValueStoreListItemSchema,
+    'Key-value stores.',
+);
+
+/**
+ * Schema for get-key-value-store-keys output (apify-client `KeyValueClientListKeysResult`).
+ * Uses key-cursor pagination (exclusiveStartKey), not the offset envelope of the list tools above.
+ */
+export const keyValueStoreKeysOutputSchema = {
+    type: 'object' as const,
+    properties: {
+        count: { type: 'number', description: 'Number of keys returned in this page.' },
+        limit: { type: 'number', description: 'Maximum number of keys requested.' },
+        exclusiveStartKey: {
+            type: ['string', 'null'],
+            description: 'Key after which this listing started (exclusive); null on the first page.',
+        },
+        isTruncated: { type: 'boolean', description: 'Whether more keys are available beyond this page.' },
+        nextExclusiveStartKey: {
+            type: ['string', 'null'],
+            description: 'Pass as exclusiveStartKey to fetch the next page; null when isTruncated is false.',
+        },
+        items: {
+            type: 'array' as const,
+            description: 'Keys in the store with the byte size of each stored value.',
+            items: {
+                type: 'object' as const,
+                properties: {
+                    key: { type: 'string', description: 'Record key.' },
+                    size: { type: 'number', description: 'Size of the stored value in bytes.' },
+                },
+                required: ['key', 'size'],
+            },
+        },
+    },
+    required: ['count', 'limit', 'isTruncated', 'items'],
+};
+
+/**
  * Schema for dataset items retrieval tools (get-dataset-items).
  * Contains dataset items with pagination and count information.
  */

--- a/src/utils/encode_text.ts
+++ b/src/utils/encode_text.ts
@@ -1,0 +1,96 @@
+import { encode } from '@toon-format/toon';
+
+import log from '@apify/log';
+
+/**
+ * Recursion guard for {@link dotFlatten}. The deepest real Apify-API fixture measured is
+ * depth 9 (a user-declared dataset schema), so 20 leaves a comfortable margin while still
+ * stopping runaway recursion on pathological input.
+ */
+const MAX_DEPTH = 20;
+
+/** Markdown code fences keyed by encoding. Labels are ASCII, so char length == byte length. */
+export const FENCES = {
+    json: { prefix: '```json\n', suffix: '\n```' },
+    toon: { prefix: '```toon\n', suffix: '\n```' },
+} as const;
+
+/** Wrap an already-encoded body in the Markdown code fence for its format. */
+function fence(format: keyof typeof FENCES, body: string): string {
+    return `${FENCES[format].prefix}${body}${FENCES[format].suffix}`;
+}
+
+function flattenValue(value: unknown, depth: number): unknown {
+    if (depth > MAX_DEPTH) throw new RangeError('dotFlatten: max depth exceeded');
+    if (Array.isArray(value)) return value.map((item) => flattenValue(item, depth + 1));
+    if (value !== null && typeof value === 'object') {
+        // Null prototype so `key in out` (below) tests own keys only: source keys named like an
+        // `Object.prototype` member (`constructor`, `__proto__`, `toString`, …) neither trip a
+        // false-positive collision nor reach the prototype setter.
+        const out: Record<string, unknown> = Object.create(null);
+        flattenInto(value as Record<string, unknown>, '', depth, out);
+        return out;
+    }
+    return value; // scalar or null — unchanged
+}
+
+function flattenInto(obj: Record<string, unknown>, prefix: string, depth: number, out: Record<string, unknown>): void {
+    if (depth > MAX_DEPTH) throw new RangeError('dotFlatten: max depth exceeded');
+    for (const [rawKey, v] of Object.entries(obj)) {
+        // `.` is the nesting separator, so normalise any literal dot in a source key to avoid
+        // ambiguity. The collision guard below catches the case where this would overwrite a key.
+        const key = prefix ? `${prefix}.${rawKey.replaceAll('.', '_')}` : rawKey.replaceAll('.', '_');
+        if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+            flattenInto(v as Record<string, unknown>, key, depth + 1, out); // lift nested object into dotted keys
+        } else {
+            // Only a genuine normalisation clash remains (`a.b` and `a_b` both map to `a_b`); fail
+            // loud so the caller drops TOON and ships lossless JSON instead of overwriting silently.
+            if (key in out) throw new RangeError(`dotFlatten: key collision on "${key}"`);
+            out[key] = flattenValue(v, depth + 1); // scalars unchanged; arrays recursed into
+        }
+    }
+}
+
+/**
+ * Lifts nested-object keys into dot-joined top-level keys so arrays of uniform objects qualify
+ * for TOON's tabular form. Arrays are preserved (each object element flattened individually);
+ * scalars, null, and inline scalar arrays are unchanged. Throws `RangeError` on depth overflow
+ * or a normalisation collision — the caller drops the TOON candidate and ships JSON.
+ *
+ * Lossy w.r.t. the original key names only when a source key contains a literal `.`
+ * (normalised to `_`); `structuredContent` preserves the originals for programmatic consumers.
+ */
+export function dotFlatten(value: unknown): unknown {
+    return flattenValue(value, 0);
+}
+
+/**
+ * Wrap a JSON-serialisable value in a ```json code fence. Used by single-object tools, which have
+ * no `structuredContent` fallback, so this can never emit anything but JSON.
+ */
+export function wrapJsonText(value: unknown): string {
+    return fence('json', JSON.stringify(value));
+}
+
+/**
+ * Encodes a JSON-serialisable value as a dot-flattened ```toon code fence for the LLM, falling back
+ * to a ```json fence only if `dotFlatten`/`encode` throws (depth overflow or a normalisation key
+ * collision). TOON is the stable shape; JSON is the error path, not a byte-driven alternative.
+ *
+ * The text may be TOON — programmatic JSON consumers must read `structuredContent` instead. Only
+ * wire this on tools that ship `structuredContent` as the JSON fallback.
+ */
+export function encodeToon(value: unknown): string {
+    // `value` is serialised through JSON so `dotFlatten` works on the JSON data model only: a `Date`
+    // (or any `toJSON` carrier) becomes its ISO string here, not an empty object. A non-serialisable
+    // value (circular, BigInt) throws here; API payloads are always JSON, so let it crash.
+    const jsonStr = JSON.stringify(value);
+    try {
+        return fence('toon', encode(dotFlatten(JSON.parse(jsonStr))));
+    } catch (err) {
+        // dotFlatten threw (depth overflow or key collision) or encode failed — ship JSON instead.
+        // Log it: the fallback is lossless, but a recurring failure means TOON is silently disabled.
+        log.debug('encodeToon: TOON encoding failed, shipping JSON', { err });
+        return fence('json', jsonStr);
+    }
+}

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -49,19 +49,6 @@ export function buildMCPResponse(options: {
     };
 }
 
-/** Markdown JSON code-fence prefix used by `wrapJsonText` and the test-side `parseFencedJson`. */
-export const JSON_FENCE_PREFIX = '```json\n';
-/** Markdown JSON code-fence suffix used by `wrapJsonText` and the test-side `parseFencedJson`. */
-export const JSON_FENCE_SUFFIX = '\n```';
-
-/**
- * Wrap a JSON-serializable value in a Markdown ` ```json ` code fence.
- * Used by any tool that returns SDK payloads to the LLM.
- */
-export function wrapJsonText(value: unknown): string {
-    return `${JSON_FENCE_PREFIX}${JSON.stringify(value)}${JSON_FENCE_SUFFIX}`;
-}
-
 /**
  * Computes tool response payload bytes, split by payload side:
  * `contentBytes` sums the UTF-8 byte length of every text item in `content[]`;

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -1,13 +1,25 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { decode as decodeToon } from '@toon-format/toon';
 import { expect } from 'vitest';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../../src/const.js';
 import type { InternalToolArgs } from '../../../src/types.js';
-import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from '../../../src/utils/mcp.js';
+import { FENCES } from '../../../src/utils/encode_text.js';
 
 /** Inverse of `wrapJsonText`; imports prod's fence constants so the two halves can't drift. */
 export function parseFencedJson(text: string): unknown {
-    return JSON.parse(text.slice(JSON_FENCE_PREFIX.length, -JSON_FENCE_SUFFIX.length));
+    return JSON.parse(text.slice(FENCES.json.prefix.length, -FENCES.json.suffix.length));
+}
+
+/**
+ * Inverse of `encodeToon` — decodes the fenced tool text whether it shipped TOON or fell back to
+ * JSON. For flat payloads (what the array-endpoint mocks use) the TOON round-trip is exact.
+ */
+export function decodeFencedToolText(text: string): unknown {
+    if (text.startsWith(FENCES.toon.prefix)) {
+        return decodeToon(text.slice(FENCES.toon.prefix.length, -FENCES.toon.suffix.length));
+    }
+    return parseFencedJson(text);
 }
 
 /**

--- a/tests/unit/tools.dataset_collection.test.ts
+++ b/tests/unit/tools.dataset_collection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getUserDatasetsList } from '../../src/tools/common/dataset_collection.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { parseFencedJson, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { decodeFencedToolText, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const MOCK_LIST = {
     total: 2,
@@ -28,7 +28,7 @@ describe('get-dataset-list', () => {
         expect(getUserDatasetsList.name).toBe(HelperTools.DATASET_LIST_GET);
     });
 
-    it('returns the list response as JSON in a fenced code block', async () => {
+    it('returns the list response as fenced text (json or toon) that round-trips to the data', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
         const result = await (getUserDatasetsList as HelperTool).call(
@@ -36,7 +36,7 @@ describe('get-dataset-list', () => {
         );
         const { content } = result as TextToolResult;
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_LIST);
+        expect(decodeFencedToolText(content[0].text)).toEqual(MOCK_LIST);
     });
 
     it('mirrors the list response in structuredContent and declares an outputSchema', async () => {

--- a/tests/unit/tools.dataset_collection.test.ts
+++ b/tests/unit/tools.dataset_collection.test.ts
@@ -39,6 +39,17 @@ describe('get-dataset-list', () => {
         expect(parseFencedJson(content[0].text)).toEqual(MOCK_LIST);
     });
 
+    it('mirrors the list response in structuredContent and declares an outputSchema', async () => {
+        const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
+
+        const result = await (getUserDatasetsList as HelperTool).call(
+            stubToolCallContext({}, stubApifyClient(listSpy)),
+        );
+
+        expect((result as TextToolResult).structuredContent).toEqual(MOCK_LIST);
+        expect((getUserDatasetsList as HelperTool).outputSchema).toMatchObject({ type: 'object' });
+    });
+
     it('forwards pagination params (limit, offset, desc, unnamed) to ApifyClient', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { extractDotPrefixes, getDatasetItems } from '../../src/tools/common/get_dataset_items.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { expectSoftFailInvalidInput, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { dotFlatten } from '../../src/utils/encode_text.js';
+import {
+    decodeFencedToolText,
+    expectSoftFailInvalidInput,
+    stubToolCallContext,
+    type TextToolResult,
+} from './helpers/tool_context.js';
 
 describe('extractDotPrefixes', () => {
     it('returns empty list when no fields contain a dot', () => {
@@ -64,6 +70,39 @@ describe('get-dataset-items', () => {
 
         expect(structuredContent.datasetId).toBe('ds-1');
         expect(structuredContent.itemCount).toBe(MOCK_ITEMS.length);
+    });
+
+    it('encodes the same payload into content text as structuredContent', async () => {
+        const result = await (getDatasetItems as HelperTool).call(
+            stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient()),
+        );
+        const { content, structuredContent } = result as TextToolResult;
+
+        expect(decodeFencedToolText(content[0].text)).toEqual(structuredContent);
+    });
+
+    it('content round-trips to structuredContent for nested items (dot-flattened when TOON wins)', async () => {
+        // Real dataset items are routinely nested; the flat happy-path mock can't exercise the
+        // dot-flatten path where the TOON text keys differ from the structuredContent keys.
+        const nestedItems = [
+            { url: 'https://a', metadata: { httpStatus: 200, depth: 1 } },
+            { url: 'https://b', metadata: { httpStatus: 404, depth: 2 } },
+            { url: 'https://c', metadata: { httpStatus: 200, depth: 3 } },
+        ];
+        const result = await (getDatasetItems as HelperTool).call(
+            stubToolCallContext(
+                { datasetId: 'ds-1' },
+                stubApifyClient(async () => ({ items: nestedItems, total: 3 })),
+            ),
+        );
+        const { content, structuredContent } = result as TextToolResult;
+        const [{ text }] = content;
+
+        // Uniform nested rows favour TOON; assert the lift actually happened, then that the text
+        // round-trips to the dot-flattened structuredContent (its true on-the-wire equivalent).
+        expect(text.startsWith('```toon\n')).toBe(true);
+        expect(text).toContain('metadata.httpStatus');
+        expect(decodeFencedToolText(text)).toEqual(dotFlatten(JSON.parse(JSON.stringify(structuredContent))));
     });
 
     it('defaults `limit` to 20 when caller omits it', async () => {

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -49,6 +49,17 @@ describe('get-key-value-store-keys', () => {
         expect(parseFencedJson(content[0].text)).toEqual(MOCK_KEYS);
     });
 
+    it('mirrors the keys response in structuredContent and declares an outputSchema', async () => {
+        const listKeysSpy = vi.fn().mockResolvedValue(MOCK_KEYS);
+
+        const result = await (getKeyValueStoreKeys as HelperTool).call(
+            stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(listKeysSpy)),
+        );
+
+        expect((result as TextToolResult).structuredContent).toEqual(MOCK_KEYS);
+        expect((getKeyValueStoreKeys as HelperTool).outputSchema).toMatchObject({ type: 'object' });
+    });
+
     it('forwards exclusiveStartKey and limit to listKeys', async () => {
         const listKeysSpy = vi.fn().mockResolvedValue(MOCK_KEYS);
 

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -4,8 +4,8 @@ import { HelperTools } from '../../src/const.js';
 import { getKeyValueStoreKeys } from '../../src/tools/common/get_key_value_store_keys.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import {
+    decodeFencedToolText,
     expectSoftFailInvalidInput,
-    parseFencedJson,
     stubToolCallContext,
     type TextToolResult,
 } from './helpers/tool_context.js';
@@ -38,7 +38,7 @@ describe('get-key-value-store-keys', () => {
         expect(getKeyValueStoreKeys.name).toBe(HelperTools.KEY_VALUE_STORE_KEYS_GET);
     });
 
-    it('returns the keys response as JSON in a fenced code block', async () => {
+    it('returns the keys response as fenced text (json or toon) that round-trips to the data', async () => {
         const listKeysSpy = vi.fn().mockResolvedValue(MOCK_KEYS);
 
         const result = await (getKeyValueStoreKeys as HelperTool).call(
@@ -46,7 +46,7 @@ describe('get-key-value-store-keys', () => {
         );
         const { content } = result as TextToolResult;
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_KEYS);
+        expect(decodeFencedToolText(content[0].text)).toEqual(MOCK_KEYS);
     });
 
     it('mirrors the keys response in structuredContent and declares an outputSchema', async () => {

--- a/tests/unit/tools.key_value_store_collection.test.ts
+++ b/tests/unit/tools.key_value_store_collection.test.ts
@@ -39,6 +39,17 @@ describe('get-key-value-store-list', () => {
         expect(parseFencedJson(content[0].text)).toEqual(MOCK_LIST);
     });
 
+    it('mirrors the list response in structuredContent and declares an outputSchema', async () => {
+        const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
+
+        const result = await (getUserKeyValueStoresList as HelperTool).call(
+            stubToolCallContext({}, stubApifyClient(listSpy)),
+        );
+
+        expect((result as TextToolResult).structuredContent).toEqual(MOCK_LIST);
+        expect((getUserKeyValueStoresList as HelperTool).outputSchema).toMatchObject({ type: 'object' });
+    });
+
     it('forwards pagination params (limit, offset, desc, unnamed) to ApifyClient', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 

--- a/tests/unit/tools.key_value_store_collection.test.ts
+++ b/tests/unit/tools.key_value_store_collection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getUserKeyValueStoresList } from '../../src/tools/common/key_value_store_collection.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { parseFencedJson, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { decodeFencedToolText, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const MOCK_LIST = {
     total: 2,
@@ -28,7 +28,7 @@ describe('get-key-value-store-list', () => {
         expect(getUserKeyValueStoresList.name).toBe(HelperTools.KEY_VALUE_STORE_LIST_GET);
     });
 
-    it('returns the list response as JSON in a fenced code block', async () => {
+    it('returns the list response as fenced text (json or toon) that round-trips to the data', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
         const result = await (getUserKeyValueStoresList as HelperTool).call(
@@ -36,7 +36,7 @@ describe('get-key-value-store-list', () => {
         );
         const { content } = result as TextToolResult;
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_LIST);
+        expect(decodeFencedToolText(content[0].text)).toEqual(MOCK_LIST);
     });
 
     it('mirrors the list response in structuredContent and declares an outputSchema', async () => {

--- a/tests/unit/tools.run_collection.test.ts
+++ b/tests/unit/tools.run_collection.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HelperTools } from '../../src/const.js';
+import { getUserRunsList } from '../../src/tools/common/run_collection.js';
+import type { HelperTool, InternalToolArgs } from '../../src/types.js';
+import { parseFencedJson, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+
+const listMock = vi.fn();
+
+vi.mock('../../src/apify_client.js', () => ({
+    ApifyClient: vi.fn().mockImplementation(function () {
+        return { runs: () => ({ list: listMock }) };
+    }),
+}));
+
+const MOCK_RUNS = {
+    total: 1,
+    offset: 0,
+    limit: 10,
+    desc: false,
+    count: 1,
+    items: [
+        {
+            id: 'run-1',
+            actId: 'act-1',
+            status: 'SUCCEEDED',
+            startedAt: '2026-05-12T09:18:27.527Z',
+            finishedAt: '2026-05-12T09:19:01.000Z',
+            defaultDatasetId: 'ds-1',
+            defaultKeyValueStoreId: 'kv-1',
+        },
+    ],
+};
+
+// run_collection constructs its own ApifyClient from the token, so the injected client is unused.
+const noClient = null as unknown as InternalToolArgs['apifyClient'];
+
+describe('get-actor-run-list', () => {
+    it('has the expected tool name', () => {
+        expect(getUserRunsList.name).toBe(HelperTools.ACTOR_RUN_LIST_GET);
+    });
+
+    it('returns the runs as fenced JSON, mirrors them in structuredContent, and declares an outputSchema', async () => {
+        listMock.mockResolvedValue(MOCK_RUNS);
+
+        const result = await (getUserRunsList as HelperTool).call(stubToolCallContext({}, noClient));
+        const { content } = result as TextToolResult;
+
+        expect(parseFencedJson(content[0].text)).toEqual(MOCK_RUNS);
+        expect((result as TextToolResult).structuredContent).toEqual(MOCK_RUNS);
+        expect((getUserRunsList as HelperTool).outputSchema).toMatchObject({ type: 'object' });
+    });
+
+    it('forwards pagination and status filters to runs().list()', async () => {
+        listMock.mockResolvedValue(MOCK_RUNS);
+
+        await (getUserRunsList as HelperTool).call(
+            stubToolCallContext({ limit: 5, offset: 2, desc: true, status: 'SUCCEEDED' }, noClient),
+        );
+
+        expect(listMock).toHaveBeenCalledWith({ limit: 5, offset: 2, desc: true, status: 'SUCCEEDED' });
+    });
+
+    it('applies defaults (limit=10, offset=0, desc=false) when no params given', async () => {
+        listMock.mockResolvedValue(MOCK_RUNS);
+
+        await (getUserRunsList as HelperTool).call(stubToolCallContext({}, noClient));
+
+        expect(listMock).toHaveBeenCalledWith({ limit: 10, offset: 0, desc: false, status: undefined });
+    });
+
+    it('rejects limit above 10 via ajv validation', () => {
+        const tool = getUserRunsList as HelperTool;
+        expect(tool.ajvValidate({ limit: 11 })).toBe(false);
+        expect(tool.ajvValidate({ limit: 10 })).toBe(true);
+    });
+});

--- a/tests/unit/tools.run_collection.test.ts
+++ b/tests/unit/tools.run_collection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getUserRunsList } from '../../src/tools/common/run_collection.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { parseFencedJson, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { decodeFencedToolText, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const listMock = vi.fn();
 
@@ -40,13 +40,13 @@ describe('get-actor-run-list', () => {
         expect(getUserRunsList.name).toBe(HelperTools.ACTOR_RUN_LIST_GET);
     });
 
-    it('returns the runs as fenced JSON, mirrors them in structuredContent, and declares an outputSchema', async () => {
+    it('returns runs as fenced text (json or toon), mirrors them in structuredContent, and declares an outputSchema', async () => {
         listMock.mockResolvedValue(MOCK_RUNS);
 
         const result = await (getUserRunsList as HelperTool).call(stubToolCallContext({}, noClient));
         const { content } = result as TextToolResult;
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_RUNS);
+        expect(decodeFencedToolText(content[0].text)).toEqual(MOCK_RUNS);
         expect((result as TextToolResult).structuredContent).toEqual(MOCK_RUNS);
         expect((getUserRunsList as HelperTool).outputSchema).toMatchObject({ type: 'object' });
     });

--- a/tests/unit/utils.encode_text.test.ts
+++ b/tests/unit/utils.encode_text.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import { dotFlatten, encodeToon, FENCES, wrapJsonText } from '../../src/utils/encode_text.js';
+import { decodeFencedToolText } from './helpers/tool_context.js';
+
+describe('dotFlatten', () => {
+    it('lifts nested object keys into dot-joined top-level keys', () => {
+        expect(dotFlatten({ id: 1, stats: { runs: 10, reads: 5 } })).toEqual({
+            id: 1,
+            'stats.runs': 10,
+            'stats.reads': 5,
+        });
+    });
+
+    it('flattens each object element of an array but keeps it an array', () => {
+        expect(
+            dotFlatten([
+                { id: 1, stats: { runs: 10 } },
+                { id: 2, stats: { runs: 20 } },
+            ]),
+        ).toEqual([
+            { id: 1, 'stats.runs': 10 },
+            { id: 2, 'stats.runs': 20 },
+        ]);
+    });
+
+    it('leaves scalars, null, and inline scalar arrays unchanged', () => {
+        expect(dotFlatten({ a: 1, b: null, tags: ['x', 'y'] })).toEqual({ a: 1, b: null, tags: ['x', 'y'] });
+    });
+
+    it('normalises literal dots in source keys to underscores', () => {
+        expect(dotFlatten({ 'a.b': 1 })).toEqual({ a_b: 1 });
+    });
+
+    it('throws on a normalisation collision (no silent data loss)', () => {
+        expect(() => dotFlatten({ 'a.b': 1, a_b: 2 })).toThrow(RangeError);
+    });
+
+    it('keeps a top-level key named like an Object.prototype member (no false-positive collision)', () => {
+        const flat = dotFlatten({ id: 1, constructor: 'Building Co' }) as Record<string, unknown>;
+        expect(flat.id).toBe(1);
+        expect(flat.constructor).toBe('Building Co');
+    });
+
+    it('keeps an own __proto__ key (from parsed JSON) as data without polluting the prototype', () => {
+        const flat = dotFlatten(JSON.parse('{"id":1,"__proto__":"x"}')) as Record<string, unknown>;
+        expect(Object.getOwnPropertyDescriptor(flat, '__proto__')?.value).toBe('x');
+        expect(Object.getPrototypeOf(flat)).toBe(null);
+    });
+
+    it('throws when nesting exceeds the depth guard', () => {
+        let deep: Record<string, unknown> = { leaf: 1 };
+        for (let i = 0; i < 25; i++) deep = { nest: deep };
+        expect(() => dotFlatten(deep)).toThrow(RangeError);
+    });
+});
+
+describe('wrapJsonText', () => {
+    it('emits a ```json … ``` fenced block', () => {
+        expect(wrapJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
+    });
+
+    it('serializes arrays', () => {
+        expect(wrapJsonText([1, 2])).toBe('```json\n[1,2]\n```');
+    });
+
+    it('serializes primitives', () => {
+        expect(wrapJsonText('x')).toBe('```json\n"x"\n```');
+    });
+});
+
+describe('encodeToon', () => {
+    const uniformRows = {
+        items: [
+            { id: 1, status: 'SUCCEEDED', cost: 0.1 },
+            { id: 2, status: 'FAILED', cost: 0.2 },
+            { id: 3, status: 'SUCCEEDED', cost: 0.3 },
+        ],
+    };
+
+    it('emits a TOON fence that round-trips to the original value', () => {
+        const text = encodeToon(uniformRows);
+        expect(text.startsWith(FENCES.toon.prefix)).toBe(true);
+        expect(decodeFencedToolText(text)).toEqual(uniformRows);
+    });
+
+    it('preserves Date, nested-object, and null fields (regression: dotFlatten dropped Date objects)', () => {
+        const startedAt = '2026-05-12T09:18:27.527Z';
+        const input = {
+            items: [
+                {
+                    id: 1,
+                    startedAt: new Date(startedAt),
+                    finishedAt: new Date('2026-05-12T09:19:01.000Z'),
+                    stats: { runs: 10 },
+                },
+                { id: 2, startedAt: new Date('2026-05-12T09:17:57.206Z'), finishedAt: null, stats: { runs: 20 } },
+            ],
+        };
+        const text = encodeToon(input);
+
+        // The Date must survive as an ISO string. An earlier revision treated a Date as an empty
+        // nested object in dotFlatten and dropped it; serialising through JSON first fixes that.
+        expect(text).toContain(startedAt);
+
+        // The TOON text round-trips to the dot-flattened, JSON-normalised value.
+        const normalized = JSON.parse(JSON.stringify(input));
+        expect(text.startsWith(FENCES.toon.prefix)).toBe(true);
+        expect(decodeFencedToolText(text)).toEqual(dotFlatten(normalized));
+    });
+
+    it('ships TOON for a prototype-name column instead of falling back to JSON', () => {
+        const value = {
+            items: [
+                { id: 1, constructor: 'a' },
+                { id: 2, constructor: 'b' },
+            ],
+        };
+        const text = encodeToon(value);
+        expect(text.startsWith(FENCES.toon.prefix)).toBe(true);
+        expect(decodeFencedToolText(text)).toEqual(value);
+    });
+
+    it('falls back to JSON on a dotFlatten collision and still round-trips', () => {
+        const value = { 'a.b': 1, a_b: 2 };
+        const text = encodeToon(value);
+        expect(text.startsWith(FENCES.toon.prefix)).toBe(false);
+        expect(decodeFencedToolText(text)).toEqual(value);
+    });
+
+    it('falls back to JSON when nesting exceeds the depth guard', () => {
+        let deep: Record<string, unknown> = { leaf: 1 };
+        for (let i = 0; i < 25; i++) deep = { nest: deep };
+        const text = encodeToon(deep);
+        expect(text.startsWith(FENCES.toon.prefix)).toBe(false);
+        expect(decodeFencedToolText(text)).toEqual(deep);
+    });
+});

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -1,20 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeToolResponseBytes, wrapJsonText } from '../../src/utils/mcp.js';
-
-describe('wrapJsonText()', () => {
-    it('emits a ```json … ``` fenced block', () => {
-        expect(wrapJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
-    });
-
-    it('serializes arrays', () => {
-        expect(wrapJsonText([1, 2])).toBe('```json\n[1,2]\n```');
-    });
-
-    it('serializes primitives', () => {
-        expect(wrapJsonText('x')).toBe('```json\n"x"\n```');
-    });
-});
+import { computeToolResponseBytes } from '../../src/utils/mcp.js';
 
 describe('computeToolResponseBytes()', () => {
     it('returns zero for null/undefined/non-object input', () => {


### PR DESCRIPTION
## What
The five array endpoints (`get-actor-run-list`, `get-dataset-list`, `get-key-value-store-list`, `get-key-value-store-keys`, `get-dataset-items`) now ship:
- `structuredContent` + an `outputSchema` (pure JSON, mirroring the `apify-client` / api.apify.com response shapes), and
- dot-flattened [TOON](https://toonformat.dev/) in `content[].text`.

`encode_text.ts` exposes two encoders: `wrapJsonText` (always JSON, single-object tools) and `encodeToon` (always TOON, list tools). `encodeToon` falls back to a JSON fence only when `dotFlatten`/`encode` throws (depth overflow or a normalisation key collision) — a lossless, logged error path, not a byte-driven picker.

This branch combines PR 1 (structuredContent/outputSchema) with the now-merged #952 (always-TOON encoding) into one change. Implements #913.

## Why
JSON repeats every object key on every array row; TOON's tabular form drops that, shrinking the list payloads that sit in the LLM context. `structuredContent` is the JSON source of truth for programmatic consumers and `outputSchema` validators, independent of how `text` is encoded — so the schema work is the additive base the TOON encoding builds on. One stable shape per tool beats a format that flips on byte count: easier to reason about and debug.

## Worth your attention
- **`content[].text` is TOON (or JSON on the rare error fallback).** All five tools declare `outputSchema`/`structuredContent`, authoritative for machine consumers. A client that blindly `JSON.parse`s `content[0].text` and ignores `structuredContent` would need to handle TOON. This knowingly deviates from the spec SHOULD ("a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block").
- **`encodeToon` serialises through `JSON.stringify` first**, so `dotFlatten` works on the JSON data model only — a `Date`/`toJSON` carrier becomes its ISO string, not an empty object (pinned by a regression test).
- **JSON fallback is an error path, not a picker.** A top-level key named `constructor`/`toString`/`__proto__`/… trips the `key in out` collision guard; TOON is dropped and JSON ships (lossless, logged). The guard also blocks `__proto__` pollution.
- Schemas validated against the **live api.apify.com**, which caught nullability gaps the SDK `.d.ts` hides — `name`, `title`, `actId`, `actRunId`, `exclusiveStartKey`, `nextExclusiveStartKey` are returned as `null` and are now typed `['string','null']`.
- `@toon-format/toon@2.3.0` — pinned, 0 deps.

## Testing
- Rebased on latest master; `type-check` and `lint` clean; unit suite green (855 passed, 2 skipped). Integration tests require `APIFY_TOKEN` and were not run.
- Live verification against a local build via [`mcpc`](https://github.com/apify/mcpc); TOON output decoded back with the real `@toon-format/toon` decoder to confirm losslessness.

## Before merge
Gated on the TOON task-performance experiment (#943) — `pnpm run evals:workflow`, no regression vs master. The byte win is proven; the LLM-comprehension win is not yet.
