### PR TITLE
ci: use apify/actions/pr-title-check wrapper for PR title checks

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -47,6 +47,4 @@ jobs:
         name: PR title check
         runs-on: ubuntu-latest
         steps:
-            -   uses: amannn/action-semantic-pull-request@v6.1.1
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            -   uses: apify/actions/pr-title-check@v1.3.0


### PR DESCRIPTION
## What

Replaces the direct `amannn/action-semantic-pull-request` usage in our PR-title workflow with the shared `apify/actions/pr-title-check@v1.3.0` wrapper.

## Why

We're consolidating PR-title checking across the org behind a single wrapper action ([apify/actions/pr-title-check](https://github.com/apify/actions/tree/main/pr-title-check)). Benefits:

- One place to pin/update the underlying action version (no more per-repo version drift — we currently have v4.5.0, v5.5.3, v6, v6.1.1 scattered across repos).
- The wrapper also spell-checks the PR title via [`crate-ci/typos`](https://github.com/crate-ci/typos).

## Changes

- Swapped the `amannn/action-semantic-pull-request@<version>` step for `apify/actions/pr-title-check@v1.3.0`.
- Dropped the manual `GITHUB_TOKEN` env wiring; the wrapper defaults to `github.token`.

## Note

This adds a PR-title spell-check that wasn't running before. The spell-checker reads a **`_typos.toml` that lives in this repository** — it's local to this repo, not a shared/org-wide config, so you have full control over it. If the check produces false positives, just add the offending words (or rules) to `_typos.toml` in this repo. If no `_typos.toml` is present, the [typos defaults](https://github.com/crate-ci/typos) apply.
