### PR TITLE
refactor: Normalize tool file and export names to match tool names

### DIFF
--- a/src/index_internals.ts
+++ b/src/index_internals.ts
@@ -8,7 +8,7 @@ import { processParamsGetTools } from './mcp/utils.js';
 import { resolvePaymentProvider } from './payments/index.js';
 import type { PaymentProvider } from './payments/types.js';
 import { getServerCard } from './server_card.js';
-import { addTool } from './tools/actors/add_actor.js';
+import { addActor } from './tools/actors/add_actor.js';
 import {
     getActorsAsTools,
     getCategoryTools,
@@ -37,7 +37,7 @@ export {
     SERVER_TITLE,
     defaults,
     getDefaultTools,
-    addTool,
+    addActor,
     getCategoryTools,
     toolCategoriesEnabledByDefault,
     type ActorStore,

--- a/src/index_internals.ts
+++ b/src/index_internals.ts
@@ -38,6 +38,10 @@ export {
     defaults,
     getDefaultTools,
     addActor,
+    /**
+     * @deprecated Use `addActor` instead. Kept for the apify-mcp-server-internal migration; remove once it no longer imports `addTool`.
+     */
+    addActor as addTool,
     getCategoryTools,
     toolCategoriesEnabledByDefault,
     type ActorStore,

--- a/src/tools/actors/add_actor.ts
+++ b/src/tools/actors/add_actor.ts
@@ -13,7 +13,7 @@ export const addToolArgsSchema = z.object({
         .min(1)
         .describe(`Actor ID or full name in the format "username/name", e.g., "apify/rag-web-browser".`),
 });
-export const addTool: ToolEntry = Object.freeze({
+export const addActor: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_ADD,
     title: 'Add tool',

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -40,10 +40,10 @@ function createCallActorTool(description: string): ToolEntry {
 }
 
 /** Default mode call-actor tool. */
-export const defaultCallActor: ToolEntry = createCallActorTool(buildCallActorDescription());
+export const callActorDefault: ToolEntry = createCallActorTool(buildCallActorDescription());
 
 /**
  * Apps mode call-actor tool.
  * Renders no widget; for a live progress UI, use the call-actor-widget sibling.
  */
-export const appsCallActor: ToolEntry = createCallActorTool(buildCallActorAppsDescription());
+export const callActorApps: ToolEntry = createCallActorTool(buildCallActorAppsDescription());

--- a/src/tools/actors/fetch_actor_details.ts
+++ b/src/tools/actors/fetch_actor_details.ts
@@ -5,7 +5,7 @@ import { buildFetchActorDetailsResult, fetchActorDetailsMetadata } from './fetch
  * Default mode fetch-actor-details tool.
  * Returns full text response with output schema fetch.
  */
-export const defaultFetchActorDetails: ToolEntry = Object.freeze({
+export const fetchActorDetails: ToolEntry = Object.freeze({
     ...fetchActorDetailsMetadata,
     call: async (toolArgs) => buildFetchActorDetailsResult(toolArgs),
 } as const);

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -17,7 +17,7 @@ import {
  * Default mode search-actors tool.
  * Returns text-based Actor cards without widget metadata.
  */
-export const defaultSearchActors: ToolEntry = Object.freeze({
+export const searchActors: ToolEntry = Object.freeze({
     ...searchActorsMetadata,
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyToken, apifyClient, apifyMcpServer } = toolArgs;

--- a/src/tools/actors/search_actors_common.ts
+++ b/src/tools/actors/search_actors_common.ts
@@ -98,7 +98,7 @@ Returns list of Actor cards with the following info:
 
 /**
  * Tool metadata for the base search-actors tool — mode-independent, no widget `_meta`.
- * Used by `defaultSearchActors` in both default and apps modes.
+ * Used by `searchActors` in both default and apps modes.
  */
 export const searchActorsMetadata: Omit<HelperTool, 'call'> = {
     type: TOOL_TYPE.INTERNAL,

--- a/src/tools/docs/fetch_apify_docs.ts
+++ b/src/tools/docs/fetch_apify_docs.ts
@@ -57,7 +57,7 @@ Please verify the URL is correct and accessible. \
 You can search for available documentation pages using the ${HelperTools.DOCS_SEARCH} tool.`;
 }
 
-export const fetchApifyDocsTool: ToolEntry = Object.freeze({
+export const fetchApifyDocs: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DOCS_FETCH,
     title: 'Fetch Apify docs',

--- a/src/tools/docs/search_apify_docs.ts
+++ b/src/tools/docs/search_apify_docs.ts
@@ -68,7 +68,7 @@ Use this to paginate through the search results. For example, if you want to get
 
 const searchApifyDocsToolInputSchema = z.toJSONSchema(searchApifyDocsToolArgsSchema) as ToolInputSchema;
 
-export const searchApifyDocsTool: ToolEntry = Object.freeze({
+export const searchApifyDocs: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DOCS_SEARCH,
     title: 'Search Apify docs',

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -22,28 +22,28 @@
 import { HelperTools } from '../const.js';
 import type { ToolEntry } from '../types.js';
 import { ServerMode } from '../types.js';
-import { addTool } from './actors/add_actor.js';
-import { appsCallActor, defaultCallActor } from './actors/call_actor.js';
-import { defaultFetchActorDetails } from './actors/fetch_actor_details.js';
-import { defaultSearchActors } from './actors/search_actors.js';
-import { fetchApifyDocsTool } from './docs/fetch_apify_docs.js';
-import { searchApifyDocsTool } from './docs/search_apify_docs.js';
+import { addActor } from './actors/add_actor.js';
+import { callActorApps, callActorDefault } from './actors/call_actor.js';
+import { fetchActorDetails } from './actors/fetch_actor_details.js';
+import { searchActors } from './actors/search_actors.js';
+import { fetchApifyDocs } from './docs/fetch_apify_docs.js';
+import { searchApifyDocs } from './docs/search_apify_docs.js';
 import { abortActorRun } from './runs/abort_actor_run.js';
-import { defaultGetActorRun } from './runs/get_actor_run.js';
+import { getActorRun } from './runs/get_actor_run.js';
+import { getActorRunList } from './runs/get_actor_run_list.js';
 import { getActorRunLog } from './runs/get_actor_run_log.js';
-import { getUserRunsList } from './runs/run_collection.js';
-import { getUserDatasetsList } from './storage/dataset_collection.js';
 import { getDataset } from './storage/get_dataset.js';
 import { getDatasetItems } from './storage/get_dataset_items.js';
+import { getDatasetList } from './storage/get_dataset_list.js';
 import { getDatasetSchema } from './storage/get_dataset_schema.js';
 import { getKeyValueStore } from './storage/get_key_value_store.js';
 import { getKeyValueStoreKeys } from './storage/get_key_value_store_keys.js';
+import { getKeyValueStoreList } from './storage/get_key_value_store_list.js';
 import { getKeyValueStoreRecord } from './storage/get_key_value_store_record.js';
-import { getUserKeyValueStoresList } from './storage/key_value_store_collection.js';
-import { appsCallActorWidget } from './widgets/call_actor_widget.js';
-import { fetchActorDetailsWidgetTool } from './widgets/fetch_actor_details_widget.js';
-import { getActorRunWidgetTool } from './widgets/get_actor_run_widget.js';
-import { searchActorsWidgetTool } from './widgets/search_actors_widget.js';
+import { callActorWidget } from './widgets/call_actor_widget.js';
+import { fetchActorDetailsWidget } from './widgets/fetch_actor_details_widget.js';
+import { getActorRunWidget } from './widgets/get_actor_run_widget.js';
+import { searchActorsWidget } from './widgets/search_actors_widget.js';
 
 type ModeMap = Partial<Record<ServerMode, ToolEntry>>;
 
@@ -64,15 +64,15 @@ function isModeMap(entry: CategoryToolEntry): entry is ModeMap {
  * Use {@link getCategoryTools} to resolve entries into concrete ToolEntry arrays for a given mode.
  */
 export const toolCategories = {
-    experimental: [addTool],
+    experimental: [addActor],
     actors: [
-        defaultSearchActors,
-        defaultFetchActorDetails,
+        searchActors,
+        fetchActorDetails,
         // call-actor is identical between modes; apps mode appends a widget addendum to the description.
-        { default: defaultCallActor, apps: appsCallActor },
+        { default: callActorDefault, apps: callActorApps },
     ],
-    docs: [searchApifyDocsTool, fetchApifyDocsTool],
-    runs: [defaultGetActorRun, getUserRunsList, getActorRunLog, abortActorRun],
+    docs: [searchApifyDocs, fetchApifyDocs],
+    runs: [getActorRun, getActorRunList, getActorRunLog, abortActorRun],
     storage: [
         getDataset,
         getDatasetItems,
@@ -80,8 +80,8 @@ export const toolCategories = {
         getKeyValueStore,
         getKeyValueStoreKeys,
         getKeyValueStoreRecord,
-        getUserDatasetsList,
-        getUserKeyValueStoresList,
+        getDatasetList,
+        getKeyValueStoreList,
     ],
     dev: [],
 } satisfies Record<string, CategoryToolEntry[]>;
@@ -146,8 +146,8 @@ export const toolCategoriesEnabledByDefault: (typeof CATEGORY_NAMES)[number][] =
  * the programmatic data tool. To get both, select the base (or both explicitly).
  */
 export const WIDGET_BY_BASE_TOOL: ReadonlyMap<HelperTools, ToolEntry> = new Map([
-    [HelperTools.STORE_SEARCH, searchActorsWidgetTool],
-    [HelperTools.ACTOR_GET_DETAILS, fetchActorDetailsWidgetTool],
-    [HelperTools.ACTOR_CALL, appsCallActorWidget],
-    [HelperTools.ACTOR_RUNS_GET, getActorRunWidgetTool],
+    [HelperTools.STORE_SEARCH, searchActorsWidget],
+    [HelperTools.ACTOR_GET_DETAILS, fetchActorDetailsWidget],
+    [HelperTools.ACTOR_CALL, callActorWidget],
+    [HelperTools.ACTOR_RUNS_GET, getActorRunWidget],
 ]);

--- a/src/tools/runs/get_actor_run.ts
+++ b/src/tools/runs/get_actor_run.ts
@@ -12,7 +12,7 @@ import {
 /**
  * Default mode `get-actor-run` — returns without any widget metadata.
  */
-export const defaultGetActorRun: ToolEntry = Object.freeze({
+export const getActorRun: ToolEntry = Object.freeze({
     ...getActorRunMetadata,
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client, apifyToken, progressTracker, mcpSessionId, extra } = toolArgs;

--- a/src/tools/runs/get_actor_run_list.ts
+++ b/src/tools/runs/get_actor_run_list.ts
@@ -33,7 +33,7 @@ const getUserRunsListArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/act-runs-get
  */
-export const getUserRunsList: ToolEntry = Object.freeze({
+export const getActorRunList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUN_LIST_GET,
     title: 'Get user runs list',

--- a/src/tools/storage/get_dataset_list.ts
+++ b/src/tools/storage/get_dataset_list.ts
@@ -33,7 +33,7 @@ const getUserDatasetsListArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/datasets-get
  */
-export const getUserDatasetsList: ToolEntry = Object.freeze({
+export const getDatasetList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.DATASET_LIST_GET,
     title: 'Get user datasets list',

--- a/src/tools/storage/get_key_value_store_list.ts
+++ b/src/tools/storage/get_key_value_store_list.ts
@@ -35,7 +35,7 @@ const getUserKeyValueStoresListArgs = z.object({
 /**
  * https://docs.apify.com/api/v2/key-value-stores-get
  */
-export const getUserKeyValueStoresList: ToolEntry = Object.freeze({
+export const getKeyValueStoreList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.KEY_VALUE_STORE_LIST_GET,
     title: 'Get user key-value stores list',

--- a/src/tools/widgets/call_actor_widget.ts
+++ b/src/tools/widgets/call_actor_widget.ts
@@ -64,7 +64,7 @@ const CALL_ACTOR_WIDGET_DESCRIPTION = dedent`
     Input: actor name and input JSON; callOptions (memory, timeout) are optional.
 `;
 
-export const appsCallActorWidget: ToolEntry = Object.freeze({
+export const callActorWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_CALL_WIDGET,
     title: 'Call Actor (widget)',

--- a/src/tools/widgets/fetch_actor_details_widget.ts
+++ b/src/tools/widgets/fetch_actor_details_widget.ts
@@ -44,7 +44,7 @@ const FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION = dedent`
     Input: the Actor ID or full name only. Output fields are fixed by the widget contract.
 `;
 
-export const fetchActorDetailsWidgetTool: ToolEntry = Object.freeze({
+export const fetchActorDetailsWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_GET_DETAILS_WIDGET,
     title: 'Fetch Actor details (widget)',

--- a/src/tools/widgets/get_actor_run_widget.ts
+++ b/src/tools/widgets/get_actor_run_widget.ts
@@ -35,7 +35,7 @@ const GET_ACTOR_RUN_WIDGET_DESCRIPTION = dedent`
     ${HelperTools.ACTOR_RUNS_GET} instead — it returns the same data without rendering a widget.
 `;
 
-export const getActorRunWidgetTool: ToolEntry = Object.freeze({
+export const getActorRunWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.ACTOR_RUNS_GET_WIDGET,
     title: 'Get Actor run (widget)',

--- a/src/tools/widgets/search_actors_widget.ts
+++ b/src/tools/widgets/search_actors_widget.ts
@@ -35,7 +35,7 @@ const SEARCH_ACTORS_WIDGET_DESCRIPTION = dedent`
     Input: keywords (plus optional limit/offset). Output fields are fixed by the widget contract.
 `;
 
-export const searchActorsWidgetTool: ToolEntry = Object.freeze({
+export const searchActorsWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HelperTools.STORE_SEARCH_WIDGET,
     title: 'Search Actors (widget)',

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -9,7 +9,7 @@ import log from '@apify/log';
 
 import { defaults, HelperTools } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
-import { addTool } from '../tools/actors/add_actor.js';
+import { addActor } from '../tools/actors/add_actor.js';
 import { getActorsAsTools } from '../tools/index.js';
 import {
     CATEGORY_NAME_SET,
@@ -19,7 +19,7 @@ import {
     WIDGET_BY_BASE_TOOL,
 } from '../tools/registry.js';
 import { abortActorRun } from '../tools/runs/abort_actor_run.js';
-import { defaultGetActorRun } from '../tools/runs/get_actor_run.js';
+import { getActorRun } from '../tools/runs/get_actor_run.js';
 import { getDatasetItems } from '../tools/storage/get_dataset_items.js';
 import { getKeyValueStoreRecord } from '../tools/storage/get_key_value_store_record.js';
 import type { ActorStore, Input, ToolCategory, ToolEntry } from '../types.js';
@@ -31,7 +31,7 @@ import { SERVER_MODES, ServerMode, TOOL_TYPE } from '../types.js';
  * fetch items → fetch KV record → abort.
  */
 export const AUTO_INJECTED_TOOLS: readonly ToolEntry[] = [
-    defaultGetActorRun,
+    getActorRun,
     getDatasetItems,
     getKeyValueStoreRecord,
     abortActorRun,
@@ -243,12 +243,12 @@ export function getToolsForServerMode(
         result.push(...internalSelections);
         // If add-actor mode is enabled, ensure add-actor tool is available alongside selected tools.
         if (addActorEnabled && !selectorsExplicitEmpty && !actorsExplicitlyEmpty) {
-            const hasAddActor = result.some((e) => e.name === addTool.name);
-            if (!hasAddActor) result.push(addTool);
+            const hasAddActor = result.some((e) => e.name === addActor.name);
+            if (!hasAddActor) result.push(addActor);
         }
     } else if (addActorEnabled && !actorsExplicitlyEmpty) {
         // No selectors: either expose only add-actor (when enabled), or default categories
-        result.push(addTool);
+        result.push(addActor);
     } else if (!actorsExplicitlyEmpty) {
         // Use mode-resolved default categories
         for (const cat of toolCategoriesEnabledByDefault) {

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -5,7 +5,7 @@ import log from '@apify/log';
 
 import { ApifyClient } from '../../src/apify_client.js';
 import { ActorsMcpServer } from '../../src/index.js';
-import { addTool } from '../../src/tools/actors/add_actor.js';
+import { addActor } from '../../src/tools/actors/add_actor.js';
 import { getActorsAsTools } from '../../src/tools/index.js';
 import { actorNameToToolName } from '../../src/tools/utils.js';
 import type { Input } from '../../src/types.js';
@@ -44,7 +44,7 @@ describe('MCP server internals integration tests', () => {
         // enableAddingActors=true seeds add-actor + 4 auto-injected helpers (get-actor-run, dataset, kv, abort);
         // then ACTOR_NORMAL_MODE is added on top.
         const expectedToolNames = [
-            addTool.name,
+            addActor.name,
             'get-actor-run',
             'get-dataset-items',
             'get-key-value-store-record',
@@ -94,7 +94,7 @@ describe('MCP server internals integration tests', () => {
         expect(toolNotificationCount).toBe(1);
         expect(latestTools.length).toBe(numberOfTools + 1);
         expect(latestTools).toContain(actor);
-        expect(latestTools).toContain(addTool.name);
+        expect(latestTools).toContain(addActor.name);
         // No default actors are present when only add-actor is enabled by default
 
         // Remove the Actor
@@ -104,7 +104,7 @@ describe('MCP server internals integration tests', () => {
         expect(toolNotificationCount).toBe(2);
         expect(latestTools.length).toBe(numberOfTools);
         expect(latestTools).not.toContain(actor);
-        expect(latestTools).toContain(addTool.name);
+        expect(latestTools).toContain(addActor.name);
         // No default actors are present by default in this mode
     });
 

--- a/tests/unit/mcp.server.capability_gating.test.ts
+++ b/tests/unit/mcp.server.capability_gating.test.ts
@@ -6,9 +6,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { HelperTools, SERVER_MODE_AUTO_DETECTION_ENABLED } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
 import { RESOURCE_MIME_TYPE } from '../../src/resources/widgets.js';
-import { appsCallActor } from '../../src/tools/actors/call_actor.js';
-import { defaultSearchActors } from '../../src/tools/actors/search_actors.js';
-import { searchActorsWidgetTool } from '../../src/tools/widgets/search_actors_widget.js';
+import { callActorApps } from '../../src/tools/actors/call_actor.js';
+import { searchActors } from '../../src/tools/actors/search_actors.js';
+import { searchActorsWidget } from '../../src/tools/widgets/search_actors_widget.js';
 import type { ServerModeOption } from '../../src/types.js';
 import { ServerMode } from '../../src/types.js';
 
@@ -106,8 +106,8 @@ describe('ActorsMcpServer initialize handler', () => {
 
             // After initialize (apps mode): composed with APPS-mode variants
             // search-actors is mode-independent (data-only); search-actors-widget is the apps-only UI variant auto-added in apps mode.
-            expect(server.tools.get(HelperTools.STORE_SEARCH)).toBe(defaultSearchActors);
-            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidgetTool);
+            expect(server.tools.get(HelperTools.STORE_SEARCH)).toBe(searchActors);
+            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidget);
         },
     );
 
@@ -154,9 +154,9 @@ describe('ActorsMcpServer initialize handler', () => {
 
             await dispatchInitialize(server, makeInitializeRequest(true));
 
-            expect(server.tools.get(HelperTools.STORE_SEARCH)).toBe(defaultSearchActors);
-            expect(server.tools.get(HelperTools.ACTOR_CALL)).toBe(appsCallActor);
-            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidgetTool);
+            expect(server.tools.get(HelperTools.STORE_SEARCH)).toBe(searchActors);
+            expect(server.tools.get(HelperTools.ACTOR_CALL)).toBe(callActorApps);
+            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidget);
         },
     );
 
@@ -176,7 +176,7 @@ describe('ActorsMcpServer initialize handler', () => {
 
             await dispatchInitialize(server, makeInitializeRequest(true));
 
-            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidgetTool);
+            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidget);
         },
     );
 });

--- a/tests/unit/tools.add_actor.test.ts
+++ b/tests/unit/tools.add_actor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
-import { addTool } from '../../src/tools/actors/add_actor.js';
+import { addActor } from '../../src/tools/actors/add_actor.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import type { TextToolResult } from './helpers/tool_context.js';
 
@@ -44,12 +44,12 @@ function buildContext(
 
 describe('add-actor tool', () => {
     it('has the expected tool name', () => {
-        expect(addTool.name).toBe(HelperTools.ACTOR_ADD);
+        expect(addActor.name).toBe(HelperTools.ACTOR_ADD);
     });
 
     it('sends list_changed and nudges the client to refresh via tools/list (#851)', async () => {
         const sendNotification = vi.fn().mockResolvedValue(undefined);
-        const result = (await (addTool as HelperTool).call(
+        const result = (await (addActor as HelperTool).call(
             buildContext({ tools: [{ name: 'apify/rag-web-browser' }], sendNotification }),
         )) as TextToolResult;
 
@@ -63,7 +63,7 @@ describe('add-actor tool', () => {
     });
 
     it('does not nudge when the actor is already available', async () => {
-        const result = (await (addTool as HelperTool).call(
+        const result = (await (addActor as HelperTool).call(
             buildContext({ actor: 'apify/already-there', alreadyLoaded: ['apify/already-there'] }),
         )) as TextToolResult;
 
@@ -72,7 +72,7 @@ describe('add-actor tool', () => {
     });
 
     it('forwards a load error without a nudge', async () => {
-        const result = (await (addTool as HelperTool).call(
+        const result = (await (addActor as HelperTool).call(
             buildContext({ errors: [{ message: 'Actor xyz was not found.' }], tools: [] }),
         )) as TextToolResult;
 

--- a/tests/unit/tools.call_actor_widget.response.test.ts
+++ b/tests/unit/tools.call_actor_widget.response.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WIDGET_URIS } from '../../src/resources/widgets.js';
-import { appsCallActorWidget } from '../../src/tools/widgets/call_actor_widget.js';
+import { callActorWidget } from '../../src/tools/widgets/call_actor_widget.js';
 import type { HelperTool, InternalToolArgs, ToolEntry } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
 import { getActorMcpUrlCached } from '../../src/utils/actor.js';
@@ -65,7 +65,7 @@ describe('call-actor-widget response', () => {
         const startSpy = vi.fn().mockResolvedValue(MOCK_RUN);
         const apifyClient = stubApifyClient(startSpy);
 
-        const result = await (appsCallActorWidget as HelperTool).call(
+        const result = await (callActorWidget as HelperTool).call(
             stubToolCallContext({ actor: 'apify/rag-web-browser', input: { query: 'test' } }, apifyClient),
         );
 
@@ -116,7 +116,7 @@ describe('call-actor-widget response', () => {
     });
 
     it('carries widget _meta on the tool definition', () => {
-        const tool = appsCallActorWidget as HelperTool;
+        const tool = callActorWidget as HelperTool;
         const meta = tool._meta as { ui?: { resourceUri?: string; visibility?: readonly string[]; csp?: unknown } };
         expect(meta.ui?.resourceUri).toBe(WIDGET_URIS.ACTOR_RUN);
         expect(meta.ui?.visibility).toEqual(['model', 'app']);
@@ -124,7 +124,7 @@ describe('call-actor-widget response', () => {
     });
 
     it('declares a strict input schema that silently strips stray keys like async/previewOutput', () => {
-        const tool = appsCallActorWidget as HelperTool;
+        const tool = callActorWidget as HelperTool;
 
         const schema = tool.inputSchema as {
             additionalProperties?: boolean;
@@ -150,7 +150,7 @@ describe('call-actor-widget response', () => {
     });
 
     it('accepts a minimal actor+input payload', () => {
-        const tool = appsCallActorWidget as HelperTool;
+        const tool = callActorWidget as HelperTool;
         const ok = tool.ajvValidate({ actor: 'apify/rag-web-browser', input: { query: 'test' } });
         expect(ok).toBe(true);
     });
@@ -159,7 +159,7 @@ describe('call-actor-widget response', () => {
         const startSpy = vi.fn();
         const apifyClient = stubApifyClient(startSpy);
 
-        const result = await (appsCallActorWidget as HelperTool).call(
+        const result = await (callActorWidget as HelperTool).call(
             stubToolCallContext(
                 { actor: 'apify/actors-mcp-server:fetch-apify-docs', input: { query: 'test' } },
                 apifyClient,

--- a/tests/unit/tools.fetch_actor_details.widget.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.widget.response.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WIDGET_URIS } from '../../src/resources/widgets.js';
-import { fetchActorDetailsWidgetTool } from '../../src/tools/widgets/fetch_actor_details_widget.js';
+import { fetchActorDetailsWidget } from '../../src/tools/widgets/fetch_actor_details_widget.js';
 import type { HelperTool } from '../../src/types.js';
 import type { ActorDetailsResult } from '../../src/utils/actor_details.js';
 import { fetchActorDetails } from '../../src/utils/actor_details.js';
@@ -64,7 +64,7 @@ describe('fetch-actor-details-widget response', () => {
     it('returns { actorDetails: { actorInfo, actorCard, readme } } as structuredContent plus widget _meta', async () => {
         vi.mocked(fetchActorDetails).mockResolvedValue(MOCK_DETAILS);
 
-        const result = await (fetchActorDetailsWidgetTool as HelperTool).call(
+        const result = await (fetchActorDetailsWidget as HelperTool).call(
             stubInternalToolArgs({ actor: 'apify/web-scraper' }),
         );
 
@@ -100,7 +100,7 @@ describe('fetch-actor-details-widget response', () => {
     });
 
     it('carries widget _meta on the tool definition', () => {
-        const tool = fetchActorDetailsWidgetTool as HelperTool;
+        const tool = fetchActorDetailsWidget as HelperTool;
         const meta = tool._meta as { ui?: { resourceUri?: string; visibility?: readonly string[]; csp?: unknown } };
         expect(meta.ui?.resourceUri).toBe(WIDGET_URIS.SEARCH_ACTORS);
         expect(meta.ui?.visibility).toEqual(['model', 'app']);
@@ -108,7 +108,7 @@ describe('fetch-actor-details-widget response', () => {
     });
 
     it('declares a strict input schema and strips stray keys like `output` at validation time', () => {
-        const tool = fetchActorDetailsWidgetTool as HelperTool;
+        const tool = fetchActorDetailsWidget as HelperTool;
 
         // Schema-level: strict shape (no extra properties allowed).
         const schema = tool.inputSchema as {
@@ -129,7 +129,7 @@ describe('fetch-actor-details-widget response', () => {
     });
 
     it('accepts a valid actor-only input', () => {
-        const tool = fetchActorDetailsWidgetTool as HelperTool;
+        const tool = fetchActorDetailsWidget as HelperTool;
         const ok = tool.ajvValidate({ actor: 'apify/web-scraper' });
         expect(ok).toBe(true);
     });

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -9,7 +9,7 @@ import {
     type RunKeyValueStore,
     type RunResponse,
 } from '../../src/tools/actors/actor_run_response.js';
-import { defaultGetActorRun } from '../../src/tools/runs/get_actor_run.js';
+import { getActorRun } from '../../src/tools/runs/get_actor_run.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
@@ -88,7 +88,7 @@ function stubClient(opts: {
 describe('get-actor-run default response', () => {
     it('end-to-end SUCCEEDED: translates fields, omits legacy preview, carries identifiers in text, attaches usage _meta', async () => {
         const run = mockSucceededRun();
-        const result = await (defaultGetActorRun as HelperTool).call(
+        const result = await (getActorRun as HelperTool).call(
             stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, stubClient({ run, dataset: mockDataset() })),
         );
 
@@ -131,7 +131,7 @@ describe('get-actor-run default response', () => {
         // The single-dataset GET does not return `inflatedBytes` (only the dataset-list endpoint does);
         // this stub injects it to verify the wiring.
         const run = mockSucceededRun();
-        const result = await (defaultGetActorRun as HelperTool).call(
+        const result = await (getActorRun as HelperTool).call(
             stubToolCallContext(
                 { runId: 'run-1', waitSecs: 0 },
                 stubClient({ run, dataset: mockDataset({ stats: { writeCount: 47, inflatedBytes: 1234 } }) }),
@@ -180,7 +180,7 @@ describe('get-actor-run default response', () => {
             },
         } as unknown as InternalToolArgs['apifyClient'];
 
-        const result = await (defaultGetActorRun as HelperTool).call(
+        const result = await (getActorRun as HelperTool).call(
             stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client),
         );
         const { structuredContent } = result as { structuredContent: RunResponse };
@@ -204,7 +204,7 @@ describe('get-actor-run default response', () => {
         const dataset = mockDataset({ itemCount: 0 });
         // Probe runs with `limit: 1`, so `items.length === 1` even when the dataset has more.
         // The recovered count must come from `total`, otherwise the lag fallback caps at 1.
-        const result = await (defaultGetActorRun as HelperTool).call(
+        const result = await (getActorRun as HelperTool).call(
             stubToolCallContext(
                 { runId: 'run-1', waitSecs: 0 },
                 stubClient({ run, dataset, listItemsProbe: { items: [{ a: 1 }], total: 47 } }),
@@ -266,7 +266,7 @@ describe('get-actor-run default response', () => {
                 }),
             } as unknown as InternalToolArgs['apifyClient'];
 
-            const callPromise = (defaultGetActorRun as HelperTool).call(
+            const callPromise = (getActorRun as HelperTool).call(
                 stubToolCallContext({ runId: 'run-1', waitSecs: 5 }, client),
             );
             await vi.runAllTimersAsync();
@@ -303,7 +303,7 @@ describe('get-actor-run default response', () => {
                 }),
             } as unknown as InternalToolArgs['apifyClient'];
 
-            const callPromise = (defaultGetActorRun as HelperTool).call(
+            const callPromise = (getActorRun as HelperTool).call(
                 stubToolCallContext({ runId: 'run-1', waitSecs: 5 }, client),
             );
             // Drive the [0, 1000, 2000, 2000]ms schedule to completion without real wall time.
@@ -339,7 +339,7 @@ describe('get-actor-run default response', () => {
             }),
         } as unknown as InternalToolArgs['apifyClient'];
 
-        await (defaultGetActorRun as HelperTool).call(stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client));
+        await (getActorRun as HelperTool).call(stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client));
         // Exactly one immediate probe — no delayed retries.
         expect(probeCalls).toBe(1);
     });
@@ -371,12 +371,12 @@ describe('get-actor-run default response', () => {
             }),
         } as unknown as InternalToolArgs['apifyClient'];
 
-        const result = await (defaultGetActorRun as HelperTool).call({
+        const result = await (getActorRun as HelperTool).call({
             ...stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client),
             extra: { signal: controller.signal } as InternalToolArgs['extra'],
         });
 
-        // Cancelled requests return no payload per MCP spec — see `defaultGetActorRun`.
+        // Cancelled requests return no payload per MCP spec — see `getActorRun`.
         expect(result).toEqual({});
         // ≤1 because raceAbort may short-circuit before or after `run().get()` is invoked; what
         // matters is that the call returns instead of hanging on the never-resolving promise.
@@ -384,12 +384,12 @@ describe('get-actor-run default response', () => {
     });
 
     it('rejects waitSecs above 45', () => {
-        const tool = defaultGetActorRun as HelperTool;
+        const tool = getActorRun as HelperTool;
         expect(tool.ajvValidate({ runId: 'run-1', waitSecs: 46 })).toBe(false);
     });
 
     it('rejects waitSecs below 0', () => {
-        const tool = defaultGetActorRun as HelperTool;
+        const tool = getActorRun as HelperTool;
         expect(tool.ajvValidate({ runId: 'run-1', waitSecs: -1 })).toBe(false);
     });
 
@@ -409,7 +409,7 @@ describe('get-actor-run default response', () => {
             }),
         } as unknown as InternalToolArgs['apifyClient'];
 
-        const result = await (defaultGetActorRun as HelperTool).call(
+        const result = await (getActorRun as HelperTool).call(
             stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client),
         );
         const { content, structuredContent, isError } = result as TextToolResult & { structuredContent: RunResponse };
@@ -447,7 +447,7 @@ describe('get-actor-run default response', () => {
             }),
         } as unknown as InternalToolArgs['apifyClient'];
 
-        const result = await (defaultGetActorRun as HelperTool).call(
+        const result = await (getActorRun as HelperTool).call(
             stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client),
         );
         const { structuredContent, isError } = result as { structuredContent: RunResponse; isError?: boolean };
@@ -564,7 +564,7 @@ describe('get-actor-run default response', () => {
         };
 
         const baseArgs = stubToolCallContext({ runId: 'run-1', waitSecs: 5 }, client);
-        await (defaultGetActorRun as HelperTool).call({
+        await (getActorRun as HelperTool).call({
             ...baseArgs,
             progressTracker: tracker as unknown as InternalToolArgs['progressTracker'],
         });
@@ -584,7 +584,7 @@ describe('get-actor-run default response', () => {
             run: (_id: string) => ({ get: async () => undefined }),
             actor: (_id: string) => ({ get: async () => ACTOR }),
         } as unknown as InternalToolArgs['apifyClient'];
-        const result = (await (defaultGetActorRun as HelperTool).call(
+        const result = (await (getActorRun as HelperTool).call(
             stubToolCallContext({ runId: 'missing', waitSecs: 0 }, client),
         )) as TextToolResult;
         expect(result.isError).toBe(true);
@@ -600,7 +600,7 @@ describe('get-actor-run default response', () => {
             vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
 
             const run = mockSucceededRun();
-            const result = await (defaultGetActorRun as HelperTool).call({
+            const result = await (getActorRun as HelperTool).call({
                 ...stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, stubClient({ run, dataset: mockDataset() })),
                 apifyToken: 'apify_ui_test',
             });
@@ -627,7 +627,7 @@ describe('get-actor-run default response', () => {
 
         it('keeps responses link-free for API tokens', async () => {
             const run = mockSucceededRun();
-            const result = await (defaultGetActorRun as HelperTool).call({
+            const result = await (getActorRun as HelperTool).call({
                 ...stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, stubClient({ run, dataset: mockDataset() })),
                 apifyToken: 'apify_api_test',
             });

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -146,7 +146,7 @@ describe('get-actor-run default response', () => {
         // The platform returns inflatedBytes: 0 when it does not yet populate the size; surfacing a
         // literal "0 bytes" is misleading for a non-empty dataset, so the field must be omitted.
         const run = mockSucceededRun();
-        const result = await (defaultGetActorRun as HelperTool).call(
+        const result = await (getActorRun as HelperTool).call(
             stubToolCallContext(
                 { runId: 'run-1', waitSecs: 0 },
                 stubClient({ run, dataset: mockDataset({ stats: { writeCount: 47, inflatedBytes: 0 } }) }),
@@ -235,7 +235,7 @@ describe('get-actor-run default response', () => {
             }),
         } as unknown as InternalToolArgs['apifyClient'];
 
-        const result = await (defaultGetActorRun as HelperTool).call(
+        const result = await (getActorRun as HelperTool).call(
             stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client),
         );
         const { structuredContent } = result as { structuredContent: RunResponse };
@@ -489,7 +489,7 @@ describe('get-actor-run default response', () => {
             }),
         } as unknown as InternalToolArgs['apifyClient'];
 
-        const result = await (defaultGetActorRun as HelperTool).call(
+        const result = await (getActorRun as HelperTool).call(
             stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client),
         );
         const { structuredContent } = result as { structuredContent: RunResponse };

--- a/tests/unit/tools.get_actor_run.widget.response.test.ts
+++ b/tests/unit/tools.get_actor_run.widget.response.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { WIDGET_URIS } from '../../src/resources/widgets.js';
 import type { RunResponse } from '../../src/tools/actors/actor_run_response.js';
-import { getActorRunWidgetTool } from '../../src/tools/widgets/get_actor_run_widget.js';
+import { getActorRunWidget } from '../../src/tools/widgets/get_actor_run_widget.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import { stubToolCallContext } from './helpers/tool_context.js';
 
@@ -38,7 +38,7 @@ function stubApifyClient(): InternalToolArgs['apifyClient'] {
 
 describe('get-actor-run-widget response', () => {
     it('returns structured content and widget _meta on the response', async () => {
-        const result = await (getActorRunWidgetTool as HelperTool).call(
+        const result = await (getActorRunWidget as HelperTool).call(
             stubToolCallContext({ runId: 'run-widget-1' }, stubApifyClient()),
         );
 
@@ -74,7 +74,7 @@ describe('get-actor-run-widget response', () => {
     });
 
     it('carries widget _meta on the tool definition', () => {
-        const tool = getActorRunWidgetTool as HelperTool;
+        const tool = getActorRunWidget as HelperTool;
         const meta = tool._meta as { ui?: { resourceUri?: string; visibility?: readonly string[]; csp?: unknown } };
         expect(meta.ui?.resourceUri).toBe(WIDGET_URIS.ACTOR_RUN);
         expect(meta.ui?.visibility).toEqual(['model', 'app']);
@@ -82,7 +82,7 @@ describe('get-actor-run-widget response', () => {
     });
 
     it('declares a strict input schema accepting runId only', () => {
-        const tool = getActorRunWidgetTool as HelperTool;
+        const tool = getActorRunWidget as HelperTool;
 
         const schema = tool.inputSchema as {
             additionalProperties?: boolean;
@@ -102,7 +102,7 @@ describe('get-actor-run-widget response', () => {
     });
 
     it('accepts a minimal runId payload', () => {
-        const tool = getActorRunWidgetTool as HelperTool;
+        const tool = getActorRunWidget as HelperTool;
         const ok = tool.ajvValidate({ runId: 'run-widget-1' });
         expect(ok).toBe(true);
     });

--- a/tests/unit/tools.get_actor_run_list.test.ts
+++ b/tests/unit/tools.get_actor_run_list.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
-import { getUserRunsList } from '../../src/tools/runs/run_collection.js';
+import { getActorRunList } from '../../src/tools/runs/get_actor_run_list.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import { decodeFencedToolText, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
 
@@ -32,29 +32,29 @@ const MOCK_RUNS = {
     ],
 };
 
-// run_collection constructs its own ApifyClient from the token, so the injected client is unused.
+// get_actor_run_list constructs its own ApifyClient from the token, so the injected client is unused.
 const noClient = null as unknown as InternalToolArgs['apifyClient'];
 
 describe('get-actor-run-list', () => {
     it('has the expected tool name', () => {
-        expect(getUserRunsList.name).toBe(HelperTools.ACTOR_RUN_LIST_GET);
+        expect(getActorRunList.name).toBe(HelperTools.ACTOR_RUN_LIST_GET);
     });
 
     it('returns runs as fenced text (json or toon), mirrors them in structuredContent, and declares an outputSchema', async () => {
         listMock.mockResolvedValue(MOCK_RUNS);
 
-        const result = await (getUserRunsList as HelperTool).call(stubToolCallContext({}, noClient));
+        const result = await (getActorRunList as HelperTool).call(stubToolCallContext({}, noClient));
         const { content } = result as TextToolResult;
 
         expect(decodeFencedToolText(content[0].text)).toEqual(MOCK_RUNS);
         expect((result as TextToolResult).structuredContent).toEqual(MOCK_RUNS);
-        expect((getUserRunsList as HelperTool).outputSchema).toMatchObject({ type: 'object' });
+        expect((getActorRunList as HelperTool).outputSchema).toMatchObject({ type: 'object' });
     });
 
     it('forwards pagination and status filters to runs().list()', async () => {
         listMock.mockResolvedValue(MOCK_RUNS);
 
-        await (getUserRunsList as HelperTool).call(
+        await (getActorRunList as HelperTool).call(
             stubToolCallContext({ limit: 5, offset: 2, desc: true, status: 'SUCCEEDED' }, noClient),
         );
 
@@ -64,13 +64,13 @@ describe('get-actor-run-list', () => {
     it('applies defaults (limit=10, offset=0, desc=false) when no params given', async () => {
         listMock.mockResolvedValue(MOCK_RUNS);
 
-        await (getUserRunsList as HelperTool).call(stubToolCallContext({}, noClient));
+        await (getActorRunList as HelperTool).call(stubToolCallContext({}, noClient));
 
         expect(listMock).toHaveBeenCalledWith({ limit: 10, offset: 0, desc: false, status: undefined });
     });
 
     it('rejects limit above 10 via ajv validation', () => {
-        const tool = getUserRunsList as HelperTool;
+        const tool = getActorRunList as HelperTool;
         expect(tool.ajvValidate({ limit: 11 })).toBe(false);
         expect(tool.ajvValidate({ limit: 10 })).toBe(true);
     });

--- a/tests/unit/tools.get_dataset_list.test.ts
+++ b/tests/unit/tools.get_dataset_list.test.ts
@@ -110,9 +110,7 @@ describe('get-dataset-list', () => {
     it('emits structuredContent that validates against the outputSchema for the last/empty page', async () => {
         const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 0, count: 0, items: [] });
 
-        const result = await (getDatasetList as HelperTool).call(
-            stubToolCallContext({}, stubApifyClient(listSpy)),
-        );
+        const result = await (getDatasetList as HelperTool).call(stubToolCallContext({}, stubApifyClient(listSpy)));
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
 
         expect(structuredContent).toHaveProperty('count', 0);

--- a/tests/unit/tools.get_dataset_list.test.ts
+++ b/tests/unit/tools.get_dataset_list.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
-import { getUserKeyValueStoresList } from '../../src/tools/storage/key_value_store_collection.js';
+import { getDatasetList } from '../../src/tools/storage/get_dataset_list.js';
 import { storageListOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import {
@@ -18,59 +18,73 @@ const MOCK_LIST = {
     desc: false,
     count: 2,
     items: [
-        { id: 'kv-1', name: 'a' },
-        { id: 'kv-2', name: 'b' },
+        { id: 'ds-1', name: 'a' },
+        { id: 'ds-2', name: 'b' },
     ],
 };
 
 function stubApifyClient(listSpy: ReturnType<typeof vi.fn>): InternalToolArgs['apifyClient'] {
     return {
-        keyValueStores: () => ({ list: listSpy }),
+        datasets: () => ({ list: listSpy }),
     } as unknown as InternalToolArgs['apifyClient'];
 }
 
-describe('get-key-value-store-list', () => {
+describe('get-dataset-list', () => {
     it('has the expected tool name', () => {
-        expect(getUserKeyValueStoresList.name).toBe(HelperTools.KEY_VALUE_STORE_LIST_GET);
+        expect(getDatasetList.name).toBe(HelperTools.DATASET_LIST_GET);
     });
 
     it('returns the list response plus a summary and nextStep in structuredContent', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
-        const result = await (getUserKeyValueStoresList as HelperTool).call(
-            stubToolCallContext({}, stubApifyClient(listSpy)),
-        );
+        const result = await (getDatasetList as HelperTool).call(stubToolCallContext({}, stubApifyClient(listSpy)));
         const { content, structuredContent } = result as TextToolResult & {
             structuredContent: Record<string, unknown>;
         };
 
         expect(structuredContent).toMatchObject(MOCK_LIST);
-        expect(structuredContent.summary).toBe('Listed 2 of 2 key-value stores.');
-        expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_GET);
+        expect(structuredContent.summary).toBe('Listed 2 of 2 datasets.');
+        // Not truncated → nextStep points at inspecting a dataset, not pagination.
+        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
         // content[0] ships the TOON-fenced data; content[1] carries the prose summary + nextStep.
         const { summary, nextStep, ...data } = structuredContent;
         expect(decodeFencedToolText(content[0].text)).toEqual(data);
         expect(content[1].text).toBe(`${summary}\n${nextStep}`);
     });
 
-    it('emits a pagination nextStep when more stores remain', async () => {
-        const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 30 });
+    it('preserves each dataset stats.inflatedBytes in structuredContent', async () => {
+        const listSpy = vi.fn().mockResolvedValue({
+            ...MOCK_LIST,
+            items: [
+                { id: 'ds-1', name: 'a', itemCount: 5, stats: { inflatedBytes: 54385 } },
+                { id: 'ds-2', name: 'b', itemCount: 0, stats: { inflatedBytes: 0 } },
+            ],
+        });
 
-        const result = await (getUserKeyValueStoresList as HelperTool).call(
-            stubToolCallContext({}, stubApifyClient(listSpy)),
-        );
+        const result = await (getDatasetList as HelperTool).call(stubToolCallContext({}, stubApifyClient(listSpy)));
+        const { structuredContent } = result as {
+            structuredContent: { items: { stats: { inflatedBytes: number } }[] };
+        };
+
+        expect(structuredContent.items[0].stats.inflatedBytes).toBe(54385);
+    });
+
+    it('emits a pagination nextStep when more datasets remain', async () => {
+        const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 25 });
+
+        const result = await (getDatasetList as HelperTool).call(stubToolCallContext({}, stubApifyClient(listSpy)));
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
 
-        expect(structuredContent.summary).toBe('Listed 2 of 30 key-value stores.');
+        expect(structuredContent.summary).toBe('Listed 2 of 25 datasets.');
         expect(structuredContent.nextStep).toBe(
-            `Call ${HelperTools.KEY_VALUE_STORE_LIST_GET} again with offset=2 to fetch the next page.`,
+            `Call ${HelperTools.DATASET_LIST_GET} again with offset=2 to fetch the next page.`,
         );
     });
 
     it('forwards pagination params (limit, offset, desc, unnamed) to ApifyClient', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
-        await (getUserKeyValueStoresList as HelperTool).call(
+        await (getDatasetList as HelperTool).call(
             stubToolCallContext(
                 {
                     limit: 5,
@@ -88,7 +102,7 @@ describe('get-key-value-store-list', () => {
     it('applies defaults (limit=10, offset=0, desc=false, unnamed=false) when no params given', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
-        await (getUserKeyValueStoresList as HelperTool).call(stubToolCallContext({}, stubApifyClient(listSpy)));
+        await (getDatasetList as HelperTool).call(stubToolCallContext({}, stubApifyClient(listSpy)));
 
         expect(listSpy).toHaveBeenCalledWith({ limit: 10, offset: 0, desc: false, unnamed: false });
     });
@@ -96,7 +110,7 @@ describe('get-key-value-store-list', () => {
     it('emits structuredContent that validates against the outputSchema for the last/empty page', async () => {
         const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 0, count: 0, items: [] });
 
-        const result = await (getUserKeyValueStoresList as HelperTool).call(
+        const result = await (getDatasetList as HelperTool).call(
             stubToolCallContext({}, stubApifyClient(listSpy)),
         );
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
@@ -105,9 +119,9 @@ describe('get-key-value-store-list', () => {
         expectSchemaConformingStructuredContent(result, storageListOutputSchema);
     });
 
-    it('rejects limit above 10 via ajv validation', () => {
-        const tool = getUserKeyValueStoresList as HelperTool;
-        expect(tool.ajvValidate({ limit: 11 })).toBe(false);
-        expect(tool.ajvValidate({ limit: 10 })).toBe(true);
+    it('rejects limit above 20 via ajv validation', () => {
+        const tool = getDatasetList as HelperTool;
+        expect(tool.ajvValidate({ limit: 21 })).toBe(false);
+        expect(tool.ajvValidate({ limit: 20 })).toBe(true);
     });
 });

--- a/tests/unit/tools.get_key_value_store_list.test.ts
+++ b/tests/unit/tools.get_key_value_store_list.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
-import { getUserDatasetsList } from '../../src/tools/storage/dataset_collection.js';
+import { getKeyValueStoreList } from '../../src/tools/storage/get_key_value_store_list.js';
 import { storageListOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import {
@@ -18,26 +18,26 @@ const MOCK_LIST = {
     desc: false,
     count: 2,
     items: [
-        { id: 'ds-1', name: 'a' },
-        { id: 'ds-2', name: 'b' },
+        { id: 'kv-1', name: 'a' },
+        { id: 'kv-2', name: 'b' },
     ],
 };
 
 function stubApifyClient(listSpy: ReturnType<typeof vi.fn>): InternalToolArgs['apifyClient'] {
     return {
-        datasets: () => ({ list: listSpy }),
+        keyValueStores: () => ({ list: listSpy }),
     } as unknown as InternalToolArgs['apifyClient'];
 }
 
-describe('get-dataset-list', () => {
+describe('get-key-value-store-list', () => {
     it('has the expected tool name', () => {
-        expect(getUserDatasetsList.name).toBe(HelperTools.DATASET_LIST_GET);
+        expect(getKeyValueStoreList.name).toBe(HelperTools.KEY_VALUE_STORE_LIST_GET);
     });
 
     it('returns the list response plus a summary and nextStep in structuredContent', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
-        const result = await (getUserDatasetsList as HelperTool).call(
+        const result = await (getKeyValueStoreList as HelperTool).call(
             stubToolCallContext({}, stubApifyClient(listSpy)),
         );
         const { content, structuredContent } = result as TextToolResult & {
@@ -45,52 +45,32 @@ describe('get-dataset-list', () => {
         };
 
         expect(structuredContent).toMatchObject(MOCK_LIST);
-        expect(structuredContent.summary).toBe('Listed 2 of 2 datasets.');
-        // Not truncated → nextStep points at inspecting a dataset, not pagination.
-        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
+        expect(structuredContent.summary).toBe('Listed 2 of 2 key-value stores.');
+        expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_GET);
         // content[0] ships the TOON-fenced data; content[1] carries the prose summary + nextStep.
         const { summary, nextStep, ...data } = structuredContent;
         expect(decodeFencedToolText(content[0].text)).toEqual(data);
         expect(content[1].text).toBe(`${summary}\n${nextStep}`);
     });
 
-    it('preserves each dataset stats.inflatedBytes in structuredContent', async () => {
-        const listSpy = vi.fn().mockResolvedValue({
-            ...MOCK_LIST,
-            items: [
-                { id: 'ds-1', name: 'a', itemCount: 5, stats: { inflatedBytes: 54385 } },
-                { id: 'ds-2', name: 'b', itemCount: 0, stats: { inflatedBytes: 0 } },
-            ],
-        });
+    it('emits a pagination nextStep when more stores remain', async () => {
+        const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 30 });
 
-        const result = await (getUserDatasetsList as HelperTool).call(
-            stubToolCallContext({}, stubApifyClient(listSpy)),
-        );
-        const { structuredContent } = result as {
-            structuredContent: { items: { stats: { inflatedBytes: number } }[] };
-        };
-
-        expect(structuredContent.items[0].stats.inflatedBytes).toBe(54385);
-    });
-
-    it('emits a pagination nextStep when more datasets remain', async () => {
-        const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 25 });
-
-        const result = await (getUserDatasetsList as HelperTool).call(
+        const result = await (getKeyValueStoreList as HelperTool).call(
             stubToolCallContext({}, stubApifyClient(listSpy)),
         );
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
 
-        expect(structuredContent.summary).toBe('Listed 2 of 25 datasets.');
+        expect(structuredContent.summary).toBe('Listed 2 of 30 key-value stores.');
         expect(structuredContent.nextStep).toBe(
-            `Call ${HelperTools.DATASET_LIST_GET} again with offset=2 to fetch the next page.`,
+            `Call ${HelperTools.KEY_VALUE_STORE_LIST_GET} again with offset=2 to fetch the next page.`,
         );
     });
 
     it('forwards pagination params (limit, offset, desc, unnamed) to ApifyClient', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
-        await (getUserDatasetsList as HelperTool).call(
+        await (getKeyValueStoreList as HelperTool).call(
             stubToolCallContext(
                 {
                     limit: 5,
@@ -108,7 +88,7 @@ describe('get-dataset-list', () => {
     it('applies defaults (limit=10, offset=0, desc=false, unnamed=false) when no params given', async () => {
         const listSpy = vi.fn().mockResolvedValue(MOCK_LIST);
 
-        await (getUserDatasetsList as HelperTool).call(stubToolCallContext({}, stubApifyClient(listSpy)));
+        await (getKeyValueStoreList as HelperTool).call(stubToolCallContext({}, stubApifyClient(listSpy)));
 
         expect(listSpy).toHaveBeenCalledWith({ limit: 10, offset: 0, desc: false, unnamed: false });
     });
@@ -116,7 +96,7 @@ describe('get-dataset-list', () => {
     it('emits structuredContent that validates against the outputSchema for the last/empty page', async () => {
         const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 0, count: 0, items: [] });
 
-        const result = await (getUserDatasetsList as HelperTool).call(
+        const result = await (getKeyValueStoreList as HelperTool).call(
             stubToolCallContext({}, stubApifyClient(listSpy)),
         );
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
@@ -125,9 +105,9 @@ describe('get-dataset-list', () => {
         expectSchemaConformingStructuredContent(result, storageListOutputSchema);
     });
 
-    it('rejects limit above 20 via ajv validation', () => {
-        const tool = getUserDatasetsList as HelperTool;
-        expect(tool.ajvValidate({ limit: 21 })).toBe(false);
-        expect(tool.ajvValidate({ limit: 20 })).toBe(true);
+    it('rejects limit above 10 via ajv validation', () => {
+        const tool = getKeyValueStoreList as HelperTool;
+        expect(tool.ajvValidate({ limit: 11 })).toBe(false);
+        expect(tool.ajvValidate({ limit: 10 })).toBe(true);
     });
 });

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 
 import { ALLOWED_TASK_TOOL_EXECUTION_MODES, HelperTools } from '../../src/const.js';
 import { searchActorsBaseArgsSchema } from '../../src/tools/actors/search_actors_common.js';
-import { searchApifyDocsTool } from '../../src/tools/docs/search_apify_docs.js';
+import { searchApifyDocs } from '../../src/tools/docs/search_apify_docs.js';
 import { CATEGORY_NAMES, getCategoryTools } from '../../src/tools/index.js';
 import { WIDGET_BY_BASE_TOOL } from '../../src/tools/registry.js';
 import type { Input, ToolBase, ToolEntry } from '../../src/types.js';
@@ -354,7 +354,7 @@ describe('getToolPublicFieldOnly _meta filtering', () => {
 
 describe('getToolPublicFieldOnly inputSchema normalization', () => {
     it('should not expose Zod-defaulted fields as JSON Schema required (search-apify-docs)', () => {
-        const { inputSchema } = getToolPublicFieldOnly(searchApifyDocsTool, { filterWidgetMeta: false });
+        const { inputSchema } = getToolPublicFieldOnly(searchApifyDocs, { filterWidgetMeta: false });
         const schema = inputSchema as { required?: string[]; properties?: Record<string, { default?: unknown }> };
 
         expect(schema.required).toEqual(['query']);

--- a/tests/unit/tools.search_actors.default.response.test.ts
+++ b/tests/unit/tools.search_actors.default.response.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { APIFY_STORE_URL, HelperTools, MAX_INPUT_FIELDS_IN_ACTOR_CARD } from '../../src/const.js';
-import { defaultSearchActors } from '../../src/tools/actors/search_actors.js';
+import { searchActors } from '../../src/tools/actors/search_actors.js';
 import { actorInfoSchema } from '../../src/tools/structured_output_schemas.js';
 import type { ActorStoreInputSchema, ActorStoreList, HelperTool } from '../../src/types.js';
 import {
@@ -39,7 +39,7 @@ function buildInputSchema(fieldCount: number): ActorStoreInputSchema {
     };
 }
 
-describe('search-actors without widget (defaultSearchActors)', () => {
+describe('search-actors without widget (searchActors)', () => {
     beforeEach(() => {
         vi.mocked(searchAgentSafeActors).mockReset();
         vi.mocked(getUserInfoCached).mockReset();
@@ -49,7 +49,7 @@ describe('search-actors without widget (defaultSearchActors)', () => {
     it('returns structured actors and markdown text; no widget payload', async () => {
         vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
 
-        const result = await (defaultSearchActors as HelperTool).call(
+        const result = await (searchActors as HelperTool).call(
             stubInternalToolArgs({
                 keywords: SEARCH_KEYWORDS,
                 limit: 5,
@@ -112,7 +112,7 @@ describe('search-actors without widget (defaultSearchActors)', () => {
         ] as ActorStoreList[];
         vi.mocked(searchAgentSafeActors).mockResolvedValue(actors);
 
-        const result = await (defaultSearchActors as HelperTool).call(
+        const result = await (searchActors as HelperTool).call(
             stubInternalToolArgs({
                 keywords: SEARCH_KEYWORDS,
                 limit: 5,
@@ -150,7 +150,7 @@ describe('search-actors without widget (defaultSearchActors)', () => {
     it('returns empty structured content and retry instructions when no actors match', async () => {
         vi.mocked(searchAgentSafeActors).mockResolvedValue([]);
 
-        const result = await (defaultSearchActors as HelperTool).call(
+        const result = await (searchActors as HelperTool).call(
             stubInternalToolArgs({
                 keywords: SEARCH_KEYWORDS,
                 limit: 5,
@@ -201,7 +201,7 @@ describe('search-actors without widget (defaultSearchActors)', () => {
         vi.mocked(getUserInfoCached).mockResolvedValue(mockUserInfo());
         vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
 
-        const result = await (defaultSearchActors as HelperTool).call({
+        const result = await (searchActors as HelperTool).call({
             ...stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }),
             apifyToken: 'apify_ui_test',
         });

--- a/tests/unit/tools.search_actors.widget.response.test.ts
+++ b/tests/unit/tools.search_actors.widget.response.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WIDGET_URIS } from '../../src/resources/widgets.js';
-import { searchActorsWidgetTool } from '../../src/tools/widgets/search_actors_widget.js';
+import { searchActorsWidget } from '../../src/tools/widgets/search_actors_widget.js';
 import type { HelperTool } from '../../src/types.js';
 import type { formatActorToStructuredCard } from '../../src/utils/actor_card.js';
 import { formatActorForWidget } from '../../src/utils/actor_card.js';
@@ -33,7 +33,7 @@ describe('search-actors-widget response', () => {
     it('returns widgetActors plus widget _meta and short pointer text', async () => {
         vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
 
-        const result = await (searchActorsWidgetTool as HelperTool).call(
+        const result = await (searchActorsWidget as HelperTool).call(
             stubInternalToolArgs({
                 keywords: SEARCH_KEYWORDS,
                 limit: 5,
@@ -77,7 +77,7 @@ describe('search-actors-widget response', () => {
     it('returns empty widgetActors and omits widget _meta when there are no results', async () => {
         vi.mocked(searchAgentSafeActors).mockResolvedValue([]);
 
-        const result = await (searchActorsWidgetTool as HelperTool).call(
+        const result = await (searchActorsWidget as HelperTool).call(
             stubInternalToolArgs({
                 keywords: SEARCH_KEYWORDS,
                 limit: 5,
@@ -105,7 +105,7 @@ describe('search-actors-widget response', () => {
     });
 
     it('carries widget _meta on the tool definition', () => {
-        const tool = searchActorsWidgetTool as HelperTool;
+        const tool = searchActorsWidget as HelperTool;
         const meta = tool._meta as { ui?: { resourceUri?: string; visibility?: readonly string[]; csp?: unknown } };
         expect(meta.ui?.resourceUri).toBe(WIDGET_URIS.SEARCH_ACTORS);
         expect(meta.ui?.visibility).toEqual(['model', 'app']);
@@ -113,7 +113,7 @@ describe('search-actors-widget response', () => {
     });
 
     it('declares a strict input schema and strips stray keys at validation time', () => {
-        const tool = searchActorsWidgetTool as HelperTool;
+        const tool = searchActorsWidget as HelperTool;
 
         // Schema-level: strict shape (no extra properties allowed).
         const schema = tool.inputSchema as { additionalProperties?: boolean; properties?: Record<string, unknown> };
@@ -129,7 +129,7 @@ describe('search-actors-widget response', () => {
     });
 
     it('accepts a valid keywords-only input', () => {
-        const tool = searchActorsWidgetTool as HelperTool;
+        const tool = searchActorsWidget as HelperTool;
         const ok = tool.ajvValidate({ keywords: 'web scraper' });
         expect(ok).toBe(true);
     });


### PR DESCRIPTION
Each tool carried three vocabularies — file name, export const, and the wire tool name (the only name users see). E.g. `dataset_collection.ts` exported `getUserDatasetsList` for the tool `get-dataset-list`, and export suffixes were inconsistent (`...Tool` sometimes, bare otherwise). This collapses all three to one vocabulary derived from the wire name. Closes #977.

## How

Pure rename, no behavior change. File = snake_case of the wire name; export = camelCase of the wire name with no `Tool`/`default`/`apps` prefix. The `HelperTools` enum values (the wire contract) are untouched.

- `git mv` the three `*_collection.ts` files → `get_actor_run_list.ts`, `get_dataset_list.ts`, `get_key_value_store_list.ts` (+ matching test files).
- Normalize the `ToolEntry` exports across actors, runs, storage, docs, and widgets: `addTool`→`addActor`, `getUser*List`→`get*List`, `defaultGetActorRun`→`getActorRun`, `default*`/`apps*`/`*Tool` prefixes dropped on single-variant exports; the genuine two-variant call-actor pair is named `callActorDefault`/`callActorApps`.
- `src/index_internals.ts` exports `addActor` (canonical) **and** re-exports `addActor as addTool` with a `@deprecated` JSDoc. This keeps `apify-mcp-server-internal` building against its pinned published version, so the two repos merge independently; the alias is removed in a later release once internal migrates off `addTool`.

Rebased onto `master` — the domain regroup (#1019) already merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEYUpGUBagZi4m14YbyJua

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEYUpGUBagZi4m14YbyJua)_