### PR TITLE
feat(tools): always TOON-encode list responses

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -146,6 +146,15 @@ To trigger the eval workflow on a PR, apply the **`validated`** label.
 The workflow then runs automatically and posts results to Phoenix.
 It also runs automatically on every merge to the `master` branch.
 
+### Test Actors
+
+Integration tests run against two purpose-built Actors defined in [apify/mcp-server-test-actor](https://github.com/apify/mcp-server-test-actor) and referenced from [`tests/const.ts`](./tests/const.ts):
+
+| Actor | Constant | Purpose |
+|---|---|---|
+| `apify/normal-mode-test-actor` | `ACTOR_NORMAL_MODE` | A normal Actor that writes dataset and key-value-store output. Exercises `call-actor`, the canonical run response, and the storage tools (`get-dataset-items`, `get-dataset`, `get-key-value-store-*`). |
+| `apify/example-mcp-server` | `ACTOR_EXAMPLE_MCP_SERVER` | A standby MCP-server Actor. Exercises the MCP-in-MCP proxy path, where the server registers the Actor's own MCP tools as sub-tools. |
+
 ### Test structure
 
 - `tests/unit/` — unit tests for individual modules

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@segment/analytics-node": "^2.3.0",
     "@sentry/node": "^10.38.0",
+    "@toon-format/toon": "2.3.0",
     "ajv": "^8.17.1",
     "algoliasearch": "^5.31.0",
     "apify-client": "^2.22.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       '@sentry/node':
         specifier: ^10.38.0
         version: 10.53.1
+      '@toon-format/toon':
+        specifier: 2.3.0
+        version: 2.3.0
       ajv:
         specifier: ^8.17.1
         version: 8.20.0
@@ -2227,6 +2230,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@toon-format/toon@2.3.0':
+    resolution: {integrity: sha512-/Ew9etdRQKVMnm9fDaCG0JjyAOK/O7T0M97oum1aW4W+UR8ZhVVPBanIV7oWgHBiGlnVxV9M55PWQCHofDV07w==}
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -6111,6 +6117,8 @@ snapshots:
   '@sindresorhus/is@4.6.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@toon-format/toon@2.3.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeJsonText } from '../../utils/mcp.js';
+import { encodeCompactText } from '../../utils/encode_text.js';
 import { datasetListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserDatasetsListArgs = z.object({
@@ -68,6 +68,6 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: encodeJsonText(datasets) }], structuredContent: datasets };
+        return { content: [{ type: 'text', text: encodeCompactText(datasets) }], structuredContent: datasets };
     },
 } as const);

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeCompactText } from '../../utils/encode_text.js';
+import { encodeSmallest } from '../../utils/encode_text.js';
 import { datasetListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserDatasetsListArgs = z.object({
@@ -68,6 +68,6 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: encodeCompactText(datasets) }], structuredContent: datasets };
+        return { content: [{ type: 'text', text: encodeSmallest(datasets) }], structuredContent: datasets };
     },
 } as const);

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeSmallest } from '../../utils/encode_text.js';
+import { encodeToon } from '../../utils/encode_text.js';
 import { datasetListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserDatasetsListArgs = z.object({
@@ -68,6 +68,6 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: encodeSmallest(datasets) }], structuredContent: datasets };
+        return { content: [{ type: 'text', text: encodeToon(datasets) }], structuredContent: datasets };
     },
 } as const);

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { encodeJsonText } from '../../utils/mcp.js';
 import { datasetListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserDatasetsListArgs = z.object({
@@ -68,6 +68,6 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: wrapJsonText(datasets) }], structuredContent: datasets };
+        return { content: [{ type: 'text', text: encodeJsonText(datasets) }], structuredContent: datasets };
     },
 } as const);

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -6,7 +6,7 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { encodeJsonText } from '../../utils/mcp.js';
 import { normalizeDatasetFields } from '../core/actor_run_response.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
@@ -58,6 +58,6 @@ export const getDataset: ToolEntry = Object.freeze({
         // normalization `buildRunDataset` applies so this tool's `fields` matches
         // the structured `storages.datasets.default.fields` shape.
         const normalized = dataset.fields ? { ...dataset, fields: normalizeDatasetFields(dataset.fields) } : dataset;
-        return { content: [{ type: 'text', text: wrapJsonText(normalized) }] };
+        return { content: [{ type: 'text', text: encodeJsonText(normalized) }] };
     },
 } as const);

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -5,8 +5,8 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { wrapJsonText } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { encodeJsonText } from '../../utils/mcp.js';
 import { normalizeDatasetFields } from '../core/actor_run_response.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
@@ -58,6 +58,6 @@ export const getDataset: ToolEntry = Object.freeze({
         // normalization `buildRunDataset` applies so this tool's `fields` matches
         // the structured `storages.datasets.default.fields` shape.
         const normalized = dataset.fields ? { ...dataset, fields: normalizeDatasetFields(dataset.fields) } : dataset;
-        return { content: [{ type: 'text', text: encodeJsonText(normalized) }] };
+        return { content: [{ type: 'text', text: wrapJsonText(normalized) }] };
     },
 } as const);

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -5,7 +5,7 @@ import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeCompactText } from '../../utils/encode_text.js';
+import { encodeSmallest } from '../../utils/encode_text.js';
 import { parseCommaSeparatedList, stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
@@ -140,6 +140,6 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             limit: effectiveLimit,
         };
 
-        return { content: [{ type: 'text', text: encodeCompactText(structuredContent) }], structuredContent };
+        return { content: [{ type: 'text', text: encodeSmallest(structuredContent) }], structuredContent };
     },
 } as const);

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -5,17 +5,13 @@ import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeSmallest } from '../../utils/encode_text.js';
+import { encodeToon } from '../../utils/encode_text.js';
 import { parseCommaSeparatedList, stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
 const DEFAULT_DATASET_ITEMS_LIMIT = 20;
-// Caps the page size: the picker serialises the response several times (JSON + dot-flattened TOON),
-// so an unbounded limit turns a large dataset page into a memory/CPU spike. 250 is well past what an
-// LLM can usefully consume in one turn while staying cheap to encode.
-const MAX_DATASET_ITEMS_LIMIT = 250;
 
 /** Top-level dot prefixes of `fields`. Apify's `flatten` recurses, so the first segment suffices. */
 export function extractDotPrefixes(fields: string[]): string[] {
@@ -42,11 +38,8 @@ const getDatasetItemsArgs = z.object({
         .number()
         .int()
         .min(1)
-        .max(MAX_DATASET_ITEMS_LIMIT)
         .optional()
-        .describe(
-            `Maximum number of items to return. Defaults to ${DEFAULT_DATASET_ITEMS_LIMIT}, max ${MAX_DATASET_ITEMS_LIMIT}.`,
-        ),
+        .describe(`Maximum number of items to return. Defaults to ${DEFAULT_DATASET_ITEMS_LIMIT}.`),
     fields: z
         .string()
         .optional()
@@ -140,6 +133,6 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             limit: effectiveLimit,
         };
 
-        return { content: [{ type: 'text', text: encodeSmallest(structuredContent) }], structuredContent };
+        return { content: [{ type: 'text', text: encodeToon(structuredContent) }], structuredContent };
     },
 } as const);

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -7,7 +7,7 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { parseCommaSeparatedList, stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { encodeJsonText } from '../../utils/mcp.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
@@ -133,6 +133,6 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             limit: effectiveLimit,
         };
 
-        return { content: [{ type: 'text', text: wrapJsonText(v) }], structuredContent };
+        return { content: [{ type: 'text', text: encodeJsonText(v) }], structuredContent };
     },
 } as const);

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -12,6 +12,10 @@ import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
 const DEFAULT_DATASET_ITEMS_LIMIT = 20;
+// Caps the page size: the picker serialises the response several times (JSON + dot-flattened TOON),
+// so an unbounded limit turns a large dataset page into a memory/CPU spike. 250 is well past what an
+// LLM can usefully consume in one turn while staying cheap to encode.
+const MAX_DATASET_ITEMS_LIMIT = 250;
 
 /** Top-level dot prefixes of `fields`. Apify's `flatten` recurses, so the first segment suffices. */
 export function extractDotPrefixes(fields: string[]): string[] {
@@ -38,8 +42,11 @@ const getDatasetItemsArgs = z.object({
         .number()
         .int()
         .min(1)
+        .max(MAX_DATASET_ITEMS_LIMIT)
         .optional()
-        .describe(`Maximum number of items to return. Defaults to ${DEFAULT_DATASET_ITEMS_LIMIT}.`),
+        .describe(
+            `Maximum number of items to return. Defaults to ${DEFAULT_DATASET_ITEMS_LIMIT}, max ${MAX_DATASET_ITEMS_LIMIT}.`,
+        ),
     fields: z
         .string()
         .optional()

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -5,9 +5,9 @@ import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { encodeCompactText } from '../../utils/encode_text.js';
 import { parseCommaSeparatedList, stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { encodeJsonText } from '../../utils/mcp.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
@@ -133,6 +133,6 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             limit: effectiveLimit,
         };
 
-        return { content: [{ type: 'text', text: encodeJsonText(v) }], structuredContent };
+        return { content: [{ type: 'text', text: encodeCompactText(v) }], structuredContent };
     },
 } as const);

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -133,6 +133,6 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             limit: effectiveLimit,
         };
 
-        return { content: [{ type: 'text', text: encodeCompactText(v) }], structuredContent };
+        return { content: [{ type: 'text', text: encodeCompactText(structuredContent) }], structuredContent };
     },
 } as const);

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -7,7 +7,7 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { buildMCPResponse, wrapJsonText } from '../../utils/mcp.js';
+import { buildMCPResponse, encodeJsonText } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
@@ -94,6 +94,6 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
             });
         }
 
-        return { content: [{ type: 'text', text: wrapJsonText(schema) }] };
+        return { content: [{ type: 'text', text: encodeJsonText(schema) }] };
     },
 } as const);

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -5,9 +5,10 @@ import { HelperTools, HTTP_NOT_FOUND, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { wrapJsonText } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { buildMCPResponse, encodeJsonText } from '../../utils/mcp.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
@@ -94,6 +95,6 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
             });
         }
 
-        return { content: [{ type: 'text', text: encodeJsonText(schema) }] };
+        return { content: [{ type: 'text', text: wrapJsonText(schema) }] };
     },
 } as const);

--- a/src/tools/common/get_key_value_store.ts
+++ b/src/tools/common/get_key_value_store.ts
@@ -6,7 +6,7 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { encodeJsonText } from '../../utils/mcp.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
 const getKeyValueStoreArgs = z.object({
@@ -47,6 +47,6 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
         if (!kvStore) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: wrapJsonText(kvStore) }] };
+        return { content: [{ type: 'text', text: encodeJsonText(kvStore) }] };
     },
 } as const);

--- a/src/tools/common/get_key_value_store.ts
+++ b/src/tools/common/get_key_value_store.ts
@@ -5,8 +5,8 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { wrapJsonText } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { encodeJsonText } from '../../utils/mcp.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
 const getKeyValueStoreArgs = z.object({
@@ -47,6 +47,6 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
         if (!kvStore) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: encodeJsonText(kvStore) }] };
+        return { content: [{ type: 'text', text: wrapJsonText(kvStore) }] };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -7,7 +7,7 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { encodeJsonText } from '../../utils/mcp.js';
 import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
@@ -66,6 +66,6 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         if (!keys) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: wrapJsonText(keys) }], structuredContent: keys };
+        return { content: [{ type: 'text', text: encodeJsonText(keys) }], structuredContent: keys };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -5,7 +5,7 @@ import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeSmallest } from '../../utils/encode_text.js';
+import { encodeToon } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
 import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
@@ -66,6 +66,6 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         if (!keys) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: encodeSmallest(keys) }], structuredContent: keys };
+        return { content: [{ type: 'text', text: encodeToon(keys) }], structuredContent: keys };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -5,9 +5,9 @@ import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { encodeCompactText } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { encodeJsonText } from '../../utils/mcp.js';
 import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound } from './storage_helpers.js';
 
@@ -66,6 +66,6 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         if (!keys) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: encodeJsonText(keys) }], structuredContent: keys };
+        return { content: [{ type: 'text', text: encodeCompactText(keys) }], structuredContent: keys };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -5,7 +5,7 @@ import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeCompactText } from '../../utils/encode_text.js';
+import { encodeSmallest } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
 import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
@@ -66,6 +66,6 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         if (!keys) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: encodeCompactText(keys) }], structuredContent: keys };
+        return { content: [{ type: 'text', text: encodeSmallest(keys) }], structuredContent: keys };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -5,8 +5,8 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { wrapJsonText } from '../../utils/encode_text.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { encodeJsonText } from '../../utils/mcp.js';
 import { buildStorageNotFound, normalizeRecordKey } from './storage_helpers.js';
 
 const getKeyValueStoreRecordArgs = z.object({
@@ -55,6 +55,6 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
                 : `Key-value store '${keyValueStoreId}' not found.`;
             return buildStorageNotFound(text);
         }
-        return { content: [{ type: 'text', text: encodeJsonText(record) }] };
+        return { content: [{ type: 'text', text: wrapJsonText(record) }] };
     },
 } as const);

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -6,7 +6,7 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { encodeJsonText } from '../../utils/mcp.js';
 import { buildStorageNotFound, normalizeRecordKey } from './storage_helpers.js';
 
 const getKeyValueStoreRecordArgs = z.object({
@@ -55,6 +55,6 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
                 : `Key-value store '${keyValueStoreId}' not found.`;
             return buildStorageNotFound(text);
         }
-        return { content: [{ type: 'text', text: wrapJsonText(record) }] };
+        return { content: [{ type: 'text', text: encodeJsonText(record) }] };
     },
 } as const);

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeSmallest } from '../../utils/encode_text.js';
+import { encodeToon } from '../../utils/encode_text.js';
 import { keyValueStoreListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserKeyValueStoresListArgs = z.object({
@@ -70,6 +70,6 @@ export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: encodeSmallest(stores) }], structuredContent: stores };
+        return { content: [{ type: 'text', text: encodeToon(stores) }], structuredContent: stores };
     },
 } as const);

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeCompactText } from '../../utils/encode_text.js';
+import { encodeSmallest } from '../../utils/encode_text.js';
 import { keyValueStoreListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserKeyValueStoresListArgs = z.object({
@@ -70,6 +70,6 @@ export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: encodeCompactText(stores) }], structuredContent: stores };
+        return { content: [{ type: 'text', text: encodeSmallest(stores) }], structuredContent: stores };
     },
 } as const);

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { encodeJsonText } from '../../utils/mcp.js';
 import { keyValueStoreListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserKeyValueStoresListArgs = z.object({
@@ -70,6 +70,6 @@ export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: wrapJsonText(stores) }], structuredContent: stores };
+        return { content: [{ type: 'text', text: encodeJsonText(stores) }], structuredContent: stores };
     },
 } as const);

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeJsonText } from '../../utils/mcp.js';
+import { encodeCompactText } from '../../utils/encode_text.js';
 import { keyValueStoreListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserKeyValueStoresListArgs = z.object({
@@ -70,6 +70,6 @@ export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: encodeJsonText(stores) }], structuredContent: stores };
+        return { content: [{ type: 'text', text: encodeCompactText(stores) }], structuredContent: stores };
     },
 } as const);

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -6,7 +6,6 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { encodeCompactText } from '../../utils/encode_text.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
 import { actorRunListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserRunsListArgs = z.object({
@@ -64,9 +63,6 @@ USAGE EXAMPLES:
         const runs = await client
             .runs()
             .list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
-        return buildMCPResponse({
-            texts: [encodeCompactText(runs)],
-            structuredContent: runs,
-        });
+        return { content: [{ type: 'text', text: encodeCompactText(runs) }], structuredContent: runs };
     },
 } as const);

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeCompactText } from '../../utils/encode_text.js';
+import { encodeSmallest } from '../../utils/encode_text.js';
 import { actorRunListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserRunsListArgs = z.object({
@@ -63,6 +63,6 @@ USAGE EXAMPLES:
         const runs = await client
             .runs()
             .list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
-        return { content: [{ type: 'text', text: encodeCompactText(runs) }], structuredContent: runs };
+        return { content: [{ type: 'text', text: encodeSmallest(runs) }], structuredContent: runs };
     },
 } as const);

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse, wrapJsonText } from '../../utils/mcp.js';
+import { buildMCPResponse, encodeJsonText } from '../../utils/mcp.js';
 import { actorRunListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserRunsListArgs = z.object({
@@ -64,7 +64,7 @@ USAGE EXAMPLES:
             .runs()
             .list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
         return buildMCPResponse({
-            texts: [wrapJsonText(runs)],
+            texts: [encodeJsonText(runs)],
             structuredContent: runs,
         });
     },

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -5,7 +5,8 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse, encodeJsonText } from '../../utils/mcp.js';
+import { encodeCompactText } from '../../utils/encode_text.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
 import { actorRunListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserRunsListArgs = z.object({
@@ -64,7 +65,7 @@ USAGE EXAMPLES:
             .runs()
             .list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
         return buildMCPResponse({
-            texts: [encodeJsonText(runs)],
+            texts: [encodeCompactText(runs)],
             structuredContent: runs,
         });
     },

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -5,7 +5,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { encodeSmallest } from '../../utils/encode_text.js';
+import { encodeToon } from '../../utils/encode_text.js';
 import { actorRunListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserRunsListArgs = z.object({
@@ -63,6 +63,6 @@ USAGE EXAMPLES:
         const runs = await client
             .runs()
             .list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
-        return { content: [{ type: 'text', text: encodeSmallest(runs) }], structuredContent: runs };
+        return { content: [{ type: 'text', text: encodeToon(runs) }], structuredContent: runs };
     },
 } as const);

--- a/src/utils/encode_text.ts
+++ b/src/utils/encode_text.ts
@@ -75,29 +75,24 @@ export function wrapJsonText(value: unknown): string {
 }
 
 /**
- * Encodes a JSON-serialisable value as fenced text for the LLM, shipping whichever of the JSON or
- * dot-flattened-TOON encodings is smaller (UTF-8 bytes). JSON is always a candidate, so the result
- * is never larger than the plain JSON fence; the TOON candidate is dropped if `dotFlatten`/`encode`
- * throws.
+ * Encodes a JSON-serialisable value as a dot-flattened ```toon code fence for the LLM, falling back
+ * to a ```json fence only if `dotFlatten`/`encode` throws (depth overflow or a normalisation key
+ * collision). TOON is the stable shape; JSON is the error path, not a byte-driven alternative.
  *
  * The text may be TOON — programmatic JSON consumers must read `structuredContent` instead. Only
  * wire this on tools that ship `structuredContent` as the JSON fallback.
  */
-export function encodeSmallest(value: unknown): string {
-    // Single source of truth: both candidates derive from this one serialisation, so the TOON
-    // candidate can never encode different data than JSON. A `Date` (or any `toJSON` carrier)
-    // becomes its ISO string here, not an empty object — `dotFlatten` works on the JSON data
-    // model only. A non-serialisable value (circular, BigInt) throws here; API payloads are
-    // always JSON, so let it crash.
+export function encodeToon(value: unknown): string {
+    // `value` is serialised through JSON so `dotFlatten` works on the JSON data model only: a `Date`
+    // (or any `toJSON` carrier) becomes its ISO string here, not an empty object. A non-serialisable
+    // value (circular, BigInt) throws here; API payloads are always JSON, so let it crash.
     const jsonStr = JSON.stringify(value);
-    const json = fence('json', jsonStr);
-    let toon: string | undefined;
     try {
-        toon = fence('toon', encode(dotFlatten(JSON.parse(jsonStr))));
+        return fence('toon', encode(dotFlatten(JSON.parse(jsonStr))));
     } catch (err) {
-        // dotFlatten threw (depth overflow or key collision) or encode failed — JSON ships.
-        // Log it: the fallback is correct, but a recurring failure means TOON is silently disabled.
-        log.warning('encodeSmallest: TOON candidate dropped, shipping JSON', { err });
+        // dotFlatten threw (depth overflow or key collision) or encode failed — ship JSON instead.
+        // Log it: the fallback is lossless, but a recurring failure means TOON is silently disabled.
+        log.warning('encodeToon: TOON encoding failed, shipping JSON', { err });
+        return fence('json', jsonStr);
     }
-    return toon !== undefined && Buffer.byteLength(toon, 'utf8') < Buffer.byteLength(json, 'utf8') ? toon : json;
 }

--- a/src/utils/encode_text.ts
+++ b/src/utils/encode_text.ts
@@ -1,0 +1,72 @@
+import { encode } from '@toon-format/toon';
+
+import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from './mcp.js';
+
+/**
+ * Recursion guard for {@link dotFlatten}. The deepest real Apify-API fixture measured is
+ * depth 9 (a user-declared dataset schema), so 20 leaves a comfortable margin while still
+ * stopping runaway recursion on pathological input.
+ */
+const MAX_DEPTH = 20;
+
+const TOON_FENCE_PREFIX = '```toon\n';
+const TOON_FENCE_SUFFIX = '\n```';
+
+function flattenValue(value: unknown, depth: number): unknown {
+    if (depth > MAX_DEPTH) throw new RangeError('dotFlatten: max depth exceeded');
+    if (Array.isArray(value)) return value.map((item) => flattenValue(item, depth + 1));
+    if (value !== null && typeof value === 'object') {
+        const out: Record<string, unknown> = {};
+        flattenInto(value as Record<string, unknown>, '', depth, out);
+        return out;
+    }
+    return value; // scalar or null — unchanged
+}
+
+function flattenInto(obj: Record<string, unknown>, prefix: string, depth: number, out: Record<string, unknown>): void {
+    if (depth > MAX_DEPTH) throw new RangeError('dotFlatten: max depth exceeded');
+    for (const [rawKey, v] of Object.entries(obj)) {
+        // `.` is the nesting separator, so normalise any literal dot in a source key to avoid
+        // ambiguity. The collision guard below catches the case where this would overwrite a key.
+        const key = prefix ? `${prefix}.${rawKey.replaceAll('.', '_')}` : rawKey.replaceAll('.', '_');
+        if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+            flattenInto(v as Record<string, unknown>, key, depth + 1, out); // lift nested object into dotted keys
+        } else {
+            if (key in out) throw new RangeError(`dotFlatten: key collision on "${key}"`);
+            out[key] = flattenValue(v, depth + 1); // scalars unchanged; arrays recursed into
+        }
+    }
+}
+
+/**
+ * Lifts nested-object keys into dot-joined top-level keys so arrays of uniform objects qualify
+ * for TOON's tabular form. Arrays are preserved (each object element flattened individually);
+ * scalars, null, and inline scalar arrays are unchanged. Throws `RangeError` on depth overflow
+ * or a normalisation collision — the caller drops the TOON candidate and ships JSON.
+ *
+ * Lossy w.r.t. the original key names only when a source key contains a literal `.`
+ * (normalised to `_`); `structuredContent` preserves the originals for programmatic consumers.
+ */
+export function dotFlatten(value: unknown): unknown {
+    return flattenValue(value, 0);
+}
+
+/**
+ * Encodes a JSON-serialisable value as fenced text for the LLM, shipping whichever of the JSON or
+ * dot-flattened-TOON encodings is smaller (UTF-8 bytes). JSON is always a candidate, so the result
+ * is never larger than the plain JSON fence; the TOON candidate is dropped if `dotFlatten`/`encode`
+ * throws.
+ *
+ * The text may be TOON — programmatic JSON consumers must read `structuredContent` instead. Only
+ * wire this on tools that ship `structuredContent` as the JSON fallback.
+ */
+export function encodeCompactText(value: unknown): string {
+    const json = `${JSON_FENCE_PREFIX}${JSON.stringify(value)}${JSON_FENCE_SUFFIX}`;
+    let toon: string | undefined;
+    try {
+        toon = `${TOON_FENCE_PREFIX}${encode(dotFlatten(value))}${TOON_FENCE_SUFFIX}`;
+    } catch {
+        // dotFlatten/encode failed (depth, key collision, non-serialisable value) — JSON ships.
+    }
+    return toon !== undefined && Buffer.byteLength(toon, 'utf8') < Buffer.byteLength(json, 'utf8') ? toon : json;
+}

--- a/src/utils/encode_text.ts
+++ b/src/utils/encode_text.ts
@@ -1,5 +1,7 @@
 import { encode } from '@toon-format/toon';
 
+import log from '@apify/log';
+
 import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from './mcp.js';
 
 /**
@@ -75,8 +77,10 @@ export function encodeCompactText(value: unknown): string {
     let toon: string | undefined;
     try {
         toon = `${TOON_FENCE_PREFIX}${encode(dotFlatten(JSON.parse(jsonStr)))}${TOON_FENCE_SUFFIX}`;
-    } catch {
+    } catch (err) {
         // dotFlatten threw (depth overflow or key collision) or encode failed — JSON ships.
+        // Log it: the fallback is correct, but a recurring failure means TOON is silently disabled.
+        log.warning('encodeCompactText: TOON candidate dropped, shipping JSON', { err });
     }
     return toon !== undefined && Buffer.byteLength(toon, 'utf8') < Buffer.byteLength(json, 'utf8') ? toon : json;
 }

--- a/src/utils/encode_text.ts
+++ b/src/utils/encode_text.ts
@@ -24,7 +24,10 @@ function flattenValue(value: unknown, depth: number): unknown {
     if (depth > MAX_DEPTH) throw new RangeError('dotFlatten: max depth exceeded');
     if (Array.isArray(value)) return value.map((item) => flattenValue(item, depth + 1));
     if (value !== null && typeof value === 'object') {
-        const out: Record<string, unknown> = {};
+        // Null prototype so `key in out` (below) tests own keys only: source keys named like an
+        // `Object.prototype` member (`constructor`, `__proto__`, `toString`, …) neither trip a
+        // false-positive collision nor reach the prototype setter.
+        const out: Record<string, unknown> = Object.create(null);
         flattenInto(value as Record<string, unknown>, '', depth, out);
         return out;
     }
@@ -40,13 +43,8 @@ function flattenInto(obj: Record<string, unknown>, prefix: string, depth: number
         if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
             flattenInto(v as Record<string, unknown>, key, depth + 1, out); // lift nested object into dotted keys
         } else {
-            // `out` is a plain object, so a source key equal to an `Object.prototype` member
-            // (`constructor`, `__proto__`, `toString`, `valueOf`, …) matches `in` on an empty
-            // object and trips this guard as a FALSE-positive collision. Such keys can legitimately
-            // occur in user/scraper-controlled `get-dataset-items` payloads; when they do, the TOON
-            // candidate is dropped and JSON ships — lossless. Accepted, not fixed: a null-prototype
-            // `out` (`Object.create(null)`) would remove the false positive, but the current guard
-            // also fires before assignment, so a `__proto__` key cannot reach the prototype setter.
+            // Only a genuine normalisation clash remains (`a.b` and `a_b` both map to `a_b`); fail
+            // loud so the caller drops TOON and ships lossless JSON instead of overwriting silently.
             if (key in out) throw new RangeError(`dotFlatten: key collision on "${key}"`);
             out[key] = flattenValue(v, depth + 1); // scalars unchanged; arrays recursed into
         }
@@ -92,7 +90,7 @@ export function encodeToon(value: unknown): string {
     } catch (err) {
         // dotFlatten threw (depth overflow or key collision) or encode failed — ship JSON instead.
         // Log it: the fallback is lossless, but a recurring failure means TOON is silently disabled.
-        log.warning('encodeToon: TOON encoding failed, shipping JSON', { err });
+        log.debug('encodeToon: TOON encoding failed, shipping JSON', { err });
         return fence('json', jsonStr);
     }
 }

--- a/src/utils/encode_text.ts
+++ b/src/utils/encode_text.ts
@@ -9,8 +9,8 @@ import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from './mcp.js';
  */
 const MAX_DEPTH = 20;
 
-const TOON_FENCE_PREFIX = '```toon\n';
-const TOON_FENCE_SUFFIX = '\n```';
+export const TOON_FENCE_PREFIX = '```toon\n';
+export const TOON_FENCE_SUFFIX = '\n```';
 
 function flattenValue(value: unknown, depth: number): unknown {
     if (depth > MAX_DEPTH) throw new RangeError('dotFlatten: max depth exceeded');
@@ -32,6 +32,10 @@ function flattenInto(obj: Record<string, unknown>, prefix: string, depth: number
         if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
             flattenInto(v as Record<string, unknown>, key, depth + 1, out); // lift nested object into dotted keys
         } else {
+            // `out` is a plain object, so a source key equal to an Object.prototype member
+            // (`constructor`, `__proto__`, `toString`, …) trips this guard as a false positive and
+            // drops the TOON candidate — JSON still ships, lossless. Apify payload keys are never
+            // named this, so we accept it rather than carry a null-prototype map.
             if (key in out) throw new RangeError(`dotFlatten: key collision on "${key}"`);
             out[key] = flattenValue(v, depth + 1); // scalars unchanged; arrays recursed into
         }
@@ -61,12 +65,18 @@ export function dotFlatten(value: unknown): unknown {
  * wire this on tools that ship `structuredContent` as the JSON fallback.
  */
 export function encodeCompactText(value: unknown): string {
-    const json = `${JSON_FENCE_PREFIX}${JSON.stringify(value)}${JSON_FENCE_SUFFIX}`;
+    // Single source of truth: both candidates derive from this one serialisation, so the TOON
+    // candidate can never encode different data than JSON. A `Date` (or any `toJSON` carrier)
+    // becomes its ISO string here, not an empty object — `dotFlatten` works on the JSON data
+    // model only. A non-serialisable value (circular, BigInt) throws here; API payloads are
+    // always JSON, so let it crash.
+    const jsonStr = JSON.stringify(value);
+    const json = `${JSON_FENCE_PREFIX}${jsonStr}${JSON_FENCE_SUFFIX}`;
     let toon: string | undefined;
     try {
-        toon = `${TOON_FENCE_PREFIX}${encode(dotFlatten(value))}${TOON_FENCE_SUFFIX}`;
+        toon = `${TOON_FENCE_PREFIX}${encode(dotFlatten(JSON.parse(jsonStr)))}${TOON_FENCE_SUFFIX}`;
     } catch {
-        // dotFlatten/encode failed (depth, key collision, non-serialisable value) — JSON ships.
+        // dotFlatten threw (depth overflow or key collision) or encode failed — JSON ships.
     }
     return toon !== undefined && Buffer.byteLength(toon, 'utf8') < Buffer.byteLength(json, 'utf8') ? toon : json;
 }

--- a/src/utils/encode_text.ts
+++ b/src/utils/encode_text.ts
@@ -2,8 +2,6 @@ import { encode } from '@toon-format/toon';
 
 import log from '@apify/log';
 
-import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from './mcp.js';
-
 /**
  * Recursion guard for {@link dotFlatten}. The deepest real Apify-API fixture measured is
  * depth 9 (a user-declared dataset schema), so 20 leaves a comfortable margin while still
@@ -11,8 +9,16 @@ import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from './mcp.js';
  */
 const MAX_DEPTH = 20;
 
-export const TOON_FENCE_PREFIX = '```toon\n';
-export const TOON_FENCE_SUFFIX = '\n```';
+/** Markdown code fences keyed by encoding. Labels are ASCII, so char length == byte length. */
+export const FENCES = {
+    json: { prefix: '```json\n', suffix: '\n```' },
+    toon: { prefix: '```toon\n', suffix: '\n```' },
+} as const;
+
+/** Wrap an already-encoded body in the Markdown code fence for its format. */
+function fence(format: keyof typeof FENCES, body: string): string {
+    return `${FENCES[format].prefix}${body}${FENCES[format].suffix}`;
+}
 
 function flattenValue(value: unknown, depth: number): unknown {
     if (depth > MAX_DEPTH) throw new RangeError('dotFlatten: max depth exceeded');
@@ -58,6 +64,14 @@ export function dotFlatten(value: unknown): unknown {
 }
 
 /**
+ * Wrap a JSON-serialisable value in a ```json code fence. Used by single-object tools, which have
+ * no `structuredContent` fallback, so this can never emit anything but JSON.
+ */
+export function wrapJsonText(value: unknown): string {
+    return fence('json', JSON.stringify(value));
+}
+
+/**
  * Encodes a JSON-serialisable value as fenced text for the LLM, shipping whichever of the JSON or
  * dot-flattened-TOON encodings is smaller (UTF-8 bytes). JSON is always a candidate, so the result
  * is never larger than the plain JSON fence; the TOON candidate is dropped if `dotFlatten`/`encode`
@@ -66,21 +80,21 @@ export function dotFlatten(value: unknown): unknown {
  * The text may be TOON — programmatic JSON consumers must read `structuredContent` instead. Only
  * wire this on tools that ship `structuredContent` as the JSON fallback.
  */
-export function encodeCompactText(value: unknown): string {
+export function encodeSmallest(value: unknown): string {
     // Single source of truth: both candidates derive from this one serialisation, so the TOON
     // candidate can never encode different data than JSON. A `Date` (or any `toJSON` carrier)
     // becomes its ISO string here, not an empty object — `dotFlatten` works on the JSON data
     // model only. A non-serialisable value (circular, BigInt) throws here; API payloads are
     // always JSON, so let it crash.
     const jsonStr = JSON.stringify(value);
-    const json = `${JSON_FENCE_PREFIX}${jsonStr}${JSON_FENCE_SUFFIX}`;
+    const json = fence('json', jsonStr);
     let toon: string | undefined;
     try {
-        toon = `${TOON_FENCE_PREFIX}${encode(dotFlatten(JSON.parse(jsonStr)))}${TOON_FENCE_SUFFIX}`;
+        toon = fence('toon', encode(dotFlatten(JSON.parse(jsonStr))));
     } catch (err) {
         // dotFlatten threw (depth overflow or key collision) or encode failed — JSON ships.
         // Log it: the fallback is correct, but a recurring failure means TOON is silently disabled.
-        log.warning('encodeCompactText: TOON candidate dropped, shipping JSON', { err });
+        log.warning('encodeSmallest: TOON candidate dropped, shipping JSON', { err });
     }
     return toon !== undefined && Buffer.byteLength(toon, 'utf8') < Buffer.byteLength(json, 'utf8') ? toon : json;
 }

--- a/src/utils/encode_text.ts
+++ b/src/utils/encode_text.ts
@@ -40,10 +40,13 @@ function flattenInto(obj: Record<string, unknown>, prefix: string, depth: number
         if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
             flattenInto(v as Record<string, unknown>, key, depth + 1, out); // lift nested object into dotted keys
         } else {
-            // `out` is a plain object, so a source key equal to an Object.prototype member
-            // (`constructor`, `__proto__`, `toString`, …) trips this guard as a false positive and
-            // drops the TOON candidate — JSON still ships, lossless. Apify payload keys are never
-            // named this, so we accept it rather than carry a null-prototype map.
+            // `out` is a plain object, so a source key equal to an `Object.prototype` member
+            // (`constructor`, `__proto__`, `toString`, `valueOf`, …) matches `in` on an empty
+            // object and trips this guard as a FALSE-positive collision. Such keys can legitimately
+            // occur in user/scraper-controlled `get-dataset-items` payloads; when they do, the TOON
+            // candidate is dropped and JSON ships — lossless. Accepted, not fixed: a null-prototype
+            // `out` (`Object.create(null)`) would remove the false positive, but the current guard
+            // also fires before assignment, so a `__proto__` key cannot reach the prototype setter.
             if (key in out) throw new RangeError(`dotFlatten: key collision on "${key}"`);
             out[key] = flattenValue(v, depth + 1); // scalars unchanged; arrays recursed into
         }

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -49,16 +49,16 @@ export function buildMCPResponse(options: {
     };
 }
 
-/** Markdown JSON code-fence prefix used by `wrapJsonText` and the test-side `parseFencedJson`. */
+/** Markdown JSON code-fence prefix used by `encodeJsonText` and the test-side `parseFencedJson`. */
 export const JSON_FENCE_PREFIX = '```json\n';
-/** Markdown JSON code-fence suffix used by `wrapJsonText` and the test-side `parseFencedJson`. */
+/** Markdown JSON code-fence suffix used by `encodeJsonText` and the test-side `parseFencedJson`. */
 export const JSON_FENCE_SUFFIX = '\n```';
 
 /**
  * Wrap a JSON-serializable value in a Markdown ` ```json ` code fence.
  * Used by any tool that returns SDK payloads to the LLM.
  */
-export function wrapJsonText(value: unknown): string {
+export function encodeJsonText(value: unknown): string {
     return `${JSON_FENCE_PREFIX}${JSON.stringify(value)}${JSON_FENCE_SUFFIX}`;
 }
 

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -49,19 +49,6 @@ export function buildMCPResponse(options: {
     };
 }
 
-/** Markdown JSON code-fence prefix used by `encodeJsonText` and the test-side `parseFencedJson`. */
-export const JSON_FENCE_PREFIX = '```json\n';
-/** Markdown JSON code-fence suffix used by `encodeJsonText` and the test-side `parseFencedJson`. */
-export const JSON_FENCE_SUFFIX = '\n```';
-
-/**
- * Wrap a JSON-serializable value in a Markdown ` ```json ` code fence.
- * Used by any tool that returns SDK payloads to the LLM.
- */
-export function encodeJsonText(value: unknown): string {
-    return `${JSON_FENCE_PREFIX}${JSON.stringify(value)}${JSON_FENCE_SUFFIX}`;
-}
-
 /**
  * Computes tool response payload bytes, split by payload side:
  * `contentBytes` sums the UTF-8 byte length of every text item in `content[]`;

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -4,21 +4,20 @@ import { expect } from 'vitest';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../../src/const.js';
 import type { InternalToolArgs } from '../../../src/types.js';
-import { TOON_FENCE_PREFIX, TOON_FENCE_SUFFIX } from '../../../src/utils/encode_text.js';
-import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from '../../../src/utils/mcp.js';
+import { FENCES } from '../../../src/utils/encode_text.js';
 
-/** Inverse of `encodeJsonText`; imports prod's fence constants so the two halves can't drift. */
+/** Inverse of `wrapJsonText`; imports prod's fence constants so the two halves can't drift. */
 export function parseFencedJson(text: string): unknown {
-    return JSON.parse(text.slice(JSON_FENCE_PREFIX.length, -JSON_FENCE_SUFFIX.length));
+    return JSON.parse(text.slice(FENCES.json.prefix.length, -FENCES.json.suffix.length));
 }
 
 /**
- * Inverse of `encodeCompactText` — decodes the fenced tool text whether the picker shipped JSON
+ * Inverse of `encodeSmallest` — decodes the fenced tool text whether the picker shipped JSON
  * or TOON. For flat payloads (what the array-endpoint mocks use) the TOON round-trip is exact.
  */
 export function decodeFencedToolText(text: string): unknown {
-    if (text.startsWith(TOON_FENCE_PREFIX)) {
-        return decodeToon(text.slice(TOON_FENCE_PREFIX.length, -TOON_FENCE_SUFFIX.length));
+    if (text.startsWith(FENCES.toon.prefix)) {
+        return decodeToon(text.slice(FENCES.toon.prefix.length, -FENCES.toon.suffix.length));
     }
     return parseFencedJson(text);
 }

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -1,4 +1,5 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { decode as decodeToon } from '@toon-format/toon';
 import { expect } from 'vitest';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../../src/const.js';
@@ -8,6 +9,17 @@ import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from '../../../src/utils/mcp.js'
 /** Inverse of `encodeJsonText`; imports prod's fence constants so the two halves can't drift. */
 export function parseFencedJson(text: string): unknown {
     return JSON.parse(text.slice(JSON_FENCE_PREFIX.length, -JSON_FENCE_SUFFIX.length));
+}
+
+/**
+ * Inverse of `encodeCompactText` — decodes the fenced tool text whether the picker shipped JSON
+ * or TOON. For flat payloads (what the array-endpoint mocks use) the TOON round-trip is exact.
+ */
+export function decodeFencedToolText(text: string): unknown {
+    if (text.startsWith('```toon\n')) {
+        return decodeToon(text.slice('```toon\n'.length, -JSON_FENCE_SUFFIX.length));
+    }
+    return parseFencedJson(text);
 }
 
 /**

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -4,6 +4,7 @@ import { expect } from 'vitest';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../../src/const.js';
 import type { InternalToolArgs } from '../../../src/types.js';
+import { TOON_FENCE_PREFIX, TOON_FENCE_SUFFIX } from '../../../src/utils/encode_text.js';
 import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from '../../../src/utils/mcp.js';
 
 /** Inverse of `encodeJsonText`; imports prod's fence constants so the two halves can't drift. */
@@ -16,8 +17,8 @@ export function parseFencedJson(text: string): unknown {
  * or TOON. For flat payloads (what the array-endpoint mocks use) the TOON round-trip is exact.
  */
 export function decodeFencedToolText(text: string): unknown {
-    if (text.startsWith('```toon\n')) {
-        return decodeToon(text.slice('```toon\n'.length, -JSON_FENCE_SUFFIX.length));
+    if (text.startsWith(TOON_FENCE_PREFIX)) {
+        return decodeToon(text.slice(TOON_FENCE_PREFIX.length, -TOON_FENCE_SUFFIX.length));
     }
     return parseFencedJson(text);
 }

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -12,8 +12,8 @@ export function parseFencedJson(text: string): unknown {
 }
 
 /**
- * Inverse of `encodeSmallest` — decodes the fenced tool text whether the picker shipped JSON
- * or TOON. For flat payloads (what the array-endpoint mocks use) the TOON round-trip is exact.
+ * Inverse of `encodeToon` — decodes the fenced tool text whether it shipped TOON or fell back to
+ * JSON. For flat payloads (what the array-endpoint mocks use) the TOON round-trip is exact.
  */
 export function decodeFencedToolText(text: string): unknown {
     if (text.startsWith(FENCES.toon.prefix)) {

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -5,7 +5,7 @@ import { FAILURE_CATEGORY, TOOL_STATUS } from '../../../src/const.js';
 import type { InternalToolArgs } from '../../../src/types.js';
 import { JSON_FENCE_PREFIX, JSON_FENCE_SUFFIX } from '../../../src/utils/mcp.js';
 
-/** Inverse of `wrapJsonText`; imports prod's fence constants so the two halves can't drift. */
+/** Inverse of `encodeJsonText`; imports prod's fence constants so the two halves can't drift. */
 export function parseFencedJson(text: string): unknown {
     return JSON.parse(text.slice(JSON_FENCE_PREFIX.length, -JSON_FENCE_SUFFIX.length));
 }

--- a/tests/unit/tools.dataset_collection.test.ts
+++ b/tests/unit/tools.dataset_collection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getUserDatasetsList } from '../../src/tools/common/dataset_collection.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { parseFencedJson, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { decodeFencedToolText, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const MOCK_LIST = {
     total: 2,
@@ -28,7 +28,7 @@ describe('get-dataset-list', () => {
         expect(getUserDatasetsList.name).toBe(HelperTools.DATASET_LIST_GET);
     });
 
-    it('returns the list response as JSON in a fenced code block', async () => {
+    it('returns the list response as fenced text (json or toon) that round-trips to the data', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
         const result = await (getUserDatasetsList as HelperTool).call(
@@ -36,7 +36,7 @@ describe('get-dataset-list', () => {
         );
         const { content } = result as TextToolResult;
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_LIST);
+        expect(decodeFencedToolText(content[0].text)).toEqual(MOCK_LIST);
     });
 
     it('mirrors the list response in structuredContent and declares an outputSchema', async () => {

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { extractDotPrefixes, getDatasetItems } from '../../src/tools/common/get_dataset_items.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { expectSoftFailInvalidInput, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { dotFlatten } from '../../src/utils/encode_text.js';
+import {
+    decodeFencedToolText,
+    expectSoftFailInvalidInput,
+    stubToolCallContext,
+    type TextToolResult,
+} from './helpers/tool_context.js';
 
 describe('extractDotPrefixes', () => {
     it('returns empty list when no fields contain a dot', () => {
@@ -64,6 +70,39 @@ describe('get-dataset-items', () => {
 
         expect(structuredContent.datasetId).toBe('ds-1');
         expect(structuredContent.itemCount).toBe(MOCK_ITEMS.length);
+    });
+
+    it('encodes the same payload into content text as structuredContent', async () => {
+        const result = await (getDatasetItems as HelperTool).call(
+            stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient()),
+        );
+        const { content, structuredContent } = result as TextToolResult;
+
+        expect(decodeFencedToolText(content[0].text)).toEqual(structuredContent);
+    });
+
+    it('content round-trips to structuredContent for nested items (dot-flattened when TOON wins)', async () => {
+        // Real dataset items are routinely nested; the flat happy-path mock can't exercise the
+        // dot-flatten path where the TOON text keys differ from the structuredContent keys.
+        const nestedItems = [
+            { url: 'https://a', metadata: { httpStatus: 200, depth: 1 } },
+            { url: 'https://b', metadata: { httpStatus: 404, depth: 2 } },
+            { url: 'https://c', metadata: { httpStatus: 200, depth: 3 } },
+        ];
+        const result = await (getDatasetItems as HelperTool).call(
+            stubToolCallContext(
+                { datasetId: 'ds-1' },
+                stubApifyClient(async () => ({ items: nestedItems, total: 3 })),
+            ),
+        );
+        const { content, structuredContent } = result as TextToolResult;
+        const [{ text }] = content;
+
+        // Uniform nested rows favour TOON; assert the lift actually happened, then that the text
+        // round-trips to the dot-flattened structuredContent (its true on-the-wire equivalent).
+        expect(text.startsWith('```toon\n')).toBe(true);
+        expect(text).toContain('metadata.httpStatus');
+        expect(decodeFencedToolText(text)).toEqual(dotFlatten(JSON.parse(JSON.stringify(structuredContent))));
     });
 
     it('defaults `limit` to 20 when caller omits it', async () => {

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -165,6 +165,12 @@ describe('get-dataset-items', () => {
         expect(tool.ajvValidate({ datasetId: 'ds-1' })).toBe(true);
     });
 
+    it('rejects limit above 250 via ajv validation', () => {
+        const tool = getDatasetItems as HelperTool;
+        expect(tool.ajvValidate({ datasetId: 'ds-1', limit: 251 })).toBe(false);
+        expect(tool.ajvValidate({ datasetId: 'ds-1', limit: 250 })).toBe(true);
+    });
+
     it('passes the wrapper-stripped datasetId to client.dataset()', async () => {
         const datasetSpy = vi.fn().mockReturnValue({ listItems: async () => ({ items: MOCK_ITEMS, total: 1 }) });
         const client = { dataset: datasetSpy } as unknown as InternalToolArgs['apifyClient'];

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -165,12 +165,6 @@ describe('get-dataset-items', () => {
         expect(tool.ajvValidate({ datasetId: 'ds-1' })).toBe(true);
     });
 
-    it('rejects limit above 250 via ajv validation', () => {
-        const tool = getDatasetItems as HelperTool;
-        expect(tool.ajvValidate({ datasetId: 'ds-1', limit: 251 })).toBe(false);
-        expect(tool.ajvValidate({ datasetId: 'ds-1', limit: 250 })).toBe(true);
-    });
-
     it('passes the wrapper-stripped datasetId to client.dataset()', async () => {
         const datasetSpy = vi.fn().mockReturnValue({ listItems: async () => ({ items: MOCK_ITEMS, total: 1 }) });
         const client = { dataset: datasetSpy } as unknown as InternalToolArgs['apifyClient'];

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -4,8 +4,8 @@ import { HelperTools } from '../../src/const.js';
 import { getKeyValueStoreKeys } from '../../src/tools/common/get_key_value_store_keys.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import {
+    decodeFencedToolText,
     expectSoftFailInvalidInput,
-    parseFencedJson,
     stubToolCallContext,
     type TextToolResult,
 } from './helpers/tool_context.js';
@@ -38,7 +38,7 @@ describe('get-key-value-store-keys', () => {
         expect(getKeyValueStoreKeys.name).toBe(HelperTools.KEY_VALUE_STORE_KEYS_GET);
     });
 
-    it('returns the keys response as JSON in a fenced code block', async () => {
+    it('returns the keys response as fenced text (json or toon) that round-trips to the data', async () => {
         const listKeysSpy = vi.fn().mockResolvedValue(MOCK_KEYS);
 
         const result = await (getKeyValueStoreKeys as HelperTool).call(
@@ -46,7 +46,7 @@ describe('get-key-value-store-keys', () => {
         );
         const { content } = result as TextToolResult;
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_KEYS);
+        expect(decodeFencedToolText(content[0].text)).toEqual(MOCK_KEYS);
     });
 
     it('mirrors the keys response in structuredContent and declares an outputSchema', async () => {

--- a/tests/unit/tools.key_value_store_collection.test.ts
+++ b/tests/unit/tools.key_value_store_collection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getUserKeyValueStoresList } from '../../src/tools/common/key_value_store_collection.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { parseFencedJson, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { decodeFencedToolText, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const MOCK_LIST = {
     total: 2,
@@ -28,7 +28,7 @@ describe('get-key-value-store-list', () => {
         expect(getUserKeyValueStoresList.name).toBe(HelperTools.KEY_VALUE_STORE_LIST_GET);
     });
 
-    it('returns the list response as JSON in a fenced code block', async () => {
+    it('returns the list response as fenced text (json or toon) that round-trips to the data', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
         const result = await (getUserKeyValueStoresList as HelperTool).call(
@@ -36,7 +36,7 @@ describe('get-key-value-store-list', () => {
         );
         const { content } = result as TextToolResult;
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_LIST);
+        expect(decodeFencedToolText(content[0].text)).toEqual(MOCK_LIST);
     });
 
     it('mirrors the list response in structuredContent and declares an outputSchema', async () => {

--- a/tests/unit/tools.run_collection.test.ts
+++ b/tests/unit/tools.run_collection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getUserRunsList } from '../../src/tools/common/run_collection.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { parseFencedJson, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { decodeFencedToolText, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const listMock = vi.fn();
 
@@ -40,13 +40,13 @@ describe('get-actor-run-list', () => {
         expect(getUserRunsList.name).toBe(HelperTools.ACTOR_RUN_LIST_GET);
     });
 
-    it('returns the runs as fenced JSON, mirrors them in structuredContent, and declares an outputSchema', async () => {
+    it('returns runs as fenced text (json or toon), mirrors them in structuredContent, and declares an outputSchema', async () => {
         listMock.mockResolvedValue(MOCK_RUNS);
 
         const result = await (getUserRunsList as HelperTool).call(stubToolCallContext({}, noClient));
         const { content } = result as TextToolResult;
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_RUNS);
+        expect(decodeFencedToolText(content[0].text)).toEqual(MOCK_RUNS);
         expect((result as TextToolResult).structuredContent).toEqual(MOCK_RUNS);
         expect((getUserRunsList as HelperTool).outputSchema).toMatchObject({ type: 'object' });
     });

--- a/tests/unit/utils.encode_text.test.ts
+++ b/tests/unit/utils.encode_text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { dotFlatten, encodeSmallest, FENCES, wrapJsonText } from '../../src/utils/encode_text.js';
+import { dotFlatten, encodeToon, FENCES, wrapJsonText } from '../../src/utils/encode_text.js';
 import { decodeFencedToolText } from './helpers/tool_context.js';
 
 describe('dotFlatten', () => {
@@ -43,8 +43,6 @@ describe('dotFlatten', () => {
     });
 });
 
-const byteLen = (s: string) => Buffer.byteLength(s, 'utf8');
-
 describe('wrapJsonText', () => {
     it('emits a ```json … ``` fenced block', () => {
         expect(wrapJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
@@ -59,7 +57,7 @@ describe('wrapJsonText', () => {
     });
 });
 
-describe('encodeSmallest', () => {
+describe('encodeToon', () => {
     const uniformRows = {
         items: [
             { id: 1, status: 'SUCCEEDED', cost: 0.1 },
@@ -68,8 +66,8 @@ describe('encodeSmallest', () => {
         ],
     };
 
-    it('ships TOON when it is smaller and round-trips to the original value', () => {
-        const text = encodeSmallest(uniformRows);
+    it('emits a TOON fence that round-trips to the original value', () => {
+        const text = encodeToon(uniformRows);
         expect(text.startsWith(FENCES.toon.prefix)).toBe(true);
         expect(decodeFencedToolText(text)).toEqual(uniformRows);
     });
@@ -87,27 +85,21 @@ describe('encodeSmallest', () => {
                 { id: 2, startedAt: new Date('2026-05-12T09:17:57.206Z'), finishedAt: null, stats: { runs: 20 } },
             ],
         };
-        const text = encodeSmallest(input);
+        const text = encodeToon(input);
 
-        // The Date must survive as an ISO string. Before the fix, dotFlatten treated a Date as an
-        // empty nested object and dropped it, so the lossy (smaller) candidate won the byte compare.
+        // The Date must survive as an ISO string. An earlier revision treated a Date as an empty
+        // nested object in dotFlatten and dropped it; serialising through JSON first fixes that.
         expect(text).toContain(startedAt);
 
-        // Whichever candidate ships, the text must round-trip to the JSON-normalised value
-        // (dot-flattened when TOON wins).
+        // The TOON text round-trips to the dot-flattened, JSON-normalised value.
         const normalized = JSON.parse(JSON.stringify(input));
-        const expected = text.startsWith(FENCES.toon.prefix) ? dotFlatten(normalized) : normalized;
-        expect(decodeFencedToolText(text)).toEqual(expected);
-    });
-
-    it('never ships more bytes than the plain JSON candidate', () => {
-        const jsonBytes = byteLen(FENCES.json.prefix + JSON.stringify(uniformRows) + FENCES.json.suffix);
-        expect(byteLen(encodeSmallest(uniformRows))).toBeLessThanOrEqual(jsonBytes);
+        expect(text.startsWith(FENCES.toon.prefix)).toBe(true);
+        expect(decodeFencedToolText(text)).toEqual(dotFlatten(normalized));
     });
 
     it('falls back to JSON on a dotFlatten collision and still round-trips', () => {
         const value = { 'a.b': 1, a_b: 2 };
-        const text = encodeSmallest(value);
+        const text = encodeToon(value);
         expect(text.startsWith(FENCES.toon.prefix)).toBe(false);
         expect(decodeFencedToolText(text)).toEqual(value);
     });
@@ -115,7 +107,7 @@ describe('encodeSmallest', () => {
     it('falls back to JSON when nesting exceeds the depth guard', () => {
         let deep: Record<string, unknown> = { leaf: 1 };
         for (let i = 0; i < 25; i++) deep = { nest: deep };
-        const text = encodeSmallest(deep);
+        const text = encodeToon(deep);
         expect(text.startsWith(FENCES.toon.prefix)).toBe(false);
         expect(decodeFencedToolText(text)).toEqual(deep);
     });

--- a/tests/unit/utils.encode_text.test.ts
+++ b/tests/unit/utils.encode_text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { dotFlatten, encodeCompactText, TOON_FENCE_PREFIX } from '../../src/utils/encode_text.js';
+import { dotFlatten, encodeSmallest, FENCES, wrapJsonText } from '../../src/utils/encode_text.js';
 import { decodeFencedToolText } from './helpers/tool_context.js';
 
 describe('dotFlatten', () => {
@@ -45,7 +45,21 @@ describe('dotFlatten', () => {
 
 const byteLen = (s: string) => Buffer.byteLength(s, 'utf8');
 
-describe('encodeCompactText', () => {
+describe('wrapJsonText', () => {
+    it('emits a ```json … ``` fenced block', () => {
+        expect(wrapJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
+    });
+
+    it('serializes arrays', () => {
+        expect(wrapJsonText([1, 2])).toBe('```json\n[1,2]\n```');
+    });
+
+    it('serializes primitives', () => {
+        expect(wrapJsonText('x')).toBe('```json\n"x"\n```');
+    });
+});
+
+describe('encodeSmallest', () => {
     const uniformRows = {
         items: [
             { id: 1, status: 'SUCCEEDED', cost: 0.1 },
@@ -55,8 +69,8 @@ describe('encodeCompactText', () => {
     };
 
     it('ships TOON when it is smaller and round-trips to the original value', () => {
-        const text = encodeCompactText(uniformRows);
-        expect(text.startsWith(TOON_FENCE_PREFIX)).toBe(true);
+        const text = encodeSmallest(uniformRows);
+        expect(text.startsWith(FENCES.toon.prefix)).toBe(true);
         expect(decodeFencedToolText(text)).toEqual(uniformRows);
     });
 
@@ -73,7 +87,7 @@ describe('encodeCompactText', () => {
                 { id: 2, startedAt: new Date('2026-05-12T09:17:57.206Z'), finishedAt: null, stats: { runs: 20 } },
             ],
         };
-        const text = encodeCompactText(input);
+        const text = encodeSmallest(input);
 
         // The Date must survive as an ISO string. Before the fix, dotFlatten treated a Date as an
         // empty nested object and dropped it, so the lossy (smaller) candidate won the byte compare.
@@ -82,27 +96,27 @@ describe('encodeCompactText', () => {
         // Whichever candidate ships, the text must round-trip to the JSON-normalised value
         // (dot-flattened when TOON wins).
         const normalized = JSON.parse(JSON.stringify(input));
-        const expected = text.startsWith(TOON_FENCE_PREFIX) ? dotFlatten(normalized) : normalized;
+        const expected = text.startsWith(FENCES.toon.prefix) ? dotFlatten(normalized) : normalized;
         expect(decodeFencedToolText(text)).toEqual(expected);
     });
 
     it('never ships more bytes than the plain JSON candidate', () => {
-        const jsonBytes = byteLen('```json\n' + JSON.stringify(uniformRows) + '\n```');
-        expect(byteLen(encodeCompactText(uniformRows))).toBeLessThanOrEqual(jsonBytes);
+        const jsonBytes = byteLen(FENCES.json.prefix + JSON.stringify(uniformRows) + FENCES.json.suffix);
+        expect(byteLen(encodeSmallest(uniformRows))).toBeLessThanOrEqual(jsonBytes);
     });
 
     it('falls back to JSON on a dotFlatten collision and still round-trips', () => {
         const value = { 'a.b': 1, a_b: 2 };
-        const text = encodeCompactText(value);
-        expect(text.startsWith(TOON_FENCE_PREFIX)).toBe(false);
+        const text = encodeSmallest(value);
+        expect(text.startsWith(FENCES.toon.prefix)).toBe(false);
         expect(decodeFencedToolText(text)).toEqual(value);
     });
 
     it('falls back to JSON when nesting exceeds the depth guard', () => {
         let deep: Record<string, unknown> = { leaf: 1 };
         for (let i = 0; i < 25; i++) deep = { nest: deep };
-        const text = encodeCompactText(deep);
-        expect(text.startsWith(TOON_FENCE_PREFIX)).toBe(false);
+        const text = encodeSmallest(deep);
+        expect(text.startsWith(FENCES.toon.prefix)).toBe(false);
         expect(decodeFencedToolText(text)).toEqual(deep);
     });
 });

--- a/tests/unit/utils.encode_text.test.ts
+++ b/tests/unit/utils.encode_text.test.ts
@@ -36,6 +36,18 @@ describe('dotFlatten', () => {
         expect(() => dotFlatten({ 'a.b': 1, a_b: 2 })).toThrow(RangeError);
     });
 
+    it('keeps a top-level key named like an Object.prototype member (no false-positive collision)', () => {
+        const flat = dotFlatten({ id: 1, constructor: 'Building Co' }) as Record<string, unknown>;
+        expect(flat.id).toBe(1);
+        expect(flat.constructor).toBe('Building Co');
+    });
+
+    it('keeps an own __proto__ key (from parsed JSON) as data without polluting the prototype', () => {
+        const flat = dotFlatten(JSON.parse('{"id":1,"__proto__":"x"}')) as Record<string, unknown>;
+        expect(Object.getOwnPropertyDescriptor(flat, '__proto__')?.value).toBe('x');
+        expect(Object.getPrototypeOf(flat)).toBe(null);
+    });
+
     it('throws when nesting exceeds the depth guard', () => {
         let deep: Record<string, unknown> = { leaf: 1 };
         for (let i = 0; i < 25; i++) deep = { nest: deep };
@@ -95,6 +107,18 @@ describe('encodeToon', () => {
         const normalized = JSON.parse(JSON.stringify(input));
         expect(text.startsWith(FENCES.toon.prefix)).toBe(true);
         expect(decodeFencedToolText(text)).toEqual(dotFlatten(normalized));
+    });
+
+    it('ships TOON for a prototype-name column instead of falling back to JSON', () => {
+        const value = {
+            items: [
+                { id: 1, constructor: 'a' },
+                { id: 2, constructor: 'b' },
+            ],
+        };
+        const text = encodeToon(value);
+        expect(text.startsWith(FENCES.toon.prefix)).toBe(true);
+        expect(decodeFencedToolText(text)).toEqual(value);
     });
 
     it('falls back to JSON on a dotFlatten collision and still round-trips', () => {

--- a/tests/unit/utils.encode_text.test.ts
+++ b/tests/unit/utils.encode_text.test.ts
@@ -1,0 +1,88 @@
+import { decode as decodeToon } from '@toon-format/toon';
+import { describe, expect, it } from 'vitest';
+
+import { dotFlatten, encodeCompactText } from '../../src/utils/encode_text.js';
+
+describe('dotFlatten', () => {
+    it('lifts nested object keys into dot-joined top-level keys', () => {
+        expect(dotFlatten({ id: 1, stats: { runs: 10, reads: 5 } })).toEqual({
+            id: 1,
+            'stats.runs': 10,
+            'stats.reads': 5,
+        });
+    });
+
+    it('flattens each object element of an array but keeps it an array', () => {
+        expect(
+            dotFlatten([
+                { id: 1, stats: { runs: 10 } },
+                { id: 2, stats: { runs: 20 } },
+            ]),
+        ).toEqual([
+            { id: 1, 'stats.runs': 10 },
+            { id: 2, 'stats.runs': 20 },
+        ]);
+    });
+
+    it('leaves scalars, null, and inline scalar arrays unchanged', () => {
+        expect(dotFlatten({ a: 1, b: null, tags: ['x', 'y'] })).toEqual({ a: 1, b: null, tags: ['x', 'y'] });
+    });
+
+    it('normalises literal dots in source keys to underscores', () => {
+        expect(dotFlatten({ 'a.b': 1 })).toEqual({ a_b: 1 });
+    });
+
+    it('throws on a normalisation collision (no silent data loss)', () => {
+        expect(() => dotFlatten({ 'a.b': 1, a_b: 2 })).toThrow(RangeError);
+    });
+
+    it('throws when nesting exceeds the depth guard', () => {
+        let deep: Record<string, unknown> = { leaf: 1 };
+        for (let i = 0; i < 25; i++) deep = { nest: deep };
+        expect(() => dotFlatten(deep)).toThrow(RangeError);
+    });
+});
+
+/** Decode whichever fence the picker shipped, back to a JSON value. */
+function decodeFenced(text: string): unknown {
+    if (text.startsWith('```toon\n')) return decodeToon(text.slice('```toon\n'.length, -'\n```'.length));
+    return JSON.parse(text.slice('```json\n'.length, -'\n```'.length));
+}
+
+const byteLen = (s: string) => Buffer.byteLength(s, 'utf8');
+
+describe('encodeCompactText', () => {
+    const uniformRows = {
+        items: [
+            { id: 1, status: 'SUCCEEDED', cost: 0.1 },
+            { id: 2, status: 'FAILED', cost: 0.2 },
+            { id: 3, status: 'SUCCEEDED', cost: 0.3 },
+        ],
+    };
+
+    it('ships TOON when it is smaller and round-trips to the original value', () => {
+        const text = encodeCompactText(uniformRows);
+        expect(text.startsWith('```toon\n')).toBe(true);
+        expect(decodeFenced(text)).toEqual(uniformRows);
+    });
+
+    it('never ships more bytes than the plain JSON candidate', () => {
+        const jsonBytes = byteLen('```json\n' + JSON.stringify(uniformRows) + '\n```');
+        expect(byteLen(encodeCompactText(uniformRows))).toBeLessThanOrEqual(jsonBytes);
+    });
+
+    it('falls back to JSON on a dotFlatten collision and still round-trips', () => {
+        const value = { 'a.b': 1, a_b: 2 };
+        const text = encodeCompactText(value);
+        expect(text.startsWith('```json\n')).toBe(true);
+        expect(decodeFenced(text)).toEqual(value);
+    });
+
+    it('falls back to JSON when nesting exceeds the depth guard', () => {
+        let deep: Record<string, unknown> = { leaf: 1 };
+        for (let i = 0; i < 25; i++) deep = { nest: deep };
+        const text = encodeCompactText(deep);
+        expect(text.startsWith('```json\n')).toBe(true);
+        expect(decodeFenced(text)).toEqual(deep);
+    });
+});

--- a/tests/unit/utils.encode_text.test.ts
+++ b/tests/unit/utils.encode_text.test.ts
@@ -1,7 +1,7 @@
-import { decode as decodeToon } from '@toon-format/toon';
 import { describe, expect, it } from 'vitest';
 
-import { dotFlatten, encodeCompactText } from '../../src/utils/encode_text.js';
+import { dotFlatten, encodeCompactText, TOON_FENCE_PREFIX } from '../../src/utils/encode_text.js';
+import { decodeFencedToolText } from './helpers/tool_context.js';
 
 describe('dotFlatten', () => {
     it('lifts nested object keys into dot-joined top-level keys', () => {
@@ -43,12 +43,6 @@ describe('dotFlatten', () => {
     });
 });
 
-/** Decode whichever fence the picker shipped, back to a JSON value. */
-function decodeFenced(text: string): unknown {
-    if (text.startsWith('```toon\n')) return decodeToon(text.slice('```toon\n'.length, -'\n```'.length));
-    return JSON.parse(text.slice('```json\n'.length, -'\n```'.length));
-}
-
 const byteLen = (s: string) => Buffer.byteLength(s, 'utf8');
 
 describe('encodeCompactText', () => {
@@ -62,8 +56,34 @@ describe('encodeCompactText', () => {
 
     it('ships TOON when it is smaller and round-trips to the original value', () => {
         const text = encodeCompactText(uniformRows);
-        expect(text.startsWith('```toon\n')).toBe(true);
-        expect(decodeFenced(text)).toEqual(uniformRows);
+        expect(text.startsWith(TOON_FENCE_PREFIX)).toBe(true);
+        expect(decodeFencedToolText(text)).toEqual(uniformRows);
+    });
+
+    it('preserves Date, nested-object, and null fields (regression: dotFlatten dropped Date objects)', () => {
+        const startedAt = '2026-05-12T09:18:27.527Z';
+        const input = {
+            items: [
+                {
+                    id: 1,
+                    startedAt: new Date(startedAt),
+                    finishedAt: new Date('2026-05-12T09:19:01.000Z'),
+                    stats: { runs: 10 },
+                },
+                { id: 2, startedAt: new Date('2026-05-12T09:17:57.206Z'), finishedAt: null, stats: { runs: 20 } },
+            ],
+        };
+        const text = encodeCompactText(input);
+
+        // The Date must survive as an ISO string. Before the fix, dotFlatten treated a Date as an
+        // empty nested object and dropped it, so the lossy (smaller) candidate won the byte compare.
+        expect(text).toContain(startedAt);
+
+        // Whichever candidate ships, the text must round-trip to the JSON-normalised value
+        // (dot-flattened when TOON wins).
+        const normalized = JSON.parse(JSON.stringify(input));
+        const expected = text.startsWith(TOON_FENCE_PREFIX) ? dotFlatten(normalized) : normalized;
+        expect(decodeFencedToolText(text)).toEqual(expected);
     });
 
     it('never ships more bytes than the plain JSON candidate', () => {
@@ -74,15 +94,15 @@ describe('encodeCompactText', () => {
     it('falls back to JSON on a dotFlatten collision and still round-trips', () => {
         const value = { 'a.b': 1, a_b: 2 };
         const text = encodeCompactText(value);
-        expect(text.startsWith('```json\n')).toBe(true);
-        expect(decodeFenced(text)).toEqual(value);
+        expect(text.startsWith(TOON_FENCE_PREFIX)).toBe(false);
+        expect(decodeFencedToolText(text)).toEqual(value);
     });
 
     it('falls back to JSON when nesting exceeds the depth guard', () => {
         let deep: Record<string, unknown> = { leaf: 1 };
         for (let i = 0; i < 25; i++) deep = { nest: deep };
         const text = encodeCompactText(deep);
-        expect(text.startsWith('```json\n')).toBe(true);
-        expect(decodeFenced(text)).toEqual(deep);
+        expect(text.startsWith(TOON_FENCE_PREFIX)).toBe(false);
+        expect(decodeFencedToolText(text)).toEqual(deep);
     });
 });

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -1,20 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeToolResponseBytes, encodeJsonText } from '../../src/utils/mcp.js';
-
-describe('encodeJsonText()', () => {
-    it('emits a ```json … ``` fenced block', () => {
-        expect(encodeJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
-    });
-
-    it('serializes arrays', () => {
-        expect(encodeJsonText([1, 2])).toBe('```json\n[1,2]\n```');
-    });
-
-    it('serializes primitives', () => {
-        expect(encodeJsonText('x')).toBe('```json\n"x"\n```');
-    });
-});
+import { computeToolResponseBytes } from '../../src/utils/mcp.js';
 
 describe('computeToolResponseBytes()', () => {
     it('returns zero for null/undefined/non-object input', () => {

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeToolResponseBytes, wrapJsonText } from '../../src/utils/mcp.js';
+import { computeToolResponseBytes, encodeJsonText } from '../../src/utils/mcp.js';
 
-describe('wrapJsonText()', () => {
+describe('encodeJsonText()', () => {
     it('emits a ```json … ``` fenced block', () => {
-        expect(wrapJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
+        expect(encodeJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
     });
 
     it('serializes arrays', () => {
-        expect(wrapJsonText([1, 2])).toBe('```json\n[1,2]\n```');
+        expect(encodeJsonText([1, 2])).toBe('```json\n[1,2]\n```');
     });
 
     it('serializes primitives', () => {
-        expect(wrapJsonText('x')).toBe('```json\n"x"\n```');
+        expect(encodeJsonText('x')).toBe('```json\n"x"\n```');
     });
 });
 


### PR DESCRIPTION
Stacked on #950 (base = `feat/list-tools-structured-content`). Implements #913.

## What

The five array endpoints (`get-actor-run-list`, `get-dataset-list`, `get-key-value-store-list`, `get-key-value-store-keys`, `get-dataset-items`) always ship dot-flattened [TOON](https://toonformat.dev/) in `content[].text`; `structuredContent` stays pure JSON. `encode_text.ts` exposes two encoders: `wrapJsonText` (always JSON, single-object tools) and `encodeToon` (always TOON, list tools). `encodeToon` falls back to a JSON fence only when `dotFlatten`/`encode` throws (depth overflow or a normalisation key collision) — a lossless error path, logged, not a byte-driven alternative.

## Why

JSON repeats every object key on every array row; TOON's tabular form drops that, shrinking the list payloads that sit in the LLM context. Per review (#952 discussion), one stable shape per tool beats a format that flips on byte count: easier to reason about and debug. `structuredContent` (from #950) remains the JSON source of truth for programmatic consumers and `outputSchema` validators.

## Worth your attention

- **`content[].text` is TOON (or JSON on the rare error fallback).** Spec-sound because all five tools declare `outputSchema`/`structuredContent`, authoritative for machine consumers. A client that blindly `JSON.parse`s `content[0].text` and ignores `structuredContent` would need to handle TOON — flagged so reviewers are aware. This knowingly deviates from the SHOULD in the spec ("a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block").
- **`encodeToon` serialises through `JSON.stringify` first**, so `dotFlatten` works on the JSON data model only — a `Date`/`toJSON` carrier becomes its ISO string, not an empty object (pinned by a regression test).
- **JSON fallback is an error path, not a picker.** A `get-dataset-items` payload with a top-level key named `constructor`/`toString`/`__proto__`/… trips the `key in out` collision guard; TOON is dropped and JSON ships (lossless, logged). `Object.create(null)` would remove the false positive; the guard also blocks `__proto__` pollution.
- `@toon-format/toon@2.3.0` — pinned, 0 deps.

## Testing

- Unit suite green (844 passed, 2 skipped); `tsc --noEmit` clean; `oxlint` 0/0. Tests cover the TOON round-trip, the `Date`/null/nested case, dot-flatten collision + depth fallback to JSON, and `content == structuredContent`.
- Live verification against a local build via [`mcpc`](https://github.com/apify/mcpc) (real Apify runs); TOON output decoded back with the real `@toon-format/toon` decoder to confirm losslessness.

## Before merge

Gated on the TOON task-performance experiment (#943) — `pnpm run evals:workflow`, no regression vs master. The byte win is proven; the LLM-comprehension win is not yet.
