### PR TITLE
chore: Use DEFAULT_DATASET_ITEMS_LIMIT in nextStep templates

### DIFF
--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -22,6 +22,7 @@ import { logHttpError } from '../../utils/logging.js';
 import { buildMCPResponse } from '../../utils/mcp.js';
 import { formatRunStatusMessage, type ProgressTracker, TERMINAL_RUN_STATUSES } from '../../utils/progress.js';
 import { cleanEmptyProperties } from '../../utils/schema_generation.js';
+import { DEFAULT_DATASET_ITEMS_LIMIT } from '../storage/get_dataset_items.js';
 
 /** Cap on `storages.keyValueStores.default.keys` array length. */
 const KV_KEYS_LIMIT = 50;
@@ -491,7 +492,7 @@ function buildSucceededSummaryNextStep(
         const fields = dataset?.fields ?? [];
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. ${itemCount} ${itemCount === 1 ? 'item' : 'items'}; ${fields.length} fields available.${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to fetch items (${itemCount} total).${datasetSizeNextStepHint(dataset?.inflatedBytes)}${fieldsProjectionHint(fields)}`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to fetch items (${itemCount} total).${datasetSizeNextStepHint(dataset?.inflatedBytes)}${fieldsProjectionHint(fields)}`,
         };
     }
 
@@ -500,7 +501,7 @@ function buildSucceededSummaryNextStep(
     if (itemCount === undefined && datasetId) {
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. Dataset metadata unavailable.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to inspect output.`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to inspect output.`,
         };
     }
 
@@ -509,7 +510,7 @@ function buildSucceededSummaryNextStep(
     if (itemCount === 0 && datasetId) {
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. No dataset items found.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to verify output (metadata reports 0 items).${fieldsProjectionHint(dataset?.fields)}`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to verify output (metadata reports 0 items).${fieldsProjectionHint(dataset?.fields)}`,
         };
     }
 
@@ -541,7 +542,7 @@ function buildTimedOutSummaryNextStep(
         const fields = dataset?.fields ?? [];
         return {
             summary: `TIMED-OUT after ${runTimeSecs}s.${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to fetch any partial output (${itemCount} ${itemCount === 1 ? 'item' : 'items'} written). Available fields: ${fields.length > 0 ? fields.join(', ') : 'none'}.`,
+            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to fetch any partial output (${itemCount} ${itemCount === 1 ? 'item' : 'items'} written). Available fields: ${fields.length > 0 ? fields.join(', ') : 'none'}.`,
         };
     }
 

--- a/src/tools/storage/get_dataset.ts
+++ b/src/tools/storage/get_dataset.ts
@@ -9,6 +9,7 @@ import { buildConsoleDatasetUrl, getConsoleLinkContext } from '../../utils/conso
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { datasetSizeNextStepHint, normalizeDatasetFields } from '../actors/actor_run_response.js';
 import { datasetMetadataOutputSchema } from '../structured_output_schemas.js';
+import { DEFAULT_DATASET_ITEMS_LIMIT } from './get_dataset_items.js';
 import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
 
 const getDatasetArgs = z.object({
@@ -68,7 +69,7 @@ export const getDataset: ToolEntry = Object.freeze({
         // response today (only the dataset-list endpoint returns it), so read it defensively.
         const inflatedBytes = (dataset.stats as { inflatedBytes?: number } | undefined)?.inflatedBytes;
         const summary = `Dataset '${normalized.name ?? datasetId}' has ${normalized.itemCount ?? 0} items${fieldCount !== undefined ? `, ${fieldCount} fields` : ''}.`;
-        const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example 20) to fetch items.${datasetSizeNextStepHint(inflatedBytes)}`;
+        const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to fetch items.${datasetSizeNextStepHint(inflatedBytes)}`;
         return buildStorageResponse({
             structuredContent: normalized as unknown as Record<string, unknown>,
             summary,

--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -11,7 +11,7 @@ import { getHttpStatusCode } from '../../utils/logging.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
 import { buildDatasetItemsSummaryNextStep, buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
 
-const DEFAULT_DATASET_ITEMS_LIMIT = 20;
+export const DEFAULT_DATASET_ITEMS_LIMIT = 20;
 
 /** Top-level dot prefixes of `fields`. Apify's `flatten` recurses, so the first segment suffices. */
 export function extractDotPrefixes(fields: string[]): string[] {

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -787,6 +787,14 @@ describe('buildStatusTemplate', () => {
         expect(t.nextStep).toContain('metadata.url, markdown');
     });
 
+    it('SUCCEEDED dataset nextStep uses DEFAULT_DATASET_ITEMS_LIMIT as example limit', () => {
+        const t = buildStatusSummaryNextStep({
+            run: makeRun('SUCCEEDED'),
+            dataset: datasetWithItems,
+        });
+        expect(t.nextStep).toContain('limit (for example 20)');
+    });
+
     it('SUCCEEDED steers nextStep away from fetching a large dataset', () => {
         const dataset: RunDataset = { id: 'ds-1', itemCount: 47, fields: ['metadata.url'], inflatedBytes: 2_400_000 };
         const t = buildStatusSummaryNextStep({ run: makeRun('SUCCEEDED'), dataset });


### PR DESCRIPTION
Based on #1027 by @mvanhorn.

That PR had three issues found in review:
- File paths were stale (refactor #1019 moved `src/tools/common/` → `src/tools/storage/` and `src/tools/core/` → `src/tools/actors/`)
- `src/tools/storage/get_dataset.ts:71` had the same hardcoded `20` but was not touched
- The drift-guard test imported the same constant it checked, making it circular

## Changes

- Export `DEFAULT_DATASET_ITEMS_LIMIT` from `src/tools/storage/get_dataset_items.ts`
- Import and use it in `src/tools/actors/actor_run_response.ts` (4 nextStep strings)
- Import and use it in `src/tools/storage/get_dataset.ts` (1 nextStep string)
- Add drift-guard unit test asserting the literal rendered value `'limit (for example 20)'`

No behavioral change — rendered output is still `for example 20`.

Fixes #826

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWMN5pYAyEAymM9PPMMgfC)_