### PR TITLE
fix(ajv): raise schema cap to 256 KB and soft-log oversized-schema errors

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,19 @@ export class TimeoutError extends Error {
     override readonly name = 'TimeoutError';
 }
 
+/**
+ * Thrown by `fixedAjvCompile` when an untrusted Actor / proxied-MCP input schema exceeds the byte
+ * cap that bounds AJV's synchronous codegen. It's a property of the schema, not a server fault, so
+ * `logHttpError` logs it as a soft fail and the caller drops just that one tool.
+ */
+export class SchemaTooLargeError extends Error {
+    override readonly name = 'SchemaTooLargeError';
+
+    constructor(public readonly limitBytes: number) {
+        super(`Input schema exceeds ${limitBytes}-byte safety limit`);
+    }
+}
+
 export const ACTOR_LOAD_ERROR_KIND = {
     NOT_FOUND: 'not-found',
     LOAD_FAILED: 'load-failed',

--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -145,10 +145,10 @@ Actor description: ${definition.description}`;
             // are declared properties and won't be stripped.
             ajvValidate = fixedAjvCompile(ajv, inputSchema);
         } catch (e) {
-            log.error('Failed to compile schema', {
+            // SchemaTooLargeError logs as a soft fail; a genuine AJV compile error stays an error.
+            logHttpError(e, 'Failed to compile schema', {
                 actorName: definition.actorFullName,
                 mcpSessionId,
-                error: e,
             });
             continue;
         }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -6,6 +6,7 @@ import type Ajv from 'ajv';
 import log from '@apify/log';
 
 import { ACTOR_ENUM_MAX_LENGTH, ACTOR_MAX_DESCRIPTION_LENGTH, RAG_WEB_BROWSER_WHITELISTED_FIELDS } from '../const.js';
+import { SchemaTooLargeError } from '../errors.js';
 import { MAX_TOOL_NAME_LENGTH, TOOL_NAME_HASH_LENGTH } from '../mcp/const.js';
 import type { ActorInfo, ActorInputSchema, SchemaProperties } from '../types.js';
 import {
@@ -69,16 +70,18 @@ export function getToolSchemaID(actorName: string): string {
     return `https://apify.com/mcp/${actorNameToToolName(actorName)}/schema.json`;
 }
 
-// Largest real Apify Actor input schema measured ~31 KB; cap at 2× to bound AJV's synchronous
-// codegen so a pathological untrusted schema can't freeze the event loop. Only the untrusted
-// callers (actor_tools_factory, mcp/proxy) reach AJV through here; trusted compileSchema() is
-// intentionally uncapped.
-const MAX_UNTRUSTED_SCHEMA_BYTES = 65_536;
+// Real Apify Actor input schemas run up to ~140 KB post-transform; cap at 256 KB to bound AJV's
+// synchronous codegen so a pathological untrusted schema can't freeze the event loop. Only the
+// untrusted callers (actor_tools_factory, mcp/proxy) reach AJV through here; trusted compileSchema()
+// is intentionally uncapped.
+export const MAX_UNTRUSTED_SCHEMA_BYTES = 262_144;
 
 // source https://github.com/ajv-validator/ajv/issues/1413#issuecomment-867064234
 export function fixedAjvCompile(ajvInstance: Ajv, schema: object): ValidateFunction<unknown> {
+    // Skip AJV codegen (synchronous, would freeze the event loop) on an oversized untrusted schema.
+    // Throws SchemaTooLargeError, which callers log as a soft fail (not a server error).
     if (Buffer.byteLength(JSON.stringify(schema)) > MAX_UNTRUSTED_SCHEMA_BYTES) {
-        throw new Error(`Input schema exceeds ${MAX_UNTRUSTED_SCHEMA_BYTES}-byte safety limit`);
+        throw new SchemaTooLargeError(MAX_UNTRUSTED_SCHEMA_BYTES);
     }
     const validate = ajvInstance.compile(schema);
     ajvInstance.removeSchema(schema);

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -2,6 +2,7 @@ import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 import log from '@apify/log';
 
+import { SchemaTooLargeError } from '../errors.js';
 import { isActorRunLimitError } from './apify_errors.js';
 
 /**
@@ -112,6 +113,12 @@ export function logHttpError<T extends object>(error: unknown, message: string, 
 
     // User concurrent-run / quota limit — arrives wrapped as a 500 but is a user billing condition.
     if (isActorRunLimitError(error)) {
+        log.softFail(message, { errMessage: softErrMessage, ...data });
+        return;
+    }
+
+    // Oversized untrusted input schema — a property of the Actor's schema, not a server fault.
+    if (error instanceof SchemaTooLargeError) {
         log.softFail(message, { errMessage: softErrMessage, ...data });
         return;
     }

--- a/tests/unit/tools.utils.test.ts
+++ b/tests/unit/tools.utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { ACTOR_ENUM_MAX_LENGTH, ACTOR_MAX_DESCRIPTION_LENGTH } from '../../src/const.js';
+import { SchemaTooLargeError } from '../../src/errors.js';
 import {
     buildActorInputSchema,
     buildApifySpecificProperties,
@@ -11,6 +12,7 @@ import {
     inferArrayItemsTypeIfMissing,
     inferArrayItemType,
     isActorBlockedUnderPaymentProvider,
+    MAX_UNTRUSTED_SCHEMA_BYTES,
     markInputPropertiesAsRequired,
     shortenProperties,
     transformActorInputSchemaProperties,
@@ -26,12 +28,12 @@ describe('fixedAjvCompile — untrusted schema size cap', () => {
         expect(validate({ url: 'https://example.com' })).toBe(true);
     });
 
-    it('rejects an oversized schema before AJV codegen runs (DoS guard)', () => {
+    it('throws SchemaTooLargeError on an oversized schema before AJV codegen runs (DoS guard)', () => {
         const properties: Record<string, unknown> = {};
-        for (let i = 0; i < 3000; i++) properties[`p${i}`] = { type: 'string' };
+        for (let i = 0; i < 16000; i++) properties[`p${i}`] = { type: 'string' };
         const huge = { type: 'object', properties };
-        expect(JSON.stringify(huge).length).toBeGreaterThan(65_536);
-        expect(() => fixedAjvCompile(ajv, huge)).toThrow(/safety limit/);
+        expect(JSON.stringify(huge).length).toBeGreaterThan(MAX_UNTRUSTED_SCHEMA_BYTES);
+        expect(() => fixedAjvCompile(ajv, huge)).toThrow(SchemaTooLargeError);
     });
 });
 

--- a/tests/unit/utils.logging.test.ts
+++ b/tests/unit/utils.logging.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import log from '@apify/log';
 
+import { SchemaTooLargeError } from '../../src/errors.js';
+import { MAX_UNTRUSTED_SCHEMA_BYTES } from '../../src/tools/utils.js';
 import {
     isMcpClientFaultMessage,
     logHttpError,
@@ -61,6 +63,18 @@ describe('logHttpError', () => {
 
         expect(exception).not.toHaveBeenCalled();
         expect(softFail).toHaveBeenCalledTimes(1);
+    });
+
+    it('soft-fails an oversized input schema (SchemaTooLargeError), not a server error', () => {
+        const softFail = vi.spyOn(log, 'softFail').mockImplementation(() => log);
+        const exception = vi.spyOn(log, 'exception').mockImplementation(() => log);
+        const error = vi.spyOn(log, 'error').mockImplementation(() => log);
+
+        logHttpError(new SchemaTooLargeError(MAX_UNTRUSTED_SCHEMA_BYTES), 'Failed to compile schema');
+
+        expect(softFail).toHaveBeenCalledTimes(1);
+        expect(exception).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
## What
Raise `MAX_UNTRUSTED_SCHEMA_BYTES` from 64 KB to 256 KB, and when a schema still exceeds the cap, throw a typed `SchemaTooLargeError` that the central `logHttpError` classifier logs as a soft fail instead of an error — mirroring how MCP SDK client faults and the run-limit condition are handled. The tool is still dropped (fail-closed), it just no longer raises an error-level alert.

## Why
Real Store Actors hit the old 64 KB cap and were dropped with error-level `Failed to compile schema` logs on `mcp.apify.com` (e.g. `websift/seek-job-scraper` 75 KB, `radeance/wellfound-job-listings-scraper` 142 KB post-transform). The cap only bounds AJV's synchronous codegen (event-loop freeze) — it is not a server fault, so it shouldn't page like one. 256 KB clears all observed real schemas while still bounding codegen; the soft classification keeps a genuinely pathological (>256 KB) schema from alerting.

## Testing
`pnpm type-check`, `pnpm lint`, `pnpm format:check`, `pnpm test:unit` (932 pass). `fixedAjvCompile` test asserts it throws `SchemaTooLargeError`; added a `logHttpError` test asserting that error soft-fails (no `error`/`exception`). Verified against the two failing Actors above using the repo's real transform: both now fit under 256 KB.