### PR TITLE
feat: hint field filtering in get-dataset-items description

### DIFF
--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -68,6 +68,7 @@ export const getDatasetItems: ToolEntry = Object.freeze({
     title: 'Get dataset items',
     description: dedent`
         Retrieve dataset items with pagination, sorting, and field selection.
+        Dataset items can be large; when you only need specific columns, pass fields to return just those and reduce response size (use ${HelperTools.DATASET_SCHEMA_GET} or ${HelperTools.DATASET_GET} first if you don't know the field names).
         For nested fields use dot notation (e.g., fields="metadata.url") — the server auto-flattens parent prefixes.
         Defaults limit to ${DEFAULT_DATASET_ITEMS_LIMIT}. Use clean=true to skip empty items and hidden fields.
 

--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -68,7 +68,7 @@ export const getDatasetItems: ToolEntry = Object.freeze({
     title: 'Get dataset items',
     description: dedent`
         Retrieve dataset items with pagination, sorting, and field selection.
-        Dataset items can be large; when you only need specific columns, pass fields to return just those and reduce response size (use ${HelperTools.DATASET_SCHEMA_GET} or ${HelperTools.DATASET_GET} first if you don't know the field names).
+        Items can be large; when you only need specific columns, pass fields to reduce response size (use ${HelperTools.DATASET_GET} first if you don't know the field names).
         For nested fields use dot notation (e.g., fields="metadata.url") — the server auto-flattens parent prefixes.
         Defaults limit to ${DEFAULT_DATASET_ITEMS_LIMIT}. Use clean=true to skip empty items and hidden fields.
 


### PR DESCRIPTION
## What

Nudges the `get-dataset-items` tool description to pass `fields` when only specific columns are needed, to reduce response size.

The hint is framed as optional ("when you only need specific columns") so the model does not under-fetch data the user actually asked for. It points only at `get-dataset` for discovering field names — a lightweight metadata call — not `get-dataset-schema`, which is often large and would blow out the context (the opposite of the goal here; see #986).

## Why

Takeaway from the workflow eval work: dataset responses are often large, and selecting only the needed columns meaningfully cuts response size when the full row isn't required.

## Verification

- `pnpm run type-check` — clean
- `pnpm run lint` — clean
- `pnpm run test:unit` — clean
- `pnpm run format` — clean
- `pnpm run check:agents` — clean