### PR TITLE
feat: add richer serverInfo (title, description, icons)

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -22,6 +22,8 @@ export const SERVER_MODE_AUTO_DETECTION_ENABLED = true;
 
 export const SERVER_NAME = 'apify-mcp-server';
 export const SERVER_TITLE = 'Apify MCP Server';
+export const SERVER_DESCRIPTION =
+    'Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡';
 export enum HelperTools {
     ACTOR_ADD = 'add-actor',
     ACTOR_CALL = 'call-actor',

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -50,13 +50,16 @@ import { parseBooleanOrNull } from '@apify/utilities';
 import { ApifyClient } from '../apify_client.js';
 import {
     ALLOWED_TASK_TOOL_EXECUTION_MODES,
+    APIFY_FAVICON_URL,
     APIFY_MCP_URL,
     DEFAULT_TELEMETRY_ENABLED,
     DEFAULT_TELEMETRY_ENV,
     FAILURE_CATEGORY,
     HelperTools,
     HTTP_PAYMENT_REQUIRED,
+    SERVER_DESCRIPTION,
     SERVER_NAME,
+    SERVER_TITLE,
     TOOL_STATUS,
 } from '../const.js';
 import { prepareToolCallContext } from '../payments/helpers.js';
@@ -232,7 +235,10 @@ export class ActorsMcpServer {
         const { setupSigintHandler = true } = options;
         this.server = new Server(
             {
+                description: SERVER_DESCRIPTION,
+                icons: [{ src: APIFY_FAVICON_URL }],
                 name: SERVER_NAME,
+                title: SERVER_TITLE,
                 version: getPackageVersion()!,
                 websiteUrl: APIFY_MCP_URL,
             },

--- a/src/server_card.ts
+++ b/src/server_card.ts
@@ -1,11 +1,8 @@
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 
-import { APIFY_DOCS_MCP_URL, APIFY_FAVICON_URL, SERVER_NAME, SERVER_TITLE } from './const.js';
+import { APIFY_DOCS_MCP_URL, APIFY_FAVICON_URL, SERVER_DESCRIPTION, SERVER_NAME, SERVER_TITLE } from './const.js';
 import type { ServerCard } from './types.js';
-import { readJsonFile } from './utils/generic.js';
 import { getPackageVersion } from './utils/version.js';
-
-const serverJson = readJsonFile<{ description: string }>(import.meta.url, '../server.json');
 
 /** Returns the MCP server card object per SEP-1649. */
 export function getServerCard(): ServerCard {
@@ -18,7 +15,7 @@ export function getServerCard(): ServerCard {
             title: SERVER_TITLE,
             version: getPackageVersion()!,
         },
-        description: serverJson.description,
+        description: SERVER_DESCRIPTION,
         iconUrl: APIFY_FAVICON_URL,
         documentationUrl: APIFY_DOCS_MCP_URL,
         transport: {

--- a/tests/unit/mcp.server.capability_gating.test.ts
+++ b/tests/unit/mcp.server.capability_gating.test.ts
@@ -3,7 +3,14 @@ import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { ApifyClient } from 'apify-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { HelperTools, SERVER_MODE_AUTO_DETECTION_ENABLED } from '../../src/const.js';
+import {
+    APIFY_FAVICON_URL,
+    HelperTools,
+    SERVER_DESCRIPTION,
+    SERVER_MODE_AUTO_DETECTION_ENABLED,
+    SERVER_NAME,
+    SERVER_TITLE,
+} from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
 import { RESOURCE_MIME_TYPE } from '../../src/resources/widgets.js';
 import { appsCallActor } from '../../src/tools/apps/call_actor.js';
@@ -65,6 +72,23 @@ describe('ActorsMcpServer initialize handler', () => {
         servers.push(server);
         return server;
     };
+
+    describe('serverInfo', () => {
+        it('includes rich implementation metadata', () => {
+            const server = track(makeServer(ServerMode.DEFAULT));
+
+            const info = (server.server as unknown as { _serverInfo: Record<string, unknown> })._serverInfo;
+            const icons = info.icons as { src: string }[];
+
+            expect(info.name).toBe(SERVER_NAME);
+            expect(info.title).toBe(SERVER_TITLE);
+            expect(info.description).toBe(SERVER_DESCRIPTION);
+            expect(Array.isArray(info.icons)).toBe(true);
+            expect(icons.length).toBeGreaterThan(0);
+            expect(icons[0].src).toBe(APIFY_FAVICON_URL);
+            expect(icons[0].src).toMatch(/^https:\/\//);
+        });
+    });
 
     describe('mode resolution', () => {
         const cases: { option: ServerModeOption; supportsUi: boolean; expectedMode: ServerMode }[] = [


### PR DESCRIPTION
## Summary

The MCP server now reports `title`, `description`, and `icons` in its `serverInfo` (the `Implementation` object sent during initialization), in addition to the existing `name`, `version`, and `websiteUrl`. Clients that surface server metadata can now show a human-readable title, a one-line description, and the Apify icon instead of just the package name.

## Why this matters

Closes #955. The MCP 2025-11-25 schema lets the `Implementation` object carry `title`, `description`, and `icons` (an `Icon[]` where each entry has at least `src`), but the server only populated the three legacy fields. The richer fields were already proven out in `src/server_card.ts`, which builds a `serverInfo` with `title` and an `iconUrl` from the same constants. This change brings the initialization handshake in line with that precedent so both surfaces present identically.

## Changes

- Added a shared `SERVER_DESCRIPTION` constant in `src/const.ts` (the description string from `server.json`) and switched `server_card.ts` to use it, so the initialization handshake and the server card cannot drift. This also drops the runtime `server.json` read in `server_card.ts`.
- Extended the `new Server({...})` `serverInfo` literal in `src/mcp/server.ts` with `title: SERVER_TITLE`, `description: SERVER_DESCRIPTION`, and `icons: [{ src: APIFY_FAVICON_URL }]`. The change is confined to the `serverInfo` literal; initialization behavior is otherwise unchanged.

## Testing

- `pnpm run type-check`
- `pnpm run lint` (oxlint) and format check (oxfmt) clean
- `pnpm run test:unit` (833 passed); added a `serverInfo` unit test asserting `title`/`description` equal the shared constants and `icons[0].src` is the https favicon URL.

Fixes #955
