### PR TITLE
fix: Resolve dataset tool schema/description inconsistencies

### DIFF
--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -16,7 +16,7 @@ const getUserDatasetsListArgs = z.object({
     limit: z
         .number()
         .max(20)
-        .describe('Maximum number of array elements to return. The default value (as well as the maximum) is 20.')
+        .describe('Maximum number of array elements to return. The default value is 10, the maximum is 20.')
         .default(10),
     desc: z
         .boolean()

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -14,14 +14,9 @@ import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js
 
 const getDatasetSchemaArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
-    limit: z
-        .number()
-        .optional()
-        .describe('Maximum number of items to use for schema generation. Default is 5.')
-        .default(5),
+    limit: z.number().describe('Maximum number of items to use for schema generation. Default is 5.').default(5),
     clean: z
         .boolean()
-        .optional()
         .describe('If true, uses only non-empty items and skips hidden fields (starting with #). Default is true.')
         .default(true),
 });

--- a/tests/unit/tools.get_dataset_schema.test.ts
+++ b/tests/unit/tools.get_dataset_schema.test.ts
@@ -65,6 +65,17 @@ describe('get-dataset-schema', () => {
         expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
     });
 
+    it('applies defaults (limit=5, clean=true) to listItems when no params given', async () => {
+        const listItemsSpy = vi.fn().mockResolvedValue({ items: MOCK_ITEMS, total: 2 });
+        const client = {
+            dataset: (_id: string) => ({ listItems: listItemsSpy }),
+        } as unknown as InternalToolArgs['apifyClient'];
+
+        await (getDatasetSchema as HelperTool).call(stubToolCallContext({ datasetId: 'ds-1' }, client));
+
+        expect(listItemsSpy).toHaveBeenCalledWith({ clean: true, limit: 5 });
+    });
+
     it('returns a schema-conforming structured response when the dataset has no items', async () => {
         const result = await (getDatasetSchema as HelperTool).call(
             stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient({ items: [], total: 0 })),


### PR DESCRIPTION
## What
Fixes the still-present schema/description contradictions in the storage tools from #885.

- **get-dataset-list** (`dataset_collection.ts`): the `limit` description said the default is `20`, but the schema is `.max(20).default(10)`. An agent following the description expects 20 and silently gets 10. Corrected the description to "The default value is 10, the maximum is 20."
- **get-dataset-schema** (`get_dataset_schema.ts`): `limit` and `clean` used `.optional().default(...)`. In Zod 4 `.default()` already makes the input optional, so `.optional()` is a no-op. Removed it.

## Why
These descriptions are LLM-facing — a wrong default misleads the model about what it gets back. The no-op `.optional()` is dead modifier noise and made the "optional contract" inconsistent with sibling tools (noted in #885).

## How / risk
- Description fix is text-only — no behavior change.
- Removing `.optional()` is behavior-preserving: with Zod 4 `.default()` already implies optional input, so the generated JSON Schema (`z.toJSONSchema`) and runtime parsing are identical. Added a unit test asserting `get-dataset-schema` still applies `limit=5, clean=true` when called with no params.

## Not included
The third bullet in #885 (`get_key_value_store_keys` USAGE example "100 keys" vs `limit` max 10) is **already consistent on master** — the example reads "10 keys" — so no change was needed. Kept minimal per CONTRIBUTING's scope discipline; the broader stylistic rewrite is intentionally left out to keep this reviewable.

## Verification
`type-check`, `lint`, `test:unit` (947 passed), `format`, `check:agents` — all green.

Refs #885