### PR TITLE
fix: Preserve empty key-value store record value in structuredContent

### DIFF
--- a/src/tools/common/get_key_value_store_record.ts
+++ b/src/tools/common/get_key_value_store_record.ts
@@ -139,6 +139,12 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
             };
         }
         // Text/JSON values serialize cleanly — return them as structuredContent per the storage-tool contract.
-        return buildStorageResponse({ structuredContent: { keyValueStoreId, ...record }, summary, apifyConsoleUrl });
+        // apify-client maps an empty record body to `undefined`, which drops the schema-required `value` on
+        // serialization; emit empty text instead (an empty OUTPUT is legitimate).
+        return buildStorageResponse({
+            structuredContent: { keyValueStoreId, ...record, value: value === undefined ? '' : value },
+            summary,
+            apifyConsoleUrl,
+        });
     },
 } as const);

--- a/tests/unit/tools.get_key_value_store_record.test.ts
+++ b/tests/unit/tools.get_key_value_store_record.test.ts
@@ -101,6 +101,20 @@ describe('get-key-value-store-record', () => {
         expect(structuredContent.summary).toBe("Read 'note.txt' (contentType=text/plain; charset=utf-8, 23 bytes).");
     });
 
+    it('returns an empty value in schema-conforming structuredContent for an empty record', async () => {
+        // apify-client maps an empty record body to `undefined` (e.g. an Actor that writes an empty OUTPUT);
+        // the value must still be present so the output schema's required `value` is satisfied.
+        const result = await (getKeyValueStoreRecord as HelperTool).call(
+            stubToolCallContext(
+                { keyValueStoreId: 'kv-1', recordKey: 'OUTPUT' },
+                stubApifyClient({ record: { key: 'OUTPUT', value: undefined, contentType: 'application/json' } }),
+            ),
+        );
+        expectSchemaConformingStructuredContent(result);
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+        expect(structuredContent).toMatchObject({ keyValueStoreId: 'kv-1', key: 'OUTPUT', value: '' });
+    });
+
     it('returns an image content block for a binary image record', async () => {
         const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]); // PNG magic bytes
         const result = await (getKeyValueStoreRecord as HelperTool).call(


### PR DESCRIPTION
## Issue
apify-client maps an empty record body to `undefined`, which results in the schema-required `value` field being dropped during serialization.

## Fix
Emit an empty string instead so the output schema is satisfied for legitimately empty records (e.g., an Actor that writes an empty OUTPUT).