### PR TITLE
feat: Add outputSchema to abort-actor-run tool

### DIFF
--- a/src/tools/common/abort_actor_run.ts
+++ b/src/tools/common/abort_actor_run.ts
@@ -4,6 +4,7 @@ import { HelperTools } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { abortActorRunOutputSchema } from '../structured_output_schemas.js';
 
 const abortRunArgs = z.object({
     runId: z.string().min(1).describe('The ID of the Actor run to abort.'),
@@ -31,6 +32,7 @@ USAGE EXAMPLES:
 - user_input: Gracefully abort run y2h7sK3Wc`,
     inputSchema: z.toJSONSchema(abortRunArgs) as ToolInputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(abortRunArgs)),
+    outputSchema: abortActorRunOutputSchema,
     paymentRequired: true,
     annotations: {
         title: 'Abort Actor run',

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -472,6 +472,22 @@ export function buildEnrichedDirectActorOutputSchema(itemProperties: Record<stri
     return clone;
 }
 
+/** Schema for abort-actor-run tool output. */
+export const abortActorRunOutputSchema = {
+    type: 'object' as const,
+    properties: {
+        runId: { type: 'string', description: 'Actor run ID' },
+        status: {
+            type: 'string',
+            description:
+                'Run status after abort request: ABORTING | ABORTED | SUCCEEDED | FAILED | TIMED-OUT | READY | RUNNING',
+        },
+        startedAt: { type: 'string', description: 'ISO timestamp when the run started' },
+        finishedAt: { type: 'string', description: 'ISO timestamp when the run finished; null while still running' },
+    },
+    required: ['runId', 'status'],
+};
+
 /** Past-tense state summary; emitted by every storage tool. */
 export const summaryProperty = {
     type: 'string' as const,

--- a/tests/unit/tools.structured_output_schemas.test.ts
+++ b/tests/unit/tools.structured_output_schemas.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { abortActorRun } from '../../src/tools/common/abort_actor_run.js';
 import { getNormalActorsAsTools } from '../../src/tools/core/actor_tools_factory.js';
 import {
+    abortActorRunOutputSchema,
     actorDetailsOutputSchema,
     actorInfoSchema,
     buildEnrichedDirectActorOutputSchema,
@@ -82,6 +84,46 @@ function createMockActorStore(schemas: Record<string, Record<string, unknown> | 
         },
     };
 }
+
+describe('abortActorRunOutputSchema', () => {
+    it('is a valid JSON Schema object', () => {
+        expect(abortActorRunOutputSchema.type).toBe('object');
+        expect(abortActorRunOutputSchema.properties).toBeDefined();
+    });
+
+    it('requires runId and status', () => {
+        expect(abortActorRunOutputSchema.required).toEqual(expect.arrayContaining(['runId', 'status']));
+    });
+
+    it('includes runId, status, startedAt, and finishedAt properties', () => {
+        const props = abortActorRunOutputSchema.properties;
+        expect(props.runId.type).toBe('string');
+        expect(props.status.type).toBe('string');
+        expect(props.startedAt.type).toBe('string');
+        expect(props.finishedAt.type).toBe('string');
+    });
+
+    it('abortActorRun tool wires the outputSchema', () => {
+        expect(abortActorRun.outputSchema).toBe(abortActorRunOutputSchema);
+    });
+
+    it('validates a minimal abort response', () => {
+        const validate = compileSchema(abortActorRunOutputSchema);
+        expect(validate({ runId: 'y2h7sK3Wc', status: 'ABORTED' })).toBe(true);
+    });
+
+    it('validates a full abort response', () => {
+        const validate = compileSchema(abortActorRunOutputSchema);
+        expect(
+            validate({
+                runId: 'y2h7sK3Wc',
+                status: 'ABORTED',
+                startedAt: '2024-01-01T00:00:00.000Z',
+                finishedAt: '2024-01-01T00:01:00.000Z',
+            }),
+        ).toBe(true);
+    });
+});
 
 describe('Structured Output Schemas', () => {
     describe('buildEnrichedDirectActorOutputSchema', () => {


### PR DESCRIPTION
## Summary

- Adds `abortActorRunOutputSchema` to `src/tools/structured_output_schemas.ts`, describing the run object returned by the abort API endpoint (`runId`, `status`, `startedAt`, `finishedAt`)
- Wires the schema into the `abortActorRun` `ToolEntry` via the `outputSchema` field, following the same pattern used by `getActorRunOutputSchema` in other tools
- Adds unit tests in `tools.structured_output_schemas.test.ts` confirming schema shape, required fields, and tool wiring

## Why this matters

The `abort-actor-run` tool was the only run-related tool without an `outputSchema` declaration, causing ChatGPT App submission validation to warn that the output schema is missing (issue #993). Adding a schema satisfies the validator and gives LLMs a concrete contract to plan against when processing abort results.

Fixes #993
