### PR TITLE
chore: remove unused TOOL_MAX_OUTPUT_CHARS constant

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -7,15 +7,6 @@ export const ACTOR_MAX_DESCRIPTION_LENGTH = 500;
 // Actor run const
 export const ACTOR_MAX_MEMORY_MBYTES = 4_096; // If the Actor requires 8GB of memory, free users can't run actors-mcp-server and requested Actor
 
-// Tool output
-/**
- * Usual tool output limit is 25k tokens where 1 token =~ 4 characters
- * thus 50k chars so we have some buffer because there was some issue with Claude code Actor call output token count.
- * This is primarily used for Actor tool call output, but we can then
- * reuse this in other tools as well.
- */
-export const TOOL_MAX_OUTPUT_CHARS = 50000;
-
 // MCP Server
 /** When `false`, `resolveServerMode('auto', ...)` forces {@link ServerMode.DEFAULT} regardless of client capabilities. */
 export const SERVER_MODE_AUTO_DETECTION_ENABLED = true;


### PR DESCRIPTION
## What
Remove the `TOOL_MAX_OUTPUT_CHARS` constant (and its doc comment) from `src/const.ts`.

## Why
It is dead code — `git grep` finds zero references anywhere outside its own definition. The intended consumer (`ensureOutputWithinCharLimit` in `src/utils/actor.ts`) takes `charLimit` as a parameter and is itself never called from production, so no tool output is actually capped by this value. Keeping it implies a response-size limit that does not exist.

## Testing
`pnpm type-check` and `oxlint` pass.