### PR TITLE
refactor: Simplify Console link flow and dedupe tests

### DIFF
--- a/src/tools/actor_executor.ts
+++ b/src/tools/actor_executor.ts
@@ -66,7 +66,6 @@ export const actorExecutor: ActorExecutor = {
             abortSignal,
             mcpSessionId,
             onAbort: abortRunOnSignal,
-            linkContext: await getConsoleLinkContext(apifyClient.token, apifyClient),
         });
 
         if ('aborted' in fetchResult) {
@@ -87,6 +86,10 @@ export const actorExecutor: ActorExecutor = {
             dataset.itemsSchema = { type: 'object', properties: params.datasetItemsSchema };
         }
 
-        return buildGetActorRunSuccessResponse({ ...fetchResult.result, widget: false }) as ActorExecutionResult;
+        return buildGetActorRunSuccessResponse({
+            ...fetchResult.result,
+            widget: false,
+            linkContext: await getConsoleLinkContext(apifyClient.token, apifyClient),
+        }) as ActorExecutionResult;
     },
 };

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -63,7 +63,7 @@ export const getDataset: ToolEntry = Object.freeze({
         return {
             content: [
                 { type: 'text', text: wrapJsonText(normalized) },
-                ...buildConsoleLinkContent(linkContext ? buildConsoleDatasetUrl(linkContext, dataset.id) : undefined),
+                ...buildConsoleLinkContent(buildConsoleDatasetUrl(linkContext, dataset.id)),
             ],
         };
     },

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -125,8 +125,7 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             return buildStorageNotFound(`Dataset '${datasetId}' not found.`);
         }
 
-        const linkContext = await getConsoleLinkContext(apifyToken, client);
-        const apifyConsoleUrl = linkContext ? buildConsoleDatasetUrl(linkContext, datasetId) : undefined;
+        const apifyConsoleUrl = buildConsoleDatasetUrl(await getConsoleLinkContext(apifyToken, client), datasetId);
         const structuredContent = {
             datasetId,
             apifyConsoleUrl,

--- a/src/tools/common/get_key_value_store.ts
+++ b/src/tools/common/get_key_value_store.ts
@@ -52,9 +52,7 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
         return {
             content: [
                 { type: 'text', text: wrapJsonText(kvStore) },
-                ...buildConsoleLinkContent(
-                    linkContext ? buildConsoleKeyValueStoreUrl(linkContext, kvStore.id) : undefined,
-                ),
+                ...buildConsoleLinkContent(buildConsoleKeyValueStoreUrl(linkContext, kvStore.id)),
             ],
         };
     },

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -71,9 +71,7 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         return {
             content: [
                 { type: 'text', text: encodeToon(keys) },
-                ...buildConsoleLinkContent(
-                    linkContext ? buildConsoleKeyValueStoreUrl(linkContext, keyValueStoreId) : undefined,
-                ),
+                ...buildConsoleLinkContent(buildConsoleKeyValueStoreUrl(linkContext, keyValueStoreId)),
             ],
             structuredContent: keys,
         };

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -60,9 +60,7 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
         return {
             content: [
                 { type: 'text', text: wrapJsonText(record) },
-                ...buildConsoleLinkContent(
-                    linkContext ? buildConsoleKeyValueStoreUrl(linkContext, keyValueStoreId) : undefined,
-                ),
+                ...buildConsoleLinkContent(buildConsoleKeyValueStoreUrl(linkContext, keyValueStoreId)),
             ],
         };
     },

--- a/src/tools/core/actor_run_response.ts
+++ b/src/tools/core/actor_run_response.ts
@@ -143,8 +143,6 @@ export type RunResponse = {
 export type FetchActorRunResult = {
     run: ActorRun;
     structuredContent: RunResponse;
-    /** Console link context resolved for the request; forwarded so the response builder mints links in one pass. */
-    linkContext?: ConsoleLinkContext;
 };
 
 // -----------------------------------------------------------------------------
@@ -711,7 +709,6 @@ export async function fetchActorRunData(params: {
     abortSignal?: AbortSignal;
     mcpSessionId?: string;
     onAbort?: (runId: string, client: ApifyClient) => Promise<void>;
-    linkContext?: ConsoleLinkContext;
 }): Promise<{ error: object } | { aborted: true } | { result: FetchActorRunResult }> {
     const { runId, waitSecs, client, progressTracker, abortSignal, mcpSessionId, onAbort } = params;
 
@@ -812,7 +809,5 @@ export async function fetchActorRunData(params: {
         nextStep,
     };
 
-    // Console links are minted once at the response-building layer (buildGetActorRunSuccessResponse),
-    // so forward the context rather than mutating here.
-    return { result: { run, structuredContent, linkContext: params.linkContext } };
+    return { result: { run, structuredContent } };
 }

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -658,14 +658,13 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<obje
             abortSignal,
             mcpSessionId: toolArgs.mcpSessionId,
             onAbort: abortRunOnSignal,
-            linkContext,
         });
 
         if ('aborted' in fetchResult) return {};
         if ('error' in fetchResult) return fetchResult.error;
 
         return {
-            ...buildGetActorRunSuccessResponse({ ...fetchResult.result, widget: false }),
+            ...buildGetActorRunSuccessResponse({ ...fetchResult.result, widget: false, linkContext }),
             toolTelemetry: { actorId: resolvedActorId },
         };
     } catch (error) {

--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -13,12 +13,7 @@ import {
     typeObjectToString,
 } from '../../utils/actor_details.js';
 import { compileSchema } from '../../utils/ajv.js';
-import {
-    buildConsoleActorUrl,
-    isConsoleUiToken,
-    resolveConsoleLinkContext,
-    VERBATIM_LINKS_NUDGE,
-} from '../../utils/console_link.js';
+import { buildConsoleActorUrl, getConsoleLinkContext, VERBATIM_LINKS_NUDGE } from '../../utils/console_link.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
 import { actorDetailsOutputSchema } from '../structured_output_schemas.js';
@@ -175,9 +170,9 @@ export function buildActorDetailsTextResponse(options: {
 } {
     const { details, output, actorOutputSchema, mcpToolsMessage, linkContext } = options;
 
-    const actorUrl = linkContext
-        ? buildConsoleActorUrl(linkContext, details.actorInfo.id)
-        : `https://apify.com/${details.actorInfo.username}/${details.actorInfo.name}`;
+    const actorUrl =
+        buildConsoleActorUrl(linkContext, details.actorInfo.id) ??
+        `https://apify.com/${details.actorInfo.username}/${details.actorInfo.name}`;
 
     const texts: string[] = [];
 
@@ -253,14 +248,11 @@ export async function buildFetchActorDetailsResult(
     // or mcpTools-only requests). In that case `userTier` is only used to fill the
     // placeholder `{ model: 'FREE', userTier }` in the structured card, where it's never
     // read, so defaulting to 'FREE' is safe and saves a request.
-    // Console UI token sessions always need the lookup — it resolves the acting
-    // account (user vs organization) for minting personalized Console links.
-    const userInfo =
-        resolvedOutput.pricing || isConsoleUiToken(apifyToken)
-            ? await getUserInfoCached(apifyToken, apifyClient)
-            : undefined;
-    const userPlanTier = userInfo?.userPlanTier ?? 'FREE';
-    const linkContext = userInfo ? resolveConsoleLinkContext(apifyToken, userInfo) : undefined;
+    const userPlanTier = resolvedOutput.pricing
+        ? (await getUserInfoCached(apifyToken, apifyClient)).userPlanTier
+        : 'FREE';
+    // Console UI tokens hit the same cached users/me lookup; non-UI tokens short-circuit.
+    const linkContext = await getConsoleLinkContext(apifyToken, apifyClient);
     const cardOptions = { ...buildCardOptions(resolvedOutput), userTier: userPlanTier, linkContext };
     const details = await fetchActorDetails(apifyClient, actorName, cardOptions);
     if (!details) {

--- a/src/tools/core/get_actor_run_common.ts
+++ b/src/tools/core/get_actor_run_common.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { HelperTools, TOOL_STATUS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
-import type { HelperTool, ToolInputSchema } from '../../types.js';
+import type { ConsoleLinkContext, HelperTool, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema, fixZodSchemaRequired } from '../../utils/ajv.js';
 import { buildMCPResponse, buildUsageMeta } from '../../utils/mcp.js';
@@ -92,7 +92,7 @@ export function buildGetActorRunError(runId: string, error: unknown): ReturnType
  * `nextStep` in default mode, a short pointer in widget mode.
  */
 export function buildGetActorRunSuccessResponse(
-    params: FetchActorRunResult & { widget: boolean },
+    params: FetchActorRunResult & { widget: boolean; linkContext?: ConsoleLinkContext },
 ): ReturnType<typeof buildMCPResponse> {
     const { run, structuredContent, widget, linkContext } = params;
 

--- a/src/tools/default/get_actor_run.ts
+++ b/src/tools/default/get_actor_run.ts
@@ -26,7 +26,6 @@ export const defaultGetActorRun: ToolEntry = Object.freeze({
                 progressTracker,
                 abortSignal: extra?.signal,
                 mcpSessionId,
-                linkContext: await getConsoleLinkContext(apifyToken, client),
             });
 
             // Per MCP spec, receivers SHOULD NOT send a response for a cancelled request:
@@ -34,7 +33,11 @@ export const defaultGetActorRun: ToolEntry = Object.freeze({
             if ('aborted' in fetchResult) return {};
             if ('error' in fetchResult) return fetchResult.error;
 
-            return buildGetActorRunSuccessResponse({ ...fetchResult.result, widget: false });
+            return buildGetActorRunSuccessResponse({
+                ...fetchResult.result,
+                widget: false,
+                linkContext: await getConsoleLinkContext(apifyToken, client),
+            });
         } catch (error) {
             logHttpError(error, 'Failed to get Actor run', { runId: parsed.runId });
             return buildGetActorRunError(parsed.runId, error);

--- a/src/tools/default/search_actors.ts
+++ b/src/tools/default/search_actors.ts
@@ -3,7 +3,7 @@ import dedent from 'dedent';
 import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry } from '../../types.js';
 import { searchAgentSafeActors } from '../../utils/actor_search.js';
-import { resolveConsoleLinkContext, VERBATIM_LINKS_NUDGE } from '../../utils/console_link.js';
+import { getConsoleLinkContext, VERBATIM_LINKS_NUDGE } from '../../utils/console_link.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
 import {
@@ -24,7 +24,7 @@ export const defaultSearchActors: ToolEntry = Object.freeze({
         const parsed = searchActorsBaseArgsSchema.parse(args);
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
-        const [actors, userInfo] = await Promise.all([
+        const [actors, { userPlanTier }] = await Promise.all([
             searchAgentSafeActors({
                 keywords: parsed.keywords,
                 apifyToken,
@@ -39,12 +39,9 @@ export const defaultSearchActors: ToolEntry = Object.freeze({
             return buildSearchActorsEmptyResponse(parsed.keywords);
         }
 
-        const linkContext = resolveConsoleLinkContext(apifyToken, userInfo);
-        const { actorCardText, actorCardStructured } = buildSearchActorsResult(
-            actors,
-            userInfo.userPlanTier,
-            linkContext,
-        );
+        // Cache hit — the Promise.all above already resolved users/me for this token.
+        const linkContext = await getConsoleLinkContext(apifyToken, apifyClient);
+        const { actorCardText, actorCardStructured } = buildSearchActorsResult(actors, userPlanTier, linkContext);
         const verbatimLinksNudge = linkContext ? `\n${VERBATIM_LINKS_NUDGE}` : '';
         const structuredContent = {
             actors: actorCardStructured,

--- a/src/types.ts
+++ b/src/types.ts
@@ -651,7 +651,7 @@ export type StructuredActorCard = {
 
 /**
  * Context for minting Apify Console links instead of public website links.
- * Resolved from the session token by `resolveConsoleLinkContext` — present only for
+ * Resolved from the session token by `getConsoleLinkContext` — present only for
  * Console UI token sessions (its presence is the signal to mint Console links). The
  * Console origin is global per cluster, so it lives in the builders, not here.
  */

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -121,9 +121,7 @@ type ExtractedActorData = {
  */
 function extractActorData(actor: Actor | ActorStoreList, options: ActorCardOptions): ExtractedActorData {
     const actorFullName = `${actor.username}/${actor.name}`;
-    const actorUrl = options.linkContext
-        ? buildConsoleActorUrl(options.linkContext, actor.id)
-        : `${APIFY_STORE_URL}/${actorFullName}`;
+    const actorUrl = buildConsoleActorUrl(options.linkContext, actor.id) ?? `${APIFY_STORE_URL}/${actorFullName}`;
 
     const data: ExtractedActorData = {
         actorFullName,

--- a/src/utils/console_link.ts
+++ b/src/utils/console_link.ts
@@ -1,7 +1,7 @@
 import type { ApifyClient } from '../apify_client.js';
 import { CONSOLE_BASE_URL, CONSOLE_BASE_URL_STAGING, STAGING_MCP_HOSTNAME } from '../const.js';
 import type { ConsoleLinkContext } from '../types.js';
-import { type CachedUserInfo, getUserInfoCached } from './userid_cache.js';
+import { getUserInfoCached } from './userid_cache.js';
 
 /** Console origin for the current cluster: staging when on the staging MCP host, production otherwise. */
 function getConsoleBaseUrl(): string {
@@ -10,11 +10,6 @@ function getConsoleBaseUrl(): string {
 
 /** Prefix of Apify Console UI (session) tokens, as opposed to `apify_api_...` API tokens. */
 const UI_TOKEN_PREFIX = 'apify_ui_';
-
-/** True when the request is authenticated with a Console UI (session) token. */
-export function isConsoleUiToken(apifyToken: string | undefined): boolean {
-    return Boolean(apifyToken?.startsWith(UI_TOKEN_PREFIX));
-}
 
 // Console links are personalized — models otherwise tend to "correct" them to
 // the public apify.com URLs they know from training data.
@@ -29,51 +24,49 @@ export const VERBATIM_LINKS_NUDGE =
  * (e.g. the Console AI chat), so they are a verifiable signal that the user is in
  * Console → Console links. All other sessions → public `apify.com` links.
  *
- * For an organization-scoped token the `users/me` lookup resolves to the
- * organization itself, which yields org-prefixed links.
- */
-export function resolveConsoleLinkContext(
-    apifyToken: string | undefined,
-    userInfo: CachedUserInfo,
-): ConsoleLinkContext | undefined {
-    if (!isConsoleUiToken(apifyToken)) return undefined;
-    return { organizationId: userInfo.isOrganization && userInfo.userId ? userInfo.userId : undefined };
-}
-
-/**
- * Resolves the Console link context straight from the request token: `undefined`
- * for non-UI tokens (no API call), otherwise backed by the cached `users/me` lookup.
+ * Non-UI tokens short-circuit without an API call. For UI tokens the cached
+ * `users/me` lookup resolves the acting account; an organization-scoped token
+ * resolves to the organization itself, which yields org-prefixed links.
  */
 export async function getConsoleLinkContext(
     apifyToken: string | undefined,
     apifyClient: ApifyClient,
 ): Promise<ConsoleLinkContext | undefined> {
-    if (!isConsoleUiToken(apifyToken)) return undefined;
-    return resolveConsoleLinkContext(apifyToken, await getUserInfoCached(apifyToken, apifyClient));
+    if (!apifyToken?.startsWith(UI_TOKEN_PREFIX)) return undefined;
+    const userInfo = await getUserInfoCached(apifyToken, apifyClient);
+    return { organizationId: userInfo.isOrganization && userInfo.userId ? userInfo.userId : undefined };
 }
 
-/** Builds `<consoleBaseUrl>[/organization/<orgId>]<path>`. */
-function buildConsoleUrl(context: ConsoleLinkContext, path: string): string {
+/**
+ * Builds `<consoleBaseUrl>[/organization/<orgId>]<path>`.
+ * Accepts an undefined context (non-Console session) and returns undefined, so
+ * call sites can pass the resolved context straight through without a ternary.
+ */
+function buildConsoleUrl(context: ConsoleLinkContext | undefined, path: string): string | undefined {
+    if (!context) return undefined;
     const orgPrefix = context.organizationId ? `/organization/${context.organizationId}` : '';
     return `${getConsoleBaseUrl()}${orgPrefix}${path}`;
 }
 
 /** Builds the Console Actor detail URL: `<consoleBaseUrl>[/organization/<orgId>]/actors/<actorId>`. */
-export function buildConsoleActorUrl(context: ConsoleLinkContext, actorId: string): string {
+export function buildConsoleActorUrl(context: ConsoleLinkContext | undefined, actorId: string): string | undefined {
     return buildConsoleUrl(context, `/actors/${actorId}`);
 }
 
 /** Builds the Console run detail URL: `<consoleBaseUrl>[/organization/<orgId>]/actors/runs/<runId>`. */
-export function buildConsoleRunUrl(context: ConsoleLinkContext, runId: string): string {
+export function buildConsoleRunUrl(context: ConsoleLinkContext | undefined, runId: string): string | undefined {
     return buildConsoleUrl(context, `/actors/runs/${runId}`);
 }
 
 /** Builds the Console dataset URL: `<consoleBaseUrl>[/organization/<orgId>]/storage/datasets/<datasetId>`. */
-export function buildConsoleDatasetUrl(context: ConsoleLinkContext, datasetId: string): string {
+export function buildConsoleDatasetUrl(context: ConsoleLinkContext | undefined, datasetId: string): string | undefined {
     return buildConsoleUrl(context, `/storage/datasets/${datasetId}`);
 }
 
 /** Builds the Console key-value store URL: `<consoleBaseUrl>[/organization/<orgId>]/storage/key-value-stores/<storeId>`. */
-export function buildConsoleKeyValueStoreUrl(context: ConsoleLinkContext, storeId: string): string {
+export function buildConsoleKeyValueStoreUrl(
+    context: ConsoleLinkContext | undefined,
+    storeId: string,
+): string | undefined {
     return buildConsoleUrl(context, `/storage/key-value-stores/${storeId}`);
 }

--- a/tests/unit/console_link.test.ts
+++ b/tests/unit/console_link.test.ts
@@ -8,40 +8,49 @@ import {
     buildConsoleKeyValueStoreUrl,
     buildConsoleRunUrl,
     getConsoleLinkContext,
-    isConsoleUiToken,
-    resolveConsoleLinkContext,
 } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
+import { mockUserInfo } from './helpers/tool_context.js';
 
 vi.mock('../../src/utils/userid_cache.js', () => ({
     getUserInfoCached: vi.fn(),
 }));
 
+describe('getConsoleLinkContext', () => {
+    const client = {} as ApifyClient;
 
-describe('resolveConsoleLinkContext', () => {
-    const personalUser = { userId: 'USER_ID', userPlanTier: 'FREE' as const, isOrganization: false };
-    const orgUser = { userId: 'ORG_ID', userPlanTier: 'FREE' as const, isOrganization: true };
-
-    it('returns undefined for API tokens', () => {
-        expect(resolveConsoleLinkContext('apify_api_abc', personalUser)).toBeUndefined();
-        expect(resolveConsoleLinkContext('apify_api_abc', orgUser)).toBeUndefined();
+    beforeEach(() => {
+        vi.mocked(getUserInfoCached).mockReset();
     });
 
-    it('returns undefined for a missing token', () => {
-        expect(resolveConsoleLinkContext(undefined, personalUser)).toBeUndefined();
+    it('returns undefined for API tokens without a users/me lookup', async () => {
+        expect(await getConsoleLinkContext('apify_api_abc', client)).toBeUndefined();
+        expect(await getConsoleLinkContext('legacy-token-format', client)).toBeUndefined();
+        expect(getUserInfoCached).not.toHaveBeenCalled();
     });
 
-    it('returns a context without organizationId for a personal UI token', () => {
-        expect(resolveConsoleLinkContext('apify_ui_abc', personalUser)).toEqual({ organizationId: undefined });
+    it('returns undefined for a missing or empty token', async () => {
+        expect(await getConsoleLinkContext(undefined, client)).toBeUndefined();
+        expect(await getConsoleLinkContext('', client)).toBeUndefined();
+        expect(getUserInfoCached).not.toHaveBeenCalled();
     });
 
-    it('returns the acting account as organizationId for an org-scoped UI token', () => {
-        expect(resolveConsoleLinkContext('apify_ui_abc', orgUser)).toEqual({ organizationId: 'ORG_ID' });
+    it('returns a context without organizationId for a personal UI token', async () => {
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
+
+        expect(await getConsoleLinkContext('apify_ui_abc', client)).toEqual({ organizationId: undefined });
     });
 
-    it('omits organizationId when the user lookup failed (anonymous fallback)', () => {
-        const anonymous = { userId: null, userPlanTier: 'FREE' as const, isOrganization: false };
-        expect(resolveConsoleLinkContext('apify_ui_abc', anonymous)).toEqual({ organizationId: undefined });
+    it('returns the acting account as organizationId for an org-scoped UI token', async () => {
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo({ userId: 'ORG_ID', isOrganization: true }));
+
+        expect(await getConsoleLinkContext('apify_ui_abc', client)).toEqual({ organizationId: 'ORG_ID' });
+    });
+
+    it('omits organizationId when the user lookup failed (anonymous fallback)', async () => {
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo({ userId: null }));
+
+        expect(await getConsoleLinkContext('apify_ui_abc', client)).toEqual({ organizationId: undefined });
     });
 });
 
@@ -70,6 +79,13 @@ describe('buildConsole*Url (production host)', () => {
             'https://console.apify.com/organization/ORG_ID/storage/key-value-stores/STORE_ID',
         );
     });
+
+    it('returns undefined without a context (non-Console session)', () => {
+        expect(buildConsoleActorUrl(undefined, 'ACTOR_ID')).toBeUndefined();
+        expect(buildConsoleRunUrl(undefined, 'RUN_ID')).toBeUndefined();
+        expect(buildConsoleDatasetUrl(undefined, 'DATASET_ID')).toBeUndefined();
+        expect(buildConsoleKeyValueStoreUrl(undefined, 'STORE_ID')).toBeUndefined();
+    });
 });
 
 describe('buildConsole*Url (staging host)', () => {
@@ -89,28 +105,5 @@ describe('buildConsole*Url (staging host)', () => {
         expect(buildConsoleDatasetUrl({ organizationId: 'ORG_ID' }, 'DATASET_ID')).toBe(
             'https://console-securitybyobscurity.apify.com/organization/ORG_ID/storage/datasets/DATASET_ID',
         );
-    });
-});
-
-describe('getConsoleLinkContext', () => {
-    const client = {} as ApifyClient;
-
-    beforeEach(() => {
-        vi.mocked(getUserInfoCached).mockReset();
-    });
-
-    it('returns undefined for API tokens without a users/me lookup', async () => {
-        expect(await getConsoleLinkContext('apify_api_abc', client)).toBeUndefined();
-        expect(getUserInfoCached).not.toHaveBeenCalled();
-    });
-
-    it('resolves the context for UI tokens via the cached users/me lookup', async () => {
-        vi.mocked(getUserInfoCached).mockResolvedValue({
-            userId: 'ORG_ID',
-            userPlanTier: 'FREE',
-            isOrganization: true,
-        });
-
-        expect(await getConsoleLinkContext('apify_ui_abc', client)).toEqual({ organizationId: 'ORG_ID' });
     });
 });

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -5,6 +5,12 @@ import { expect } from 'vitest';
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../../src/const.js';
 import type { InternalToolArgs } from '../../../src/types.js';
 import { FENCES } from '../../../src/utils/encode_text.js';
+import type { CachedUserInfo } from '../../../src/utils/userid_cache.js';
+
+/** Default `CachedUserInfo` for tests that mock `getUserInfoCached`. */
+export function mockUserInfo(overrides: Partial<CachedUserInfo> = {}): CachedUserInfo {
+    return { userId: 'USER_ID', userPlanTier: 'FREE', isOrganization: false, ...overrides };
+}
 
 /** Inverse of `wrapJsonText`; imports prod's fence constants so the two halves can't drift. */
 export function parseFencedJson(text: string): unknown {

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -9,6 +9,7 @@ import type { ActorDetailsResult } from '../../src/utils/actor_details.js';
 import { fetchActorDetails } from '../../src/utils/actor_details.js';
 import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
+import { mockUserInfo } from './helpers/tool_context.js';
 import { stubInternalToolArgs } from './tools.search_actors.fixtures.js';
 
 vi.mock('../../src/utils/actor_details.js', async () => {
@@ -177,11 +178,7 @@ describe('buildFetchActorDetailsResult()', () => {
     });
 
     it('performs the lookup for Console UI tokens and mints Console links', async () => {
-        vi.mocked(getUserInfoCached).mockResolvedValue({
-            userId: 'USER_ID',
-            userPlanTier: 'FREE',
-            isOrganization: false,
-        });
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
 
         const { content } = await callWithToken('apify_ui_test');
 

--- a/tests/unit/tools.fetch_actor_details.widget.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.widget.response.test.ts
@@ -6,6 +6,7 @@ import type { HelperTool } from '../../src/types.js';
 import type { ActorDetailsResult } from '../../src/utils/actor_details.js';
 import { fetchActorDetails } from '../../src/utils/actor_details.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
+import { mockUserInfo } from './helpers/tool_context.js';
 import { stubInternalToolArgs } from './tools.search_actors.fixtures.js';
 
 /**
@@ -57,7 +58,7 @@ describe('fetch-actor-details-widget response', () => {
     beforeEach(() => {
         vi.mocked(fetchActorDetails).mockReset();
         vi.mocked(getUserInfoCached).mockReset();
-        vi.mocked(getUserInfoCached).mockResolvedValue({ userId: null, userPlanTier: 'FREE', isOrganization: false });
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo({ userId: null }));
     });
 
     it('returns { actorDetails: { actorInfo, actorCard, readme } } as structuredContent plus widget _meta', async () => {

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -13,7 +13,7 @@ import { defaultGetActorRun } from '../../src/tools/default/get_actor_run.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
-import { stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import { mockUserInfo, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
 // Only Console UI token sessions reach the users/me lookup; the default 'test-token'
 // stub never triggers it.
@@ -489,11 +489,7 @@ describe('get-actor-run default response', () => {
         });
 
         it('mints run + dataset + KV Console links and appends the Console line + nudge to the narrative', async () => {
-            vi.mocked(getUserInfoCached).mockResolvedValue({
-                userId: 'USER_ID',
-                userPlanTier: 'FREE',
-                isOrganization: false,
-            });
+            vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
 
             const run = mockSucceededRun();
             const result = await (defaultGetActorRun as HelperTool).call({
@@ -580,11 +576,12 @@ describe('buildStartRunResponse()', () => {
         expect(_meta).toBeUndefined();
     });
 
-    it('mints org-prefixed Console links and appends the Console line when linkContext is set', () => {
+    // Org-prefixed URL variants are covered by the builder tests in console_link.test.ts.
+    it('mints Console links and appends the Console line when linkContext is set', () => {
         const result = buildStartRunResponse({
             actorName: 'apify/rag-web-browser',
             actorRun,
-            linkContext: { organizationId: 'ORG_ID' },
+            linkContext: {},
         });
 
         const { structuredContent, content } = result as {
@@ -592,17 +589,15 @@ describe('buildStartRunResponse()', () => {
             content: { type: string; text: string }[];
         };
 
-        expect(structuredContent.apifyConsoleUrl).toBe(
-            'https://console.apify.com/organization/ORG_ID/actors/runs/run-abc',
-        );
+        expect(structuredContent.apifyConsoleUrl).toBe('https://console.apify.com/actors/runs/run-abc');
         expect(structuredContent.storages.datasets?.default.apifyConsoleUrl).toBe(
-            'https://console.apify.com/organization/ORG_ID/storage/datasets/dataset-abc',
+            'https://console.apify.com/storage/datasets/dataset-abc',
         );
         expect(structuredContent.storages.keyValueStores?.default.apifyConsoleUrl).toBe(
-            'https://console.apify.com/organization/ORG_ID/storage/key-value-stores/kv-abc',
+            'https://console.apify.com/storage/key-value-stores/kv-abc',
         );
         expect(JSON.parse(content[0].text)).toEqual(structuredContent);
-        expect(content[1].text).toContain('Apify Console: run https://console.apify.com/organization/ORG_ID');
+        expect(content[1].text).toContain('Apify Console: run https://console.apify.com/actors/runs/run-abc');
         expect(content[1].text).toContain(VERBATIM_LINKS_NUDGE);
     });
 

--- a/tests/unit/tools.get_dataset.test.ts
+++ b/tests/unit/tools.get_dataset.test.ts
@@ -7,6 +7,7 @@ import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     expectSoftFailInvalidInput,
+    mockUserInfo,
     parseFencedJson,
     stubToolCallContext,
     type TextToolResult,
@@ -156,11 +157,7 @@ describe('get-dataset fields normalization', () => {
     });
 
     it('appends the dataset Console link (from the API-returned id) for Console UI token sessions', async () => {
-        vi.mocked(getUserInfoCached).mockResolvedValue({
-            userId: 'USER_ID',
-            userPlanTier: 'FREE',
-            isOrganization: false,
-        });
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
 
         // Slug input — the link must use the API-returned id, not the slug.
         const result = await (getDataset as HelperTool).call({

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -9,6 +9,7 @@ import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     decodeFencedToolText,
     expectSoftFailInvalidInput,
+    mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
 } from './helpers/tool_context.js';
@@ -186,11 +187,7 @@ describe('get-dataset-items', () => {
     });
 
     it('adds the dataset Console link to structuredContent and content for Console UI token sessions', async () => {
-        vi.mocked(getUserInfoCached).mockResolvedValue({
-            userId: 'USER_ID',
-            userPlanTier: 'FREE',
-            isOrganization: false,
-        });
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
 
         const result = await (getDatasetItems as HelperTool).call({
             ...stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient()),
@@ -205,18 +202,5 @@ describe('get-dataset-items', () => {
         expect(content[1].text).toBe(
             `Apify Console: https://console.apify.com/storage/datasets/ds-1\n${VERBATIM_LINKS_NUDGE}`,
         );
-    });
-
-    it('keeps the response link-free for API tokens', async () => {
-        const result = await (getDatasetItems as HelperTool).call({
-            ...stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient()),
-            apifyToken: 'apify_api_test',
-        });
-        const { structuredContent, content } = result as TextToolResult & {
-            structuredContent: Record<string, unknown>;
-        };
-
-        expect(structuredContent.apifyConsoleUrl).toBeUndefined();
-        expect(content).toHaveLength(1);
     });
 });

--- a/tests/unit/tools.get_key_value_store.test.ts
+++ b/tests/unit/tools.get_key_value_store.test.ts
@@ -7,6 +7,7 @@ import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     expectSoftFailInvalidInput,
+    mockUserInfo,
     parseFencedJson,
     stubToolCallContext,
     type TextToolResult,
@@ -61,11 +62,7 @@ describe('get-key-value-store', () => {
     });
 
     it('appends the store Console link (from the API-returned id) for Console UI token sessions', async () => {
-        vi.mocked(getUserInfoCached).mockResolvedValue({
-            userId: 'USER_ID',
-            userPlanTier: 'FREE',
-            isOrganization: false,
-        });
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
 
         const result = await (getKeyValueStore as HelperTool).call({
             ...stubToolCallContext({ keyValueStoreId: 'user~my-store' }, stubApifyClient(MOCK_STORE)),

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -8,6 +8,7 @@ import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     decodeFencedToolText,
     expectSoftFailInvalidInput,
+    mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
 } from './helpers/tool_context.js';
@@ -128,11 +129,7 @@ describe('get-key-value-store-keys', () => {
     });
 
     it('appends the store Console link for Console UI token sessions', async () => {
-        vi.mocked(getUserInfoCached).mockResolvedValue({
-            userId: 'USER_ID',
-            userPlanTier: 'FREE',
-            isOrganization: false,
-        });
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
 
         const result = await (getKeyValueStoreKeys as HelperTool).call({
             ...stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(vi.fn().mockResolvedValue(MOCK_KEYS))),

--- a/tests/unit/tools.get_key_value_store_record.test.ts
+++ b/tests/unit/tools.get_key_value_store_record.test.ts
@@ -7,6 +7,7 @@ import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     expectSoftFailInvalidInput,
+    mockUserInfo,
     parseFencedJson,
     stubToolCallContext,
     type TextToolResult,
@@ -100,11 +101,7 @@ describe('get-key-value-store-record', () => {
     });
 
     it('appends the store Console link for Console UI token sessions', async () => {
-        vi.mocked(getUserInfoCached).mockResolvedValue({
-            userId: 'USER_ID',
-            userPlanTier: 'FREE',
-            isOrganization: false,
-        });
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
 
         const result = await (getKeyValueStoreRecord as HelperTool).call({
             ...stubToolCallContext(

--- a/tests/unit/tools.search_actors.default.response.test.ts
+++ b/tests/unit/tools.search_actors.default.response.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../src/utils/actor_card.js';
 import { searchAgentSafeActors } from '../../src/utils/actor_search.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
+import { mockUserInfo } from './helpers/tool_context.js';
 import { MOCK_STORE_ACTOR, SEARCH_KEYWORDS, stubInternalToolArgs } from './tools.search_actors.fixtures.js';
 
 /**
@@ -41,7 +42,7 @@ describe('search-actors without widget (defaultSearchActors)', () => {
     beforeEach(() => {
         vi.mocked(searchAgentSafeActors).mockReset();
         vi.mocked(getUserInfoCached).mockReset();
-        vi.mocked(getUserInfoCached).mockResolvedValue({ userId: null, userPlanTier: 'FREE', isOrganization: false });
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo({ userId: null }));
     });
 
     it('returns structured actors and markdown text; no widget payload', async () => {
@@ -170,60 +171,24 @@ describe('search-actors without widget (defaultSearchActors)', () => {
         expect(content[0].text).toContain(SEARCH_KEYWORDS);
     });
 
-    describe('Console UI token sessions (personalized Console links)', () => {
-        const callWithToken = async (apifyToken: string) => {
-            vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
-            const result = await (defaultSearchActors as HelperTool).call({
-                ...stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }),
-                apifyToken,
-            });
-            return result as {
-                structuredContent: { actors: { url: string }[] };
-                content: { type: string; text: string }[];
-            };
+    // Org-prefixed and non-Console variants are covered by console_link.test.ts and
+    // the get-actor-run response tests.
+    it('mints Console links for a Console UI token', async () => {
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+
+        const result = await (defaultSearchActors as HelperTool).call({
+            ...stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }),
+            apifyToken: 'apify_ui_test',
+        });
+        const { structuredContent, content } = result as {
+            structuredContent: { actors: { url: string }[] };
+            content: { type: string; text: string }[];
         };
+        const consoleUrl = `https://console.apify.com/actors/${MOCK_STORE_ACTOR.id}`;
 
-        it('mints personal Console links for a personal UI token', async () => {
-            vi.mocked(getUserInfoCached).mockResolvedValue({
-                userId: 'USER_ID',
-                userPlanTier: 'FREE',
-                isOrganization: false,
-            });
-
-            const { structuredContent, content } = await callWithToken('apify_ui_test');
-            const consoleUrl = `https://console.apify.com/actors/${MOCK_STORE_ACTOR.id}`;
-
-            expect(structuredContent.actors[0].url).toBe(consoleUrl);
-            expect(content[0].text).toContain(`## [${MOCK_STORE_ACTOR.title}](${consoleUrl})`);
-            expect(content[0].text).not.toContain(`${APIFY_STORE_URL}/apify/web-scraper`);
-        });
-
-        it('mints org-prefixed Console links for an org-scoped UI token', async () => {
-            vi.mocked(getUserInfoCached).mockResolvedValue({
-                userId: 'ORG_ID',
-                userPlanTier: 'FREE',
-                isOrganization: true,
-            });
-
-            const { structuredContent, content } = await callWithToken('apify_ui_test');
-            const consoleUrl = `https://console.apify.com/organization/ORG_ID/actors/${MOCK_STORE_ACTOR.id}`;
-
-            expect(structuredContent.actors[0].url).toBe(consoleUrl);
-            expect(content[0].text).toContain(`## [${MOCK_STORE_ACTOR.title}](${consoleUrl})`);
-        });
-
-        it('keeps public website links for API tokens', async () => {
-            vi.mocked(getUserInfoCached).mockResolvedValue({
-                userId: 'USER_ID',
-                userPlanTier: 'FREE',
-                isOrganization: false,
-            });
-
-            const { structuredContent, content } = await callWithToken('apify_api_test');
-
-            expect(structuredContent.actors[0].url).toBe(`${APIFY_STORE_URL}/apify/web-scraper`);
-            expect(content[0].text).toContain(`${APIFY_STORE_URL}/apify/web-scraper`);
-            expect(content[0].text).not.toContain('console.apify.com');
-        });
+        expect(structuredContent.actors[0].url).toBe(consoleUrl);
+        expect(content[0].text).toContain(`## [${MOCK_STORE_ACTOR.title}](${consoleUrl})`);
+        expect(content[0].text).not.toContain(`${APIFY_STORE_URL}/apify/web-scraper`);
     });
 });

--- a/tests/unit/tools.search_actors.widget.response.test.ts
+++ b/tests/unit/tools.search_actors.widget.response.test.ts
@@ -7,6 +7,7 @@ import type { formatActorToStructuredCard } from '../../src/utils/actor_card.js'
 import { formatActorForWidget } from '../../src/utils/actor_card.js';
 import { searchAgentSafeActors } from '../../src/utils/actor_search.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
+import { mockUserInfo } from './helpers/tool_context.js';
 import { MOCK_STORE_ACTOR, SEARCH_KEYWORDS, stubInternalToolArgs } from './tools.search_actors.fixtures.js';
 
 /**
@@ -26,7 +27,7 @@ describe('search-actors-widget response', () => {
     beforeEach(() => {
         vi.mocked(searchAgentSafeActors).mockReset();
         vi.mocked(getUserInfoCached).mockReset();
-        vi.mocked(getUserInfoCached).mockResolvedValue({ userId: null, userPlanTier: 'FREE', isOrganization: false });
+        vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo({ userId: null }));
     });
 
     it('returns widgetActors plus widget _meta and short pointer text', async () => {


### PR DESCRIPTION
Follow-up to #958 review feedback — simplifies the Console-link code and dedupes its tests. Net −137 lines, no behavior change.

## Code
- One exported gate function: `getConsoleLinkContext`. `isConsoleUiToken` and `resolveConsoleLinkContext` are gone (the token check is module-private); `search_actors.ts` and `fetch_actor_details_common.ts` go back to their original shape.
- `linkContext` is no longer threaded through `fetchActorRunData` — callers pass it to `buildGetActorRunSuccessResponse` directly.
- Console URL builders accept `undefined` and return `undefined`, removing the repeated ternary in the five storage tools.

## Tests
- New `mockUserInfo()` factory replaces ~10 copies of the same user-info literal.
- Duplicated "no links for API tokens" tests dropped; the `get-actor-run` one and the integration suite keep the negative path covered.
- Org-prefix URL variants are tested once, in `console_link.test.ts`; tool-level tests use one token case each.

## Verification
- `type-check`, `lint`, `format:check`, `test:unit` (878 passed) green.
- mcpc probe with an API token: all affected tools byte-identical to pre-feature output (no `apifyConsoleUrl`, no Console line, no nudge).

https://claude.ai/code/session_01EPfn4BHrCbQiz9DsEufMZb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPfn4BHrCbQiz9DsEufMZb)_