### PR TITLE
chore(dev): default dev server telemetry env to DEV

### DIFF
--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -21,6 +21,11 @@ import { resolvePaymentProvider } from './payments/index.js';
 import type { ApifyRequestParams } from './types.js';
 import { parseServerMode } from './utils/server_mode.js';
 
+// This is the local dev/standby-emulation server only; production runs dist/stdio.js.
+// Default telemetry to the DEV Segment source so local tool calls never land in PROD
+// analytics. Still overridable by an explicit TELEMETRY_ENV (e.g. PROD) in the env.
+process.env.TELEMETRY_ENV ??= 'DEV';
+
 enum TransportType {
     HTTP = 'HTTP',
     SSE = 'SSE',


### PR DESCRIPTION
## What
Default `process.env.TELEMETRY_ENV` to `DEV` at the top of `src/dev_server.ts` (the local dev / standby-emulation server, run via `pnpm run dev` / `pnpm run start`). Still overridable by an explicit `TELEMETRY_ENV` in the environment.

## Why
`dev_server.ts` constructs `ActorsMcpServer` with only `telemetry.enabled` and never `telemetry.env`, so it fell through to `DEFAULT_TELEMETRY_ENV='PROD'` (`src/const.ts:142`) and sent `MCP Tool Call` events to the **PROD** Segment source during local development. This matches the Doppler staging/local config in `apify-mcp-server-internal`, which already sets `TELEMETRY_ENV=DEV`.

Production is unaffected: the published package / Docker entrypoint is `dist/stdio.js`, not this file. Sentry is the only other server-side egress and does not run from `dev_server.ts` (only from `stdio.ts`); note it is gated by `TELEMETRY_ENABLED`, independent of `TELEMETRY_ENV`, so if `instrument.js` is ever imported here it would still need separate handling.

## Testing
- `pnpm run type-check` — passes.
- `pnpm run lint` — 0 warnings, 0 errors.
- Traced the resolution path (`dev_server.ts` → `server.ts:294` `setupTelemetry` → `telemetry.ts` `getTelemetryEnv`/`getOrInitAnalyticsClient`): with the default in place, an unset `TELEMETRY_ENV` now selects `DEV_WRITE_KEY` instead of `PROD_WRITE_KEY`.