### PR TITLE
fix(ajv): prevent ReDoS and compile-time DoS from untrusted schemas

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -69,8 +69,17 @@ export function getToolSchemaID(actorName: string): string {
     return `https://apify.com/mcp/${actorNameToToolName(actorName)}/schema.json`;
 }
 
+// Largest real Apify Actor input schema measured ~31 KB; cap at 2× to bound AJV's synchronous
+// codegen so a pathological untrusted schema can't freeze the event loop. Only the untrusted
+// callers (actor_tools_factory, mcp/proxy) reach AJV through here; trusted compileSchema() is
+// intentionally uncapped.
+const MAX_UNTRUSTED_SCHEMA_BYTES = 65_536;
+
 // source https://github.com/ajv-validator/ajv/issues/1413#issuecomment-867064234
 export function fixedAjvCompile(ajvInstance: Ajv, schema: object): ValidateFunction<unknown> {
+    if (Buffer.byteLength(JSON.stringify(schema)) > MAX_UNTRUSTED_SCHEMA_BYTES) {
+        throw new Error(`Input schema exceeds ${MAX_UNTRUSTED_SCHEMA_BYTES}-byte safety limit`);
+    }
     const validate = ajvInstance.compile(schema);
     ajvInstance.removeSchema(schema);
 

--- a/src/utils/ajv.ts
+++ b/src/utils/ajv.ts
@@ -3,6 +3,15 @@ import Ajv from 'ajv';
 
 export const ajv = new Ajv({ coerceTypes: 'array', strict: false, removeAdditional: true });
 
+// `pattern`/`patternProperties` compile a RegExp from untrusted Actor / proxied-MCP input schemas;
+// a catastrophic-backtracking pattern freezes the single-threaded event loop (ReDoS). `format` is
+// inert today (ajv-formats is not registered) but would arm the same vector if it ever were. This
+// layer only sanitizes LLM args — the Actor re-validates its real input on the run — so dropping
+// regex enforcement removes the DoS surface with no loss of protection. No `src/` schema uses them.
+ajv.removeKeyword('pattern');
+ajv.removeKeyword('patternProperties');
+ajv.removeKeyword('format');
+
 /**
  * Removes the `$schema` property and drops fields with real `default` values from `required`.
  *

--- a/tests/unit/tools.utils.test.ts
+++ b/tests/unit/tools.utils.test.ts
@@ -7,6 +7,7 @@ import {
     decodeDotPropertyNames,
     encodeDotPropertyNames,
     filterAndShortenEnum,
+    fixedAjvCompile,
     inferArrayItemsTypeIfMissing,
     inferArrayItemType,
     isActorBlockedUnderPaymentProvider,
@@ -16,7 +17,23 @@ import {
 } from '../../src/tools/utils.js';
 import type { ActorInfo, ActorInputSchema, SchemaProperties, ToolBase, ToolEntry } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
+import { ajv } from '../../src/utils/ajv.js';
 import { extractActorName, getToolFullName, getToolPublicFieldOnly } from '../../src/utils/tools.js';
+
+describe('fixedAjvCompile — untrusted schema size cap', () => {
+    it('compiles a normal-sized schema', () => {
+        const validate = fixedAjvCompile(ajv, { type: 'object', properties: { url: { type: 'string' } } });
+        expect(validate({ url: 'https://example.com' })).toBe(true);
+    });
+
+    it('rejects an oversized schema before AJV codegen runs (DoS guard)', () => {
+        const properties: Record<string, unknown> = {};
+        for (let i = 0; i < 3000; i++) properties[`p${i}`] = { type: 'string' };
+        const huge = { type: 'object', properties };
+        expect(JSON.stringify(huge).length).toBeGreaterThan(65_536);
+        expect(() => fixedAjvCompile(ajv, huge)).toThrow(/safety limit/);
+    });
+});
 
 describe('buildApifySpecificProperties', () => {
     it('should add resource picker structure to array items with editor resourcePicker', () => {

--- a/tests/unit/utils.ajv.test.ts
+++ b/tests/unit/utils.ajv.test.ts
@@ -109,6 +109,36 @@ describe('fixZodSchemaRequired', () => {
     });
 });
 
+describe('ajv instance — regex keywords disabled (ReDoS guard)', () => {
+    // The `pattern`/`patternProperties`/`format` keywords compile an attacker-controlled RegExp from
+    // untrusted schemas, enabling catastrophic-backtracking ReDoS. They are removed from the instance,
+    // so the keyword is ignored: a value that would violate the pattern still validates.
+    it('does not enforce `pattern` (no RegExp is compiled from the schema)', () => {
+        const validate = ajv.compile({
+            type: 'object',
+            properties: { q: { type: 'string', pattern: '^(a+)+$' } },
+            required: ['q'],
+        });
+        expect(validate({ q: 'this-would-never-match-the-pattern!' })).toBe(true);
+    });
+
+    it('does not enforce `patternProperties`', () => {
+        const validate = ajv.compile({
+            type: 'object',
+            patternProperties: { '^(a+)+$': { type: 'string' } },
+        });
+        expect(validate({ anything: 123 })).toBe(true);
+    });
+
+    it('does not enforce `format`', () => {
+        const validate = ajv.compile({
+            type: 'object',
+            properties: { email: { type: 'string', format: 'email' } },
+        });
+        expect(validate({ email: 'not-an-email' })).toBe(true);
+    });
+});
+
 describe('ajv instance — Actor input schemas', () => {
     it('should strip extra properties when schema has additionalProperties: false', () => {
         const validate = ajv.compile({


### PR DESCRIPTION
## What
Two small changes to the shared AJV usage that close a confirmed denial-of-service from untrusted schemas:
1. Disable the `pattern` / `patternProperties` / `format` keywords on the shared validator (`src/utils/ajv.ts`).
2. Cap untrusted schema size in `fixedAjvCompile` before AJV codegen runs (`src/tools/utils.ts`).

## Why
A malicious Store Actor (loadable via `add-actor` / search) or a proxied Actor-MCP server controls the input schema we feed to AJV. Two synchronous, uninterruptible costs result, and Node is single-threaded — on hosted `mcp.apify.com` either one stalls every concurrent session:
- **ReDoS**: a `pattern` regex with catastrophic backtracking. Measured **12.7 s** event-loop freeze from a 91-byte schema + a 31-char input.
- **Compile blowup**: a nested-combinator schema (proxy path; arbitrary JSON Schema). Measured **4.7 s** synchronous `compile()`.

`removeKeyword` is position-aware (AJV knows keyword vs. data) so a field literally named `pattern` is untouched. No `src/` schema uses these keywords, and this layer only sanitizes LLM args — the Actor re-validates its real input on the run — so dropping regex enforcement loses no protection. The byte cap is 2× the largest real Actor input schema observed (~31 KB); both untrusted callers route through `fixedAjvCompile` while the trusted `compileSchema()` path stays uncapped. A rejected schema throws and is already caught fail-closed at both call sites (`actor_tools_factory` skips the tool; `mcp/proxy` drops that server's tool list).

## Testing
`pnpm type-check`, `pnpm lint`, `pnpm format:check`, `pnpm test:unit` — 868 pass. Added 5 regression tests: oversized schema throws before codegen; `pattern`/`patternProperties`/`format` no longer enforced. Reproduced the original 12.7 s freeze against the repo's ajv and confirmed it drops to ~0.06 ms after the change.
