### PR TITLE
fix(mcp): contain webServerMcpPath origin errors to one actor during tool load

### DIFF
--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -211,19 +211,21 @@ export async function getMCPServersAsTools(
             return [];
         }
 
-        const mcpServerUrl = await getActorMCPServerURL(
-            actorInfo.definition.id, // Real ID of the Actor
-            actorInfo.webServerMcpPath,
-        );
-        log.debug('Retrieved MCP server URL for Actor', {
-            actorFullName: actorInfo.definition.actorFullName,
-            actorId,
-            mcpServerUrl,
-            mcpSessionId,
-        });
-
         let client: Client | null = null;
         try {
+            // getActorMCPServerURL rejects a webServerMcpPath that escapes the Actor's standby origin.
+            // Resolve it inside the try so one Actor's bad path skips only that Actor, not the whole batch.
+            const mcpServerUrl = await getActorMCPServerURL(
+                actorInfo.definition.id, // Real ID of the Actor
+                actorInfo.webServerMcpPath,
+            );
+            log.debug('Retrieved MCP server URL for Actor', {
+                actorFullName: actorInfo.definition.actorFullName,
+                actorId,
+                mcpServerUrl,
+                mcpSessionId,
+            });
+
             client = await connectMCPClient(mcpServerUrl, apifyToken, mcpSessionId);
             if (!client) {
                 // Skip this Actor, connectMCPClient will log the error

--- a/tests/unit/tools.mcp_servers_as_tools.test.ts
+++ b/tests/unit/tools.mcp_servers_as_tools.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ActorInfo, ToolEntry } from '../../src/types.js';
+
+const getActorMCPServerURL = vi.fn();
+const connectMCPClient = vi.fn();
+const getMCPServerTools = vi.fn();
+
+vi.mock('../../src/mcp/actors.js', () => ({
+    getActorMCPServerURL: (...args: unknown[]) => getActorMCPServerURL(...args),
+    getActorMCPServerPath: vi.fn(),
+}));
+vi.mock('../../src/mcp/client.js', () => ({
+    connectMCPClient: (...args: unknown[]) => connectMCPClient(...args),
+}));
+vi.mock('../../src/mcp/proxy.js', () => ({
+    getMCPServerTools: (...args: unknown[]) => getMCPServerTools(...args),
+}));
+
+const { getMCPServersAsTools } = await import('../../src/tools/core/actor_tools_factory.js');
+
+function makeActorInfo(id: string, webServerMcpPath: string): ActorInfo {
+    return {
+        webServerMcpPath,
+        definition: { id, actorFullName: `user/${id}` },
+        actor: {},
+    } as unknown as ActorInfo;
+}
+
+describe('getMCPServersAsTools', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('skips only the Actor whose webServerMcpPath escapes its standby origin, not the whole batch', async () => {
+        const goodTool = { tool: { name: 'good-tool' } } as unknown as ToolEntry;
+        getActorMCPServerURL.mockImplementation(async (realActorId: string) => {
+            if (realActorId === 'evil') throw new Error('resolves outside its standby origin');
+            return `https://${realActorId}.apify.actor/mcp`;
+        });
+        connectMCPClient.mockResolvedValue({ close: vi.fn() });
+        getMCPServerTools.mockResolvedValue([goodTool]);
+
+        const tools = await getMCPServersAsTools(
+            [makeActorInfo('evil', '//attacker.com/mcp'), makeActorInfo('good', '/mcp')],
+            'token-123',
+        );
+
+        expect(tools).toEqual([goodTool]);
+        expect(getActorMCPServerURL).toHaveBeenCalledTimes(2);
+        expect(connectMCPClient).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## What
When loading MCP-server Actors as tools, resolve each Actor's standby MCP URL **inside** the per-Actor `try` in `getMCPServersAsTools`, so a failure is contained to that one Actor instead of rejecting the whole batch.

## Why
`getActorMCPServerURL` throws when an Actor's publisher-controlled `webServerMcpPath` resolves outside the Actor's standby origin (the cross-origin guard added in #927). It was called *before* the `try`, so the throw escaped the per-Actor isolation: a single Actor with a crafted `webServerMcpPath` rejected the `Promise.all`, failing tool loading for **every** Actor in the session — a denial-of-service with a trivial precondition (get one bad Actor into a session's tool set via add-actor/search). Moving the resolve inside the existing `try` degrades it to "skip this one Actor", which is how connection failures already behave.

## Testing
- New unit test `tools.mcp_servers_as_tools.test.ts`: two Actors, one whose path makes `getActorMCPServerURL` throw — asserts the valid Actor's tools still load. Verified it **fails** on the pre-fix code (whole batch rejects) and passes after.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check`, `pnpm test:unit` (864 pass / 2 skipped) all green.