### PR TITLE
feat: Extract server info into reusable getServerInfo() function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,7 @@ WORKDIR /app
 COPY --from=builder /app /build
 RUN cd /build && pnpm deploy --legacy --filter "@apify/actors-mcp-server" --prod /app && rm -rf /build
 COPY --from=builder /app/dist ./dist
+# server_card.ts reads server.json at load (resolved as dist/../server.json).
+COPY server.json ./
 
 ENTRYPOINT ["node", "dist/stdio.js"]

--- a/src/const.ts
+++ b/src/const.ts
@@ -129,6 +129,7 @@ export const ALLOWED_DOC_DOMAINS = ['https://docs.apify.com', 'https://crawlee.d
 
 export const APIFY_STORE_URL = 'https://apify.com';
 export const APIFY_FAVICON_URL = `${APIFY_STORE_URL}/favicon.ico`;
+export const APIFY_LOGO_URL = `${APIFY_STORE_URL}/apple-icon.png`;
 export const APIFY_MCP_URL = 'https://mcp.apify.com';
 export const APIFY_DOCS_MCP_URL = 'https://docs.apify.com/platform/integrations/mcp';
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -229,34 +229,31 @@ export class ActorsMcpServer {
         this.serverModeResolved = this.serverModeOption !== 'auto';
 
         const { setupSigintHandler = true } = options;
-        this.server = new Server(
-            getServerInfo(),
-            {
-                capabilities: {
-                    tools: {
-                        listChanged: true,
-                    },
-                    // Declare long-running task support
-                    tasks: {
-                        list: {},
-                        cancel: {},
-                        requests: {
-                            tools: {
-                                call: {},
-                            },
+        this.server = new Server(getServerInfo(), {
+            capabilities: {
+                tools: {
+                    listChanged: true,
+                },
+                // Declare long-running task support
+                tasks: {
+                    list: {},
+                    cancel: {},
+                    requests: {
+                        tools: {
+                            call: {},
                         },
                     },
-                    /**
-                     * Declaring resources even though we are not using them
-                     * to prevent clients like Claude desktop from failing.
-                     */
-                    resources: {},
-                    prompts: {},
-                    logging: {},
                 },
-                instructions: getServerInstructions(),
+                /**
+                 * Declaring resources even though we are not using them
+                 * to prevent clients like Claude desktop from failing.
+                 */
+                resources: {},
+                prompts: {},
+                logging: {},
             },
-        );
+            instructions: getServerInstructions(),
+        });
         this.setupTelemetry();
         this.setupInitializeHandler();
         this.setupLoggingProxy();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -50,13 +50,11 @@ import { parseBooleanOrNull } from '@apify/utilities';
 import { ApifyClient } from '../apify_client.js';
 import {
     ALLOWED_TASK_TOOL_EXECUTION_MODES,
-    APIFY_MCP_URL,
     DEFAULT_TELEMETRY_ENABLED,
     DEFAULT_TELEMETRY_ENV,
     FAILURE_CATEGORY,
     HelperTools,
     HTTP_PAYMENT_REQUIRED,
-    SERVER_NAME,
     TOOL_STATUS,
 } from '../const.js';
 import { prepareToolCallContext } from '../payments/helpers.js';
@@ -64,6 +62,7 @@ import { prompts } from '../prompts/index.js';
 import { createResourceService } from '../resources/resource_service.js';
 import type { AvailableWidget } from '../resources/widgets.js';
 import { resolveAvailableWidgets } from '../resources/widgets.js';
+import { getServerInfo } from '../server_card.js';
 import { getTelemetryEnv, trackToolCall } from '../telemetry.js';
 import { actorExecutor } from '../tools/actor_executor.js';
 import {
@@ -231,11 +230,7 @@ export class ActorsMcpServer {
 
         const { setupSigintHandler = true } = options;
         this.server = new Server(
-            {
-                name: SERVER_NAME,
-                version: getPackageVersion()!,
-                websiteUrl: APIFY_MCP_URL,
-            },
+            getServerInfo(),
             {
                 capabilities: {
                     tools: {

--- a/src/server_card.ts
+++ b/src/server_card.ts
@@ -1,7 +1,7 @@
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 
-import { APIFY_DOCS_MCP_URL, APIFY_FAVICON_URL, APIFY_MCP_URL, SERVER_NAME, SERVER_TITLE } from './const.js';
+import { APIFY_DOCS_MCP_URL, APIFY_FAVICON_URL, APIFY_LOGO_URL, APIFY_MCP_URL, SERVER_NAME, SERVER_TITLE } from './const.js';
 import type { ServerCard } from './types.js';
 import { readJsonFile } from './utils/generic.js';
 import { getPackageVersion } from './utils/version.js';
@@ -18,8 +18,9 @@ export function getServerInfo(): Implementation {
         websiteUrl: APIFY_MCP_URL,
         icons: [
             {
-                src: APIFY_FAVICON_URL,
-                mimeType: 'image/x-icon',
+                src: APIFY_LOGO_URL,
+                mimeType: 'image/png',
+                sizes: ['180x180'],
             },
         ],
     };

--- a/src/server_card.ts
+++ b/src/server_card.ts
@@ -1,11 +1,29 @@
+import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 
-import { APIFY_DOCS_MCP_URL, APIFY_FAVICON_URL, SERVER_NAME, SERVER_TITLE } from './const.js';
+import { APIFY_DOCS_MCP_URL, APIFY_FAVICON_URL, APIFY_MCP_URL, SERVER_NAME, SERVER_TITLE } from './const.js';
 import type { ServerCard } from './types.js';
 import { readJsonFile } from './utils/generic.js';
 import { getPackageVersion } from './utils/version.js';
 
 const serverJson = readJsonFile<{ description: string }>(import.meta.url, '../server.json');
+
+/** Returns the `serverInfo` (MCP `Implementation`) advertised in the initialize response. */
+export function getServerInfo(): Implementation {
+    return {
+        name: SERVER_NAME,
+        title: SERVER_TITLE,
+        version: getPackageVersion()!,
+        description: serverJson.description,
+        websiteUrl: APIFY_MCP_URL,
+        icons: [
+            {
+                src: APIFY_FAVICON_URL,
+                mimeType: 'image/x-icon',
+            },
+        ],
+    };
+}
 
 /** Returns the MCP server card object per SEP-1649. */
 export function getServerCard(): ServerCard {

--- a/src/server_card.ts
+++ b/src/server_card.ts
@@ -1,7 +1,14 @@
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 
-import { APIFY_DOCS_MCP_URL, APIFY_FAVICON_URL, APIFY_LOGO_URL, APIFY_MCP_URL, SERVER_NAME, SERVER_TITLE } from './const.js';
+import {
+    APIFY_DOCS_MCP_URL,
+    APIFY_FAVICON_URL,
+    APIFY_LOGO_URL,
+    APIFY_MCP_URL,
+    SERVER_NAME,
+    SERVER_TITLE,
+} from './const.js';
 import type { ServerCard } from './types.js';
 import { readJsonFile } from './utils/generic.js';
 import { getPackageVersion } from './utils/version.js';

--- a/tests/unit/server_card.test.ts
+++ b/tests/unit/server_card.test.ts
@@ -1,7 +1,7 @@
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it } from 'vitest';
 
-import { APIFY_FAVICON_URL, APIFY_MCP_URL, SERVER_NAME, SERVER_TITLE } from '../../src/const.js';
+import { APIFY_LOGO_URL, APIFY_MCP_URL, SERVER_NAME, SERVER_TITLE } from '../../src/const.js';
 import { getServerCard, getServerInfo } from '../../src/server_card.js';
 import { readJsonFile } from '../../src/utils/generic.js';
 import { getPackageVersion } from '../../src/utils/version.js';
@@ -80,9 +80,9 @@ describe('getServerInfo', () => {
         expect(info.websiteUrl).toBe(APIFY_MCP_URL);
     });
 
-    it('includes an icon pointing at the Apify favicon', () => {
+    it('includes a PNG icon pointing at the Apify logo', () => {
         const info = getServerInfo();
 
-        expect(info.icons).toEqual([{ src: APIFY_FAVICON_URL, mimeType: 'image/x-icon' }]);
+        expect(info.icons).toEqual([{ src: APIFY_LOGO_URL, mimeType: 'image/png', sizes: ['180x180'] }]);
     });
 });

--- a/tests/unit/server_card.test.ts
+++ b/tests/unit/server_card.test.ts
@@ -1,8 +1,8 @@
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it } from 'vitest';
 
-import { SERVER_NAME, SERVER_TITLE } from '../../src/const.js';
-import { getServerCard } from '../../src/server_card.js';
+import { APIFY_FAVICON_URL, APIFY_MCP_URL, SERVER_NAME, SERVER_TITLE } from '../../src/const.js';
+import { getServerCard, getServerInfo } from '../../src/server_card.js';
 import { readJsonFile } from '../../src/utils/generic.js';
 import { getPackageVersion } from '../../src/utils/version.js';
 
@@ -61,5 +61,28 @@ describe('getServerCard', () => {
         const card = getServerCard();
 
         expect(card.documentationUrl).toBe('https://docs.apify.com/platform/integrations/mcp');
+    });
+});
+
+describe('getServerInfo', () => {
+    it('returns name, title and version', () => {
+        const info = getServerInfo();
+
+        expect(info.name).toBe(SERVER_NAME);
+        expect(info.title).toBe(SERVER_TITLE);
+        expect(info.version).toBe(getPackageVersion());
+    });
+
+    it('includes description from server.json and the website URL', () => {
+        const info = getServerInfo();
+
+        expect(info.description).toBe(serverJson.description);
+        expect(info.websiteUrl).toBe(APIFY_MCP_URL);
+    });
+
+    it('includes an icon pointing at the Apify favicon', () => {
+        const info = getServerInfo();
+
+        expect(info.icons).toEqual([{ src: APIFY_FAVICON_URL, mimeType: 'image/x-icon' }]);
     });
 });

--- a/tests/unit/server_card.test.ts
+++ b/tests/unit/server_card.test.ts
@@ -71,18 +71,8 @@ describe('getServerInfo', () => {
         expect(info.name).toBe(SERVER_NAME);
         expect(info.title).toBe(SERVER_TITLE);
         expect(info.version).toBe(getPackageVersion());
-    });
-
-    it('includes description from server.json and the website URL', () => {
-        const info = getServerInfo();
-
         expect(info.description).toBe(serverJson.description);
         expect(info.websiteUrl).toBe(APIFY_MCP_URL);
-    });
-
-    it('includes a PNG icon pointing at the Apify logo', () => {
-        const info = getServerInfo();
-
         expect(info.icons).toEqual([{ src: APIFY_LOGO_URL, mimeType: 'image/png', sizes: ['180x180'] }]);
     });
 });


### PR DESCRIPTION
Extract the MCP `Implementation` object (server name, title, version, description, website URL, and icon) into a dedicated `getServerInfo()` function in `server_card.ts`. This centralizes server metadata and eliminates duplication in `ActorsMcpServer`.

**Changes:**
- Added `getServerInfo()` function that returns an `Implementation` object with all server metadata
- Updated `ActorsMcpServer` to use `getServerInfo()` instead of inline object construction
- Removed unused imports (`SERVER_NAME`, `APIFY_MCP_URL`) from `mcp/server.ts`
- Added comprehensive unit tests for `getServerInfo()` covering name/title/version, description/website URL, and icon metadata

**Implementation details:**
- `getServerInfo()` reads server description from `server.json` and constructs the full `Implementation` object
- Centralizes the single source of truth for server metadata advertised in the MCP initialize response
- Tests verify all fields are correctly populated and match expected constants

Closes #955

https://claude.ai/code/session_01CQRuskcnpPdt4RZJPmSbTo

MCPJam

<img width="1053" height="670" alt="image" src="https://github.com/user-attachments/assets/5476c77e-e648-4b4c-8bbb-e1717fc1c75f" />
