### PR TITLE
feat: add large-dataset and scraper workflow eval cases

### DIFF
--- a/evals/workflows/test_cases.json
+++ b/evals/workflows/test_cases.json
@@ -173,6 +173,76 @@
       "reference": "The agent must call call-actor for apify/rag-web-browser, then call get-key-value-store-keys with the keyValueStoreId from that run. PASS only if get-key-value-store-keys was actually called with a keyValueStoreId argument and the final answer states a key count and lists one or more key names.",
       "tools": ["actors", "get-key-value-store-keys"],
       "maxTurns": 14
+    },
+    {
+      "id": "call-google-search-results",
+      "category": "call",
+      "query": "Use Apify to run a Google search for 'best open source web scraping libraries' and give me the title and URL of the top 5 organic results.",
+      "reference": "The agent must find the Google Search Results scraper (e.g. apify/google-search-scraper), call it with the query 'best open source web scraping libraries', and present at least 5 organic results, each with a title and a URL."
+    },
+    {
+      "id": "storage-dataset-items-google-search",
+      "category": "storage",
+      "query": "Run a Google search via Apify for 'apify web scraping' and request the top 10 organic results. When the run finishes, retrieve only the title and URL of each result and list them.",
+      "reference": "The agent must find the Google Search Results scraper and call-actor it for the query 'apify web scraping', then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists at least five results, each with a title and a URL.",
+      "tools": ["actors", "get-dataset-items"],
+      "maxTurns": 16
+    },
+    {
+      "id": "call-instagram-recent-posts",
+      "category": "call",
+      "query": "Using Apify, get the 3 most recent posts from the nasa Instagram profile and tell me each post's caption and like count.",
+      "reference": "The agent must find an Instagram scraper (e.g. apify/instagram-scraper), call it for the nasa profile, and present at least 3 recent posts, each with a caption and a like count."
+    },
+    {
+      "id": "storage-dataset-items-instagram",
+      "category": "storage",
+      "query": "Scrape the 10 latest posts from the natgeo Instagram profile using Apify. When the run finishes, retrieve only the caption and like count of each post and list them.",
+      "reference": "The agent must find an Instagram scraper and call-actor it for the natgeo profile, then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists several posts, each with a caption and a like count.",
+      "tools": ["actors", "get-dataset-items"],
+      "maxTurns": 18
+    },
+    {
+      "id": "call-tiktok-recent-videos",
+      "category": "call",
+      "query": "Use Apify to get the 5 latest TikTok videos from the @nasa profile and report each video's view count.",
+      "reference": "The agent must find a TikTok scraper, call it for the @nasa profile, and present at least 5 recent videos, each with a view count."
+    },
+    {
+      "id": "storage-dataset-items-tiktok",
+      "category": "storage",
+      "query": "Scrape the 10 latest TikTok videos from the @natgeo profile using Apify. When the run finishes, retrieve only each video's URL and view count and list them.",
+      "reference": "The agent must find a TikTok scraper and call-actor it for the @natgeo profile, then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists several videos, each with a URL and a view count.",
+      "tools": ["actors", "get-dataset-items"],
+      "maxTurns": 18
+    },
+    {
+      "id": "call-youtube-channel-videos",
+      "category": "call",
+      "query": "Find a YouTube scraper on Apify and get the 5 latest videos from the NASA YouTube channel, with each video's title and view count.",
+      "reference": "The agent must find a YouTube scraper (e.g. streamers/youtube-scraper), call it for the NASA channel, and present at least 5 videos, each with a title and a view count."
+    },
+    {
+      "id": "storage-dataset-items-youtube",
+      "category": "storage",
+      "query": "Use Apify to scrape 10 videos from the MrBeast YouTube channel. When the run finishes, retrieve only the title and view count of each video and list them.",
+      "reference": "The agent must find a YouTube scraper and call-actor it for the MrBeast channel, then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists several videos, each with a title and a view count.",
+      "tools": ["actors", "get-dataset-items"],
+      "maxTurns": 18
+    },
+    {
+      "id": "call-reddit-subreddit-posts",
+      "category": "call",
+      "query": "Use Apify to get the top 5 posts from the r/programming subreddit and tell me each post's title and number of upvotes.",
+      "reference": "The agent must find a Reddit scraper, call it for the r/programming subreddit, and present at least 5 posts, each with a title and an upvote count."
+    },
+    {
+      "id": "storage-dataset-items-reddit",
+      "category": "storage",
+      "query": "Scrape 10 posts from the r/technology subreddit using Apify. When the run finishes, retrieve only the title and upvote count of each post and list them.",
+      "reference": "The agent must find a Reddit scraper and call-actor it for the r/technology subreddit, then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists several posts, each with a title and an upvote count.",
+      "tools": ["actors", "get-dataset-items"],
+      "maxTurns": 18
     }
   ]
 }

--- a/evals/workflows/test_cases.json
+++ b/evals/workflows/test_cases.json
@@ -162,7 +162,7 @@
       "id": "storage-run-list-recent",
       "category": "storage",
       "query": "List my 10 most recent Actor runs, newest first. For each run report its run ID, the Actor it ran, and its status.",
-      "reference": "The agent must call get-actor-run-list (newest first, limit 10). PASS only if get-actor-run-list was actually called and the final answer reports several runs, each with a run ID and a status.",
+      "reference": "The agent must call get-actor-run-list (newest first, limit 10). PASS only if get-actor-run-list was actually called and if there are runs, the final answer reports the runs, each with a run ID and a status.",
       "tools": ["get-actor-run-list"],
       "maxTurns": 6
     },

--- a/evals/workflows/test_cases.json
+++ b/evals/workflows/test_cases.json
@@ -133,6 +133,46 @@
       "reference": "The agent must call call-actor for apify/rag-web-browser, then call get-actor-run-list. PASS only if get-actor-run-list was actually called and the final answer reports a run ID and a status matching the run the agent just started.",
       "tools": ["actors", "get-actor-run-list"],
       "maxTurns": 12
+    },
+    {
+      "id": "storage-dataset-items-maps-bulk",
+      "category": "storage",
+      "query": "Use the Google Maps Scraper to find the best 20 restaurants in Prague. When the run finishes, retrieve all of them in a single call. Then tell me how many restaurants were returned and list the names and ratings of the first five.",
+      "reference": "The agent must find the Google Maps scraper and call-actor it for restaurants in Prague, then call get-dataset-items with the datasetId from that run and a limit high enough to return every row in one call. PASS only if get-dataset-items was called with a datasetId argument and the final answer states a restaurant count and lists at least five restaurant names with ratings.",
+      "tools": ["actors", "get-dataset-items"],
+      "maxTurns": 20
+    },
+    {
+      "id": "storage-dataset-items-hotels-bulk",
+      "category": "storage",
+      "query": "Use the Google Maps Scraper to find at least 20 hotels in Vienna. When the run finishes, retrieve all the results and tell me how many hotels were returned and the names and addresses of the first five.",
+      "reference": "The agent must find the Google Maps scraper and call-actor it for hotels in Vienna, then call get-dataset-items with the datasetId from that run and a limit high enough to return every row in one call. PASS only if get-dataset-items was called with a datasetId argument and the final answer states a hotel count and lists at least five hotel names with addresses.",
+      "tools": ["actors", "get-dataset-items"],
+      "maxTurns": 20
+    },
+    {
+      "id": "storage-dataset-items-rag-bulk",
+      "category": "storage",
+      "query": "Run the apify/rag-web-browser Actor to search for the best open source web scraping libraries. Set maxResults to 8, waiting up to 45 seconds for it to finish. Then give me the title and URL of each result.",
+      "reference": "The agent must call call-actor for apify/rag-web-browser with maxResults 8, then call get-dataset-items with the datasetId from that run and a limit high enough to return every row in one call. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists a title and a URL for at least five results.",
+      "tools": ["actors", "get-dataset-items"],
+      "maxTurns": 16
+    },
+    {
+      "id": "storage-run-list-recent",
+      "category": "storage",
+      "query": "List my 10 most recent Actor runs, newest first. For each run report its run ID, the Actor it ran, and its status.",
+      "reference": "The agent must call get-actor-run-list (newest first, limit 10). PASS only if get-actor-run-list was actually called and the final answer reports several runs, each with a run ID and a status.",
+      "tools": ["get-actor-run-list"],
+      "maxTurns": 6
+    },
+    {
+      "id": "storage-kv-keys-bulk",
+      "category": "storage",
+      "query": "Run the apify/rag-web-browser Actor with the search query 'web scraping' and maxResults set to 3, waiting up to 45 seconds for it to finish. Then list the keys in that run's key-value store (limit 10) and tell me how many keys there are and what they are named.",
+      "reference": "The agent must call call-actor for apify/rag-web-browser, then call get-key-value-store-keys with the keyValueStoreId from that run. PASS only if get-key-value-store-keys was actually called with a keyValueStoreId argument and the final answer states a key count and lists one or more key names.",
+      "tools": ["actors", "get-key-value-store-keys"],
+      "maxTurns": 14
     }
   ]
 }

--- a/evals/workflows/test_cases.json
+++ b/evals/workflows/test_cases.json
@@ -151,28 +151,12 @@
       "maxTurns": 20
     },
     {
-      "id": "storage-dataset-items-rag-bulk",
-      "category": "storage",
-      "query": "Run the apify/rag-web-browser Actor to search for the best open source web scraping libraries. Set maxResults to 8, waiting up to 45 seconds for it to finish. Then give me the title and URL of each result.",
-      "reference": "The agent must call call-actor for apify/rag-web-browser with maxResults 8, then call get-dataset-items with the datasetId from that run and a limit high enough to return every row in one call. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists a title and a URL for at least five results.",
-      "tools": ["actors", "get-dataset-items"],
-      "maxTurns": 16
-    },
-    {
       "id": "storage-run-list-recent",
       "category": "storage",
       "query": "List my 10 most recent Actor runs, newest first. For each run report its run ID, the Actor it ran, and its status.",
       "reference": "The agent must call get-actor-run-list (newest first, limit 10). PASS only if get-actor-run-list was actually called and if there are runs, the final answer reports the runs, each with a run ID and a status.",
       "tools": ["get-actor-run-list"],
       "maxTurns": 6
-    },
-    {
-      "id": "storage-kv-keys-bulk",
-      "category": "storage",
-      "query": "Run the apify/rag-web-browser Actor with the search query 'web scraping' and maxResults set to 3, waiting up to 45 seconds for it to finish. Then list the keys in that run's key-value store (limit 10) and tell me how many keys there are and what they are named.",
-      "reference": "The agent must call call-actor for apify/rag-web-browser, then call get-key-value-store-keys with the keyValueStoreId from that run. PASS only if get-key-value-store-keys was actually called with a keyValueStoreId argument and the final answer states a key count and lists one or more key names.",
-      "tools": ["actors", "get-key-value-store-keys"],
-      "maxTurns": 14
     },
     {
       "id": "storage-dataset-items-google-search",

--- a/evals/workflows/test_cases.json
+++ b/evals/workflows/test_cases.json
@@ -201,8 +201,8 @@
     {
       "id": "storage-dataset-items-youtube",
       "category": "storage",
-      "query": "Use Apify to scrape 15 videos from the MrBeast YouTube channel. When the run finishes, retrieve only the title and view count of each video and list them.",
-      "reference": "The agent must find a YouTube scraper and call-actor it for the MrBeast channel, then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists several videos, each with a title and a view count.",
+      "query": "Use Apify to scrape 15 videos from the Apify YouTube channel. When the run finishes, retrieve only the title and view count of each video and list them.",
+      "reference": "The agent must find a YouTube scraper and call-actor it for the Apify channel, then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists several videos, each with a title and a view count.",
       "tools": ["actors", "get-dataset-items"],
       "maxTurns": 18
     },

--- a/evals/workflows/test_cases.json
+++ b/evals/workflows/test_cases.json
@@ -175,71 +175,41 @@
       "maxTurns": 14
     },
     {
-      "id": "call-google-search-results",
-      "category": "call",
-      "query": "Use Apify to run a Google search for 'best open source web scraping libraries' and give me the title and URL of the top 5 organic results.",
-      "reference": "The agent must find the Google Search Results scraper (e.g. apify/google-search-scraper), call it with the query 'best open source web scraping libraries', and present at least 5 organic results, each with a title and a URL."
-    },
-    {
       "id": "storage-dataset-items-google-search",
       "category": "storage",
-      "query": "Run a Google search via Apify for 'apify web scraping' and request the top 10 organic results. When the run finishes, retrieve only the title and URL of each result and list them.",
+      "query": "Run a Google search via Apify for 'apify web scraping' and request the top 15 organic results. When the run finishes, retrieve only the title and URL of each result and list them.",
       "reference": "The agent must find the Google Search Results scraper and call-actor it for the query 'apify web scraping', then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists at least five results, each with a title and a URL.",
       "tools": ["actors", "get-dataset-items"],
       "maxTurns": 16
     },
     {
-      "id": "call-instagram-recent-posts",
-      "category": "call",
-      "query": "Using Apify, get the 3 most recent posts from the nasa Instagram profile and tell me each post's caption and like count.",
-      "reference": "The agent must find an Instagram scraper (e.g. apify/instagram-scraper), call it for the nasa profile, and present at least 3 recent posts, each with a caption and a like count."
-    },
-    {
       "id": "storage-dataset-items-instagram",
       "category": "storage",
-      "query": "Scrape the 10 latest posts from the natgeo Instagram profile using Apify. When the run finishes, retrieve only the caption and like count of each post and list them.",
+      "query": "Scrape the 15 latest posts from the natgeo Instagram profile using Apify. When the run finishes, retrieve only the caption and like count of each post and list them.",
       "reference": "The agent must find an Instagram scraper and call-actor it for the natgeo profile, then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists several posts, each with a caption and a like count.",
       "tools": ["actors", "get-dataset-items"],
       "maxTurns": 18
     },
     {
-      "id": "call-tiktok-recent-videos",
-      "category": "call",
-      "query": "Use Apify to get the 5 latest TikTok videos from the @nasa profile and report each video's view count.",
-      "reference": "The agent must find a TikTok scraper, call it for the @nasa profile, and present at least 5 recent videos, each with a view count."
-    },
-    {
       "id": "storage-dataset-items-tiktok",
       "category": "storage",
-      "query": "Scrape the 10 latest TikTok videos from the @natgeo profile using Apify. When the run finishes, retrieve only each video's URL and view count and list them.",
+      "query": "Scrape the 15 latest TikTok videos from the @natgeo profile using Apify. When the run finishes, retrieve only each video's URL and view count and list them.",
       "reference": "The agent must find a TikTok scraper and call-actor it for the @natgeo profile, then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists several videos, each with a URL and a view count.",
       "tools": ["actors", "get-dataset-items"],
       "maxTurns": 18
     },
     {
-      "id": "call-youtube-channel-videos",
-      "category": "call",
-      "query": "Find a YouTube scraper on Apify and get the 5 latest videos from the NASA YouTube channel, with each video's title and view count.",
-      "reference": "The agent must find a YouTube scraper (e.g. streamers/youtube-scraper), call it for the NASA channel, and present at least 5 videos, each with a title and a view count."
-    },
-    {
       "id": "storage-dataset-items-youtube",
       "category": "storage",
-      "query": "Use Apify to scrape 10 videos from the MrBeast YouTube channel. When the run finishes, retrieve only the title and view count of each video and list them.",
+      "query": "Use Apify to scrape 15 videos from the MrBeast YouTube channel. When the run finishes, retrieve only the title and view count of each video and list them.",
       "reference": "The agent must find a YouTube scraper and call-actor it for the MrBeast channel, then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists several videos, each with a title and a view count.",
       "tools": ["actors", "get-dataset-items"],
       "maxTurns": 18
     },
     {
-      "id": "call-reddit-subreddit-posts",
-      "category": "call",
-      "query": "Use Apify to get the top 5 posts from the r/programming subreddit and tell me each post's title and number of upvotes.",
-      "reference": "The agent must find a Reddit scraper, call it for the r/programming subreddit, and present at least 5 posts, each with a title and an upvote count."
-    },
-    {
       "id": "storage-dataset-items-reddit",
       "category": "storage",
-      "query": "Scrape 10 posts from the r/technology subreddit using Apify. When the run finishes, retrieve only the title and upvote count of each post and list them.",
+      "query": "Scrape 15 posts from the r/technology subreddit using Apify. When the run finishes, retrieve only the title and upvote count of each post and list them.",
       "reference": "The agent must find a Reddit scraper and call-actor it for the r/technology subreddit, then call get-dataset-items with the datasetId from that run. PASS only if get-dataset-items was called with a datasetId argument and the final answer lists several posts, each with a title and an upvote count.",
       "tools": ["actors", "get-dataset-items"],
       "maxTurns": 18


### PR DESCRIPTION
## What

Adds workflow eval cases that exercise larger and more varied tool responses.

- **Large-dataset retrieval cases** — Google Maps, hotels, and rag-web-browser bulk pulls, plus run-list and key-value-store-keys cases.
- **Scraper cases** — call + storage pairs for Google Search, Instagram, TikTok, YouTube, and Reddit scrapers.

Test data only (`evals/workflows/test_cases.json`). No harness or product code changes.

## Notes

Split out of #1031 (workflow eval cost metrics) so the harness changes and the new eval cases land separately.

## Verification

`type-check`, `lint`, `test:unit` (963 pass), `format`, `check:agents` — all clean. JSON validated (35 cases).

New tests:
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/72267769-d0a0-4965-b86c-653346580b63" />

First failed due to a flaky Actor.
