### PR TITLE
fix: Add top-level Tool.title per MCP 2025-11-25

### DIFF
--- a/src/tools/apps/call_actor_widget.ts
+++ b/src/tools/apps/call_actor_widget.ts
@@ -67,6 +67,7 @@ const CALL_ACTOR_WIDGET_DESCRIPTION = dedent`
 export const appsCallActorWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_CALL_WIDGET,
+    title: 'Call Actor (widget)',
     description: CALL_ACTOR_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(callActorWidgetArgsSchema) as ToolInputSchema,
     outputSchema: getActorRunOutputSchema,

--- a/src/tools/apps/fetch_actor_details_widget.ts
+++ b/src/tools/apps/fetch_actor_details_widget.ts
@@ -47,6 +47,7 @@ const FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION = dedent`
 export const fetchActorDetailsWidgetTool: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_GET_DETAILS_WIDGET,
+    title: 'Fetch Actor details (widget)',
     description: FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(fetchActorDetailsWidgetArgsSchema) as ToolInputSchema,
     outputSchema: actorDetailsWidgetOutputSchema,

--- a/src/tools/apps/get_actor_run_widget.ts
+++ b/src/tools/apps/get_actor_run_widget.ts
@@ -38,6 +38,7 @@ const GET_ACTOR_RUN_WIDGET_DESCRIPTION = dedent`
 export const getActorRunWidgetTool: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUNS_GET_WIDGET,
+    title: 'Get Actor run (widget)',
     description: GET_ACTOR_RUN_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(getActorRunWidgetArgsSchema) as ToolInputSchema,
     outputSchema: getActorRunOutputSchema,

--- a/src/tools/apps/search_actors_widget.ts
+++ b/src/tools/apps/search_actors_widget.ts
@@ -38,6 +38,7 @@ const SEARCH_ACTORS_WIDGET_DESCRIPTION = dedent`
 export const searchActorsWidgetTool: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.STORE_SEARCH_WIDGET,
+    title: 'Search Actors (widget)',
     description: SEARCH_ACTORS_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(searchActorsWidgetArgsSchema) as ToolInputSchema,
     outputSchema: actorSearchWidgetOutputSchema,

--- a/src/tools/common/abort_actor_run.ts
+++ b/src/tools/common/abort_actor_run.ts
@@ -19,6 +19,7 @@ const abortRunArgs = z.object({
 export const abortActorRun: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUNS_ABORT,
+    title: 'Abort Actor run',
     description: `Abort an Actor run that is currently starting or running.
 For runs with status FINISHED, FAILED, ABORTING, or TIMED-OUT, this call has no effect.
 The results will include the updated run details after the abort request.

--- a/src/tools/common/add_actor.ts
+++ b/src/tools/common/add_actor.ts
@@ -16,6 +16,7 @@ export const addToolArgsSchema = z.object({
 export const addTool: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_ADD,
+    title: 'Add tool',
     description: `Add an Actor or MCP server to the Apify MCP Server as an available tool.
 This does not execute the Actor; it only registers it so it can be called later.
 

--- a/src/tools/common/dataset_collection.ts
+++ b/src/tools/common/dataset_collection.ts
@@ -36,6 +36,7 @@ const getUserDatasetsListArgs = z.object({
 export const getUserDatasetsList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_LIST_GET,
+    title: 'Get user datasets list',
     description: dedent`
         List datasets (collections of Actor run data) for the authenticated user.
         Actor runs automatically produce unnamed datasets (set unnamed=true to include them). Users can also create named datasets.

--- a/src/tools/common/fetch_apify_docs.ts
+++ b/src/tools/common/fetch_apify_docs.ts
@@ -60,6 +60,7 @@ You can search for available documentation pages using the ${HelperTools.DOCS_SE
 export const fetchApifyDocsTool: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DOCS_FETCH,
+    title: 'Fetch Apify docs',
     description: `Fetch the full content of an Apify or Crawlee documentation page by its URL.
 Use this after finding a relevant page with the ${HelperTools.DOCS_SEARCH} tool.
 

--- a/src/tools/common/get_actor_run_log.ts
+++ b/src/tools/common/get_actor_run_log.ts
@@ -17,6 +17,7 @@ const GetRunLogArgs = z.object({
 export const getActorRunLog: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUNS_LOG,
+    title: 'Get Actor run log',
     description: `Retrieve recent log lines for a specific Actor run.
 The results will include the last N lines of the run's log output (plain text).
 

--- a/src/tools/common/get_dataset.ts
+++ b/src/tools/common/get_dataset.ts
@@ -21,6 +21,7 @@ const getDatasetArgs = z.object({
 export const getDataset: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_GET,
+    title: 'Get dataset',
     description: dedent`
         Get metadata for a dataset (collection of structured data created by an Actor run).
         The results will include dataset details such as itemCount, schema, fields, and stats.

--- a/src/tools/common/get_dataset_items.ts
+++ b/src/tools/common/get_dataset_items.ts
@@ -65,6 +65,7 @@ const getDatasetItemsArgs = z.object({
 export const getDatasetItems: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_GET_ITEMS,
+    title: 'Get dataset items',
     description: dedent`
         Retrieve dataset items with pagination, sorting, and field selection.
         For nested fields use dot notation (e.g., fields="metadata.url") — the server auto-flattens parent prefixes.

--- a/src/tools/common/get_dataset_schema.ts
+++ b/src/tools/common/get_dataset_schema.ts
@@ -32,6 +32,7 @@ const getDatasetSchemaArgs = z.object({
 export const getDatasetSchema: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_SCHEMA_GET,
+    title: 'Get dataset schema',
     description: dedent`
         Generate a JSON schema from a sample of dataset items.
         The schema describes the structure of the data and can be used for validation, documentation, or processing.

--- a/src/tools/common/get_key_value_store.ts
+++ b/src/tools/common/get_key_value_store.ts
@@ -20,6 +20,7 @@ const getKeyValueStoreArgs = z.object({
 export const getKeyValueStore: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_GET,
+    title: 'Get key-value store',
     description: dedent`
         Get details about a key-value store by ID or username~store-name.
         The results will include store metadata (ID, name, owner, access settings) and usage statistics.

--- a/src/tools/common/get_key_value_store_keys.ts
+++ b/src/tools/common/get_key_value_store_keys.ts
@@ -26,6 +26,7 @@ const getKeyValueStoreKeysArgs = z.object({
 export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_KEYS_GET,
+    title: 'Get key-value store keys',
     description: dedent`
         List keys in a key-value store with optional pagination.
         The results will include keys and basic info about stored values (e.g., size).

--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -27,6 +27,7 @@ const getKeyValueStoreRecordArgs = z.object({
 export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_RECORD_GET,
+    title: 'Get key-value store record',
     description: dedent`
         Get a value stored in a key-value store under a specific key.
         The response preserves the original Content-Encoding; most clients handle decompression automatically.

--- a/src/tools/common/key_value_store_collection.ts
+++ b/src/tools/common/key_value_store_collection.ts
@@ -38,6 +38,7 @@ const getUserKeyValueStoresListArgs = z.object({
 export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_LIST_GET,
+    title: 'Get user key-value stores list',
     description: dedent`
         List key-value stores owned by the authenticated user.
         Actor runs automatically produce unnamed stores (set unnamed=true to include them). Users can also create named stores.

--- a/src/tools/common/run_collection.ts
+++ b/src/tools/common/run_collection.ts
@@ -36,6 +36,7 @@ const getUserRunsListArgs = z.object({
 export const getUserRunsList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUN_LIST_GET,
+    title: 'Get user runs list',
     description: `List Actor runs for the authenticated user with optional filtering and sorting.
 The results will include run details (including datasetId and keyValueStoreId) and can be filtered by status.
 Valid statuses: READY (not allocated), RUNNING (executing), SUCCEEDED (finished), FAILED (failed), TIMING-OUT, TIMED-OUT, ABORTING, ABORTED.

--- a/src/tools/common/search_apify_docs.ts
+++ b/src/tools/common/search_apify_docs.ts
@@ -71,6 +71,7 @@ const searchApifyDocsToolInputSchema = z.toJSONSchema(searchApifyDocsToolArgsSch
 export const searchApifyDocsTool: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DOCS_SEARCH,
+    title: 'Search Apify docs',
     description: buildToolDescription(),
     inputSchema: searchApifyDocsToolInputSchema,
     outputSchema: searchApifyDocsToolOutputSchema,

--- a/src/tools/core/actor_tools_factory.ts
+++ b/src/tools/core/actor_tools_factory.ts
@@ -156,6 +156,7 @@ Actor description: ${definition.description}`;
         tools.push({
             type: TOOL_TYPE.ACTOR,
             name: actorNameToToolName(definition.actorFullName),
+            title: definition.actorFullName,
             actorId: definition.id,
             actorFullName: definition.actorFullName,
             description,

--- a/src/tools/core/fetch_actor_details_common.ts
+++ b/src/tools/core/fetch_actor_details_common.ts
@@ -124,6 +124,7 @@ EXAMPLES:
 export const fetchActorDetailsMetadata: Omit<HelperTool, 'call'> = {
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_GET_DETAILS,
+    title: 'Fetch Actor details',
     description: FETCH_ACTOR_DETAILS_DESCRIPTION,
     inputSchema: z.toJSONSchema(fetchActorDetailsToolArgsSchema) as ToolInputSchema,
     outputSchema: actorDetailsOutputSchema,

--- a/src/tools/core/get_actor_run_common.ts
+++ b/src/tools/core/get_actor_run_common.ts
@@ -52,6 +52,7 @@ USAGE EXAMPLES:
 export const getActorRunMetadata: Omit<HelperTool, 'call'> = {
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUNS_GET,
+    title: 'Get Actor run',
     description: GET_ACTOR_RUN_DESCRIPTION,
     // `fixZodSchemaRequired` strips fields with a real `default` from `required` so MCP clients
     // that read `tools/list` see `waitSecs` as optional (matching its runtime behavior).

--- a/src/tools/core/search_actors_common.ts
+++ b/src/tools/core/search_actors_common.ts
@@ -103,6 +103,7 @@ Returns list of Actor cards with the following info:
 export const searchActorsMetadata: Omit<HelperTool, 'call'> = {
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.STORE_SEARCH,
+    title: 'Search Actors',
     description: SEARCH_ACTORS_DESCRIPTION,
     inputSchema: z.toJSONSchema(searchActorsBaseArgsSchema) as ToolInputSchema,
     outputSchema: actorSearchOutputSchema,

--- a/src/tools/default/call_actor.ts
+++ b/src/tools/default/call_actor.ts
@@ -18,6 +18,7 @@ function createCallActorTool(description: string): ToolEntry {
     return Object.freeze({
         type: TOOL_TYPE.INTERNAL,
         name: HelperTools.ACTOR_CALL,
+        title: 'Call Actor',
         description,
         inputSchema: callActorInputSchema,
         outputSchema: getActorRunOutputSchema,

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -210,35 +210,6 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
     });
 });
 
-describe('top-level Tool.title (MCP 2025-11-25)', () => {
-    // The 2025-11-25 spec moved the human-readable display name to a top-level `Tool.title`
-    // and deprecated `annotations.title`. Every tool must set both: top-level for new clients,
-    // annotations for older ones during the transition. Guards against new tools regressing.
-    for (const mode of SERVER_MODES) {
-        const categories = getCategoryTools(mode);
-
-        for (const categoryName of CATEGORY_NAMES) {
-            for (const tool of categories[categoryName]) {
-                it(`${tool.name} (${mode} mode) sets a top-level title matching annotations.title`, () => {
-                    expect(tool.title).toBeTruthy();
-                    expect(tool.title).toBe(tool.annotations?.title);
-                });
-
-                it(`${tool.name} (${mode} mode) exposes title via getToolPublicFieldOnly`, () => {
-                    expect(getToolPublicFieldOnly(tool).title).toBe(tool.title);
-                });
-            }
-        }
-    }
-
-    for (const widget of WIDGET_BY_BASE_TOOL.values()) {
-        it(`${widget.name} widget sets a top-level title matching annotations.title`, () => {
-            expect(widget.title).toBeTruthy();
-            expect(widget.title).toBe(widget.annotations?.title);
-        });
-    }
-});
-
 describe('apps-mode widget pairing in getToolsForServerMode', () => {
     function namesFor(input: Input, mode: ServerMode): string[] {
         return getToolsForServerMode(input, [], mode).map((t) => t.name);

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -210,6 +210,35 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
     });
 });
 
+describe('top-level Tool.title (MCP 2025-11-25)', () => {
+    // The 2025-11-25 spec moved the human-readable display name to a top-level `Tool.title`
+    // and deprecated `annotations.title`. Every tool must set both: top-level for new clients,
+    // annotations for older ones during the transition. Guards against new tools regressing.
+    for (const mode of SERVER_MODES) {
+        const categories = getCategoryTools(mode);
+
+        for (const categoryName of CATEGORY_NAMES) {
+            for (const tool of categories[categoryName]) {
+                it(`${tool.name} (${mode} mode) sets a top-level title matching annotations.title`, () => {
+                    expect(tool.title).toBeTruthy();
+                    expect(tool.title).toBe(tool.annotations?.title);
+                });
+
+                it(`${tool.name} (${mode} mode) exposes title via getToolPublicFieldOnly`, () => {
+                    expect(getToolPublicFieldOnly(tool).title).toBe(tool.title);
+                });
+            }
+        }
+    }
+
+    for (const widget of WIDGET_BY_BASE_TOOL.values()) {
+        it(`${widget.name} widget sets a top-level title matching annotations.title`, () => {
+            expect(widget.title).toBeTruthy();
+            expect(widget.title).toBe(widget.annotations?.title);
+        });
+    }
+});
+
 describe('apps-mode widget pairing in getToolsForServerMode', () => {
     function namesFor(input: Input, mode: ServerMode): string[] {
         return getToolsForServerMode(input, [], mode).map((t) => t.name);


### PR DESCRIPTION
## What

Set a top-level `title` on every tool so the `tools/list` response carries it, per **MCP spec 2025-11-25**, which added the human-readable display name as a top-level `Tool.title`.

> **Note:** an earlier version of this PR (and issue #729) said 2025-11-25 "deprecated `annotations.title`". That is **not** correct — the spec/SDK carry no `@deprecated` marker on it. The spec defines a display **precedence: `title` → `annotations.title` → `name`**. `annotations.title` remains the valid fallback, so we set both.

## Why

`getToolPublicFieldOnly` (`src/utils/tools.ts`) already returns `title: tool.title`, but no tool definition set a top-level `title` — only `annotations.title`. So `tool.title` was `undefined` for every tool, and clients following 2025-11-25 (which read top-level `Tool.title` first) got no canonical top-level display name for any tool.

## How

Added `title` at the top level of each tool definition, mirroring the existing `annotations.title`:

- Static helper + widget tools under `src/tools/common`, `src/tools/core`, `src/tools/default`, `src/tools/apps`.
- The dynamic Actor tools built in `src/tools/core/actor_tools_factory.ts` (`title: definition.actorFullName`).

`annotations.title` is kept on every tool — it is the documented fallback in the precedence chain (`title` → `annotations.title` → `name`), not a deprecated field.

23 lines of production code, no behavior change beyond the added field.

## Tests

No new test. An earlier revision added a per-tool contract block asserting every tool sets a top-level `title`; it was dropped because the suite has no equivalent presence guard for any other display field (`description`, `annotations.title`, …), and a missing top-level `title` falls back to `annotations.title` → `name` per the 2025-11-25 precedence — so it is not a real regression. The added `title` fields are covered by the existing tool/mode suite.

Local run (no token needed):

```
pnpm run type-check   # ok
pnpm run lint         # 0 warnings, 0 errors
pnpm run format:check # all files correctly formatted
pnpm run check:agents # AGENTS.md link check passed
pnpm run build        # ok (core + widgets)
pnpm run test:unit    # 66 files, 946 passed | 2 skipped
```

## Risks

Low. Additive field only; `annotations.title` is unchanged. Dynamic Actor-MCP tools (passthrough from upstream MCP servers) are intentionally untouched.

## References
- Tools: https://modelcontextprotocol.io/specification/2025-11-25/server/tools
- Schema (precedence): https://modelcontextprotocol.io/specification/2025-11-25/schema#basemetadata

Closes #729

---
Prepared with AI assistance (Claude Code); every line was reviewed by a human before submitting.
