### PR TITLE
feat: Track file response bytes separately in telemetry

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -9,14 +9,6 @@ export const ACTOR_MAX_MEMORY_MBYTES = 4_096; // If the Actor requires 8GB of me
 
 // Tool output
 /**
- * Usual tool output limit is 25k tokens where 1 token =~ 4 characters
- * thus 50k chars so we have some buffer because there was some issue with Claude code Actor call output token count.
- * This is primarily used for Actor tool call output, but we can then
- * reuse this in other tools as well.
- */
-export const TOOL_MAX_OUTPUT_CHARS = 50000;
-
-/**
  * Binary key-value store records larger than this are returned as a fetchable link instead of
  * inline base64. base64 inflates the payload ~33%, so inlining large binaries (images, audio,
  * other files) would blow up the context window. Text and JSON records are not capped — the

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -88,7 +88,12 @@ import type {
 } from '../types.js';
 import { ServerMode, TOOL_TYPE } from '../types.js';
 import { getHttpStatusCode, logHttpError } from '../utils/logging.js';
-import { buildMCPResponse, computeToolResponseBytes, getToolCallErrorUserText } from '../utils/mcp.js';
+import {
+    buildMCPResponse,
+    buildResponseBytesTelemetry,
+    computeToolResponseBytes,
+    getToolCallErrorUserText,
+} from '../utils/mcp.js';
 import { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
@@ -1400,10 +1405,7 @@ export class ActorsMcpServer {
                 ...params.telemetryData,
                 tool_status: params.toolStatus,
                 tool_exec_time_ms: durationMs,
-                ...(params.responseBytes !== undefined && {
-                    tool_response_content_bytes: params.responseBytes.contentBytes,
-                    tool_response_structured_content_bytes: params.responseBytes.structuredContentBytes,
-                }),
+                ...buildResponseBytesTelemetry(params.responseBytes),
                 // Always include actor_name/actor_id; failure-specific fields are only present when callDiagnostics has them.
                 ...params.callDiagnostics,
             };

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1396,6 +1396,7 @@ export class ActorsMcpServer {
             ...(params.responseBytes !== undefined && {
                 responseContentBytes: params.responseBytes.contentBytes,
                 responseStructuredContentBytes: params.responseBytes.structuredContentBytes,
+                responseFileBytes: params.responseBytes.fileBytes,
             }),
             ...(params.taskId !== undefined && { taskId: params.taskId }),
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,6 +369,8 @@ export type ToolCallTelemetryProperties = {
     tool_response_content_bytes?: number;
     /** UTF-8 bytes of JSON-stringified structured content. */
     tool_response_structured_content_bytes?: number;
+    /** UTF-8 bytes of returned files/records: image/audio base64 `data` and embedded `resource` blob/text. */
+    tool_response_file_bytes?: number;
     failure_category?: FailureCategory;
     failure_http_status?: number;
     failure_detail?: string;

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -64,26 +64,40 @@ export function wrapJsonText(value: unknown): string {
 
 /**
  * Computes tool response payload bytes, split by payload side:
- * `contentBytes` sums the UTF-8 byte length of every text item in `content[]`;
- * `structuredContentBytes` is the UTF-8 byte length of JSON-stringified
- * `structuredContent` (if present). Kept separate because clients consume only
- * one side — newer read `structuredContent`, older read `content[]` — so summing
- * them double-counts mirrored payloads. Other fields (`isError`, `_meta`, etc.)
+ * `contentBytes` sums the UTF-8 byte length of every `text` item in `content[]` (conversational text);
+ * `fileBytes` sums returned file/record payloads in `content[]` — image/audio base64 `data` and
+ * embedded `resource` `blob`/`text` — kept separate so binary/file size doesn't skew the text metric;
+ * `structuredContentBytes` is the UTF-8 byte length of JSON-stringified `structuredContent` (if present).
+ * Kept separate because clients consume only one side — newer read `structuredContent`, older read
+ * `content[]` — so summing them double-counts mirrored payloads. Other fields (`isError`, `_meta`, etc.)
  * are not counted.
  */
 export function computeToolResponseBytes(result: unknown): {
     contentBytes: number;
     structuredContentBytes: number;
+    fileBytes: number;
 } {
     let contentBytes = 0;
     let structuredContentBytes = 0;
+    let fileBytes = 0;
     if (result && typeof result === 'object') {
         const res = result as { content?: unknown; structuredContent?: unknown };
         if (Array.isArray(res.content)) {
             for (const item of res.content) {
-                const text = (item as { text?: unknown })?.text;
-                if (typeof text === 'string') {
-                    contentBytes += Buffer.byteLength(text, 'utf8');
+                const block = item as {
+                    text?: unknown;
+                    data?: unknown;
+                    resource?: { blob?: unknown; text?: unknown };
+                };
+                // Conversational text the tool wrote for the model.
+                if (typeof block?.text === 'string') {
+                    contentBytes += Buffer.byteLength(block.text, 'utf8');
+                }
+                // Returned files/records: image/audio base64 `data`, embedded `resource` blob/text.
+                for (const payload of [block?.data, block?.resource?.blob, block?.resource?.text]) {
+                    if (typeof payload === 'string') {
+                        fileBytes += Buffer.byteLength(payload, 'utf8');
+                    }
                 }
             }
         }
@@ -96,22 +110,26 @@ export function computeToolResponseBytes(result: unknown): {
             }
         }
     }
-    return { contentBytes, structuredContentBytes };
+    return { contentBytes, structuredContentBytes, fileBytes };
 }
 
 /**
  * Maps computed response byte counts to their `tool_response_*_bytes` telemetry fields.
- * Single source of truth for the field set, so the call site spreads one helper instead of
- * enumerating each field. Returns `{}` when bytes weren't computed (e.g. telemetry-disabled
- * path) so callers can spread it unconditionally.
+ * Single source of truth for the field set, so adding a byte metric touches only
+ * `computeToolResponseBytes` and this mapping. Returns `{}` when bytes weren't computed
+ * (e.g. telemetry-disabled path) so callers can spread it unconditionally.
  */
 export function buildResponseBytesTelemetry(
     responseBytes?: ReturnType<typeof computeToolResponseBytes>,
-): Pick<ToolCallTelemetryProperties, 'tool_response_content_bytes' | 'tool_response_structured_content_bytes'> {
+): Pick<
+    ToolCallTelemetryProperties,
+    'tool_response_content_bytes' | 'tool_response_structured_content_bytes' | 'tool_response_file_bytes'
+> {
     if (!responseBytes) return {};
     return {
         tool_response_content_bytes: responseBytes.contentBytes,
         tool_response_structured_content_bytes: responseBytes.structuredContentBytes,
+        tool_response_file_bytes: responseBytes.fileBytes,
     };
 }
 

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -1,4 +1,4 @@
-import type { ToolTelemetryContext } from '../types.js';
+import type { ToolCallTelemetryProperties, ToolTelemetryContext } from '../types.js';
 import { getHttpStatusCode } from './logging.js';
 
 /** MCP `_meta` key for Apify Actor run information. Namespaced per MCP spec. */
@@ -97,6 +97,22 @@ export function computeToolResponseBytes(result: unknown): {
         }
     }
     return { contentBytes, structuredContentBytes };
+}
+
+/**
+ * Maps computed response byte counts to their `tool_response_*_bytes` telemetry fields.
+ * Single source of truth for the field set, so the call site spreads one helper instead of
+ * enumerating each field. Returns `{}` when bytes weren't computed (e.g. telemetry-disabled
+ * path) so callers can spread it unconditionally.
+ */
+export function buildResponseBytesTelemetry(
+    responseBytes?: ReturnType<typeof computeToolResponseBytes>,
+): Pick<ToolCallTelemetryProperties, 'tool_response_content_bytes' | 'tool_response_structured_content_bytes'> {
+    if (!responseBytes) return {};
+    return {
+        tool_response_content_bytes: responseBytes.contentBytes,
+        tool_response_structured_content_bytes: responseBytes.structuredContentBytes,
+    };
 }
 
 /** User-facing error text for tool execution failures with HTTP-aware hints. */

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -64,10 +64,8 @@ export function wrapJsonText(value: unknown): string {
 
 /**
  * Computes tool response payload bytes, split by payload side:
- * `contentBytes` sums the UTF-8 byte length of every `text` item in `content[]` (conversational text);
- * `fileBytes` sums returned file/record payloads in `content[]` — image/audio base64 `data` and
- * embedded `resource` `blob`/`text` — kept separate so binary/file size doesn't skew the text metric;
- * `structuredContentBytes` is the UTF-8 byte length of JSON-stringified `structuredContent` (if present).
+ * `fileBytes` sums the UTF-8 byte length of file/record payload strings in `content[]` — image/audio base64 `data` and
+ * embedded `resource` base64 `blob` / inline `text` — kept separate so binary/file payloads don't skew the text metric;
  * Kept separate because clients consume only one side — newer read `structuredContent`, older read
  * `content[]` — so summing them double-counts mirrored payloads. Other fields (`isError`, `_meta`, etc.)
  * are not counted.

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -18,14 +18,18 @@ describe('wrapJsonText()', () => {
 
 describe('computeToolResponseBytes()', () => {
     it('returns zero for null/undefined/non-object input', () => {
-        expect(computeToolResponseBytes(null)).toEqual({ contentBytes: 0, structuredContentBytes: 0 });
-        expect(computeToolResponseBytes(undefined)).toEqual({ contentBytes: 0, structuredContentBytes: 0 });
-        expect(computeToolResponseBytes('text')).toEqual({ contentBytes: 0, structuredContentBytes: 0 });
-        expect(computeToolResponseBytes(42)).toEqual({ contentBytes: 0, structuredContentBytes: 0 });
+        expect(computeToolResponseBytes(null)).toEqual({ contentBytes: 0, structuredContentBytes: 0, fileBytes: 0 });
+        expect(computeToolResponseBytes(undefined)).toEqual({
+            contentBytes: 0,
+            structuredContentBytes: 0,
+            fileBytes: 0,
+        });
+        expect(computeToolResponseBytes('text')).toEqual({ contentBytes: 0, structuredContentBytes: 0, fileBytes: 0 });
+        expect(computeToolResponseBytes(42)).toEqual({ contentBytes: 0, structuredContentBytes: 0, fileBytes: 0 });
     });
 
     it('returns zero for empty result object', () => {
-        expect(computeToolResponseBytes({})).toEqual({ contentBytes: 0, structuredContentBytes: 0 });
+        expect(computeToolResponseBytes({})).toEqual({ contentBytes: 0, structuredContentBytes: 0, fileBytes: 0 });
     });
 
     it('sums UTF-8 byte length of every text item in content[]', () => {
@@ -36,14 +40,14 @@ describe('computeToolResponseBytes()', () => {
             ],
         };
         // "hello" = 5 bytes, "world" = 5 bytes -> 10
-        expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 10, structuredContentBytes: 0 });
+        expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 10, structuredContentBytes: 0, fileBytes: 0 });
     });
 
     it('counts multi-byte UTF-8 characters correctly', () => {
         const result = {
             content: [{ type: 'text', text: 'café' }], // c=1 a=1 f=1 é=2 → 5 bytes
         };
-        expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 5, structuredContentBytes: 0 });
+        expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 5, structuredContentBytes: 0, fileBytes: 0 });
     });
 
     it('reports content and structuredContent bytes separately', () => {
@@ -54,17 +58,30 @@ describe('computeToolResponseBytes()', () => {
         expect(computeToolResponseBytes(result)).toEqual({
             contentBytes: Buffer.byteLength('ok', 'utf8'),
             structuredContentBytes: Buffer.byteLength(JSON.stringify({ url: 'https://x' }), 'utf8'),
+            fileBytes: 0,
         });
     });
 
-    it('ignores non-text items in content[]', () => {
+    it('counts image/audio base64 data as file bytes, not content bytes', () => {
         const result = {
             content: [
-                { type: 'image', data: 'base64...' },
+                { type: 'image', data: 'base64img' },
                 { type: 'text', text: 'hi' },
             ],
         };
-        expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 2, structuredContentBytes: 0 });
+        // "base64img" = 9 file bytes; "hi" = 2 content bytes — kept in separate buckets.
+        expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 2, structuredContentBytes: 0, fileBytes: 9 });
+    });
+
+    it('counts embedded resource blob and text as file bytes', () => {
+        const result = {
+            content: [
+                { type: 'resource', resource: { uri: 'https://x', blob: 'AAAA', mimeType: 'application/pdf' } },
+                { type: 'resource', resource: { uri: 'https://y', text: 'hello' } },
+            ],
+        };
+        // "AAAA" = 4 + "hello" = 5 -> 9 file bytes (uri/mimeType are metadata, not payload)
+        expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 0, structuredContentBytes: 0, fileBytes: 9 });
     });
 
     it('handles structuredContent without content[]', () => {
@@ -72,6 +89,7 @@ describe('computeToolResponseBytes()', () => {
         expect(computeToolResponseBytes(result)).toEqual({
             contentBytes: 0,
             structuredContentBytes: Buffer.byteLength(JSON.stringify({ a: 1 }), 'utf8'),
+            fileBytes: 0,
         });
     });
 
@@ -79,7 +97,7 @@ describe('computeToolResponseBytes()', () => {
         const circular: Record<string, unknown> = {};
         circular.self = circular;
         const result = { structuredContent: circular };
-        expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 0, structuredContentBytes: 0 });
+        expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 0, structuredContentBytes: 0, fileBytes: 0 });
     });
 });
 
@@ -90,9 +108,10 @@ describe('buildResponseBytesTelemetry()', () => {
     });
 
     it('maps byte counts to their telemetry fields', () => {
-        expect(buildResponseBytesTelemetry({ contentBytes: 10, structuredContentBytes: 20 })).toEqual({
+        expect(buildResponseBytesTelemetry({ contentBytes: 10, structuredContentBytes: 20, fileBytes: 30 })).toEqual({
             tool_response_content_bytes: 10,
             tool_response_structured_content_bytes: 20,
+            tool_response_file_bytes: 30,
         });
     });
 });

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeToolResponseBytes, wrapJsonText } from '../../src/utils/mcp.js';
+import { buildResponseBytesTelemetry, computeToolResponseBytes, wrapJsonText } from '../../src/utils/mcp.js';
 
 describe('wrapJsonText()', () => {
     it('emits a ```json … ``` fenced block', () => {
@@ -80,5 +80,19 @@ describe('computeToolResponseBytes()', () => {
         circular.self = circular;
         const result = { structuredContent: circular };
         expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 0, structuredContentBytes: 0 });
+    });
+});
+
+describe('buildResponseBytesTelemetry()', () => {
+    it('returns an empty object when no bytes are provided', () => {
+        expect(buildResponseBytesTelemetry()).toEqual({});
+        expect(buildResponseBytesTelemetry(undefined)).toEqual({});
+    });
+
+    it('maps byte counts to their telemetry fields', () => {
+        expect(buildResponseBytesTelemetry({ contentBytes: 10, structuredContentBytes: 20 })).toEqual({
+            tool_response_content_bytes: 10,
+            tool_response_structured_content_bytes: 20,
+        });
     });
 });

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -1,20 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildResponseBytesTelemetry, computeToolResponseBytes, wrapJsonText } from '../../src/utils/mcp.js';
-
-describe('wrapJsonText()', () => {
-    it('emits a ```json … ``` fenced block', () => {
-        expect(wrapJsonText({ a: 1 })).toBe('```json\n{"a":1}\n```');
-    });
-
-    it('serializes arrays', () => {
-        expect(wrapJsonText([1, 2])).toBe('```json\n[1,2]\n```');
-    });
-
-    it('serializes primitives', () => {
-        expect(wrapJsonText('x')).toBe('```json\n"x"\n```');
-    });
-});
+import { buildResponseBytesTelemetry, computeToolResponseBytes } from '../../src/utils/mcp.js';
 
 describe('computeToolResponseBytes()', () => {
     it('returns zero for null/undefined/non-object input', () => {


### PR DESCRIPTION
Stacked on #964.

## What

Adds a third tool-response size metric, `tool_response_file_bytes`, to `ToolCallTelemetryProperties`, alongside the existing `tool_response_content_bytes` (text) and `tool_response_structured_content_bytes`.

## Why

WIP work counted base64 media and embedded-resource bytes as text content, which would **skew** `tool_response_content_bytes` (meant to measure conversational text the tool wrote for the model). File/record payloads can dwarf the text, so this PR keeps them in a separate bucket.

## Changes

- `computeToolResponseBytes` now returns `fileBytes` — the UTF-8 bytes of returned files/records in `content[]`: image/audio base64 `data` and embedded `resource` `blob`/`text`. `contentBytes` stays text-only (`content[].text`).
- New `tool_response_file_bytes` telemetry field + matching `responseFileBytes` log field.
- `buildResponseBytesTelemetry` is the single source of truth for the `tool_response_*_bytes` field set, so the call site spreads one helper instead of enumerating each field (the repetition this metric would otherwise have tripled).
- Unit tests for the new bucket and the helper.

## Internal repo

Touches `ToolCallTelemetryProperties` (a field the hosted server consumes via Segment). The new field is optional and additive — no breaking change — but `apify-mcp-server-internal`'s telemetry contract suite may want a matching assertion.