### PR TITLE
feat: Add structured output to remaining storage tools

### DIFF
--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -5,7 +5,8 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { storageListOutputSchema } from '../structured_output_schemas.js';
+import { buildStorageListSummaryNextStep, buildStorageResponse } from './storage_helpers.js';
 
 const getUserDatasetsListArgs = z.object({
     offset: z
@@ -49,6 +50,7 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
         - user_input: List my last 10 datasets (newest first)
         - user_input: List unnamed datasets`,
     inputSchema: z.toJSONSchema(getUserDatasetsListArgs) as ToolInputSchema,
+    outputSchema: storageListOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getUserDatasetsListArgs)),
     annotations: {
         title: 'Get user datasets list',
@@ -66,6 +68,18 @@ export const getUserDatasetsList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: wrapJsonText(datasets) }] };
+        const { summary, nextStep } = buildStorageListSummaryNextStep({
+            count: datasets.items.length,
+            total: datasets.total,
+            offset: datasets.offset,
+            noun: 'datasets',
+            listToolName: HelperTools.DATASET_LIST_GET,
+            inspectHint: `Use ${HelperTools.DATASET_GET} with a datasetId from the list to inspect a dataset.`,
+        });
+        return buildStorageResponse({
+            structuredContent: datasets as unknown as Record<string, unknown>,
+            summary,
+            nextStep,
+        });
     },
 } as const);

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -61,7 +61,7 @@ export const getDataset: ToolEntry = Object.freeze({
         const normalized = dataset.fields ? { ...dataset, fields: normalizeDatasetFields(dataset.fields) } : dataset;
         const fieldCount = Array.isArray(normalized.fields) ? normalized.fields.length : undefined;
         const summary = `Dataset '${normalized.name ?? datasetId}' has ${normalized.itemCount ?? 0} items${fieldCount !== undefined ? `, ${fieldCount} fields` : ''}.`;
-        const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to fetch items.`;
+        const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to fetch items.`;
         return buildStorageResponse({
             structuredContent: normalized as unknown as Record<string, unknown>,
             summary,

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -59,8 +59,8 @@ export const getDataset: ToolEntry = Object.freeze({
         // normalization `buildRunDataset` applies so this tool's `fields` matches
         // the structured `storages.datasets.default.fields` shape.
         const normalized = dataset.fields ? { ...dataset, fields: normalizeDatasetFields(dataset.fields) } : dataset;
-        const fieldCount = Array.isArray(normalized.fields) ? normalized.fields.length : 0;
-        const summary = `Dataset '${normalized.name ?? datasetId}' has ${normalized.itemCount ?? 0} items, ${fieldCount} fields.`;
+const fieldCount = Array.isArray(normalized.fields) ? normalized.fields.length : undefined;
+const summary = `Dataset '${normalized.name ?? datasetId}' has ${normalized.itemCount ?? 0} items${fieldCount !== undefined ? `, ${fieldCount} fields` : ''}.`;
         const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to fetch items.`;
         return buildStorageResponse({
             structuredContent: normalized as unknown as Record<string, unknown>,

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -6,9 +6,9 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { wrapJsonText } from '../../utils/mcp.js';
 import { normalizeDatasetFields } from '../core/actor_run_response.js';
-import { buildStorageNotFound } from './storage_helpers.js';
+import { datasetMetadataOutputSchema } from '../structured_output_schemas.js';
+import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
 
 const getDatasetArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
@@ -33,6 +33,7 @@ export const getDataset: ToolEntry = Object.freeze({
         - user_input: Show info for dataset xyz123
         - user_input: What fields does username~my-dataset have?`,
     inputSchema: z.toJSONSchema(getDatasetArgs) as ToolInputSchema,
+    outputSchema: datasetMetadataOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getDatasetArgs)),
     paymentRequired: true,
     annotations: {
@@ -58,6 +59,13 @@ export const getDataset: ToolEntry = Object.freeze({
         // normalization `buildRunDataset` applies so this tool's `fields` matches
         // the structured `storages.datasets.default.fields` shape.
         const normalized = dataset.fields ? { ...dataset, fields: normalizeDatasetFields(dataset.fields) } : dataset;
-        return { content: [{ type: 'text', text: wrapJsonText(normalized) }] };
+        const fieldCount = Array.isArray(normalized.fields) ? normalized.fields.length : 0;
+        const summary = `Dataset '${normalized.name ?? datasetId}' has ${normalized.itemCount ?? 0} items, ${fieldCount} fields.`;
+        const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to fetch items.`;
+        return buildStorageResponse({
+            structuredContent: normalized as unknown as Record<string, unknown>,
+            summary,
+            nextStep,
+        });
     },
 } as const);

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -8,36 +8,8 @@ import { compileSchema } from '../../utils/ajv.js';
 import { parseCommaSeparatedList, stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
-import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
-
+import { buildStorageNotFound, buildStorageResponse, buildDatasetItemsSummaryNextStep } from './storage_helpers.js';
 const DEFAULT_DATASET_ITEMS_LIMIT = 20;
-
-/**
- * Pagination-aware {summary, nextStep}: when more items remain, point at the next page;
- * otherwise point at get-dataset-schema for structure inspection.
- */
-function buildDatasetItemsSummaryNextStep(params: {
-    datasetId: string;
-    itemCount: number;
-    totalItemCount: number;
-    offset: number;
-}): { summary: string; nextStep: string } {
-    const { datasetId, itemCount, totalItemCount, offset } = params;
-    if (offset + itemCount < totalItemCount) {
-        return {
-            summary: `Fetched ${itemCount} of ${totalItemCount} items (offset=${offset}).`,
-            nextStep: `Call ${HelperTools.DATASET_GET_ITEMS} again with offset=${offset + itemCount} to fetch the next page.`,
-        };
-    }
-    const summary =
-        offset === 0 && itemCount === totalItemCount
-            ? `Fetched all ${itemCount} items.`
-            : `Fetched ${itemCount} of ${totalItemCount} items (offset=${offset}); no more pages.`;
-    return {
-        summary,
-        nextStep: `Use ${HelperTools.DATASET_SCHEMA_GET} with datasetId=${datasetId} to inspect structure if needed.`,
-    };
-}
 
 /** Top-level dot prefixes of `fields`. Apify's `flatten` recurses, so the first segment suffices. */
 export function extractDotPrefixes(fields: string[]): string[] {

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -7,11 +7,37 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { parseCommaSeparatedList, stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { wrapJsonText } from '../../utils/mcp.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
-import { buildStorageNotFound } from './storage_helpers.js';
+import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
 
 const DEFAULT_DATASET_ITEMS_LIMIT = 20;
+
+/**
+ * Pagination-aware {summary, nextStep}: when more items remain, point at the next page;
+ * otherwise point at get-dataset-schema for structure inspection.
+ */
+function buildDatasetItemsSummaryNextStep(params: {
+    datasetId: string;
+    itemCount: number;
+    totalItemCount: number;
+    offset: number;
+}): { summary: string; nextStep: string } {
+    const { datasetId, itemCount, totalItemCount, offset } = params;
+    if (offset + itemCount < totalItemCount) {
+        return {
+            summary: `Fetched ${itemCount} of ${totalItemCount} items (offset=${offset}).`,
+            nextStep: `Call ${HelperTools.DATASET_GET_ITEMS} again with offset=${offset + itemCount} to fetch the next page.`,
+        };
+    }
+    const summary =
+        offset === 0 && itemCount === totalItemCount
+            ? `Fetched all ${itemCount} items.`
+            : `Fetched ${itemCount} of ${totalItemCount} items (offset=${offset}); no more pages.`;
+    return {
+        summary,
+        nextStep: `Use ${HelperTools.DATASET_SCHEMA_GET} with datasetId=${datasetId} to inspect structure if needed.`,
+    };
+}
 
 /** Top-level dot prefixes of `fields`. Apify's `flatten` recurses, so the first segment suffices. */
 export function extractDotPrefixes(fields: string[]): string[] {
@@ -124,15 +150,22 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             return buildStorageNotFound(`Dataset '${datasetId}' not found.`);
         }
 
+        const offset = parsed.offset ?? 0;
         const structuredContent = {
             datasetId,
             items: v.items,
             itemCount: v.items.length,
             totalItemCount: v.total,
-            offset: parsed.offset ?? 0,
+            offset,
             limit: effectiveLimit,
         };
 
-        return { content: [{ type: 'text', text: wrapJsonText(v) }], structuredContent };
+        const { summary, nextStep } = buildDatasetItemsSummaryNextStep({
+            datasetId,
+            itemCount: v.items.length,
+            totalItemCount: v.total,
+            offset,
+        });
+        return buildStorageResponse({ structuredContent, summary, nextStep });
     },
 } as const);

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -7,9 +7,10 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { buildMCPResponse, wrapJsonText } from '../../utils/mcp.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
-import { buildStorageNotFound } from './storage_helpers.js';
+import { datasetSchemaOutputSchema } from '../structured_output_schemas.js';
+import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
 
 const getDatasetSchemaArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
@@ -43,6 +44,7 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
         - user_input: Generate schema for dataset 34das2 using 10 items
         - user_input: Show schema of username~my-dataset (clean items only)`,
     inputSchema: z.toJSONSchema(getDatasetSchemaArgs) as ToolInputSchema,
+    outputSchema: datasetSchemaOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getDatasetSchemaArgs)),
     paymentRequired: true,
     annotations: {
@@ -94,6 +96,9 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
             });
         }
 
-        return { content: [{ type: 'text', text: wrapJsonText(schema) }] };
+        const fieldCount = Object.keys(schema.items.properties ?? {}).length;
+        const summary = `Schema inferred from ${datasetItems.length} ${datasetItems.length === 1 ? 'item' : 'items'}, ${fieldCount} ${fieldCount === 1 ? 'field' : 'fields'}.`;
+        const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and fields="..." to project specific fields.`;
+        return buildStorageResponse({ structuredContent: { datasetId, schema }, summary, nextStep });
     },
 } as const);

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -78,7 +78,11 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
         const datasetItems = datasetResponse.items;
 
         if (datasetItems.length === 0) {
-            return { content: [{ type: 'text', text: `Dataset '${datasetId}' is empty.` }] };
+            // Empty dataset: no items to infer from, but still emit a schema-conforming
+            // response (empty schema = "any") rather than bare text.
+            const summary = `Dataset '${datasetId}' is empty; no schema to infer.`;
+            const nextStep = `Use ${HelperTools.DATASET_GET} with datasetId=${datasetId} to check itemCount and stats.`;
+            return buildStorageResponse({ structuredContent: { datasetId, schema: {} }, summary, nextStep });
         }
 
         // Generate schema using the shared utility

--- a/src/tools/common/get_key_value_store.ts
+++ b/src/tools/common/get_key_value_store.ts
@@ -6,8 +6,8 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { wrapJsonText } from '../../utils/mcp.js';
-import { buildStorageNotFound } from './storage_helpers.js';
+import { keyValueStoreOutputSchema } from '../structured_output_schemas.js';
+import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
 
 const getKeyValueStoreArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -30,6 +30,7 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
         - user_input: Show info for key-value store username~my-store
         - user_input: Get details for store adb123`,
     inputSchema: z.toJSONSchema(getKeyValueStoreArgs) as ToolInputSchema,
+    outputSchema: keyValueStoreOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getKeyValueStoreArgs)),
     paymentRequired: true,
     annotations: {
@@ -47,6 +48,13 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
         if (!kvStore) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: wrapJsonText(kvStore) }] };
+        const bytes = (kvStore.stats as { storageBytes?: number } | undefined)?.storageBytes;
+        const summary = `Key-value store '${kvStore.name ?? keyValueStoreId}'${bytes !== undefined ? ` holds ${bytes} bytes` : ''}.`;
+        const nextStep = `Use ${HelperTools.KEY_VALUE_STORE_KEYS_GET} with keyValueStoreId=${keyValueStoreId} to list keys.`;
+        return buildStorageResponse({
+            structuredContent: kvStore as unknown as Record<string, unknown>,
+            summary,
+            nextStep,
+        });
     },
 } as const);

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -7,8 +7,8 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { wrapJsonText } from '../../utils/mcp.js';
-import { buildStorageNotFound } from './storage_helpers.js';
+import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
+import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
 
 const getKeyValueStoreKeysArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -37,6 +37,7 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         - user_input: List first 10 keys in store username~my-store
         - user_input: Continue listing keys in store a123 from key data.json`,
     inputSchema: z.toJSONSchema(getKeyValueStoreKeysArgs) as ToolInputSchema,
+    outputSchema: keyValueStoreKeysOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getKeyValueStoreKeysArgs)),
     paymentRequired: true,
     annotations: {
@@ -64,6 +65,16 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         if (!keys) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        return { content: [{ type: 'text', text: wrapJsonText(keys) }] };
+        const n = keys.items.length;
+        const summary = `Listed ${n} ${n === 1 ? 'key' : 'keys'}${keys.isTruncated ? ' (more available)' : ''}.`;
+        const firstKey = keys.items[0]?.key;
+        const nextStep = firstKey
+            ? `Use ${HelperTools.KEY_VALUE_STORE_RECORD_GET} with keyValueStoreId=${keyValueStoreId} and recordKey=${firstKey} to read a value.`
+            : `Use ${HelperTools.KEY_VALUE_STORE_GET} with keyValueStoreId=${keyValueStoreId} to inspect the store.`;
+        return buildStorageResponse({
+            structuredContent: { keyValueStoreId, ...keys },
+            summary,
+            nextStep,
+        });
     },
 } as const);

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -8,7 +8,7 @@ import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
 import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
-import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
+import { buildKvsKeysSummaryNextStep, buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
 
 const getKeyValueStoreKeysArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -65,12 +65,13 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         if (!keys) {
             return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
         }
-        const n = keys.items.length;
-        const summary = `Listed ${n} ${n === 1 ? 'key' : 'keys'}${keys.isTruncated ? ' (more available)' : ''}.`;
-        const firstKey = keys.items[0]?.key;
-        const nextStep = firstKey
-            ? `Use ${HelperTools.KEY_VALUE_STORE_RECORD_GET} with keyValueStoreId=${keyValueStoreId} and recordKey=${firstKey} to read a value.`
-            : `Use ${HelperTools.KEY_VALUE_STORE_GET} with keyValueStoreId=${keyValueStoreId} to inspect the store.`;
+        const { summary, nextStep } = buildKvsKeysSummaryNextStep({
+            keyValueStoreId,
+            count: keys.items.length,
+            isTruncated: keys.isTruncated,
+            nextExclusiveStartKey: keys.nextExclusiveStartKey,
+            firstKey: keys.items[0]?.key,
+        });
         return buildStorageResponse({
             structuredContent: { keyValueStoreId, ...keys },
             summary,

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -9,7 +9,6 @@ import { computeValueBytes, stripQuoteWrappers } from '../../utils/generic.js';
 import { keyValueStoreRecordOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound, buildStorageResponse, normalizeRecordKey } from './storage_helpers.js';
 
-
 const getKeyValueStoreRecordArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
     recordKey: z.string().min(1).describe('Key of the record to retrieve.'),

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -5,20 +5,10 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { stripQuoteWrappers } from '../../utils/generic.js';
+import { computeValueBytes, stripQuoteWrappers } from '../../utils/generic.js';
 import { keyValueStoreRecordOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageNotFound, buildStorageResponse, normalizeRecordKey } from './storage_helpers.js';
 
-/** Best-effort byte size of a stored value for the summary. */
-function computeValueBytes(value: unknown): number | undefined {
-    if (Buffer.isBuffer(value)) return value.length;
-    if (typeof value === 'string') return Buffer.byteLength(value);
-    try {
-        return Buffer.byteLength(JSON.stringify(value));
-    } catch {
-        return undefined;
-    }
-}
 
 const getKeyValueStoreRecordArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -6,8 +6,19 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { wrapJsonText } from '../../utils/mcp.js';
-import { buildStorageNotFound, normalizeRecordKey } from './storage_helpers.js';
+import { keyValueStoreRecordOutputSchema } from '../structured_output_schemas.js';
+import { buildStorageNotFound, buildStorageResponse, normalizeRecordKey } from './storage_helpers.js';
+
+/** Best-effort byte size of a stored value for the summary. */
+function computeValueBytes(value: unknown): number | undefined {
+    if (Buffer.isBuffer(value)) return value.length;
+    if (typeof value === 'string') return Buffer.byteLength(value);
+    try {
+        return Buffer.byteLength(JSON.stringify(value));
+    } catch {
+        return undefined;
+    }
+}
 
 const getKeyValueStoreRecordArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -31,6 +42,7 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
         - user_input: Get record INPUT from store abc123
         - user_input: Get record data.json from store username~my-store`,
     inputSchema: z.toJSONSchema(getKeyValueStoreRecordArgs) as ToolInputSchema,
+    outputSchema: keyValueStoreRecordOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getKeyValueStoreRecordArgs)),
     paymentRequired: true,
     annotations: {
@@ -55,6 +67,13 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
                 : `Key-value store '${keyValueStoreId}' not found.`;
             return buildStorageNotFound(text);
         }
-        return { content: [{ type: 'text', text: wrapJsonText(record) }] };
+        const bytes = computeValueBytes(record.value);
+        const details = [
+            record.contentType ? `contentType=${record.contentType}` : undefined,
+            bytes !== undefined ? `${bytes} bytes` : undefined,
+        ].filter(Boolean);
+        const summary = `Read '${recordKey}'${details.length ? ` (${details.join(', ')})` : ''}.`;
+        // Reading a record is terminal — no nextStep.
+        return buildStorageResponse({ structuredContent: { keyValueStoreId, ...record }, summary });
     },
 } as const);

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -5,7 +5,8 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { wrapJsonText } from '../../utils/mcp.js';
+import { storageListOutputSchema } from '../structured_output_schemas.js';
+import { buildStorageListSummaryNextStep, buildStorageResponse } from './storage_helpers.js';
 
 const getUserKeyValueStoresListArgs = z.object({
     offset: z
@@ -51,6 +52,7 @@ export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
         - user_input: List my last 10 key-value stores (newest first)
         - user_input: List unnamed key-value stores`,
     inputSchema: z.toJSONSchema(getUserKeyValueStoresListArgs) as ToolInputSchema,
+    outputSchema: storageListOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getUserKeyValueStoresListArgs)),
     annotations: {
         title: 'Get user key-value stores list',
@@ -68,6 +70,18 @@ export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
             desc: parsed.desc,
             unnamed: parsed.unnamed,
         });
-        return { content: [{ type: 'text', text: wrapJsonText(stores) }] };
+        const { summary, nextStep } = buildStorageListSummaryNextStep({
+            count: stores.items.length,
+            total: stores.total,
+            offset: stores.offset,
+            noun: 'key-value stores',
+            listToolName: HelperTools.KEY_VALUE_STORE_LIST_GET,
+            inspectHint: `Use ${HelperTools.KEY_VALUE_STORE_GET} with a keyValueStoreId from the list to inspect a store.`,
+        });
+        return buildStorageResponse({
+            structuredContent: stores as unknown as Record<string, unknown>,
+            summary,
+            nextStep,
+        });
     },
 } as const);

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -1,5 +1,4 @@
-import { FAILURE_CATEGORY, TOOL_STATUS } from '../../const.js';
-import { HelperTools } from '../../const.js';
+import { FAILURE_CATEGORY, TOOL_STATUS, HelperTools } from '../../const.js';
 import { encodeToon } from '../../utils/encode_text.js';
 import { QUOTE_WRAPPER_CHARS } from '../../utils/generic.js';
 import { buildMCPResponse } from '../../utils/mcp.js';

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -18,14 +18,15 @@ export function buildStorageNotFound(text: string) {
 
 /**
  * Build a storage tool response, mirroring `actor_run_response.ts`:
- * `structuredContent` carries the data plus `summary` (and `nextStep` unless terminal);
- * `content[0]` is the encoded dump of `structuredContent` (spec compat for clients that read
- * `content[]`), `content[1]` is the human-readable `summary`/`nextStep`.
+ * `structuredContent` carries the data plus `summary` (and `nextStep` unless terminal).
  * `nextStep` is omitted for terminal responses (e.g. get-key-value-store-record).
  *
- * `toon: true` TOON-encodes `content[0]` (token-cheaper for the uniform-row arrays the list
- * tools return); single-object tools leave it off and ship raw JSON. Either way `structuredContent`
- * is the lossless source of truth — programmatic consumers read it, not `content[0]`.
+ * `toon: true` (the list tools) emits a single text: the data TOON-encoded in a ```toon fence
+ * (token-cheaper for uniform-row arrays; `summary`/`nextStep` are prose, not tabular, so they
+ * stay out of the fence) followed by `summary`/`nextStep` as plain text. Single-object tools
+ * leave it off and ship `content[0]` as the raw-JSON dump of `structuredContent` plus
+ * `content[1]` with `summary`/`nextStep`. Either way `structuredContent` is the lossless source
+ * of truth — programmatic consumers read it, not `content[]`.
  */
 export function buildStorageResponse(params: {
     structuredContent: Record<string, unknown>;
@@ -35,11 +36,11 @@ export function buildStorageResponse(params: {
 }) {
     const { structuredContent, summary, nextStep, toon } = params;
     const full = { ...structuredContent, summary, ...(nextStep !== undefined && { nextStep }) };
+    const summaryText = nextStep !== undefined ? `${summary}\n${nextStep}` : summary;
     return buildMCPResponse({
-        texts: [
-            toon ? encodeToon(full) : JSON.stringify(full),
-            nextStep !== undefined ? `${summary}\n${nextStep}` : summary,
-        ],
+        texts: toon
+            ? [`${encodeToon(structuredContent)}\n\n${summaryText}`]
+            : [JSON.stringify(full), summaryText],
         structuredContent: full,
     });
 }

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -1,8 +1,8 @@
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../const.js';
+import { HelperTools } from '../../const.js';
 import { encodeToon } from '../../utils/encode_text.js';
 import { QUOTE_WRAPPER_CHARS } from '../../utils/generic.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
-import { HelperTools } from '../../const.js';
 
 /**
  * Soft-fail not-found response for storage tools. Centralizes
@@ -39,9 +39,7 @@ export function buildStorageResponse(params: {
     const full = { ...structuredContent, summary, ...(nextStep !== undefined && { nextStep }) };
     const summaryText = nextStep !== undefined ? `${summary}\n${nextStep}` : summary;
     return buildMCPResponse({
-        texts: toon
-            ? [`${encodeToon(structuredContent)}\n\n${summaryText}`]
-            : [JSON.stringify(full), summaryText],
+        texts: toon ? [`${encodeToon(structuredContent)}\n\n${summaryText}`] : [JSON.stringify(full), summaryText],
         structuredContent: full,
     });
 }

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -39,7 +39,7 @@ export function buildStorageResponse(params: {
     const full = { ...structuredContent, summary, ...(nextStep !== undefined && { nextStep }) };
     const summaryText = nextStep !== undefined ? `${summary}\n${nextStep}` : summary;
     return buildMCPResponse({
-        texts: toon ? [`${encodeToon(structuredContent)}\n\n${summaryText}`] : [JSON.stringify(full), summaryText],
+        texts: toon ? [encodeToon(structuredContent), summaryText] : [JSON.stringify(full), summaryText],
         structuredContent: full,
     });
 }

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -38,7 +38,7 @@ export function buildStorageResponse(params: {
     const full = { ...structuredContent, summary, ...(nextStep !== undefined && { nextStep }) };
     const summaryText = nextStep !== undefined ? `${summary}\n${nextStep}` : summary;
     return buildMCPResponse({
-        texts: toon ? [encodeToon(structuredContent), summaryText] : [JSON.stringify(full), summaryText],
+        texts: toon ? [encodeToon(structuredContent), summaryText] : [JSON.stringify(structuredContent), summaryText],
         structuredContent: full,
     });
 }

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -96,6 +96,34 @@ export function buildDatasetItemsSummaryNextStep(params: {
 }
 
 /**
+ * {summary, nextStep} for cursor-paginated key-value store key listings.
+ * When truncated, nextStep points at the next page; otherwise at inspecting a record or the store.
+ */
+export function buildKvsKeysSummaryNextStep(params: {
+    keyValueStoreId: string;
+    count: number;
+    isTruncated: boolean;
+    nextExclusiveStartKey?: string;
+    firstKey?: string;
+}): { summary: string; nextStep: string } {
+    const { keyValueStoreId, count, isTruncated, nextExclusiveStartKey, firstKey } = params;
+    const noun = count === 1 ? 'key' : 'keys';
+    const summary = `Listed ${count} ${noun}${isTruncated ? ' (more available)' : ''}.`;
+    if (isTruncated && nextExclusiveStartKey) {
+        return {
+            summary,
+            nextStep: `Call ${HelperTools.KEY_VALUE_STORE_KEYS_GET} again with exclusiveStartKey=${nextExclusiveStartKey} to fetch the next page.`,
+        };
+    }
+    return {
+        summary,
+        nextStep: firstKey
+            ? `Use ${HelperTools.KEY_VALUE_STORE_RECORD_GET} with keyValueStoreId=${keyValueStoreId} and recordKey=${firstKey} to read a value.`
+            : `Use ${HelperTools.KEY_VALUE_STORE_GET} with keyValueStoreId=${keyValueStoreId} to inspect the store.`,
+    };
+}
+
+/**
  * Normalize a key-value store record key before SDK lookup.
  *
  * Strips the same LLM-leaked wrapper chars as `stripQuoteWrappers` (shared

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -2,6 +2,7 @@ import { FAILURE_CATEGORY, TOOL_STATUS } from '../../const.js';
 import { encodeToon } from '../../utils/encode_text.js';
 import { QUOTE_WRAPPER_CHARS } from '../../utils/generic.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
+import { HelperTools } from '../../const.js';
 
 /**
  * Soft-fail not-found response for storage tools. Centralizes
@@ -64,6 +65,33 @@ export function buildStorageListSummaryNextStep(params: {
             offset + count < total
                 ? `Call ${listToolName} again with offset=${offset + count} to fetch the next page.`
                 : inspectHint,
+    };
+}
+
+/**
+ * Pagination-aware {summary, nextStep}: when more items remain, point at the next page;
+ * otherwise point at get-dataset-schema for structure inspection.
+ */
+export function buildDatasetItemsSummaryNextStep(params: {
+    datasetId: string;
+    itemCount: number;
+    totalItemCount: number;
+    offset: number;
+}): { summary: string; nextStep: string } {
+    const { datasetId, itemCount, totalItemCount, offset } = params;
+    if (offset + itemCount < totalItemCount) {
+        return {
+            summary: `Fetched ${itemCount} of ${totalItemCount} items (offset=${offset}).`,
+            nextStep: `Call ${HelperTools.DATASET_GET_ITEMS} again with offset=${offset + itemCount} to fetch the next page.`,
+        };
+    }
+    const summary =
+        offset === 0 && itemCount === totalItemCount
+            ? `Fetched all ${itemCount} items.`
+            : `Fetched ${itemCount} of ${totalItemCount} items (offset=${offset}); no more pages.`;
+    return {
+        summary,
+        nextStep: `Use ${HelperTools.DATASET_SCHEMA_GET} with datasetId=${datasetId} to inspect structure if needed.`,
     };
 }
 

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -16,6 +16,26 @@ export function buildStorageNotFound(text: string) {
 }
 
 /**
+ * Build a storage tool response, mirroring `actor_run_response.ts`:
+ * `structuredContent` carries the data plus `summary` (and `nextStep` unless terminal);
+ * `content[0]` is the JSON dump of `structuredContent` (spec compat for clients that read
+ * `content[]`), `content[1]` is the human-readable `summary`/`nextStep`.
+ * `nextStep` is omitted for terminal responses (e.g. get-key-value-store-record).
+ */
+export function buildStorageResponse(params: {
+    structuredContent: Record<string, unknown>;
+    summary: string;
+    nextStep?: string;
+}) {
+    const { structuredContent, summary, nextStep } = params;
+    const full = { ...structuredContent, summary, ...(nextStep !== undefined && { nextStep }) };
+    return buildMCPResponse({
+        texts: [JSON.stringify(full), nextStep !== undefined ? `${summary}\n${nextStep}` : summary],
+        structuredContent: full,
+    });
+}
+
+/**
  * Normalize a key-value store record key before SDK lookup.
  *
  * Strips the same LLM-leaked wrapper chars as `stripQuoteWrappers` (shared

--- a/src/tools/common/storage_helpers.ts
+++ b/src/tools/common/storage_helpers.ts
@@ -36,6 +36,28 @@ export function buildStorageResponse(params: {
 }
 
 /**
+ * {summary, nextStep} for paginated storage listings (datasets, key-value stores).
+ * When more items remain, nextStep points at the next page; otherwise at inspecting an entry.
+ */
+export function buildStorageListSummaryNextStep(params: {
+    count: number;
+    total: number;
+    offset: number;
+    noun: string;
+    listToolName: string;
+    inspectHint: string;
+}): { summary: string; nextStep: string } {
+    const { count, total, offset, noun, listToolName, inspectHint } = params;
+    return {
+        summary: `Listed ${count} of ${total} ${noun}.`,
+        nextStep:
+            offset + count < total
+                ? `Call ${listToolName} again with offset=${offset + count} to fetch the next page.`
+                : inspectHint,
+    };
+}
+
+/**
  * Normalize a key-value store record key before SDK lookup.
  *
  * Strips the same LLM-leaked wrapper chars as `stripQuoteWrappers` (shared

--- a/src/tools/core/actor_run_response.ts
+++ b/src/tools/core/actor_run_response.ts
@@ -376,7 +376,7 @@ function buildSucceededSummaryNextStep(
         const fields = dataset?.fields ?? [];
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. ${itemCount} ${itemCount === 1 ? 'item' : 'items'}; ${fields.length} fields available.${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to fetch items (${itemCount} total).${fieldsProjectionHint(fields)}`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to fetch items (${itemCount} total).${fieldsProjectionHint(fields)}`,
         };
     }
 
@@ -385,7 +385,7 @@ function buildSucceededSummaryNextStep(
     if (itemCount === undefined && datasetId) {
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. Dataset metadata unavailable.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to inspect output.`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to inspect output.`,
         };
     }
 
@@ -394,7 +394,7 @@ function buildSucceededSummaryNextStep(
     if (itemCount === 0 && datasetId) {
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. No dataset items found.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to verify output (metadata reports 0 items).${fieldsProjectionHint(dataset?.fields)}`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to verify output (metadata reports 0 items).${fieldsProjectionHint(dataset?.fields)}`,
         };
     }
 
@@ -423,7 +423,7 @@ function buildTimedOutSummaryNextStep(
         const fields = dataset?.fields ?? [];
         return {
             summary: `TIMED-OUT after ${runTimeSecs}s.${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit=20 to fetch any partial output (${itemCount} ${itemCount === 1 ? 'item' : 'items'} written). Available fields: ${fields.length > 0 ? fields.join(', ') : 'none'}.`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to fetch any partial output (${itemCount} ${itemCount === 1 ? 'item' : 'items'} written). Available fields: ${fields.length > 0 ? fields.join(', ') : 'none'}.`,
         };
     }
 

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -488,3 +488,60 @@ export const datasetItemsOutputSchema = {
     // offset/limit/totalItemCount and summary/nextStep are always emitted by the tool.
     required: ['datasetId', 'items', 'itemCount', 'totalItemCount', 'offset', 'limit', 'summary', 'nextStep'],
 };
+
+/**
+ * Schema for dataset metadata (get-dataset). Documents the fields the LLM acts on; the raw API
+ * response carries more keys (stats, schema, access settings), allowed as additional properties.
+ */
+export const datasetMetadataOutputSchema = {
+    type: 'object' as const,
+    properties: {
+        id: { type: 'string', description: 'Dataset ID' },
+        name: { type: 'string', description: 'Dataset name (null for unnamed datasets)' },
+        itemCount: { type: 'number', description: 'Number of items in the dataset' },
+        fields: {
+            type: 'array' as const,
+            items: { type: 'string' },
+            description: 'Field paths in dot notation (e.g. ["metadata.url"])',
+        },
+        summary: summaryProperty,
+        nextStep: nextStepProperty,
+    },
+    required: ['id', 'summary', 'nextStep'],
+};
+
+/**
+ * Schema for dataset schema inference (get-dataset-schema).
+ */
+export const datasetSchemaOutputSchema = {
+    type: 'object' as const,
+    properties: {
+        datasetId: { type: 'string', description: 'Dataset ID' },
+        schema: { type: 'object' as const, description: 'Inferred JSON schema describing dataset item structure' },
+        summary: summaryProperty,
+        nextStep: nextStepProperty,
+    },
+    required: ['datasetId', 'schema', 'summary', 'nextStep'],
+};
+
+/**
+ * Schema for storage collection listings (get-dataset-list, get-key-value-store-list).
+ * Mirrors the Apify paginated-list response shape plus the narrative fields.
+ */
+export const storageListOutputSchema = {
+    type: 'object' as const,
+    properties: {
+        total: { type: 'number', description: 'Total number of items available for the user' },
+        count: { type: 'number', description: 'Number of items returned in this page' },
+        offset: { type: 'number', description: 'Offset used for pagination' },
+        limit: { type: 'number', description: 'Limit used for pagination' },
+        items: {
+            type: 'array' as const,
+            items: { type: 'object' as const },
+            description: 'Storage metadata objects',
+        },
+        summary: summaryProperty,
+        nextStep: nextStepProperty,
+    },
+    required: ['items', 'total', 'count', 'summary', 'nextStep'],
+};

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -458,6 +458,17 @@ export function buildEnrichedDirectActorOutputSchema(itemProperties: Record<stri
     return clone;
 }
 
+/** Past-tense state summary; emitted by every storage tool. */
+export const summaryProperty = {
+    type: 'string' as const,
+    description: 'Past-tense summary of the result with concrete numbers.',
+};
+/** One primary follow-up action with identifiers interpolated; emitted by every non-terminal storage tool. */
+export const nextStepProperty = {
+    type: 'string' as const,
+    description: 'One primary follow-up action with tool name, identifier, and a specific param value.',
+};
+
 /**
  * Schema for dataset items retrieval tools (get-dataset-items).
  * Contains dataset items with pagination and count information.
@@ -471,6 +482,9 @@ export const datasetItemsOutputSchema = {
         totalItemCount: { type: 'number', description: 'Total items in dataset' },
         offset: { type: 'number', description: 'Offset used for pagination' },
         limit: { type: 'number', description: 'Limit used for pagination' },
+        summary: summaryProperty,
+        nextStep: nextStepProperty,
     },
-    required: ['datasetId', 'items', 'itemCount'],
+    // offset/limit/totalItemCount and summary/nextStep are always emitted by the tool.
+    required: ['datasetId', 'items', 'itemCount', 'totalItemCount', 'offset', 'limit', 'summary', 'nextStep'],
 };

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -593,7 +593,7 @@ export const storageListOutputSchema = {
         summary: summaryProperty,
         nextStep: nextStepProperty,
     },
-    required: ['items', 'total', 'count', 'summary', 'nextStep'],
+    required: ['items', 'total', 'count', 'offset', 'limit', 'summary', 'nextStep'],
 };
 
 /**
@@ -626,6 +626,7 @@ export const keyValueStoreKeysOutputSchema = {
                     key: { type: 'string', description: 'Record key' },
                     size: { type: 'number', description: 'Value size in bytes' },
                 },
+                required: ['key', 'size'],
             },
             description: 'Keys with value sizes',
         },
@@ -638,7 +639,7 @@ export const keyValueStoreKeysOutputSchema = {
         summary: summaryProperty,
         nextStep: nextStepProperty,
     },
-    required: ['keyValueStoreId', 'items', 'summary', 'nextStep'],
+    required: ['keyValueStoreId', 'items', 'count', 'isTruncated', 'nextExclusiveStartKey', 'summary', 'nextStep'],
 };
 
 /**

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -458,6 +458,17 @@ export function buildEnrichedDirectActorOutputSchema(itemProperties: Record<stri
     return clone;
 }
 
+/** Past-tense state summary; emitted by every storage tool. */
+export const summaryProperty = {
+    type: 'string' as const,
+    description: 'Summary of the result',
+};
+/** One primary follow-up action; emitted by every non-terminal storage tool. */
+export const nextStepProperty = {
+    type: 'string' as const,
+    description: 'One follow-up action with tool name',
+};
+
 /**
  * Schema for dataset items retrieval tools (get-dataset-items).
  * Contains dataset items with pagination and count information.
@@ -471,8 +482,8 @@ export const datasetItemsOutputSchema = {
         totalItemCount: { type: 'number', description: 'Total items in dataset' },
         offset: { type: 'number', description: 'Offset used for pagination' },
         limit: { type: 'number', description: 'Limit used for pagination' },
-        summary: { type: 'string' as const, description: 'Summary of the result' },
-        nextStep: { type: 'string' as const, description: 'One follow-up action with tool name' },
+        summary: summaryProperty,
+        nextStep: nextStepProperty,
     },
     // offset/limit/totalItemCount and summary/nextStep are always emitted by the tool.
     required: ['datasetId', 'items', 'itemCount', 'totalItemCount', 'offset', 'limit', 'summary', 'nextStep'],

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -545,3 +545,63 @@ export const storageListOutputSchema = {
     },
     required: ['items', 'total', 'count', 'summary', 'nextStep'],
 };
+
+/**
+ * Schema for key-value store metadata (get-key-value-store). The raw API response carries more
+ * keys (stats, access settings), allowed as additional properties.
+ */
+export const keyValueStoreOutputSchema = {
+    type: 'object' as const,
+    properties: {
+        id: { type: 'string', description: 'Key-value store ID' },
+        name: { type: 'string', description: 'Store name (null for unnamed stores)' },
+        summary: summaryProperty,
+        nextStep: nextStepProperty,
+    },
+    required: ['id', 'summary', 'nextStep'],
+};
+
+/**
+ * Schema for key listing (get-key-value-store-keys).
+ */
+export const keyValueStoreKeysOutputSchema = {
+    type: 'object' as const,
+    properties: {
+        keyValueStoreId: { type: 'string', description: 'Key-value store ID' },
+        items: {
+            type: 'array' as const,
+            items: {
+                type: 'object' as const,
+                properties: {
+                    key: { type: 'string', description: 'Record key' },
+                    size: { type: 'number', description: 'Value size in bytes' },
+                },
+            },
+            description: 'Keys with value sizes',
+        },
+        count: { type: 'number', description: 'Number of keys returned' },
+        isTruncated: { type: 'boolean', description: 'Whether more keys are available' },
+        nextExclusiveStartKey: {
+            type: 'string',
+            description: 'Pass as exclusiveStartKey to fetch the next page of keys',
+        },
+        summary: summaryProperty,
+        nextStep: nextStepProperty,
+    },
+    required: ['keyValueStoreId', 'items', 'summary', 'nextStep'],
+};
+
+/**
+ * Schema for a single record (get-key-value-store-record). Terminal: no nextStep.
+ */
+export const keyValueStoreRecordOutputSchema = {
+    type: 'object' as const,
+    properties: {
+        keyValueStoreId: { type: 'string', description: 'Key-value store ID' },
+        key: { type: 'string', description: 'Record key' },
+        value: { description: 'The stored value (JSON, text, or binary)' },
+        contentType: { type: 'string', description: 'MIME type of the stored value' },
+        summary: summaryProperty,
+    },
+    required: ['key', 'value', 'summary'],
+};

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -497,7 +497,7 @@ export const datasetMetadataOutputSchema = {
     type: 'object' as const,
     properties: {
         id: { type: 'string', description: 'Dataset ID' },
-        name: { type: 'string', description: 'Dataset name (null for unnamed datasets)' },
+        name: { type: ['string', 'null'], description: 'Dataset name (null for unnamed datasets)' },
         itemCount: { type: 'number', description: 'Number of items in the dataset' },
         fields: {
             type: 'array' as const,
@@ -554,7 +554,7 @@ export const keyValueStoreOutputSchema = {
     type: 'object' as const,
     properties: {
         id: { type: 'string', description: 'Key-value store ID' },
-        name: { type: 'string', description: 'Store name (null for unnamed stores)' },
+        name: { type: ['string', 'null'], description: 'Store name (null for unnamed stores)' },
         summary: summaryProperty,
         nextStep: nextStepProperty,
     },
@@ -603,5 +603,5 @@ export const keyValueStoreRecordOutputSchema = {
         contentType: { type: 'string', description: 'MIME type of the stored value' },
         summary: summaryProperty,
     },
-    required: ['key', 'value', 'summary'],
+    required: ['keyValueStoreId', 'key', 'value', 'summary'],
 };

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -582,8 +582,8 @@ export const keyValueStoreKeysOutputSchema = {
         count: { type: 'number', description: 'Number of keys returned' },
         isTruncated: { type: 'boolean', description: 'Whether more keys are available' },
         nextExclusiveStartKey: {
-            type: 'string',
-            description: 'Pass as exclusiveStartKey to fetch the next page of keys',
+            type: ['string', 'null'],
+            description: 'Pass as exclusiveStartKey to fetch the next page of keys; null when not truncated',
         },
         summary: summaryProperty,
         nextStep: nextStepProperty,

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -458,17 +458,6 @@ export function buildEnrichedDirectActorOutputSchema(itemProperties: Record<stri
     return clone;
 }
 
-/** Past-tense state summary; emitted by every storage tool. */
-export const summaryProperty = {
-    type: 'string' as const,
-    description: 'Past-tense summary of the result with concrete numbers.',
-};
-/** One primary follow-up action with identifiers interpolated; emitted by every non-terminal storage tool. */
-export const nextStepProperty = {
-    type: 'string' as const,
-    description: 'One primary follow-up action with tool name, identifier, and a specific param value.',
-};
-
 /**
  * Schema for dataset items retrieval tools (get-dataset-items).
  * Contains dataset items with pagination and count information.
@@ -482,8 +471,8 @@ export const datasetItemsOutputSchema = {
         totalItemCount: { type: 'number', description: 'Total items in dataset' },
         offset: { type: 'number', description: 'Offset used for pagination' },
         limit: { type: 'number', description: 'Limit used for pagination' },
-        summary: summaryProperty,
-        nextStep: nextStepProperty,
+        summary: { type: 'string' as const, description: 'Summary of the result' },
+        nextStep: { type: 'string' as const, description: 'One follow-up action with tool name' },
     },
     // offset/limit/totalItemCount and summary/nextStep are always emitted by the tool.
     required: ['datasetId', 'items', 'itemCount', 'totalItemCount', 'offset', 'limit', 'summary', 'nextStep'],

--- a/src/utils/generic.ts
+++ b/src/utils/generic.ts
@@ -112,6 +112,17 @@ export function stripQuoteWrappers(s: string): string {
     return s.trim().replace(STRIP_QUOTE_WRAPPERS_REGEX, '').trim();
 }
 
+/** Best-effort byte size of a value for summaries. */
+export function computeValueBytes(value: unknown): number | undefined {
+    if (Buffer.isBuffer(value)) return value.length;
+    if (typeof value === 'string') return Buffer.byteLength(value);
+    try {
+        return Buffer.byteLength(JSON.stringify(value));
+    } catch {
+        return undefined;
+    }
+}
+
 /**
  * Validates whether a given string is a well-formed URL.
  *

--- a/src/web/src/widgets/actor-run-widget.dev.ts
+++ b/src/web/src/widgets/actor-run-widget.dev.ts
@@ -257,7 +257,8 @@ export function setupActorRunWidgetDev(): void {
                     },
                 },
                 summary: `SUCCEEDED in 12s. ${mockPreviewItems.length} items; 3 fields available.`,
-                nextStep: 'Use get-dataset-items with datasetId=test_dataset_456 and limit (for example 20) to fetch items.',
+                nextStep:
+                    'Use get-dataset-items with datasetId=test_dataset_456 and limit (for example 20) to fetch items.',
             },
         });
     }, LOADING_DELAY_MS);

--- a/src/web/src/widgets/actor-run-widget.dev.ts
+++ b/src/web/src/widgets/actor-run-widget.dev.ts
@@ -219,7 +219,7 @@ export function setupActorRunWidgetDev(): void {
                             ? `SUCCEEDED in 12s. ${mockPreviewItems.length} items; 3 fields available.`
                             : 'RUNNING for 5s. In progress.',
                         nextStep: isComplete
-                            ? 'Use get-dataset-items with datasetId=test_dataset_456 and limit=20 to fetch items.'
+                            ? 'Use get-dataset-items with datasetId=test_dataset_456 and limit (for example 20) to fetch items.'
                             : 'Use get-actor-run with runId=test_run_123 and waitSecs=10 to poll for completion.',
                     },
                 };
@@ -257,7 +257,7 @@ export function setupActorRunWidgetDev(): void {
                     },
                 },
                 summary: `SUCCEEDED in 12s. ${mockPreviewItems.length} items; 3 fields available.`,
-                nextStep: 'Use get-dataset-items with datasetId=test_dataset_456 and limit=20 to fetch items.',
+                nextStep: 'Use get-dataset-items with datasetId=test_dataset_456 and limit (for example 20) to fetch items.',
             },
         });
     }, LOADING_DELAY_MS);

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -1993,6 +1993,11 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     });
                     expect(kvResult.isError).not.toBe(true);
                     expect((kvResult.content as { text: string }[])[0].text).toContain('firstNumber');
+                    // Reading a record is terminal: summary present, no nextStep.
+                    const kvSc = (kvResult as { structuredContent?: { summary?: string; nextStep?: string } })
+                        .structuredContent;
+                    expect(kvSc?.summary).toContain("Read 'INPUT'");
+                    expect(kvSc).not.toHaveProperty('nextStep');
                     await client.close();
                 });
 
@@ -2007,6 +2012,10 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     expect(text).toContain(datasetId);
                     expect(text).toContain('firstNumber');
                     expect(text).toContain('sum');
+                    const sc = (result as { structuredContent?: { summary?: string; nextStep?: string } })
+                        .structuredContent;
+                    expect(sc?.summary).toContain('items');
+                    expect(sc?.nextStep).toContain(HelperTools.DATASET_GET_ITEMS);
                     await client.close();
                 });
 
@@ -2022,6 +2031,10 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     // `math` is a nested object in the default-dataset item; its presence in the schema
                     // proves the inference walks nested shapes, not just top-level fields.
                     expect(text).toContain('math');
+                    const sc = (result as { structuredContent?: { summary?: string; nextStep?: string } })
+                        .structuredContent;
+                    expect(sc?.summary).toContain('Schema inferred');
+                    expect(sc?.nextStep).toContain(HelperTools.DATASET_GET_ITEMS);
                     await client.close();
                 });
 
@@ -2035,6 +2048,8 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     const { text } = (result.content as { text: string }[])[0];
                     // desc=true → newest first, so the run's dataset is on page 1.
                     expect(text).toContain(datasetId);
+                    const sc = (result as { structuredContent?: { summary?: string } }).structuredContent;
+                    expect(sc?.summary).toContain('datasets');
                     await client.close();
                 });
 
@@ -2047,6 +2062,8 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     expect(result.isError).not.toBe(true);
                     const { text } = (result.content as { text: string }[])[0];
                     expect(text).toContain(defaultKvId);
+                    const sc = (result as { structuredContent?: { nextStep?: string } }).structuredContent;
+                    expect(sc?.nextStep).toContain(HelperTools.KEY_VALUE_STORE_KEYS_GET);
                     await client.close();
                 });
 
@@ -2063,6 +2080,10 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     expect(text).toContain('STATS');
                     expect(text).toContain('LOG');
                     expect(text).toContain('COVER');
+                    const sc = (result as { structuredContent?: { summary?: string; nextStep?: string } })
+                        .structuredContent;
+                    expect(sc?.summary).toContain('keys');
+                    expect(sc?.nextStep).toContain(HelperTools.KEY_VALUE_STORE_RECORD_GET);
                     await client.close();
                 });
 
@@ -2075,6 +2096,8 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     expect(result.isError).not.toBe(true);
                     const { text } = (result.content as { text: string }[])[0];
                     expect(text).toContain(defaultKvId);
+                    const sc = (result as { structuredContent?: { summary?: string } }).structuredContent;
+                    expect(sc?.summary).toContain('key-value stores');
                     await client.close();
                 });
 

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -13,13 +13,14 @@ export function parseFencedJson(text: string): unknown {
 
 /**
  * Inverse of `encodeToon` — decodes the fenced tool text whether it shipped TOON or fell back to
- * JSON. For flat payloads (what the array-endpoint mocks use) the TOON round-trip is exact.
+ * JSON. Tolerates prose after the closing fence (storage list tools append summary/nextStep).
+ * For flat payloads (what the array-endpoint mocks use) the TOON round-trip is exact.
  */
 export function decodeFencedToolText(text: string): unknown {
-    if (text.startsWith(FENCES.toon.prefix)) {
-        return decodeToon(text.slice(FENCES.toon.prefix.length, -FENCES.toon.suffix.length));
-    }
-    return parseFencedJson(text);
+    const format = text.startsWith(FENCES.toon.prefix) ? 'toon' : 'json';
+    const { prefix, suffix } = FENCES[format];
+    const body = text.slice(prefix.length, text.indexOf(suffix, prefix.length));
+    return format === 'toon' ? decodeToon(body) : JSON.parse(body);
 }
 
 /**

--- a/tests/unit/tools.dataset_collection.test.ts
+++ b/tests/unit/tools.dataset_collection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getUserDatasetsList } from '../../src/tools/common/dataset_collection.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { parseFencedJson, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const MOCK_LIST = {
     total: 2,
@@ -28,15 +28,36 @@ describe('get-dataset-list', () => {
         expect(getUserDatasetsList.name).toBe(HelperTools.DATASET_LIST_GET);
     });
 
-    it('returns the list response as JSON in a fenced code block', async () => {
+    it('returns the list response plus a summary and nextStep in structuredContent', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
         const result = await (getUserDatasetsList as HelperTool).call(
             stubToolCallContext({}, stubApifyClient(listSpy)),
         );
-        const { content } = result as TextToolResult;
+        const { content, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_LIST);
+        expect(structuredContent).toMatchObject(MOCK_LIST);
+        expect(structuredContent.summary).toBe('Listed 2 of 2 datasets.');
+        // Not truncated → nextStep points at inspecting a dataset, not pagination.
+        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
+        expect(JSON.parse(content[0].text)).toEqual(structuredContent);
+        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+    });
+
+    it('emits a pagination nextStep when more datasets remain', async () => {
+        const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 25 });
+
+        const result = await (getUserDatasetsList as HelperTool).call(
+            stubToolCallContext({}, stubApifyClient(listSpy)),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expect(structuredContent.summary).toBe('Listed 2 of 25 datasets.');
+        expect(structuredContent.nextStep).toBe(
+            `Call ${HelperTools.DATASET_LIST_GET} again with offset=2 to fetch the next page.`,
+        );
     });
 
     it('forwards pagination params (limit, offset, desc, unnamed) to ApifyClient', async () => {

--- a/tests/unit/tools.dataset_collection.test.ts
+++ b/tests/unit/tools.dataset_collection.test.ts
@@ -42,9 +42,10 @@ describe('get-dataset-list', () => {
         expect(structuredContent.summary).toBe('Listed 2 of 2 datasets.');
         // Not truncated → nextStep points at inspecting a dataset, not pagination.
         expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
-        // content[0] ships TOON (or JSON fallback) and round-trips to the full structuredContent.
-        expect(decodeFencedToolText(content[0].text)).toEqual(structuredContent);
-        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+        // content[0] ships the TOON-fenced data (no summary/nextStep) followed by the prose summary.
+        const { summary, nextStep, ...data } = structuredContent;
+        expect(decodeFencedToolText(content[0].text)).toEqual(data);
+        expect(content[0].text.endsWith(`\n\n${summary}\n${nextStep}`)).toBe(true);
     });
 
     it('emits a pagination nextStep when more datasets remain', async () => {

--- a/tests/unit/tools.dataset_collection.test.ts
+++ b/tests/unit/tools.dataset_collection.test.ts
@@ -42,10 +42,10 @@ describe('get-dataset-list', () => {
         expect(structuredContent.summary).toBe('Listed 2 of 2 datasets.');
         // Not truncated → nextStep points at inspecting a dataset, not pagination.
         expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
-        // content[0] ships the TOON-fenced data (no summary/nextStep) followed by the prose summary.
+        // content[0] ships the TOON-fenced data; content[1] carries the prose summary + nextStep.
         const { summary, nextStep, ...data } = structuredContent;
         expect(decodeFencedToolText(content[0].text)).toEqual(data);
-        expect(content[0].text.endsWith(`\n\n${summary}\n${nextStep}`)).toBe(true);
+        expect(content[1].text).toBe(`${summary}\n${nextStep}`);
     });
 
     it('emits a pagination nextStep when more datasets remain', async () => {

--- a/tests/unit/tools.get_dataset.test.ts
+++ b/tests/unit/tools.get_dataset.test.ts
@@ -38,9 +38,10 @@ describe('get-dataset', () => {
         expect(structuredContent.summary).toBe("Dataset 'my-dataset' has 42 items, 2 fields.");
         expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET_ITEMS);
         expect(structuredContent.nextStep).toContain('datasetId=ds-1');
-        // content[0] is the spec-compat JSON dump; content[1] is the narrative.
-        expect(JSON.parse(content[0].text)).toEqual(structuredContent);
-        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+        // content[0] is the data-only JSON dump (no narrative); content[1] is the narrative.
+        const { summary, nextStep, ...data } = structuredContent;
+        expect(JSON.parse(content[0].text)).toEqual(data);
+        expect(content[1].text).toBe(`${summary}\n${nextStep}`);
     });
 
     it('returns isError with a not-found message when the dataset does not exist', async () => {

--- a/tests/unit/tools.get_dataset.test.ts
+++ b/tests/unit/tools.get_dataset.test.ts
@@ -3,12 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getDataset } from '../../src/tools/common/get_dataset.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import {
-    expectSoftFailInvalidInput,
-    parseFencedJson,
-    stubToolCallContext,
-    type TextToolResult,
-} from './helpers/tool_context.js';
+import { expectSoftFailInvalidInput, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const MOCK_DATASET = {
     id: 'ds-1',
@@ -29,14 +24,23 @@ describe('get-dataset', () => {
         expect(getDataset.name).toBe(HelperTools.DATASET_GET);
     });
 
-    it('returns dataset metadata as JSON in a fenced code block', async () => {
+    it('returns dataset metadata plus a summary and nextStep in structuredContent', async () => {
         const result = await (getDataset as HelperTool).call(
             stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient(MOCK_DATASET)),
         );
-        const { content, isError } = result as TextToolResult;
+        const { content, isError, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
 
         expect(isError).not.toBe(true);
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_DATASET);
+        // structuredContent preserves the metadata and adds the narrative fields.
+        expect(structuredContent).toMatchObject(MOCK_DATASET);
+        expect(structuredContent.summary).toBe("Dataset 'my-dataset' has 42 items, 2 fields.");
+        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET_ITEMS);
+        expect(structuredContent.nextStep).toContain('datasetId=ds-1');
+        // content[0] is the spec-compat JSON dump; content[1] is the narrative.
+        expect(JSON.parse(content[0].text)).toEqual(structuredContent);
+        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
     });
 
     it('returns isError with a not-found message when the dataset does not exist', async () => {
@@ -75,12 +79,8 @@ describe('get-dataset fields normalization', () => {
                 }),
             ),
         );
-        const { content } = result as TextToolResult;
-        expect((parseFencedJson(content[0].text) as { fields: string[] }).fields).toEqual([
-            'crawl.httpStatusCode',
-            'metadata.url',
-            'markdown',
-        ]);
+        const { structuredContent } = result as { structuredContent: { fields: string[] } };
+        expect(structuredContent.fields).toEqual(['crawl.httpStatusCode', 'metadata.url', 'markdown']);
     });
 
     it('collapses array-index segments and dedupes', async () => {
@@ -105,8 +105,8 @@ describe('get-dataset fields normalization', () => {
                 }),
             ),
         );
-        const { content } = result as TextToolResult;
-        expect((parseFencedJson(content[0].text) as { fields: string[] }).fields).toEqual([
+        const { structuredContent } = result as { structuredContent: { fields: string[] } };
+        expect(structuredContent.fields).toEqual([
             'latestComments.id',
             'latestComments.text',
             'latestComments.owner.username',
@@ -126,8 +126,8 @@ describe('get-dataset fields normalization', () => {
         const result = await (getDataset as HelperTool).call(
             stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient(raw)),
         );
-        const { content } = result as TextToolResult;
-        expect(parseFencedJson(content[0].text)).toEqual({
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+        expect(structuredContent).toMatchObject({
             id: 'ds-1',
             name: null,
             userId: 'u-1',
@@ -142,9 +142,8 @@ describe('get-dataset fields normalization', () => {
         const result = await (getDataset as HelperTool).call(
             stubToolCallContext({ datasetId: 'ds-empty' }, stubApifyClient(raw)),
         );
-        const { content } = result as TextToolResult;
-        const json = parseFencedJson(content[0].text) as Record<string, unknown>;
-        expect(json).toEqual(raw);
-        expect(json).not.toHaveProperty('fields');
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+        expect(structuredContent).toMatchObject(raw);
+        expect(structuredContent).not.toHaveProperty('fields');
     });
 });

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -192,8 +192,8 @@ describe('get-dataset-items', () => {
         expect(structuredContent.summary).toBe('Fetched all 1 items.');
         expect(structuredContent.nextStep).toContain(HelperTools.DATASET_SCHEMA_GET);
         expect(structuredContent.nextStep).toContain('datasetId=ds-1');
-        // summary + nextStep follow the fenced data in the single text block.
-        expect(content[0].text.endsWith(`\n\n${structuredContent.summary}\n${structuredContent.nextStep}`)).toBe(true);
+        // summary + nextStep ship as a separate text block after the fenced data.
+        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
     });
 
     it('emits a pagination nextStep when more items remain', async () => {

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -73,13 +73,14 @@ describe('get-dataset-items', () => {
         expect(structuredContent.itemCount).toBe(MOCK_ITEMS.length);
     });
 
-    it('encodes the same payload into content text as structuredContent', async () => {
+    it('encodes the data payload (without summary/nextStep) into the fenced content text', async () => {
         const result = await (getDatasetItems as HelperTool).call(
             stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient()),
         );
         const { content, structuredContent } = result as TextToolResult;
 
-        expect(decodeFencedToolText(content[0].text)).toEqual(structuredContent);
+        const { summary, nextStep, ...data } = structuredContent as Record<string, unknown>;
+        expect(decodeFencedToolText(content[0].text)).toEqual(data);
     });
 
     it('content round-trips to structuredContent for nested items (dot-flattened when TOON wins)', async () => {
@@ -99,11 +100,12 @@ describe('get-dataset-items', () => {
         const { content, structuredContent } = result as TextToolResult;
         const [{ text }] = content;
 
-        // Uniform nested rows favour TOON; assert the lift actually happened, then that the text
-        // round-trips to the dot-flattened structuredContent (its true on-the-wire equivalent).
+        // Uniform nested rows favour TOON; assert the lift actually happened, then that the fenced
+        // text round-trips to the dot-flattened data (summary/nextStep stay outside the fence).
+        const { summary, nextStep, ...data } = structuredContent as Record<string, unknown>;
         expect(text.startsWith('```toon\n')).toBe(true);
         expect(text).toContain('metadata.httpStatus');
-        expect(decodeFencedToolText(text)).toEqual(dotFlatten(JSON.parse(JSON.stringify(structuredContent))));
+        expect(decodeFencedToolText(text)).toEqual(dotFlatten(JSON.parse(JSON.stringify(data))));
     });
 
     it('defaults `limit` to 20 when caller omits it', async () => {
@@ -190,8 +192,8 @@ describe('get-dataset-items', () => {
         expect(structuredContent.summary).toBe('Fetched all 1 items.');
         expect(structuredContent.nextStep).toContain(HelperTools.DATASET_SCHEMA_GET);
         expect(structuredContent.nextStep).toContain('datasetId=ds-1');
-        // content[1] mirrors summary + nextStep for text-only clients.
-        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+        // summary + nextStep follow the fenced data in the single text block.
+        expect(content[0].text.endsWith(`\n\n${structuredContent.summary}\n${structuredContent.nextStep}`)).toBe(true);
     });
 
     it('emits a pagination nextStep when more items remain', async () => {
@@ -209,7 +211,7 @@ describe('get-dataset-items', () => {
         );
     });
 
-    it('content[0] mirrors structuredContent and does not echo the desc input param', async () => {
+    it('content[0] mirrors the structuredContent data and does not echo the desc input param', async () => {
         const result = await (getDatasetItems as HelperTool).call(
             stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient()),
         );
@@ -217,7 +219,8 @@ describe('get-dataset-items', () => {
             structuredContent: Record<string, unknown>;
         };
 
-        expect(decodeFencedToolText(content[0].text)).toEqual(structuredContent);
+        const { summary, nextStep, ...data } = structuredContent;
+        expect(decodeFencedToolText(content[0].text)).toEqual(data);
         expect(structuredContent).not.toHaveProperty('desc');
     });
 });

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -157,7 +157,10 @@ describe('get-dataset-items', () => {
 
     it('emits a pagination nextStep when more items remain', async () => {
         const result = await (getDatasetItems as HelperTool).call(
-            stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient(async () => ({ items: MANY_ITEMS, total: 100 }))),
+            stubToolCallContext(
+                { datasetId: 'ds-1' },
+                stubApifyClient(async () => ({ items: MANY_ITEMS, total: 100 })),
+            ),
         );
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
 

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -36,6 +36,7 @@ describe('extractDotPrefixes', () => {
 });
 
 const MOCK_ITEMS = [{ first_number: 3, second_number: 4, sum: 7 }];
+const MANY_ITEMS = Array.from({ length: 20 }, (_, i) => ({ n: i }));
 
 function stubApifyClient(
     listItems: (...args: unknown[]) => unknown = async () => ({ items: MOCK_ITEMS, total: 1 }),
@@ -137,5 +138,44 @@ describe('get-dataset-items', () => {
         expect(datasetSpy).toHaveBeenCalledWith('user~my-dataset');
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
         expect(structuredContent.datasetId).toBe('user~my-dataset');
+    });
+
+    it('emits a last-page summary and a schema nextStep when all items are returned', async () => {
+        const result = await (getDatasetItems as HelperTool).call(
+            stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient()),
+        );
+        const { content, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
+
+        expect(structuredContent.summary).toBe('Fetched all 1 items.');
+        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_SCHEMA_GET);
+        expect(structuredContent.nextStep).toContain('datasetId=ds-1');
+        // content[1] mirrors summary + nextStep for text-only clients.
+        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+    });
+
+    it('emits a pagination nextStep when more items remain', async () => {
+        const result = await (getDatasetItems as HelperTool).call(
+            stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient(async () => ({ items: MANY_ITEMS, total: 100 }))),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expect(structuredContent.summary).toBe('Fetched 20 of 100 items (offset=0).');
+        expect(structuredContent.nextStep).toBe(
+            `Call ${HelperTools.DATASET_GET_ITEMS} again with offset=20 to fetch the next page.`,
+        );
+    });
+
+    it('content[0] is the plain-JSON dump of structuredContent (no raw desc echo)', async () => {
+        const result = await (getDatasetItems as HelperTool).call(
+            stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient()),
+        );
+        const { content, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
+
+        expect(JSON.parse(content[0].text)).toEqual(structuredContent);
+        expect(structuredContent).not.toHaveProperty('desc');
     });
 });

--- a/tests/unit/tools.get_dataset_schema.test.ts
+++ b/tests/unit/tools.get_dataset_schema.test.ts
@@ -65,14 +65,20 @@ describe('get-dataset-schema', () => {
         expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
     });
 
-    it('returns a plain "is empty" message when the dataset has no items', async () => {
+    it('returns a schema-conforming structured response when the dataset has no items', async () => {
         const result = await (getDatasetSchema as HelperTool).call(
             stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient({ items: [], total: 0 })),
         );
-        const { content, isError } = result as TextToolResult;
+        const { content, isError, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
 
         expect(isError).not.toBe(true);
-        expect(content[0].text).toBe("Dataset 'ds-1' is empty.");
+        expect(structuredContent.datasetId).toBe('ds-1');
+        expect(structuredContent.schema).toEqual({});
+        expect(structuredContent.summary).toBe("Dataset 'ds-1' is empty; no schema to infer.");
+        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
+        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
     });
 
     it('returns isError with a not-found message when listItems throws 404', async () => {

--- a/tests/unit/tools.get_dataset_schema.test.ts
+++ b/tests/unit/tools.get_dataset_schema.test.ts
@@ -7,7 +7,6 @@ import type * as SchemaGenModule from '../../src/utils/schema_generation.js';
 import { generateSchemaFromItems } from '../../src/utils/schema_generation.js';
 import {
     expectSoftFailInvalidInput,
-    parseFencedJson,
     stubToolCallContext,
     type TextToolResult,
     type ToolTelemetrySnapshot,
@@ -49,14 +48,21 @@ describe('get-dataset-schema', () => {
         expect(getDatasetSchema.name).toBe(HelperTools.DATASET_SCHEMA_GET);
     });
 
-    it('returns a JSON schema in a fenced code block on the happy path', async () => {
+    it('returns the inferred schema plus a summary and nextStep on the happy path', async () => {
         const result = await (getDatasetSchema as HelperTool).call(
             stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient({ items: MOCK_ITEMS, total: 2 })),
         );
-        const { content, isError } = result as TextToolResult;
+        const { content, isError, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
 
         expect(isError).not.toBe(true);
-        expect(parseFencedJson(content[0].text)).toMatchObject({ type: 'array' });
+        expect(structuredContent.datasetId).toBe('ds-1');
+        expect(structuredContent.schema).toMatchObject({ type: 'array' });
+        // MOCK_ITEMS has 2 items, each with 2 fields (title, count).
+        expect(structuredContent.summary).toBe('Schema inferred from 2 items, 2 fields.');
+        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET_ITEMS);
+        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
     });
 
     it('returns a plain "is empty" message when the dataset has no items', async () => {

--- a/tests/unit/tools.get_key_value_store.test.ts
+++ b/tests/unit/tools.get_key_value_store.test.ts
@@ -35,8 +35,10 @@ describe('get-key-value-store', () => {
         expect(structuredContent.summary).toBe("Key-value store 'my-store'.");
         expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_KEYS_GET);
         expect(structuredContent.nextStep).toContain('keyValueStoreId=kv-1');
-        expect(JSON.parse(content[0].text)).toEqual(structuredContent);
-        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+        // content[0] is the data-only JSON dump (no narrative); content[1] is the narrative.
+        const { summary, nextStep, ...data } = structuredContent;
+        expect(JSON.parse(content[0].text)).toEqual(data);
+        expect(content[1].text).toBe(`${summary}\n${nextStep}`);
     });
 
     it('includes the byte count in the summary when stats are present', async () => {

--- a/tests/unit/tools.get_key_value_store.test.ts
+++ b/tests/unit/tools.get_key_value_store.test.ts
@@ -3,12 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getKeyValueStore } from '../../src/tools/common/get_key_value_store.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import {
-    expectSoftFailInvalidInput,
-    parseFencedJson,
-    stubToolCallContext,
-    type TextToolResult,
-} from './helpers/tool_context.js';
+import { expectSoftFailInvalidInput, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const MOCK_STORE = {
     id: 'kv-1',
@@ -27,14 +22,33 @@ describe('get-key-value-store', () => {
         expect(getKeyValueStore.name).toBe(HelperTools.KEY_VALUE_STORE_GET);
     });
 
-    it('returns store metadata as JSON in a fenced code block', async () => {
+    it('returns store metadata plus a summary and nextStep in structuredContent', async () => {
         const result = await (getKeyValueStore as HelperTool).call(
             stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(MOCK_STORE)),
         );
-        const { content, isError } = result as TextToolResult;
+        const { content, isError, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
 
         expect(isError).not.toBe(true);
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_STORE);
+        expect(structuredContent).toMatchObject(MOCK_STORE);
+        expect(structuredContent.summary).toBe("Key-value store 'my-store'.");
+        expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_KEYS_GET);
+        expect(structuredContent.nextStep).toContain('keyValueStoreId=kv-1');
+        expect(JSON.parse(content[0].text)).toEqual(structuredContent);
+        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+    });
+
+    it('includes the byte count in the summary when stats are present', async () => {
+        const result = await (getKeyValueStore as HelperTool).call(
+            stubToolCallContext(
+                { keyValueStoreId: 'kv-1' },
+                stubApifyClient({ ...MOCK_STORE, stats: { storageBytes: 2048 } }),
+            ),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expect(structuredContent.summary).toBe("Key-value store 'my-store' holds 2048 bytes.");
     });
 
     it('returns isError with a not-found message when the store does not exist', async () => {

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -1,7 +1,9 @@
+import Ajv from 'ajv';
 import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
 import { getKeyValueStoreKeys } from '../../src/tools/common/get_key_value_store_keys.js';
+import { keyValueStoreKeysOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import { expectSoftFailInvalidInput, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
@@ -51,6 +53,22 @@ describe('get-key-value-store-keys', () => {
         );
         expect(JSON.parse(content[0].text)).toEqual(structuredContent);
         expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+    });
+
+    it('emits structuredContent that validates against the outputSchema when not truncated', async () => {
+        // The SDK returns `nextExclusiveStartKey: null` when `isTruncated` is false — the common
+        // single-page case. The output schema must accept that, or the MCP SDK rejects the response.
+        // Validated with a strict AJV (no coercion) to mirror the SDK's output-schema check; the
+        // repo's lenient `compileSchema` coerces types and would hide the mismatch.
+        const listKeysSpy = vi.fn().mockResolvedValue({ ...MOCK_KEYS, nextExclusiveStartKey: null });
+        const validate = new Ajv({ strict: false }).compile(keyValueStoreKeysOutputSchema);
+
+        const result = await (getKeyValueStoreKeys as HelperTool).call(
+            stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(listKeysSpy)),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expect(validate(structuredContent)).toBe(true);
     });
 
     it('flags truncation in the summary when more keys are available', async () => {

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -56,9 +56,10 @@ describe('get-key-value-store-keys', () => {
         expect(structuredContent.nextStep).toBe(
             `Use ${HelperTools.KEY_VALUE_STORE_RECORD_GET} with keyValueStoreId=kv-1 and recordKey=INPUT to read a value.`,
         );
-        // content[0] ships TOON (or JSON fallback) and round-trips to the full structuredContent.
-        expect(decodeFencedToolText(content[0].text)).toEqual(structuredContent);
-        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+        // content[0] ships the TOON-fenced data (no summary/nextStep) followed by the prose summary.
+        const { summary, nextStep, ...data } = structuredContent;
+        expect(decodeFencedToolText(content[0].text)).toEqual(data);
+        expect(content[0].text.endsWith(`\n\n${summary}\n${nextStep}`)).toBe(true);
     });
 
     it('emits structuredContent that validates against the outputSchema when not truncated', async () => {

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -3,12 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getKeyValueStoreKeys } from '../../src/tools/common/get_key_value_store_keys.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import {
-    expectSoftFailInvalidInput,
-    parseFencedJson,
-    stubToolCallContext,
-    type TextToolResult,
-} from './helpers/tool_context.js';
+import { expectSoftFailInvalidInput, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const MOCK_KEYS = {
     items: [
@@ -38,15 +33,47 @@ describe('get-key-value-store-keys', () => {
         expect(getKeyValueStoreKeys.name).toBe(HelperTools.KEY_VALUE_STORE_KEYS_GET);
     });
 
-    it('returns the keys response as JSON in a fenced code block', async () => {
+    it('returns the keys response plus a summary and read nextStep in structuredContent', async () => {
         const listKeysSpy = vi.fn().mockResolvedValue(MOCK_KEYS);
 
         const result = await (getKeyValueStoreKeys as HelperTool).call(
             stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(listKeysSpy)),
         );
-        const { content } = result as TextToolResult;
+        const { content, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_KEYS);
+        expect(structuredContent).toMatchObject({ keyValueStoreId: 'kv-1', ...MOCK_KEYS });
+        expect(structuredContent.summary).toBe('Listed 2 keys.');
+        // nextStep points at reading the first listed key.
+        expect(structuredContent.nextStep).toBe(
+            `Use ${HelperTools.KEY_VALUE_STORE_RECORD_GET} with keyValueStoreId=kv-1 and recordKey=INPUT to read a value.`,
+        );
+        expect(JSON.parse(content[0].text)).toEqual(structuredContent);
+        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+    });
+
+    it('flags truncation in the summary when more keys are available', async () => {
+        const listKeysSpy = vi.fn().mockResolvedValue({ ...MOCK_KEYS, isTruncated: true });
+
+        const result = await (getKeyValueStoreKeys as HelperTool).call(
+            stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(listKeysSpy)),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expect(structuredContent.summary).toBe('Listed 2 keys (more available).');
+    });
+
+    it('points at inspecting the store when it has no keys', async () => {
+        const listKeysSpy = vi.fn().mockResolvedValue({ ...MOCK_KEYS, items: [], count: 0 });
+
+        const result = await (getKeyValueStoreKeys as HelperTool).call(
+            stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(listKeysSpy)),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expect(structuredContent.summary).toBe('Listed 0 keys.');
+        expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_GET);
     });
 
     it('forwards exclusiveStartKey and limit to listKeys', async () => {

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -56,10 +56,10 @@ describe('get-key-value-store-keys', () => {
         expect(structuredContent.nextStep).toBe(
             `Use ${HelperTools.KEY_VALUE_STORE_RECORD_GET} with keyValueStoreId=kv-1 and recordKey=INPUT to read a value.`,
         );
-        // content[0] ships the TOON-fenced data (no summary/nextStep) followed by the prose summary.
+        // content[0] ships the TOON-fenced data; content[1] carries the prose summary + nextStep.
         const { summary, nextStep, ...data } = structuredContent;
         expect(decodeFencedToolText(content[0].text)).toEqual(data);
-        expect(content[0].text.endsWith(`\n\n${summary}\n${nextStep}`)).toBe(true);
+        expect(content[1].text).toBe(`${summary}\n${nextStep}`);
     });
 
     it('emits structuredContent that validates against the outputSchema when not truncated', async () => {

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -78,8 +78,12 @@ describe('get-key-value-store-keys', () => {
         expect(validate(structuredContent)).toBe(true);
     });
 
-    it('flags truncation in the summary when more keys are available', async () => {
-        const listKeysSpy = vi.fn().mockResolvedValue({ ...MOCK_KEYS, isTruncated: true });
+    it('flags truncation in the summary and points to the next page when more keys are available', async () => {
+        const listKeysSpy = vi.fn().mockResolvedValue({
+            ...MOCK_KEYS,
+            isTruncated: true,
+            nextExclusiveStartKey: 'OUTPUT',
+        });
 
         const result = await (getKeyValueStoreKeys as HelperTool).call(
             stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(listKeysSpy)),
@@ -87,6 +91,9 @@ describe('get-key-value-store-keys', () => {
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
 
         expect(structuredContent.summary).toBe('Listed 2 keys (more available).');
+        expect(structuredContent.nextStep).toBe(
+            `Call ${HelperTools.KEY_VALUE_STORE_KEYS_GET} again with exclusiveStartKey=OUTPUT to fetch the next page.`,
+        );
     });
 
     it('points at inspecting the store when it has no keys', async () => {

--- a/tests/unit/tools.get_key_value_store_record.test.ts
+++ b/tests/unit/tools.get_key_value_store_record.test.ts
@@ -42,7 +42,9 @@ describe('get-key-value-store-record', () => {
         expect(structuredContent).not.toHaveProperty('nextStep');
         expect(content).toHaveLength(2);
         expect(content[1].text).toBe(structuredContent.summary);
-        expect(JSON.parse(content[0].text)).toEqual(structuredContent);
+        // content[0] is the data-only JSON dump (no narrative summary).
+        const { summary, ...data } = structuredContent;
+        expect(JSON.parse(content[0].text)).toEqual(data);
     });
 
     it('returns isError "record not found" when getRecord is undefined but the store exists', async () => {

--- a/tests/unit/tools.get_key_value_store_record.test.ts
+++ b/tests/unit/tools.get_key_value_store_record.test.ts
@@ -3,12 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getKeyValueStoreRecord } from '../../src/tools/common/get_key_value_store_record.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import {
-    expectSoftFailInvalidInput,
-    parseFencedJson,
-    stubToolCallContext,
-    type TextToolResult,
-} from './helpers/tool_context.js';
+import { expectSoftFailInvalidInput, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const MOCK_RECORD = { key: 'INPUT', value: { query: 'hello' }, contentType: 'application/json' };
 const MOCK_STORE = { id: 'kv-1', name: 'my-store' };
@@ -28,17 +23,26 @@ describe('get-key-value-store-record', () => {
         expect(getKeyValueStoreRecord.name).toBe(HelperTools.KEY_VALUE_STORE_RECORD_GET);
     });
 
-    it('returns the record as JSON in a fenced code block', async () => {
+    it('returns the record plus a terminal summary (no nextStep) in structuredContent', async () => {
         const result = await (getKeyValueStoreRecord as HelperTool).call(
             stubToolCallContext(
                 { keyValueStoreId: 'kv-1', recordKey: 'INPUT' },
                 stubApifyClient({ record: MOCK_RECORD }),
             ),
         );
-        const { content, isError } = result as TextToolResult;
+        const { content, isError, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
 
         expect(isError).not.toBe(true);
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_RECORD);
+        expect(structuredContent).toMatchObject({ keyValueStoreId: 'kv-1', ...MOCK_RECORD });
+        // {"query":"hello"} serializes to 17 bytes.
+        expect(structuredContent.summary).toBe("Read 'INPUT' (contentType=application/json, 17 bytes).");
+        // Reading a record is terminal — no nextStep, and content[1] is the summary alone.
+        expect(structuredContent).not.toHaveProperty('nextStep');
+        expect(content).toHaveLength(2);
+        expect(content[1].text).toBe(structuredContent.summary);
+        expect(JSON.parse(content[0].text)).toEqual(structuredContent);
     });
 
     it('returns isError "record not found" when getRecord is undefined but the store exists', async () => {

--- a/tests/unit/tools.key_value_store_collection.test.ts
+++ b/tests/unit/tools.key_value_store_collection.test.ts
@@ -41,10 +41,10 @@ describe('get-key-value-store-list', () => {
         expect(structuredContent).toMatchObject(MOCK_LIST);
         expect(structuredContent.summary).toBe('Listed 2 of 2 key-value stores.');
         expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_GET);
-        // content[0] ships the TOON-fenced data (no summary/nextStep) followed by the prose summary.
+        // content[0] ships the TOON-fenced data; content[1] carries the prose summary + nextStep.
         const { summary, nextStep, ...data } = structuredContent;
         expect(decodeFencedToolText(content[0].text)).toEqual(data);
-        expect(content[0].text.endsWith(`\n\n${summary}\n${nextStep}`)).toBe(true);
+        expect(content[1].text).toBe(`${summary}\n${nextStep}`);
     });
 
     it('emits a pagination nextStep when more stores remain', async () => {

--- a/tests/unit/tools.key_value_store_collection.test.ts
+++ b/tests/unit/tools.key_value_store_collection.test.ts
@@ -41,9 +41,10 @@ describe('get-key-value-store-list', () => {
         expect(structuredContent).toMatchObject(MOCK_LIST);
         expect(structuredContent.summary).toBe('Listed 2 of 2 key-value stores.');
         expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_GET);
-        // content[0] ships TOON (or JSON fallback) and round-trips to the full structuredContent.
-        expect(decodeFencedToolText(content[0].text)).toEqual(structuredContent);
-        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+        // content[0] ships the TOON-fenced data (no summary/nextStep) followed by the prose summary.
+        const { summary, nextStep, ...data } = structuredContent;
+        expect(decodeFencedToolText(content[0].text)).toEqual(data);
+        expect(content[0].text.endsWith(`\n\n${summary}\n${nextStep}`)).toBe(true);
     });
 
     it('emits a pagination nextStep when more stores remain', async () => {

--- a/tests/unit/tools.key_value_store_collection.test.ts
+++ b/tests/unit/tools.key_value_store_collection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HelperTools } from '../../src/const.js';
 import { getUserKeyValueStoresList } from '../../src/tools/common/key_value_store_collection.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { parseFencedJson, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 const MOCK_LIST = {
     total: 2,
@@ -28,15 +28,35 @@ describe('get-key-value-store-list', () => {
         expect(getUserKeyValueStoresList.name).toBe(HelperTools.KEY_VALUE_STORE_LIST_GET);
     });
 
-    it('returns the list response as JSON in a fenced code block', async () => {
+    it('returns the list response plus a summary and nextStep in structuredContent', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
         const result = await (getUserKeyValueStoresList as HelperTool).call(
             stubToolCallContext({}, stubApifyClient(listSpy)),
         );
-        const { content } = result as TextToolResult;
+        const { content, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
 
-        expect(parseFencedJson(content[0].text)).toEqual(MOCK_LIST);
+        expect(structuredContent).toMatchObject(MOCK_LIST);
+        expect(structuredContent.summary).toBe('Listed 2 of 2 key-value stores.');
+        expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_GET);
+        expect(JSON.parse(content[0].text)).toEqual(structuredContent);
+        expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+    });
+
+    it('emits a pagination nextStep when more stores remain', async () => {
+        const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 30 });
+
+        const result = await (getUserKeyValueStoresList as HelperTool).call(
+            stubToolCallContext({}, stubApifyClient(listSpy)),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expect(structuredContent.summary).toBe('Listed 2 of 30 key-value stores.');
+        expect(structuredContent.nextStep).toBe(
+            `Call ${HelperTools.KEY_VALUE_STORE_LIST_GET} again with offset=2 to fetch the next page.`,
+        );
     });
 
     it('forwards pagination params (limit, offset, desc, unnamed) to ApifyClient', async () => {

--- a/tests/unit/tools.structured_output_schemas.test.ts
+++ b/tests/unit/tools.structured_output_schemas.test.ts
@@ -5,6 +5,7 @@ import {
     actorDetailsOutputSchema,
     actorInfoSchema,
     buildEnrichedDirectActorOutputSchema,
+    datasetItemsOutputSchema,
     getActorRunOutputSchema,
 } from '../../src/tools/structured_output_schemas.js';
 import type { ActorInfo, ActorStore, ActorTool } from '../../src/types.js';
@@ -107,6 +108,25 @@ describe('Structured Output Schemas', () => {
             const enriched = buildEnrichedDirectActorOutputSchema(itemProperties);
 
             expect(pickItemsSchema(enriched)?.properties).toEqual(itemProperties);
+        });
+    });
+
+    describe('datasetItemsOutputSchema', () => {
+        // Both consumer tools always emit offset/limit/totalItemCount and now summary/nextStep,
+        // so `required` must list them (issue #884).
+        it('requires the always-emitted pagination, count, and narrative fields', () => {
+            expect(datasetItemsOutputSchema.required).toEqual(
+                expect.arrayContaining([
+                    'datasetId',
+                    'items',
+                    'itemCount',
+                    'totalItemCount',
+                    'offset',
+                    'limit',
+                    'summary',
+                    'nextStep',
+                ]),
+            );
         });
     });
 


### PR DESCRIPTION
Closes #884.

## What

All remaining storage tools now declare an `outputSchema` and emit `structuredContent` with `summary` + `nextStep`, mirroring `actor_run_response.ts`:

- `structuredContent`: existing shape + `summary` + `nextStep`
- `content[0]`: JSON dump of `structuredContent` (spec compat)
- `content[1]`: `${summary}\n${nextStep}`

`summary` is a past-tense state with concrete numbers; `nextStep` is one primary follow-up with tool name + identifier + a specific param value.

| Tool | summary | nextStep |
|---|---|---|
| `get-dataset` | `Dataset 'X' has N items, K fields.` | fetch items |
| `get-dataset-items` | `Fetched N of M items (offset=0).` / `Fetched all N items.` | next page / inspect schema |
| `get-dataset-schema` | `Schema inferred from N items, K fields.` | project fields |
| `get-dataset-list` | `Listed N of M datasets.` | next page (if truncated) / inspect |
| `get-key-value-store` | `Key-value store 'X' holds B bytes.` | list keys |
| `get-key-value-store-keys` | `Listed N keys (more available).` | read first key / inspect store |
| `get-key-value-store-record` | `Read 'KEY' (contentType=…, B bytes).` | — (terminal) |
| `get-key-value-store-list` | `Listed N of M key-value stores.` | next page (if truncated) / inspect |

Also per the issue:
- Tightened `datasetItemsOutputSchema.required` to include `offset`/`limit`/`totalItemCount` (+ `summary`/`nextStep`) — both consumer tools always emit them.
- Dropped the noisy raw `desc`/`count` echo from `get-dataset-items` (`content[0]` is now the curated `structuredContent`).

Shared `buildStorageResponse` + `buildStorageListSummaryNextStep` helpers keep the 8 tools DRY.

## Deviation from the spec table

`get-key-value-store` reports bytes rather than "N keys": the store `.get()` metadata has no key count, and I avoided an extra `listKeys` call (cost/latency on a `paymentRequired` tool). `nextStep` points at `get-key-value-store-keys` to discover them.

## Tests

24 new/updated unit tests; integration suite extended with end-to-end `structuredContent` assertions for all storage tools.

## ⚠️ Internal repo coordination

Touches `structuredContent` + `outputSchema` for 7 tools the hosted server consumes — `apify-mcp-server-internal`'s contract suite likely needs matching assertions. The integration assertions added here are the reference contract.