### PR TITLE
fix: Detect standalone "error" word for Mezmo promotion rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,9 +261,9 @@ Use comments to guide reviewers:
         * `warn` - suspicious but non-critical behavior
         * `info` - progress or important state changes
         * `debug` - local development
-    * **Mezmo (logDNA) promotion rule:** Mezmo automatically promotes log entries to error level when the log message or a data value contains the lowercase word `"error"` (capitalized `Error`/`ERROR`, e.g. the `mcpErrorCode` key or `INTERNAL_ERROR`, is safe). To avoid false error alerts in `softFail` calls:
+    * **Mezmo (logDNA) promotion rule:** Mezmo automatically promotes log entries to error level when the log message or a data value contains the standalone word `"error"` (case-insensitive, e.g. the SDK send-path wrap `Failed to send response: Error: …`). `Error`/`ERROR` embedded in identifiers (`mcpErrorCode` key, `INTERNAL_ERROR`) has no word boundary and is safe. To avoid false error alerts in `softFail` calls:
         * Use `errMessage` as the data key (not `error`) when logging an error message string.
-        * Sanitize the error message string with `sanitizeMezmoMessage()` from `src/utils/logging.ts` (replaces every lowercase `"error"` substring with `"failure"`).
+        * Sanitize the error message string with `sanitizeMezmoMessage()` from `src/utils/logging.ts` (replaces every whole-word `"error"` — any case — with `"failure"`).
         * Avoid the word `"error"` in the `softFail` message string itself.
         * Example: `log.softFail('Client disconnected', { errMessage: sanitizeMezmoMessage(err.message) })`
 

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -34,13 +34,14 @@ export function getHttpStatusCode(error: unknown): number | undefined {
 }
 
 /**
- * Mezmo (logDNA) promotes a log entry to error level when its message contains the lowercase
- * substring "error". Replace those occurrences with "failure" so soft logs keep their level.
- * Case-sensitive: capitalized `Error`/`ERROR` does not trigger promotion, so leave it intact.
- * See CONTRIBUTING.md § Logging → Mezmo promotion rule.
+ * Mezmo (logDNA) promotes a log entry to error level when its message contains the standalone
+ * word "error" (case-insensitive), e.g. the SDK send-path wrap `Failed to send response: Error: …`.
+ * Replace whole-word occurrences with "failure" so soft logs keep their level. Word-bounded, so
+ * `Error`/`ERROR` embedded in identifiers (`mcpErrorCode`, `INTERNAL_ERROR`) stays intact — Mezmo
+ * does not promote those. See CONTRIBUTING.md § Logging → Mezmo promotion rule.
  */
 export function sanitizeMezmoMessage(message: string): string {
-    return message.replace(/error/g, 'failure');
+    return message.replace(/\berror\b/gi, 'failure');
 }
 
 // Client faults surfaced by the MCP SDK's `onerror` — expected noise, not server bugs.

--- a/tests/unit/utils.logging.test.ts
+++ b/tests/unit/utils.logging.test.ts
@@ -52,6 +52,18 @@ describe('sanitizeMezmoMessage', () => {
             'MCP failure -32001: Request timed out',
         );
     });
+
+    it('replaces the standalone capitalized "Error" word from the SDK send-path wrap', () => {
+        // The SDK wraps disconnects as `Failed to send response: Error: <message>`. The standalone
+        // word "Error" is space/colon-delimited, so Mezmo promotes the entry despite the capital E.
+        expect(
+            sanitizeMezmoMessage('Failed to send response: Error: No connection established for request ID: 1'),
+        ).toBe('Failed to send response: failure: No connection established for request ID: 1');
+    });
+
+    it('keeps "Error" embedded in identifiers intact (no word boundary, Mezmo does not promote)', () => {
+        expect(sanitizeMezmoMessage('mcpErrorCode INTERNAL_ERROR')).toBe('mcpErrorCode INTERNAL_ERROR');
+    });
 });
 
 describe('logHttpError', () => {


### PR DESCRIPTION
Mezmo promotes log entries to error level on the standalone word "error" (case-insensitive), so the SDK send-path wrap `Failed to send response: Error: …` slips through despite the capital E. `softFail` already routes it, but the entry still surfaces as an error.

Fix: `sanitizeMezmoMessage()` now strips the whole word case-insensitively (`/error/g` → `/\berror\b/gi`). Catches standalone `Error`/`ERROR`; keeps `mcpErrorCode`/`INTERNAL_ERROR` intact (no word boundary). Tests + docs updated.

https://claude.ai/code/session_01L1dk5C4xoTB5rXtmjzaz8j