### PR TITLE
fix(cache): drop Actor definition cache on build change

### DIFF
--- a/src/tools/actor_executor.ts
+++ b/src/tools/actor_executor.ts
@@ -1,6 +1,7 @@
 import log from '@apify/log';
 
 import type { ActorExecutionParams, ActorExecutionResult, ActorExecutor } from '../types.js';
+import { invalidateActorDefinitionCacheIfBuildChanged } from '../utils/actor.js';
 import { getConsoleLinkContext } from '../utils/console_link.js';
 import { redactSkyfirePayId } from '../utils/logging.js';
 import { abortRunOnSignal, CALL_ACTOR_WAIT_SECS_DEFAULT, fetchActorRunData } from './core/actor_run_response.js';
@@ -38,6 +39,7 @@ export const actorExecutor: ActorExecutor = {
         }
 
         const actorRun = await apifyClient.actor(actorFullName).start(actorInput, params.callOptions);
+        invalidateActorDefinitionCacheIfBuildChanged(actorFullName, actorRun, params.callOptions?.build);
 
         log.debug('Started Actor run (direct actor tool)', {
             actorName: actorFullName,

--- a/src/tools/apps/call_actor_widget.ts
+++ b/src/tools/apps/call_actor_widget.ts
@@ -7,6 +7,7 @@ import { HelperTools } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
+import { invalidateActorDefinitionCacheIfBuildChanged } from '../../utils/actor.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { extractActorId } from '../../utils/tools.js';
@@ -118,6 +119,7 @@ export const appsCallActorWidget: ToolEntry = Object.freeze({
 
             const actorClient = apifyClient.actor(baseActorName);
             const actorRun = await actorClient.start(input, callOptions);
+            invalidateActorDefinitionCacheIfBuildChanged(baseActorName, actorRun, callOptions?.build);
             log.debug('Started Actor run (widget)', {
                 actorName: baseActorName,
                 runId: actorRun.id,

--- a/src/tools/build.ts
+++ b/src/tools/build.ts
@@ -48,6 +48,7 @@ export async function getActorDefinition(
             return {
                 definition: pruneActorDefinition(actorDefinitions),
                 info: actor,
+                buildId: buildDetails.id,
             };
         }
         return null;

--- a/src/tools/core/call_actor_common.ts
+++ b/src/tools/core/call_actor_common.ts
@@ -18,7 +18,11 @@ import { ACTOR_LOAD_ERROR_KIND, ActorLoadError } from '../../errors.js';
 import { connectMCPClient } from '../../mcp/client.js';
 import type { PaymentProvider } from '../../payments/types.js';
 import type { ActorInfo, ApifyToken, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { getActorDefinitionCached, getActorMcpUrlCached } from '../../utils/actor.js';
+import {
+    getActorDefinitionCached,
+    getActorMcpUrlCached,
+    invalidateActorDefinitionCacheIfBuildChanged,
+} from '../../utils/actor.js';
 import { compileSchema } from '../../utils/ajv.js';
 import {
     ACTOR_RUN_LIMIT_MESSAGE,
@@ -635,6 +639,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<obje
         if (abortSignal?.aborted) return {};
 
         const actorRun = await apifyClient.actor(baseActorName).start(input, callOptions);
+        invalidateActorDefinitionCacheIfBuildChanged(baseActorName, actorRun, callOptions?.build);
         log.debug('Started Actor run', {
             actorName: baseActorName,
             runId: actorRun.id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,9 @@ export type ActorDefinitionPruned = Pick<
 export type ActorDefinitionWithInfo = {
     definition: ActorDefinitionPruned;
     info: ActorOutdated;
+    /** ID of the default build this definition (and its input schema) was read from. Lets a run
+     *  detect a rebuilt Actor and drop the stale cache entry before the TTL expires. */
+    buildId?: string;
 };
 
 /**

--- a/src/utils/actor.ts
+++ b/src/utils/actor.ts
@@ -45,6 +45,22 @@ export async function getActorDefinitionCached(
 }
 
 /**
+ * Drops the cached Actor definition when its build no longer matches the build a run actually used —
+ * an Actor rebuilt within the cache TTL would otherwise keep serving a stale input schema. The build
+ * a run used is reported by the run API (`ActorRun.buildId`). Skipped when the caller requested an
+ * explicit `build`, since running a non-default build is an expected mismatch, not staleness.
+ */
+export function invalidateActorDefinitionCacheIfBuildChanged(
+    actorIdOrName: string,
+    actorRun: { buildId?: string },
+    requestedBuild?: string,
+): void {
+    if (requestedBuild || !actorRun.buildId) return;
+    const cached = actorDefinitionCache.get(actorIdOrName);
+    if (cached?.buildId && cached.buildId !== actorRun.buildId) actorDefinitionCache.delete(actorIdOrName);
+}
+
+/**
  * Resolve the Actor's MCP server URL, or `false` if it isn't an MCP server. The URL is a pure function of
  * the definition (`getActorMCPServerURL` does no I/O), so this rides the authorization-gated
  * `getActorDefinitionCached` instead of a separate cache that would leak a private Actor's URL across tenants.

--- a/src/utils/ttl_lru.ts
+++ b/src/utils/ttl_lru.ts
@@ -66,4 +66,12 @@ export class TTLLRUCache<T> {
         this.cache.remove(key); // Remove expired entry
         return null;
     }
+
+    /**
+     * Remove an entry by key. No-op if the key is absent.
+     * @param key Cache key
+     */
+    delete(key: string) {
+        this.cache.remove(key);
+    }
 }

--- a/tests/unit/tools.call_actor_widget.response.test.ts
+++ b/tests/unit/tools.call_actor_widget.response.test.ts
@@ -14,6 +14,7 @@ import { stubToolCallContext, type TextToolResult } from './helpers/tool_context
  */
 vi.mock('../../src/utils/actor.js', () => ({
     getActorMcpUrlCached: vi.fn(),
+    invalidateActorDefinitionCacheIfBuildChanged: vi.fn(),
 }));
 
 vi.mock('../../src/tools/core/actor_tools_factory.js', async () => {

--- a/tests/unit/utils.actor.cache.test.ts
+++ b/tests/unit/utils.actor.cache.test.ts
@@ -8,7 +8,11 @@ vi.mock('../../src/utils/userid_cache.js', () => ({ getUserInfoCached: vi.fn() }
 
 import { actorDefinitionCache } from '../../src/state.js';
 import { getActorDefinition } from '../../src/tools/build.js';
-import { getActorDefinitionCached, getActorMcpUrlCached } from '../../src/utils/actor.js';
+import {
+    getActorDefinitionCached,
+    getActorMcpUrlCached,
+    invalidateActorDefinitionCacheIfBuildChanged,
+} from '../../src/utils/actor.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 
 const getActorDefinitionMock = vi.mocked(getActorDefinition);
@@ -19,7 +23,7 @@ function seedCache(
     name: string,
     isPublic: boolean,
     ownerUserId: string,
-    opts: { id?: string; webServerMcpPath?: string } = {},
+    opts: { id?: string; webServerMcpPath?: string; buildId?: string } = {},
 ): ActorDefinitionWithInfo {
     const id = opts.id ?? name;
     const entry = {
@@ -29,6 +33,7 @@ function seedCache(
             ...(opts.webServerMcpPath && { webServerMcpPath: opts.webServerMcpPath }),
         },
         info: { id, isPublic, userId: ownerUserId },
+        ...(opts.buildId && { buildId: opts.buildId }),
     } as unknown as ActorDefinitionWithInfo;
     actorDefinitionCache.set(name, entry);
     return entry;
@@ -115,5 +120,31 @@ describe('getActorMcpUrlCached — tenant isolation', () => {
         getActorDefinitionMock.mockResolvedValue(null);
 
         await expect(getActorMcpUrlCached('acme/missing', client)).resolves.toBe(false);
+    });
+});
+
+describe('invalidateActorDefinitionCacheIfBuildChanged', () => {
+    it('drops the cached entry when the run used a different build', () => {
+        seedCache('acme/rebuilt', true, 'owner-8', { buildId: 'build-old' });
+
+        invalidateActorDefinitionCacheIfBuildChanged('acme/rebuilt', { buildId: 'build-new' });
+
+        expect(actorDefinitionCache.get('acme/rebuilt')).toBeNull();
+    });
+
+    it('keeps the cached entry when the run used the same build', () => {
+        const cached = seedCache('acme/unchanged', true, 'owner-9', { buildId: 'build-1' });
+
+        invalidateActorDefinitionCacheIfBuildChanged('acme/unchanged', { buildId: 'build-1' });
+
+        expect(actorDefinitionCache.get('acme/unchanged')).toBe(cached);
+    });
+
+    it('keeps the cached entry when an explicit build was requested', () => {
+        const cached = seedCache('acme/explicit-build', true, 'owner-10', { buildId: 'build-default' });
+
+        invalidateActorDefinitionCacheIfBuildChanged('acme/explicit-build', { buildId: 'build-beta' }, 'beta');
+
+        expect(actorDefinitionCache.get('acme/explicit-build')).toBe(cached);
     });
 });


### PR DESCRIPTION
## What
Record the build ID an Actor's cached definition was read from, and drop the cache entry after a run if the build the run actually used differs.

## Why
`actorDefinitionCache` serves an Actor's input schema for 30 min. If the Actor is rebuilt within that window, the cache keeps serving the stale schema, so `call-actor` / direct-actor-tool / widget input validation runs against the wrong schema → broken runs. The run API already reports the build that ran (`ActorRun.buildId`), so a post-start comparison self-heals the cache before the TTL expires. The check is skipped when the caller passed an explicit `build` override, since a non-default build is an expected mismatch, not staleness.

## Testing
`pnpm type-check`, `pnpm lint`, `pnpm format:check`, and `pnpm test:unit` (965 pass). Added 3 unit tests for the invalidation helper (drop on mismatch, keep on match, keep on explicit build); confirmed the drop test fails against a no-op implementation.