### PR TITLE
fix(logging): softFail the send-path-wrapped 'No connection established' fault

### DIFF
--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -63,6 +63,7 @@ const MCP_CLIENT_FAULT_MESSAGES: ReadonlySet<string> = new Set([
 // Transport/runtime disconnects with variable tails — anchored at the start, not substring-anywhere.
 const MCP_CLIENT_FAULT_PREFIXES: readonly string[] = [
     'No connection established for request ID:', // webStandardStreamableHttp.js sendRequest
+    'Failed to send response: Error: No connection established for request ID:', // send-path wrap of the above
     'Failed to send response: Error: Not connected', // send-path wrap
     'Invalid state: Controller is already closed', // Node web-streams ERR_INVALID_STATE
 ];

--- a/tests/unit/utils.logging.test.ts
+++ b/tests/unit/utils.logging.test.ts
@@ -29,7 +29,9 @@ describe('isMcpClientFaultMessage', () => {
 
     it('matches the variable-tail disconnect messages by prefix', () => {
         expect(isMcpClientFaultMessage('No connection established for request ID: abc-123')).toBe(true);
-        expect(isMcpClientFaultMessage('Failed to send response: Error: No connection established for request ID: 1')).toBe(true);
+        expect(
+            isMcpClientFaultMessage('Failed to send response: Error: No connection established for request ID: 1'),
+        ).toBe(true);
         expect(isMcpClientFaultMessage('Failed to send response: Error: Not connected')).toBe(true);
         expect(isMcpClientFaultMessage('Invalid state: Controller is already closed')).toBe(true);
     });

--- a/tests/unit/utils.logging.test.ts
+++ b/tests/unit/utils.logging.test.ts
@@ -29,6 +29,7 @@ describe('isMcpClientFaultMessage', () => {
 
     it('matches the variable-tail disconnect messages by prefix', () => {
         expect(isMcpClientFaultMessage('No connection established for request ID: abc-123')).toBe(true);
+        expect(isMcpClientFaultMessage('Failed to send response: Error: No connection established for request ID: 1')).toBe(true);
         expect(isMcpClientFaultMessage('Failed to send response: Error: Not connected')).toBe(true);
         expect(isMcpClientFaultMessage('Invalid state: Controller is already closed')).toBe(true);
     });


### PR DESCRIPTION
## What
Add the send-path-wrapped form `Failed to send response: Error: No connection established for request ID:` to `MCP_CLIENT_FAULT_PREFIXES` so it soft-fails instead of error-logging.

## Why
Disconnected clients flood Mezmo error alerts with:

```
[MCP Error] Failed to send response: Error: No connection established for request ID: 1
```

The SDK throws `No connection established for request ID: N` in `webStandardStreamableHttp.js`, then `protocol.js:415` wraps it as `Failed to send response: Error: ...` before calling `onerror`. The existing `No connection established for request ID:` prefix only matches the raw, unwrapped form, so the wrapped message slipped through to `log.error`. This is a client disconnect (expected noise), not a server bug — same class as the already-handled `Failed to send response: Error: Not connected`.

## Testing
- Added a prefix assertion in `utils.logging.test.ts`.
- `pnpm vitest run tests/unit/utils.logging.test.ts tests/unit/mcp.server.error_handling.test.ts` → 11 passed.
- `pnpm type-check` and `pnpm lint` clean.