### PR TITLE
feat(tools): nudge clients to refresh tool list after add-actor

### DIFF
--- a/src/tools/actors/add_actor.ts
+++ b/src/tools/actors/add_actor.ts
@@ -64,8 +64,14 @@ USAGE EXAMPLES:
         }
         await sendNotification({ method: 'notifications/tools/list_changed' });
         const toolNames = tools.map((t: ToolEntry) => t.name).join(', ');
+        // Many MCP clients ignore `notifications/tools/list_changed`, so nudge the LLM to
+        // re-list tools itself — otherwise the freshly added Actor stays invisible until the
+        // client happens to refresh (apify-mcp-server#851).
         return buildMCPResponse({
-            texts: [`Actor ${parsed.actor} has been added. Newly available tools: ${toolNames}.`],
+            texts: [
+                `Actor ${parsed.actor} has been added. Newly available tools: ${toolNames}. ` +
+                    `If they are not visible yet, refresh the tool list using the tools/list request before calling them.`,
+            ],
         });
     },
 } as const);

--- a/tests/unit/tools.add_actor.test.ts
+++ b/tests/unit/tools.add_actor.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HelperTools } from '../../src/const.js';
+import { addTool } from '../../src/tools/actors/add_actor.js';
+import type { HelperTool, InternalToolArgs } from '../../src/types.js';
+import type { TextToolResult } from './helpers/tool_context.js';
+
+// add-actor constructs its own ApifyClient from the token; a stub constructor is enough
+// to keep the test network-free.
+vi.mock('../../src/apify_client.js', () => ({
+    ApifyClient: vi.fn().mockImplementation(function () {
+        return {};
+    }),
+}));
+
+function buildContext(
+    overrides: {
+        actor?: string;
+        alreadyLoaded?: string[];
+        tools?: { name: string }[];
+        errors?: { message: string }[];
+        sendNotification?: ReturnType<typeof vi.fn>;
+    } = {},
+): InternalToolArgs {
+    const {
+        actor = 'apify/rag-web-browser',
+        alreadyLoaded = [],
+        tools = [{ name: 'apify/rag-web-browser' }],
+        errors = [],
+        sendNotification = vi.fn().mockResolvedValue(undefined),
+    } = overrides;
+    return {
+        args: { actor },
+        apifyToken: 'test-token',
+        apifyClient: null,
+        extra: { sendNotification },
+        mcpServer: {},
+        apifyMcpServer: {
+            listAllToolNames: () => alreadyLoaded,
+            loadActorsAsTools: vi.fn().mockResolvedValue({ tools, errors }),
+        },
+    } as unknown as InternalToolArgs;
+}
+
+describe('add-actor tool', () => {
+    it('has the expected tool name', () => {
+        expect(addTool.name).toBe(HelperTools.ACTOR_ADD);
+    });
+
+    it('sends list_changed and nudges the client to refresh via tools/list (#851)', async () => {
+        const sendNotification = vi.fn().mockResolvedValue(undefined);
+        const result = (await (addTool as HelperTool).call(
+            buildContext({ tools: [{ name: 'apify/rag-web-browser' }], sendNotification }),
+        )) as TextToolResult;
+
+        expect(sendNotification).toHaveBeenCalledWith({ method: 'notifications/tools/list_changed' });
+
+        const { text } = result.content[0];
+        expect(text).toContain('Actor apify/rag-web-browser has been added');
+        expect(text).toContain('apify/rag-web-browser');
+        expect(text).toMatch(/tools\/list/);
+        expect(result.isError).toBeFalsy();
+    });
+
+    it('does not nudge when the actor is already available', async () => {
+        const result = (await (addTool as HelperTool).call(
+            buildContext({ actor: 'apify/already-there', alreadyLoaded: ['apify/already-there'] }),
+        )) as TextToolResult;
+
+        expect(result.content[0].text).toContain('already available');
+        expect(result.content[0].text).not.toMatch(/tools\/list/);
+    });
+
+    it('forwards a load error without a nudge', async () => {
+        const result = (await (addTool as HelperTool).call(
+            buildContext({ errors: [{ message: 'Actor xyz was not found.' }], tools: [] }),
+        )) as TextToolResult;
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toBe('Actor xyz was not found.');
+        expect(result.content[0].text).not.toMatch(/tools\/list/);
+    });
+});


### PR DESCRIPTION
Replaces #1026 (which conflicts with master after #1019 moved `src/tools/common/` → `src/tools/actors/`).

## What & why

After `add-actor` registers a new Actor, the server fires `notifications/tools/list_changed`. Most MCP clients don't act on that notification, so the freshly added Actor stays invisible until the client happens to re-list — the "extra nudge for the LLM to refresh it" that #851 asks for.

## Change

`src/tools/actors/add_actor.ts` — append a short nudge to the success-path response text:

> `Actor <id> has been added. Newly available tools: <names>. If they are not visible yet, refresh the tool list using the tools/list request before calling them.`

- The `notifications/tools/list_changed` notification is still sent — this is an additional hint for clients that ignore it.
- The nudge is only on the success path — already-available and load-error responses are unchanged.

~2 lines of production change (plus a clarifying comment).

## Tests

Added `tests/unit/tools.add_actor.test.ts` (network-free; mocks `ApifyClient`) covering: nudge + `list_changed` on success path, and their absence on already-available and load-error paths.

All gates green:
```
pnpm run type-check   # clean
pnpm run lint         # 0 warnings, 0 errors
pnpm run test:unit    # 967 passed | 2 skipped
pnpm run format       # clean
pnpm run check:agents # passed
```

Closes #851

---
_Generated by [Claude Code](https://claude.ai/code/session_018LeUAGrTCcEKVoAutp9D9n)_