### PR TITLE
feat: Add MCP Storage Access telemetry event

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -160,6 +160,12 @@ export const FAILURE_CATEGORY = {
     INTERNAL_ERROR: 'INTERNAL_ERROR',
 } as const;
 
+// Storage type for the dedicated `MCP Storage Access` telemetry event.
+export const STORAGE_TYPE = {
+    DATASET: 'DATASET',
+    KEY_VALUE_STORE: 'KEY_VALUE_STORE',
+} as const;
+
 // Apify API error types
 export const APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED = 'full-permission-actor-not-approved';
 export const APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED = 'memory-limit-exceeded';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -64,7 +64,7 @@ import { prompts } from '../prompts/index.js';
 import { createResourceService } from '../resources/resource_service.js';
 import type { AvailableWidget } from '../resources/widgets.js';
 import { resolveAvailableWidgets } from '../resources/widgets.js';
-import { getTelemetryEnv, trackToolCall } from '../telemetry.js';
+import { buildStorageAccessProperties, getTelemetryEnv, trackStorageAccess, trackToolCall } from '../telemetry.js';
 import { actorExecutor } from '../tools/actor_executor.js';
 import {
     buildPermissionApprovalResponse,
@@ -103,6 +103,7 @@ import {
     buildActorFields,
     extractActorId,
     extractActorName,
+    getStorageType,
     getToolFullName,
     getToolPublicFieldOnly,
 } from '../utils/tools.js';
@@ -1408,6 +1409,17 @@ export class ActorsMcpServer {
                 ...params.callDiagnostics,
             };
             trackToolCall(params.userId, this.telemetryEnv, finalizedTelemetryData);
+
+            // Storage tools additionally emit a dedicated event so storage usage and
+            // error rates can be analysed separately from the generic tool-call event.
+            const storageType = getStorageType(params.toolName);
+            if (storageType) {
+                trackStorageAccess(
+                    params.userId,
+                    this.telemetryEnv,
+                    buildStorageAccessProperties(finalizedTelemetryData, storageType),
+                );
+            }
         }
     }
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -5,7 +5,12 @@ import { Analytics } from '@segment/analytics-node';
 import log from '@apify/log';
 
 import { DEFAULT_TELEMETRY_ENV, TELEMETRY_ENV } from './const.js';
-import type { TelemetryEnv, ToolCallTelemetryProperties } from './types.js';
+import type {
+    StorageAccessTelemetryProperties,
+    StorageType,
+    TelemetryEnv,
+    ToolCallTelemetryProperties,
+} from './types.js';
 
 const DEV_WRITE_KEY = '9rPHlMtxX8FJhilGEwkfUoZ0uzWxnzcT';
 const PROD_WRITE_KEY = 'cOkp5EIJaN69gYaN8bcp7KtaD0fGABwJ';
@@ -21,6 +26,7 @@ const SEGMENT_FLUSH_INTERVAL_MS = 5_000;
 // Event names following apify-core naming convention (Title Case)
 const SEGMENT_EVENTS = {
     TOOL_CALL: 'MCP Tool Call',
+    STORAGE_ACCESS: 'MCP Storage Access',
 } as const;
 
 /**
@@ -64,9 +70,31 @@ export function getOrInitAnalyticsClient(telemetryEnv: TelemetryEnv): Analytics 
 }
 
 /**
+ * Sends an event to Segment.
+ * Segment requires either userId OR anonymousId, but not both:
+ * when userId is available, use it; otherwise use a random anonymousId.
+ */
+function trackEvent(
+    userId: string | null,
+    telemetryEnv: TelemetryEnv,
+    event: (typeof SEGMENT_EVENTS)[keyof typeof SEGMENT_EVENTS],
+    properties: ToolCallTelemetryProperties | StorageAccessTelemetryProperties,
+): void {
+    const client = getOrInitAnalyticsClient(telemetryEnv);
+
+    try {
+        client?.track({
+            ...(userId ? { userId } : { anonymousId: crypto.randomUUID() }),
+            event,
+            properties,
+        });
+    } catch (error) {
+        log.error('Failed to track telemetry event', { error, userId, event, toolName: properties.tool_name });
+    }
+}
+
+/**
  * Tracks a tool call event to Segment.
- * Segment requires either userId OR anonymousId, but not both
- * When userId is available, use it; otherwise use anonymousId
  *
  * @param userId - Apify user ID (null if not available)
  * @param telemetryEnv - Telemetry environment
@@ -77,15 +105,52 @@ export function trackToolCall(
     telemetryEnv: TelemetryEnv,
     properties: ToolCallTelemetryProperties,
 ): void {
-    const client = getOrInitAnalyticsClient(telemetryEnv);
+    trackEvent(userId, telemetryEnv, SEGMENT_EVENTS.TOOL_CALL, properties);
+}
 
-    try {
-        client?.track({
-            ...(userId ? { userId } : { anonymousId: crypto.randomUUID() }),
-            event: SEGMENT_EVENTS.TOOL_CALL,
-            properties,
-        });
-    } catch (error) {
-        log.error('Failed to track tool call event', { error, userId, toolName: properties.tool_name });
-    }
+/**
+ * Tracks a storage access event to Segment. Fired for storage tools (dataset /
+ * key-value store) in addition to the `MCP Tool Call` event, so storage usage
+ * and error rates can be analysed on a dedicated event.
+ */
+export function trackStorageAccess(
+    userId: string | null,
+    telemetryEnv: TelemetryEnv,
+    properties: StorageAccessTelemetryProperties,
+): void {
+    trackEvent(userId, telemetryEnv, SEGMENT_EVENTS.STORAGE_ACCESS, properties);
+}
+
+/**
+ * Projects a finalized tool-call event onto the dedicated storage-access event:
+ * keeps the common envelope plus status / error fields and adds `storage_type`.
+ * Actor / validation fields are dropped — they carry no meaning for storage tools.
+ */
+export function buildStorageAccessProperties(
+    toolCall: ToolCallTelemetryProperties,
+    storageType: StorageType,
+): StorageAccessTelemetryProperties {
+    return {
+        app: toolCall.app,
+        app_version: toolCall.app_version,
+        mcp_client_name: toolCall.mcp_client_name,
+        mcp_client_version: toolCall.mcp_client_version,
+        mcp_protocol_version: toolCall.mcp_protocol_version,
+        mcp_client_capabilities: toolCall.mcp_client_capabilities,
+        mcp_session_id: toolCall.mcp_session_id,
+        transport_type: toolCall.transport_type,
+        tool_name: toolCall.tool_name,
+        tool_status: toolCall.tool_status,
+        tool_exec_time_ms: toolCall.tool_exec_time_ms,
+        ...(toolCall.tool_response_content_bytes !== undefined && {
+            tool_response_content_bytes: toolCall.tool_response_content_bytes,
+        }),
+        ...(toolCall.tool_response_structured_content_bytes !== undefined && {
+            tool_response_structured_content_bytes: toolCall.tool_response_structured_content_bytes,
+        }),
+        ...(toolCall.failure_category !== undefined && { failure_category: toolCall.failure_category }),
+        ...(toolCall.failure_http_status !== undefined && { failure_http_status: toolCall.failure_http_status }),
+        ...(toolCall.failure_detail !== undefined && { failure_detail: toolCall.failure_detail }),
+        storage_type: storageType,
+    };
 }

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, HTTP_NOT_FOUND, TOOL_STATUS } from '../../const.js';
+import { FAILURE_CATEGORY, HelperTools, HTTP_NOT_FOUND, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -90,7 +90,11 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
             return buildMCPResponse({
                 texts: [`Failed to generate schema for dataset '${datasetId}'.`],
                 isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.FAILED },
+                telemetry: {
+                    toolStatus: TOOL_STATUS.FAILED,
+                    failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR,
+                    failureDetail: `Schema generation returned no schema for dataset '${datasetId}'.`,
+                },
             });
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ import type {
 import type z from 'zod';
 
 import type { ApifyClient } from './apify_client.js';
-import type { FAILURE_CATEGORY, TELEMETRY_ENV, TOOL_STATUS } from './const.js';
+import type { FAILURE_CATEGORY, STORAGE_TYPE, TELEMETRY_ENV, TOOL_STATUS } from './const.js';
 import type { ActorsMcpServer } from './mcp/server.js';
 import type { PaymentProvider } from './payments/types.js';
 import type { CATEGORY_NAMES } from './tools/categories.js';
@@ -349,6 +349,7 @@ export type ApifyToken = string | null | undefined;
  */
 export type ToolStatus = (typeof TOOL_STATUS)[keyof typeof TOOL_STATUS];
 export type FailureCategory = (typeof FAILURE_CATEGORY)[keyof typeof FAILURE_CATEGORY];
+export type StorageType = (typeof STORAGE_TYPE)[keyof typeof STORAGE_TYPE];
 
 /**
  * Properties for tool call telemetry events sent to Segment.
@@ -379,6 +380,34 @@ export type ToolCallTelemetryProperties = {
     validation_missing_property?: string;
     validation_additional_property?: string;
     validation_error_count?: number;
+};
+
+/**
+ * Properties for the dedicated `MCP Storage Access` telemetry event, fired for
+ * storage tools (dataset / key-value store) in addition to `MCP Tool Call`.
+ * Reuses the common envelope plus status / error fields so storage usage and
+ * error rates can be analysed on their own event, discriminated by `storage_type`.
+ */
+export type StorageAccessTelemetryProperties = Pick<
+    ToolCallTelemetryProperties,
+    | 'app'
+    | 'app_version'
+    | 'mcp_client_name'
+    | 'mcp_client_version'
+    | 'mcp_protocol_version'
+    | 'mcp_client_capabilities'
+    | 'mcp_session_id'
+    | 'transport_type'
+    | 'tool_name'
+    | 'tool_status'
+    | 'tool_exec_time_ms'
+    | 'tool_response_content_bytes'
+    | 'tool_response_structured_content_bytes'
+    | 'failure_category'
+    | 'failure_http_status'
+    | 'failure_detail'
+> & {
+    storage_type: StorageType;
 };
 
 export type AjvErrorDetails = Pick<

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,10 +1,10 @@
-import { type HelperTools } from '../const.js';
+import { HelperTools, STORAGE_TYPE } from '../const.js';
 import {
     SKYFIRE_ENABLED_TOOLS,
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../payments/const.js';
-import type { CallDiagnostics, HelperTool, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
+import type { CallDiagnostics, HelperTool, StorageType, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
 import { ServerMode, TOOL_TYPE } from '../types.js';
 import { fixZodSchemaRequired } from './ajv.js';
 
@@ -45,6 +45,26 @@ export function buildActorFields(
         ...(actorName ? { actor_name: actorName } : {}),
         ...(actorId ? { actor_id: actorId } : {}),
     };
+}
+
+/** Maps storage tool names to their storage type for the `MCP Storage Access` event. */
+const STORAGE_TOOL_TYPES: Partial<Record<HelperTools, StorageType>> = {
+    [HelperTools.DATASET_GET]: STORAGE_TYPE.DATASET,
+    [HelperTools.DATASET_LIST_GET]: STORAGE_TYPE.DATASET,
+    [HelperTools.DATASET_GET_ITEMS]: STORAGE_TYPE.DATASET,
+    [HelperTools.DATASET_SCHEMA_GET]: STORAGE_TYPE.DATASET,
+    [HelperTools.KEY_VALUE_STORE_GET]: STORAGE_TYPE.KEY_VALUE_STORE,
+    [HelperTools.KEY_VALUE_STORE_LIST_GET]: STORAGE_TYPE.KEY_VALUE_STORE,
+    [HelperTools.KEY_VALUE_STORE_KEYS_GET]: STORAGE_TYPE.KEY_VALUE_STORE,
+    [HelperTools.KEY_VALUE_STORE_RECORD_GET]: STORAGE_TYPE.KEY_VALUE_STORE,
+};
+
+/**
+ * Returns the storage type for a storage tool, or null for non-storage tools.
+ * Used to decide whether to emit the dedicated `MCP Storage Access` telemetry event.
+ */
+export function getStorageType(toolName: string): StorageType | null {
+    return STORAGE_TOOL_TYPES[toolName as HelperTools] ?? null;
 }
 
 /**

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -22,6 +22,7 @@ export type TextToolResult = Omit<CallToolResult, 'content'> & {
 export type ToolTelemetrySnapshot = {
     toolStatus?: string;
     failureCategory?: string;
+    failureDetail?: string;
 };
 
 /** Minimal `InternalToolArgs` stub for unit tests. */

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { trackToolCall } from '../../src/telemetry.js';
+import { STORAGE_TYPE } from '../../src/const.js';
+import { buildStorageAccessProperties, trackStorageAccess, trackToolCall } from '../../src/telemetry.js';
+import type { ToolCallTelemetryProperties } from '../../src/types.js';
 
 // Mock the Segment Analytics client
 const mockTrack = vi.fn();
@@ -113,5 +115,110 @@ describe('telemetry', () => {
             event: 'MCP Tool Call',
             properties,
         });
+    });
+});
+
+describe('trackStorageAccess()', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('sends the dedicated "MCP Storage Access" event', () => {
+        const properties = {
+            app: 'mcp' as const,
+            app_version: '0.5.6',
+            mcp_client_name: 'test-client',
+            mcp_client_version: '1.0.0',
+            mcp_protocol_version: '2024-11-05',
+            mcp_client_capabilities: {},
+            mcp_session_id: 'session-123',
+            transport_type: 'stdio',
+            tool_name: 'get-dataset-items',
+            tool_status: 'SUCCEEDED' as const,
+            tool_exec_time_ms: 100,
+            storage_type: STORAGE_TYPE.DATASET,
+        };
+
+        trackStorageAccess('test-user-123', 'DEV', properties);
+
+        expect(mockTrack).toHaveBeenCalledWith({
+            userId: 'test-user-123',
+            event: 'MCP Storage Access',
+            properties,
+        });
+    });
+});
+
+describe('buildStorageAccessProperties()', () => {
+    const toolCall: ToolCallTelemetryProperties = {
+        app: 'mcp',
+        app_version: '0.5.6',
+        mcp_client_name: 'test-client',
+        mcp_client_version: '1.0.0',
+        mcp_protocol_version: '2024-11-05',
+        mcp_client_capabilities: {},
+        mcp_session_id: 'session-123',
+        transport_type: 'stdio',
+        tool_name: 'get-key-value-store-record',
+        tool_status: 'SOFT_FAIL',
+        tool_exec_time_ms: 42,
+        tool_response_content_bytes: 10,
+        failure_category: 'INVALID_INPUT',
+        failure_detail: "Record 'x' not found.",
+    };
+
+    it('keeps the envelope plus status / error fields and adds storage_type', () => {
+        const result = buildStorageAccessProperties(toolCall, STORAGE_TYPE.KEY_VALUE_STORE);
+
+        expect(result).toEqual({
+            app: 'mcp',
+            app_version: '0.5.6',
+            mcp_client_name: 'test-client',
+            mcp_client_version: '1.0.0',
+            mcp_protocol_version: '2024-11-05',
+            mcp_client_capabilities: {},
+            mcp_session_id: 'session-123',
+            transport_type: 'stdio',
+            tool_name: 'get-key-value-store-record',
+            tool_status: 'SOFT_FAIL',
+            tool_exec_time_ms: 42,
+            tool_response_content_bytes: 10,
+            failure_category: 'INVALID_INPUT',
+            failure_detail: "Record 'x' not found.",
+            storage_type: STORAGE_TYPE.KEY_VALUE_STORE,
+        });
+    });
+
+    it('drops actor and validation fields that carry no meaning for storage tools', () => {
+        const result = buildStorageAccessProperties(
+            { ...toolCall, actor_name: 'apify/x', actor_id: 'abc', validation_keyword: 'required' },
+            STORAGE_TYPE.DATASET,
+        );
+
+        expect(result).not.toHaveProperty('actor_name');
+        expect(result).not.toHaveProperty('actor_id');
+        expect(result).not.toHaveProperty('validation_keyword');
+    });
+
+    it('omits absent optional fields rather than setting them undefined', () => {
+        const minimal: ToolCallTelemetryProperties = {
+            app: 'mcp',
+            app_version: '0.5.6',
+            mcp_client_name: 'test-client',
+            mcp_client_version: '1.0.0',
+            mcp_protocol_version: '2024-11-05',
+            mcp_client_capabilities: null,
+            mcp_session_id: 'session-123',
+            transport_type: 'stdio',
+            tool_name: 'get-dataset',
+            tool_status: 'SUCCEEDED',
+            tool_exec_time_ms: 5,
+        };
+
+        const result = buildStorageAccessProperties(minimal, STORAGE_TYPE.DATASET);
+
+        expect(result).not.toHaveProperty('failure_category');
+        expect(result).not.toHaveProperty('tool_response_content_bytes');
+        expect(Object.keys(result)).not.toContain('failure_detail');
     });
 });

--- a/tests/unit/tools.get_dataset_schema.test.ts
+++ b/tests/unit/tools.get_dataset_schema.test.ts
@@ -101,7 +101,12 @@ describe('get-dataset-schema', () => {
 
         expect(isError).toBe(true);
         expect(content[0].text).toContain("Failed to generate schema for dataset 'ds-1'");
-        expect(toolTelemetry).toEqual(expect.objectContaining({ toolStatus: TOOL_STATUS.FAILED }));
-        expect(toolTelemetry?.failureCategory).not.toBe(FAILURE_CATEGORY.INVALID_INPUT);
+        expect(toolTelemetry).toEqual(
+            expect.objectContaining({
+                toolStatus: TOOL_STATUS.FAILED,
+                failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR,
+            }),
+        );
+        expect(toolTelemetry?.failureDetail).toBeTruthy();
     });
 });

--- a/tests/unit/utils.tools.test.ts
+++ b/tests/unit/utils.tools.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { HelperTools, STORAGE_TYPE } from '../../src/const.js';
+import { getStorageType } from '../../src/utils/tools.js';
+
+describe('getStorageType()', () => {
+    it('maps dataset tools to DATASET', () => {
+        expect(getStorageType(HelperTools.DATASET_GET)).toBe(STORAGE_TYPE.DATASET);
+        expect(getStorageType(HelperTools.DATASET_LIST_GET)).toBe(STORAGE_TYPE.DATASET);
+        expect(getStorageType(HelperTools.DATASET_GET_ITEMS)).toBe(STORAGE_TYPE.DATASET);
+        expect(getStorageType(HelperTools.DATASET_SCHEMA_GET)).toBe(STORAGE_TYPE.DATASET);
+    });
+
+    it('maps key-value store tools to KEY_VALUE_STORE', () => {
+        expect(getStorageType(HelperTools.KEY_VALUE_STORE_GET)).toBe(STORAGE_TYPE.KEY_VALUE_STORE);
+        expect(getStorageType(HelperTools.KEY_VALUE_STORE_LIST_GET)).toBe(STORAGE_TYPE.KEY_VALUE_STORE);
+        expect(getStorageType(HelperTools.KEY_VALUE_STORE_KEYS_GET)).toBe(STORAGE_TYPE.KEY_VALUE_STORE);
+        expect(getStorageType(HelperTools.KEY_VALUE_STORE_RECORD_GET)).toBe(STORAGE_TYPE.KEY_VALUE_STORE);
+    });
+
+    it('returns null for non-storage tools', () => {
+        expect(getStorageType(HelperTools.ACTOR_CALL)).toBeNull();
+        expect(getStorageType(HelperTools.STORE_SEARCH)).toBeNull();
+        expect(getStorageType('apify/rag-web-browser')).toBeNull();
+        expect(getStorageType('')).toBeNull();
+    });
+});


### PR DESCRIPTION
Closes #887.

Adds a dedicated `MCP Storage Access` Segment event for storage tools (dataset / key-value store), so storage usage and error rates can be analysed separately from the generic `MCP Tool Call` event.

## What changed

- **New event.** Storage tools now emit `MCP Storage Access` in addition to `MCP Tool Call`. `getStorageType()` maps each storage tool name to `DATASET` or `KEY_VALUE_STORE`; non-storage tools return `null` and emit nothing extra.
- **Event properties.** `buildStorageAccessProperties()` projects the finalized tool-call event onto the storage event: keeps the common envelope plus status / error fields, adds `storage_type`, and drops actor / validation fields that carry no meaning for storage tools. Absent optional fields are omitted rather than set to `undefined`.
- **Telemetry plumbing.** Extracted a shared `trackEvent()` helper; `trackToolCall()` and the new `trackStorageAccess()` both delegate to it.
- **Error classification fix.** `get-dataset-schema` now classifies a no-schema generation failure as `INTERNAL_ERROR` with a `failureDetail`, instead of leaving the failure uncategorised — so it shows up correctly in the error-rate breakdown.

## Tests

- `getStorageType()` — dataset / KVS mapping + null for non-storage tools.
- `trackStorageAccess()` — emits the dedicated event.
- `buildStorageAccessProperties()` — field projection, dropped fields, omitted optionals.
- Updated `get-dataset-schema` failure test to assert the new category + detail.

type-check, lint, and `test:unit` (834 pass) all green.