### PR TITLE
fix: Expose stdio CLI version

### DIFF
--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -39,6 +39,7 @@ import type { ApifyRequestParams, Input, ServerModeOption, TelemetryEnv, ToolSel
 import { isApiTokenRequired } from './utils/auth.js';
 import { parseCommaSeparatedList } from './utils/generic.js';
 import { parseServerMode } from './utils/server_mode.js';
+import { getPackageVersion } from './utils/version.js';
 
 // Keeping this type here and not types.ts since
 // it is only relevant to the CLI/STDIO transport in this file
@@ -82,6 +83,7 @@ function getTokenFromAuthFile(): string | undefined {
 
 // Configure logging, set to ERROR
 log.setLevel(log.LEVELS.ERROR);
+const packageVersion = getPackageVersion() ?? '0.0.0';
 
 // Parse command line arguments using yargs
 const argv = yargs(hideBin(process.argv))
@@ -144,7 +146,7 @@ Only used when --telemetry-enabled is true`,
     })
     .help('help')
     .alias('h', 'help')
-    .version(false)
+    .version(packageVersion)
     .epilogue(
         'To connect, set your MCP client server command to `npx @apify/actors-mcp-server`' +
             ' and set the environment variable `APIFY_TOKEN` to your Apify API token.\n',


### PR DESCRIPTION
## Summary
- expose the stdio CLI top-level --version flag from package.json
- keep normal stdio startup behavior unchanged

## Why
The published @apify/actors-mcp-server@0.10.12 binary exits during token validation when a user runs actors-mcp-server --version without APIFY_TOKEN. Version metadata should be available before server startup.

## Validation
- npm view @apify/actors-mcp-server version -> 0.10.12
- env -u APIFY_TOKEN ./node_modules/.bin/actors-mcp-server --version exits 1 on the published package
- npx --yes pnpm@11.1.3 -C /tmp/automoney-apify run build:core
- env -u APIFY_TOKEN node dist/stdio.js --help exits 0
- env -u APIFY_TOKEN node dist/stdio.js --version exits 0 and prints 0.10.13
- git diff --check