### PR TITLE
feat: support Requesty as an OpenAI-compatible eval provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@ PHOENIX_HOST=
 
 OPENROUTER_API_KEY=
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+
+# Alternative OpenAI-compatible eval provider (set EVAL_LLM_PROVIDER=requesty to use)
+# EVAL_LLM_PROVIDER=requesty
+# REQUESTY_API_KEY=
+# REQUESTY_BASE_URL=https://router.requesty.ai/v1

--- a/evals/README.md
+++ b/evals/README.md
@@ -21,6 +21,8 @@ To trigger evaluations on a PR, add the `validated` label to your pull request.
 
 Unified API for Gemini, Claude, GPT. No separate integrations needed.
 
+To use [Requesty](https://requesty.ai) instead, set `EVAL_LLM_PROVIDER=requesty` and `REQUESTY_API_KEY` (base URL `https://router.requesty.ai/v1`, optionally overridable via `REQUESTY_BASE_URL`); it is OpenAI-compatible and uses the same `provider/model` naming.
+
 ## Judge model
 
 - model: `openai/gpt-4o-mini`

--- a/evals/config.ts
+++ b/evals/config.ts
@@ -11,6 +11,9 @@ import log from '@apify/log';
 // Re-export shared config
 export {
     OPENROUTER_CONFIG,
+    REQUESTY_CONFIG,
+    getProviderConfig,
+    getEvalProvider,
     sanitizeEnvValue,
     sanitizeProcessEnv,
     validateEnvVars,

--- a/evals/evaluation_utils.ts
+++ b/evals/evaluation_utils.ts
@@ -18,7 +18,7 @@ import {
     TOOL_SELECTION_EVAL_MODEL,
     EVALUATOR_NAMES,
     TEMPERATURE,
-    OPENROUTER_CONFIG,
+    getProviderConfig,
 } from './config.js';
 import { transformToolsToOpenAIFormat } from './shared/openai_tools.js';
 import { loadTestCases as loadTestCasesShared, filterByCategory, filterById } from './shared/test_case_loader.js';
@@ -60,7 +60,7 @@ export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
         context: string;
         reference: string;
     }> => {
-        const client = new OpenAI(OPENROUTER_CONFIG);
+        const client = new OpenAI(getProviderConfig());
 
         log.info(`Input: ${JSON.stringify(example)}`);
 
@@ -105,7 +105,7 @@ export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
 }
 
 export function createClassifierEvaluator() {
-    const openai = createOpenAI(OPENROUTER_CONFIG);
+    const openai = createOpenAI(getProviderConfig());
 
     return createClassifierFn({
         model: openai(TOOL_SELECTION_EVAL_MODEL),

--- a/evals/shared/config.ts
+++ b/evals/shared/config.ts
@@ -1,6 +1,6 @@
 /**
  * Shared configuration for evaluation systems
- * Contains OpenRouter config, environment validation, and common utilities
+ * Contains eval LLM provider config, environment validation, and common utilities
  */
 
 /**
@@ -13,13 +13,42 @@ export const OPENROUTER_CONFIG = {
 };
 
 /**
+ * Requesty API configuration (OpenAI-compatible LLM gateway)
+ * REQUESTY_BASE_URL is optional and defaults to the standard Requesty router URL.
+ * Models use the same provider/model naming as OpenRouter (e.g. openai/gpt-4o-mini).
+ */
+export const REQUESTY_CONFIG = {
+    baseURL: sanitizeEnvValue(process.env.REQUESTY_BASE_URL) || 'https://router.requesty.ai/v1',
+    apiKey: sanitizeEnvValue(process.env.REQUESTY_API_KEY) || '',
+};
+
+/**
+ * Selects which OpenAI-compatible eval provider to use.
+ * Set EVAL_LLM_PROVIDER=requesty to use Requesty; defaults to OpenRouter.
+ */
+export type EvalProvider = 'openrouter' | 'requesty';
+
+export function getEvalProvider(): EvalProvider {
+    return sanitizeEnvValue(process.env.EVAL_LLM_PROVIDER) === 'requesty' ? 'requesty' : 'openrouter';
+}
+
+/**
+ * Resolve the active provider's OpenAI-compatible client config ({ baseURL, apiKey }).
+ * Both OpenRouter and Requesty expose an OpenAI-compatible API and share the
+ * provider/model naming convention, so the rest of the harness is unchanged.
+ */
+export function getProviderConfig(): { baseURL: string; apiKey: string } {
+    return getEvalProvider() === 'requesty' ? REQUESTY_CONFIG : OPENROUTER_CONFIG;
+}
+
+/**
  * Get required environment variables
- * Note: OPENROUTER_BASE_URL is optional (defaults to https://openrouter.ai/api/v1)
+ * Note: the *_BASE_URL vars are optional (each provider has a sensible default).
  */
 export function getRequiredEnvVars(): Record<string, string | undefined> {
-    return {
-        OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
-    };
+    return getEvalProvider() === 'requesty'
+        ? { REQUESTY_API_KEY: process.env.REQUESTY_API_KEY }
+        : { OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY };
 }
 
 /**
@@ -45,7 +74,14 @@ export function sanitizeEnvValue(value?: string): string | undefined {
  * throws ERR_INVALID_CHAR on any control characters. We can't intercept that
  * read, so we sanitize process.env itself before any library loads.
  */
-const ENV_KEYS_TO_SANITIZE = ['OPENROUTER_API_KEY', 'OPENROUTER_BASE_URL', 'PHOENIX_API_KEY', 'PHOENIX_BASE_URL'];
+const ENV_KEYS_TO_SANITIZE = [
+    'OPENROUTER_API_KEY',
+    'OPENROUTER_BASE_URL',
+    'REQUESTY_API_KEY',
+    'REQUESTY_BASE_URL',
+    'PHOENIX_API_KEY',
+    'PHOENIX_BASE_URL',
+];
 
 /**
  * Redact a value for safe logging: shows first 4 and last 4 chars, masks the rest.

--- a/evals/workflows/config.ts
+++ b/evals/workflows/config.ts
@@ -6,7 +6,15 @@
  */
 
 // Re-export shared config for convenience
-export { OPENROUTER_CONFIG, sanitizeEnvValue, sanitizeProcessEnv, validateEnvVars } from '../shared/config.js';
+export {
+    OPENROUTER_CONFIG,
+    REQUESTY_CONFIG,
+    getProviderConfig,
+    getEvalProvider,
+    sanitizeEnvValue,
+    sanitizeProcessEnv,
+    validateEnvVars,
+} from '../shared/config.js';
 
 /**
  * Default model configuration for agent and judge

--- a/evals/workflows/llm_client.ts
+++ b/evals/workflows/llm_client.ts
@@ -1,5 +1,6 @@
 /**
- * LLM client for calling OpenRouter API
+ * LLM client for the eval harness, using an OpenAI-compatible provider
+ * (OpenRouter by default, or Requesty when EVAL_LLM_PROVIDER=requesty).
  * Phase 3: Added support for tool calling
  */
 
@@ -9,7 +10,7 @@ import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/reso
 // eslint-disable-next-line import/extensions
 import type { ResponseFormatJSONSchema } from 'openai/resources/shared';
 
-import { OPENROUTER_CONFIG } from './config.js';
+import { getEvalProvider, getProviderConfig } from './config.js';
 
 /**
  * Response from LLM - either text or tool calls
@@ -32,13 +33,15 @@ export class LlmClient {
     private openai: OpenAI;
 
     constructor() {
-        if (!OPENROUTER_CONFIG.apiKey) {
-            throw new Error('OPENROUTER_API_KEY environment variable is required');
+        const providerConfig = getProviderConfig();
+        if (!providerConfig.apiKey) {
+            const envVar = getEvalProvider() === 'requesty' ? 'REQUESTY_API_KEY' : 'OPENROUTER_API_KEY';
+            throw new Error(`${envVar} environment variable is required`);
         }
 
         this.openai = new OpenAI({
-            baseURL: OPENROUTER_CONFIG.baseURL,
-            apiKey: OPENROUTER_CONFIG.apiKey,
+            baseURL: providerConfig.baseURL,
+            apiKey: providerConfig.apiKey,
         });
     }
 

--- a/evals/workflows/run_workflow_evals.ts
+++ b/evals/workflows/run_workflow_evals.ts
@@ -21,7 +21,7 @@ import { hideBin } from 'yargs/helpers';
 import { filterByLineRanges } from '../shared/line_range_filter.js';
 import type { LineRange } from '../shared/line_range_parser.js';
 import { checkRangesOutOfBounds, parseLineRanges, validateLineRanges } from '../shared/line_range_parser.js';
-import { DEFAULT_TOOL_TIMEOUT_SECONDS, MODELS, sanitizeEnvValue } from './config.js';
+import { DEFAULT_TOOL_TIMEOUT_SECONDS, getEvalProvider, getProviderConfig, MODELS, sanitizeEnvValue } from './config.js';
 import { executeConversation } from './conversation_executor.js';
 import { LlmClient } from './llm_client.js';
 import { McpClient } from './mcp_client.js';
@@ -211,15 +211,16 @@ async function main() {
 
     // Check environment variables
     const apifyToken = sanitizeEnvValue(process.env.APIFY_TOKEN);
-    const openrouterKey = sanitizeEnvValue(process.env.OPENROUTER_API_KEY);
+    const providerApiKey = getProviderConfig().apiKey;
+    const providerKeyEnvVar = getEvalProvider() === 'requesty' ? 'REQUESTY_API_KEY' : 'OPENROUTER_API_KEY';
 
     if (!apifyToken) {
         console.error('❌ Error: APIFY_TOKEN environment variable is required');
         process.exit(1);
     }
 
-    if (!openrouterKey) {
-        console.error('❌ Error: OPENROUTER_API_KEY environment variable is required');
+    if (!providerApiKey) {
+        console.error(`❌ Error: ${providerKeyEnvVar} environment variable is required`);
         process.exit(1);
     }
 

--- a/tests/unit/evals.config.test.ts
+++ b/tests/unit/evals.config.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { sanitizeEnvValue, sanitizeProcessEnv } from '../../evals/shared/config.js';
+import { getEvalProvider, getProviderConfig, sanitizeEnvValue, sanitizeProcessEnv } from '../../evals/shared/config.js';
 
 describe('sanitizeEnvValue', () => {
     it('passes through undefined and null', () => {
@@ -58,5 +58,29 @@ describe('sanitizeProcessEnv', () => {
     it('leaves unset vars untouched', () => {
         sanitizeProcessEnv();
         expect(process.env.PHOENIX_API_KEY).toBeUndefined();
+    });
+});
+
+describe('getEvalProvider / getProviderConfig', () => {
+    afterEach(() => {
+        delete process.env.EVAL_LLM_PROVIDER;
+    });
+
+    it('defaults to openrouter when EVAL_LLM_PROVIDER is unset', () => {
+        delete process.env.EVAL_LLM_PROVIDER;
+        expect(getEvalProvider()).toBe('openrouter');
+        expect(getProviderConfig().baseURL).toBe('https://openrouter.ai/api/v1');
+    });
+
+    it('selects requesty when EVAL_LLM_PROVIDER=requesty', () => {
+        process.env.EVAL_LLM_PROVIDER = 'requesty';
+        expect(getEvalProvider()).toBe('requesty');
+        expect(getProviderConfig().baseURL).toBe('https://router.requesty.ai/v1');
+    });
+
+    it('falls back to openrouter for any other value', () => {
+        process.env.EVAL_LLM_PROVIDER = 'something-else';
+        expect(getEvalProvider()).toBe('openrouter');
+        expect(getProviderConfig().baseURL).toBe('https://openrouter.ai/api/v1');
     });
 });


### PR DESCRIPTION
## What

Lets the evals harness use Requesty as an alternative OpenAI-compatible eval provider, mirroring the existing OpenRouter eval provider. OpenRouter stays the default, so the change is fully backward-compatible.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM gateway, reachable at `https://router.requesty.ai/v1` with `provider/model` naming (e.g. `openai/gpt-4o-mini`), the same shape the harness already uses for OpenRouter.

## Changes

- `evals/shared/config.ts` — add `REQUESTY_CONFIG` (base URL `https://router.requesty.ai/v1`, env `REQUESTY_API_KEY`, optional `REQUESTY_BASE_URL`) alongside the existing `OPENROUTER_CONFIG`, plus `getEvalProvider()` / `getProviderConfig()` selectors driven by `EVAL_LLM_PROVIDER` (defaults to `openrouter`). The new env vars are added to the sanitize list and `getRequiredEnvVars()` is made provider-aware.
- `evals/evaluation_utils.ts`, `evals/workflows/llm_client.ts`, `evals/workflows/run_workflow_evals.ts` — route the three existing OpenAI-compatible client call sites through `getProviderConfig()`.
- `evals/config.ts`, `evals/workflows/config.ts` — re-export the new symbols.
- `evals/README.md` — one factual line documenting `EVAL_LLM_PROVIDER=requesty`.
- `.env.example` — parallel commented entries for the Requesty env vars.
- `tests/unit/evals.config.test.ts` — 3 provider-selection tests.

## Testing

- `pnpm run type-check` — clean.
- `oxlint` on changed files — 0 warnings / 0 errors.
- Full unit suite — 67 files, 965 passed / 2 skipped (includes the 3 new tests).
- Live check against the real endpoint: `POST https://router.requesty.ai/v1/chat/completions` with `openai/gpt-4o-mini` → HTTP 200 with a valid completion.

The CI workflow (`.github/workflows/_evaluations.yaml`) is intentionally left untouched — OpenRouter remains the CI default and the change is opt-in via `EVAL_LLM_PROVIDER`.

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust wording/placement or close it if it's not a fit.
