### PR TITLE
refactor: add return type to cn function

### DIFF
--- a/src/web/src/utils/cn.ts
+++ b/src/web/src/utils/cn.ts
@@ -1,3 +1,3 @@
-export function cn(...classes: (string | false | null | undefined)[]) {
+export function cn(...classes: (string | false | null | undefined)[]): string {
     return classes.filter(Boolean).join(' ');
 }


### PR DESCRIPTION
### 问题背景
函数 `cn` 在 `src/web/src/utils/cn.ts` 中缺少显式的返回类型注解，依赖 TypeScript 的类型推断。虽然类型推断在大多数情况下工作良好，但显式注解可以提高代码的可读性、可维护性，并有助于在大型代码库中保持类型一致性。

### 修改内容
- 为 `cn` 函数添加了显式的返回类型注解 `: string`。
- 这样修改的原因是：显式注解使函数签名更清晰，便于开发者快速理解返回类型，减少潜在的误解和错误。
- 提升：增强代码质量和可维护性，通过显式类型注解提高类型安全性，符合 TypeScript 最佳实践。

### 验证方式
- 现有测试应该继续通过，因为此修改不改变函数的外部行为。
- 可以运行项目的测试套件和 TypeScript 编译器（如 `tsc`）来验证代码编译和测试正确性。
- 进行了手动检查，确保函数行为不变。

### 其他信息
- 没有 breaking changes。
- 不需要更新文档。
- 没有已知的限制。