### PR TITLE
fix: Wrong default telemetry for isError without classification

### DIFF
--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -98,7 +98,7 @@ export function extractAjvErrorDetails(errors: ErrorObject[] | null | undefined)
  *
  * toolStatus resolution:
  * 1. `toolTelemetry.toolStatus` present → use it directly.
- * 2. `isError` set without toolStatus → SOFT_FAIL.
+ * 2. `isError` set without toolStatus → FAILED.
  * 3. Neither → SUCCEEDED.
  *
  * actorName/actorId are server-side context (from tool resolution).
@@ -118,7 +118,7 @@ export function extractToolTelemetry(
     if (!telemetry) {
         if (res.isError) {
             return {
-                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                toolStatus: TOOL_STATUS.FAILED,
                 callDiagnostics: { failure_category: FAILURE_CATEGORY.INTERNAL_ERROR, ...actorFields },
             };
         }

--- a/tests/unit/utils.tool_status.test.ts
+++ b/tests/unit/utils.tool_status.test.ts
@@ -169,10 +169,27 @@ describe('extractToolTelemetry', () => {
         expect(res.content).toBe('ok');
     });
 
-    it('defaults to SOFT_FAIL when isError without toolTelemetry', () => {
+    it('defaults to FAILED when isError without toolTelemetry', () => {
         const { toolStatus, callDiagnostics } = extractToolTelemetry({ isError: true }, undefined, undefined);
-        expect(toolStatus).toBe(TOOL_STATUS.SOFT_FAIL);
+        expect(toolStatus).toBe(TOOL_STATUS.FAILED);
         expect(callDiagnostics.failure_category).toBe(FAILURE_CATEGORY.INTERNAL_ERROR);
+    });
+
+    it('keeps explicit telemetry when isError is true', () => {
+        const { toolStatus, callDiagnostics } = extractToolTelemetry(
+            {
+                isError: true,
+                toolTelemetry: {
+                    toolStatus: TOOL_STATUS.SOFT_FAIL,
+                    failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                },
+            },
+            undefined,
+            undefined,
+        );
+
+        expect(toolStatus).toBe(TOOL_STATUS.SOFT_FAIL);
+        expect(callDiagnostics.failure_category).toBe(FAILURE_CATEGORY.INVALID_INPUT);
     });
 
     it('returns SUCCEEDED when no error signals', () => {


### PR DESCRIPTION
## Summary

`extractToolTelemetry` now defaults an `isError: true` response without explicit telemetry to `FAILED` instead of `SOFT_FAIL`. The previous default paired `SOFT_FAIL` ("user error") with `failure_category: INTERNAL_ERROR` ("server fault"), which is an incoherent combination.

## Why this matters

As described in #936, `buildPermissionApprovalResponse` and several `server.ts` paths fall into the no-telemetry branch today, so Segment receives events that claim a user error caused by an internal server problem. Flipping the default to `FAILED + INTERNAL_ERROR` keeps unclassified errors visible as server failures to investigate, and any caller that means `SOFT_FAIL` can still say so explicitly via `toolTelemetry.toolStatus` (that path is untouched and now covered by a test).

## Changes

- The default branch in `src/utils/tool_status.ts:118-126` returns `TOOL_STATUS.FAILED`; explicit telemetry still wins (resolution order unchanged, doc comment updated to match).

## Testing

- Updated the existing default-branch unit test to assert `FAILED + INTERNAL_ERROR`, written test-first against the old behavior.
- Added a regression test asserting explicit `toolTelemetry` (`SOFT_FAIL + INVALID_INPUT`) is preserved when `isError` is true.
- `pnpm format:check`, `pnpm lint`, `pnpm type-check`, and `pnpm test:unit` (828 passed, 2 skipped) all clean locally.

Fixes #936
