### PR TITLE
fix(payments): widen paid-tool outputSchema to accept x402 PaymentRequired (#917)

### DIFF
--- a/src/payments/x402.ts
+++ b/src/payments/x402.ts
@@ -59,6 +59,42 @@ export type X402PaymentRequirements = {
     accepts?: X402PaymentAccept[];
 };
 
+/**
+ * JSON Schema for the x402 `PaymentRequired` object a paid tool returns in
+ * `structuredContent` on a 402, per the x402 MCP transport spec
+ * (coinbase/x402 `specs/transports-v2/mcp.md` → "Server Requirements").
+ * `required: [x402Version, accepts]` are the spec-required fields we use as the branch
+ * discriminator. `accepts[]` item internals are left unconstrained — the payload is
+ * forwarded verbatim from the trusted Apify API and may carry scheme-specific extras.
+ */
+export const X402_PAYMENT_REQUIRED_OUTPUT_SCHEMA = {
+    type: 'object' as const,
+    properties: {
+        x402Version: { type: 'number' as const },
+        error: { type: 'string' as const },
+        resource: { type: 'object' as const },
+        accepts: { type: 'array' as const, items: { type: 'object' as const } },
+    },
+    required: ['x402Version', 'accepts'],
+} as const;
+
+/**
+ * True if `schema` already carries the x402 PaymentRequired branch — i.e. it was
+ * produced by a previous {@link X402PaymentProvider.decorateToolSchema} pass.
+ * Keeps re-decoration idempotent (the server may decorate an already-decorated tool).
+ */
+function hasPaymentRequiredBranch(schema: Record<string, unknown> | undefined): boolean {
+    const { anyOf } = schema ?? {};
+    if (!Array.isArray(anyOf)) return false;
+    // Derive the discriminator from the schema itself so the two can't drift: a drifted
+    // guard would miss our own output and silently double-wrap (nested anyOf).
+    const discriminator = X402_PAYMENT_REQUIRED_OUTPUT_SCHEMA.required;
+    return anyOf.some((branch) => {
+        const req = (branch as { required?: unknown })?.required;
+        return Array.isArray(req) && discriminator.every((key) => req.includes(key));
+    });
+}
+
 // Module-level cache for X402 payment requirements.
 // We cache the Promise itself (rather than just the JSON result) to prevent the "thundering herd"
 // problem during server startup, where multiple concurrent incoming requests might otherwise
@@ -225,6 +261,23 @@ export class X402PaymentProvider implements PaymentProvider {
         // Append x402 instructions to description (idempotent)
         if (cloned.description && !cloned.description.includes(X402_TOOL_INSTRUCTIONS)) {
             cloned.description += `\n\n${X402_TOOL_INSTRUCTIONS}`;
+        }
+
+        // A paid tool's output is a sum type: its declared success shape OR a 402
+        // PaymentRequired object (carried in `structuredContent` per the x402 MCP spec).
+        // The MCP SDK *client* validates `structuredContent` against the advertised
+        // `outputSchema` even when `isError: true`, so a tool that declares only the
+        // success shape makes strict clients (e.g. Cursor) reject the 402 with -32602
+        // before the agent sees the payment hint (issue #917). Advertise both shapes via
+        // `anyOf` of two disjoint-`required` branches so the spec-mandated PaymentRequired
+        // validates while a success payload missing required keys is still rejected.
+        // `structuredClone` keeps each tool's schema self-owned — the const is never aliased.
+        const outputSchema = cloned.outputSchema as Record<string, unknown> | undefined;
+        if (outputSchema && !hasPaymentRequiredBranch(outputSchema)) {
+            cloned.outputSchema = {
+                type: 'object',
+                anyOf: [outputSchema, structuredClone(X402_PAYMENT_REQUIRED_OUTPUT_SCHEMA)],
+            } as typeof cloned.outputSchema;
         }
 
         return Object.freeze(cloned);

--- a/tests/unit/tools.x402.test.ts
+++ b/tests/unit/tools.x402.test.ts
@@ -2,10 +2,16 @@
  * Tests for X402PaymentProvider — payment extraction (_meta["x402/payment"] vs
  * HTTP PAYMENT-SIGNATURE header) and tool-schema decoration with multi-scheme `accepts[]`.
  */
+import Ajv from 'ajv';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PaymentMeta, RequestHeaders } from '../../src/payments/types.js';
-import { X402PaymentProvider, type X402PaymentRequirements } from '../../src/payments/x402.js';
+import {
+    X402_PAYMENT_REQUIRED_OUTPUT_SCHEMA,
+    X402PaymentProvider,
+    type X402PaymentRequirements,
+} from '../../src/payments/x402.js';
+import { getActorRunOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
 
@@ -35,6 +41,25 @@ const UPTO_ACCEPT = {
     maxTimeoutSeconds: 18_000,
     extra: { name: 'USDC', version: '2', facilitatorAddress: '0xFac' },
 } as const;
+
+/** A successful Actor run result — satisfies the `getActorRunOutputSchema` branch. */
+const SAMPLE_RUN_RESPONSE = {
+    runId: 'abc123',
+    actorId: 'JxcaGGqy7TwBdHxMz',
+    actorName: 'janedoe/my-actor',
+    status: 'SUCCEEDED',
+    storages: { datasets: { default: { id: 'ds1' } } },
+    summary: 'Run finished.',
+    nextStep: 'Call get-dataset-items with datasetId ds1.',
+};
+
+/** A 402 PaymentRequired payload — satisfies the x402 branch. */
+const SAMPLE_PAYMENT_REQUIRED = {
+    x402Version: 2,
+    error: 'Payment required',
+    resource: { url: 'mcp://tool/paid-tool' },
+    accepts: [EXACT_ACCEPT],
+};
 
 function makePaidTool(overrides: Partial<HelperTool> = {}): HelperTool {
     return {
@@ -200,5 +225,63 @@ describe('decorateToolSchema()', () => {
         expect(getX402Meta(twice)).toEqual(getX402Meta(once));
         const instructionsCount = (twice.description ?? '').match(/This tool requires an x402 payment/g)?.length ?? 0;
         expect(instructionsCount).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// outputSchema widening (issue #917)
+// ---------------------------------------------------------------------------
+
+describe('decorateToolSchema() — outputSchema widening (#917)', () => {
+    const requirements: X402PaymentRequirements = { x402Version: 2, accepts: [EXACT_ACCEPT] };
+
+    function decorateWithSchema(outputSchema: unknown) {
+        return new X402PaymentProvider(requirements).decorateToolSchema(
+            makePaidTool({ outputSchema } as unknown as Partial<HelperTool>),
+        );
+    }
+
+    it('wraps an existing outputSchema in anyOf:[success, PaymentRequired] with root type:object', () => {
+        const schema = decorateWithSchema(getActorRunOutputSchema).outputSchema as {
+            type: string;
+            anyOf: unknown[];
+        };
+        // MCP requires root type:'object'; the SDK Tool.outputSchema zod keeps `anyOf` via .catchall().
+        expect(schema.type).toBe('object');
+        expect(schema.anyOf).toHaveLength(2);
+        expect(schema.anyOf[0]).toEqual(getActorRunOutputSchema);
+        expect(schema.anyOf[1]).toEqual(X402_PAYMENT_REQUIRED_OUTPUT_SCHEMA);
+    });
+
+    it('does not invent an outputSchema for a paid tool that declares none', () => {
+        const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
+        expect(decorated.outputSchema).toBeUndefined();
+    });
+
+    it('is idempotent — re-decorating an already-widened tool does not nest anyOf', () => {
+        const provider2 = new X402PaymentProvider(requirements);
+        const once = provider2.decorateToolSchema(
+            makePaidTool({ outputSchema: getActorRunOutputSchema } as unknown as Partial<HelperTool>),
+        );
+        const twice = provider2.decorateToolSchema(once);
+
+        const { anyOf } = twice.outputSchema as unknown as { anyOf: unknown[] };
+        expect(anyOf).toHaveLength(2);
+        // If the guard regressed and re-wrapped, anyOf[0] would be the nested
+        // { type, anyOf:[...] } wrapper rather than the original success schema.
+        expect(anyOf[0]).toEqual(getActorRunOutputSchema);
+    });
+
+    it('widened schema validates a successful run AND a PaymentRequired, and rejects garbage', () => {
+        const widened = decorateWithSchema(getActorRunOutputSchema).outputSchema as object;
+        // new Ajv({ strict:false }) matches the MCP SDK client validator here: the SDK also
+        // adds ajv-formats, but neither branch uses a `format` keyword, so results are identical.
+        const validate = new Ajv({ strict: false, allErrors: true }).compile(widened);
+
+        expect(validate(SAMPLE_RUN_RESPONSE)).toBe(true); // normal output keeps working
+        expect(validate(SAMPLE_PAYMENT_REQUIRED)).toBe(true); // 402 payload now validates
+        expect(validate({})).toBe(false); // disjoint required-sets still reject garbage
+        // anyOf did NOT loosen success validation: a run missing required keys still fails.
+        expect(validate({ status: 'SUCCEEDED' })).toBe(false);
     });
 });


### PR DESCRIPTION
## What
On x402 sessions, widen each paid tool's declared `outputSchema` to `anyOf: [<success schema>, X402_PAYMENT_REQUIRED_OUTPUT_SCHEMA]` so the spec-mandated 402 `PaymentRequired` payload validates as a legal tool output.

## Why
Closes #917. Paid tools (e.g. `call-actor`) declare a static success `outputSchema` (`getActorRunOutputSchema`). The x402 MCP transport spec requires a 402 response to carry the `PaymentRequired` object in `structuredContent`. The MCP SDK **client** validates `structuredContent` against the tool's `outputSchema` even when `isError: true`, so strict clients (Cursor) rejected the 402 with `-32602` before the agent ever saw the payment hint. A paid tool's output is genuinely a sum type (`RunResponse | PaymentRequired`); the schema now says so. Scoped to x402 sessions (where the 402 branch is reachable) via `X402PaymentProvider.decorateToolSchema`; only tools that already declare an `outputSchema` are widened. The two branches have disjoint `required` sets, so success validation stays strict and garbage is still rejected.

Note: after widening, the advertised schema is `{ type:'object', anyOf:[…] }` with no top-level `properties` — validating clients resolve `anyOf` correctly, but a client reading `outputSchema.properties.<field>` directly for display will see `undefined`. Inherent to the sum-type approach.

## Testing
`pnpm type-check`, `pnpm lint`, `pnpm test:unit` (831 pass). Added unit tests in `tests/unit/tools.x402.test.ts`: the widened schema validates a successful run AND a `PaymentRequired`, rejects garbage and a run missing required keys (proves `anyOf` didn't loosen success validation), doesn't invent a schema for tools without one, and is idempotent (no nested `anyOf` on re-decoration).
