### PR TITLE
chore: Add output-schema conformance tests for storage tools

### DIFF
--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -1,5 +1,6 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { decode as decodeToon } from '@toon-format/toon';
+import Ajv from 'ajv';
 import { expect } from 'vitest';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../../src/const.js';
@@ -67,4 +68,16 @@ export function expectSoftFailInvalidInput(result: { isError?: boolean; toolTele
             failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
         }),
     );
+}
+
+/**
+ * Assert that `structuredContent` validates against `schema` under a non-coercing AJV
+ * (`new Ajv({ strict: false })` compiled directly on the schema) — the same shape of check the MCP
+ * SDK client runs on tool results. The repo's lenient `compileSchema` coerces types and would hide a
+ * mismatch, so conformance tests compile here instead. Surfaces AJV errors in the failure message.
+ */
+export function expectStructuredContentMatchesSchema(schema: object, structuredContent: unknown): void {
+    const validate = new Ajv({ strict: false }).compile(schema);
+    const valid = validate(structuredContent);
+    expect(valid, JSON.stringify(validate.errors)).toBe(true);
 }

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -71,12 +71,16 @@ export function expectSoftFailInvalidInput(result: { isError?: boolean; toolTele
 }
 
 /**
- * Assert that `structuredContent` validates against `schema` under a non-coercing AJV
- * (`new Ajv({ strict: false })` compiled directly on the schema) — the same shape of check the MCP
- * SDK client runs on tool results. The repo's lenient `compileSchema` coerces types and would hide a
- * mismatch, so conformance tests compile here instead. Surfaces AJV errors in the failure message.
+ * Assert a tool result's `structuredContent` conforms to its declared `outputSchema` under a
+ * non-coercing AJV (`new Ajv({ strict: false })` compiled directly on the schema) — the same check
+ * the MCP SDK client runs on tool results: a result that declares a schema but returns absent or
+ * non-conforming `structuredContent` is rejected. The repo's `compileSchema` coerces types and would
+ * hide a mismatch, so compile strictly here. Surfaces AJV errors in the failure message.
  */
-export function expectStructuredContentMatchesSchema(schema: object, structuredContent: unknown): void {
+export function expectSchemaConformingStructuredContent(result: unknown, schema: object): void {
+    const { structuredContent, isError } = result as { structuredContent?: unknown; isError?: boolean };
+    expect(isError).not.toBe(true);
+    expect(structuredContent).toBeDefined();
     const validate = new Ajv({ strict: false }).compile(schema);
     const valid = validate(structuredContent);
     expect(valid, JSON.stringify(validate.errors)).toBe(true);

--- a/tests/unit/tools.dataset_collection.test.ts
+++ b/tests/unit/tools.dataset_collection.test.ts
@@ -6,7 +6,7 @@ import { storageListOutputSchema } from '../../src/tools/structured_output_schem
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import {
     decodeFencedToolText,
-    expectStructuredContentMatchesSchema,
+    expectSchemaConformingStructuredContent,
     stubToolCallContext,
     type TextToolResult,
 } from './helpers/tool_context.js';
@@ -122,7 +122,7 @@ describe('get-dataset-list', () => {
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
 
         expect(structuredContent).toHaveProperty('count', 0);
-        expectStructuredContentMatchesSchema(storageListOutputSchema, structuredContent);
+        expectSchemaConformingStructuredContent(result, storageListOutputSchema);
     });
 
     it('rejects limit above 20 via ajv validation', () => {

--- a/tests/unit/tools.dataset_collection.test.ts
+++ b/tests/unit/tools.dataset_collection.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
 import { getUserDatasetsList } from '../../src/tools/storage/dataset_collection.js';
+import { storageListOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { decodeFencedToolText, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import {
+    decodeFencedToolText,
+    expectStructuredContentMatchesSchema,
+    stubToolCallContext,
+    type TextToolResult,
+} from './helpers/tool_context.js';
 
 const MOCK_LIST = {
     total: 2,
@@ -105,6 +111,18 @@ describe('get-dataset-list', () => {
         await (getUserDatasetsList as HelperTool).call(stubToolCallContext({}, stubApifyClient(listSpy)));
 
         expect(listSpy).toHaveBeenCalledWith({ limit: 10, offset: 0, desc: false, unnamed: false });
+    });
+
+    it('emits structuredContent that validates against the outputSchema for the last/empty page', async () => {
+        const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 0, count: 0, items: [] });
+
+        const result = await (getUserDatasetsList as HelperTool).call(
+            stubToolCallContext({}, stubApifyClient(listSpy)),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expect(structuredContent).toHaveProperty('count', 0);
+        expectStructuredContentMatchesSchema(storageListOutputSchema, structuredContent);
     });
 
     it('rejects limit above 20 via ajv validation', () => {

--- a/tests/unit/tools.get_dataset.test.ts
+++ b/tests/unit/tools.get_dataset.test.ts
@@ -8,7 +8,7 @@ import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     expectSoftFailInvalidInput,
-    expectStructuredContentMatchesSchema,
+    expectSchemaConformingStructuredContent,
     mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
@@ -87,9 +87,7 @@ describe('get-dataset', () => {
         const result = await (getDataset as HelperTool).call(
             stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient({ ...MOCK_DATASET, name: null })),
         );
-        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
-
-        expectStructuredContentMatchesSchema(datasetMetadataOutputSchema, structuredContent);
+        expectSchemaConformingStructuredContent(result, datasetMetadataOutputSchema);
     });
 
     it('returns isError with a not-found message when the dataset does not exist', async () => {

--- a/tests/unit/tools.get_dataset.test.ts
+++ b/tests/unit/tools.get_dataset.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
 import { getDataset } from '../../src/tools/storage/get_dataset.js';
+import { datasetMetadataOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     expectSoftFailInvalidInput,
+    expectStructuredContentMatchesSchema,
     mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
@@ -81,13 +83,23 @@ describe('get-dataset', () => {
         expect(structuredContent.nextStep).not.toContain('may exceed context');
     });
 
+    it('emits structuredContent that validates against the outputSchema for an unnamed dataset', async () => {
+        const result = await (getDataset as HelperTool).call(
+            stubToolCallContext({ datasetId: 'ds-1' }, stubApifyClient({ ...MOCK_DATASET, name: null })),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expectStructuredContentMatchesSchema(datasetMetadataOutputSchema, structuredContent);
+    });
+
     it('returns isError with a not-found message when the dataset does not exist', async () => {
         const result = await (getDataset as HelperTool).call(
             stubToolCallContext({ datasetId: 'missing' }, stubApifyClient(undefined)),
         );
-        const { content } = result as TextToolResult;
+        const { content, structuredContent } = result as TextToolResult & { structuredContent?: unknown };
 
         expectSoftFailInvalidInput(result);
+        expect(structuredContent).toBeUndefined();
         expect(content[0].text).toContain("Dataset 'missing' not found");
     });
 

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
 import { extractDotPrefixes, getDatasetItems } from '../../src/tools/storage/get_dataset_items.js';
+import { datasetItemsOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { dotFlatten } from '../../src/utils/encode_text.js';
@@ -9,6 +10,7 @@ import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     decodeFencedToolText,
     expectSoftFailInvalidInput,
+    expectStructuredContentMatchesSchema,
     mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
@@ -134,14 +136,27 @@ describe('get-dataset-items', () => {
         expect(structuredContent).toHaveProperty('limit', 10);
     });
 
+    it('emits structuredContent that validates against the outputSchema for an empty dataset', async () => {
+        const result = await (getDatasetItems as HelperTool).call(
+            stubToolCallContext(
+                { datasetId: 'ds-1' },
+                stubApifyClient(async () => ({ items: [], total: 0 })),
+            ),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expectStructuredContentMatchesSchema(datasetItemsOutputSchema, structuredContent);
+    });
+
     it('returns isError with a not-found message when listItems throws 404', async () => {
         const notFound = Object.assign(new Error('Dataset was not found'), { statusCode: 404 });
         const result = await (getDatasetItems as HelperTool).call(
             stubToolCallContext({ datasetId: 'missing' }, stubApifyClientThrowing(notFound)),
         );
-        const { content } = result as TextToolResult;
+        const { content, structuredContent } = result as TextToolResult & { structuredContent?: unknown };
 
         expectSoftFailInvalidInput(result);
+        expect(structuredContent).toBeUndefined();
         expect(content[0].text).toContain("Dataset 'missing' not found");
     });
 

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -10,7 +10,7 @@ import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     decodeFencedToolText,
     expectSoftFailInvalidInput,
-    expectStructuredContentMatchesSchema,
+    expectSchemaConformingStructuredContent,
     mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
@@ -143,9 +143,7 @@ describe('get-dataset-items', () => {
                 stubApifyClient(async () => ({ items: [], total: 0 })),
             ),
         );
-        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
-
-        expectStructuredContentMatchesSchema(datasetItemsOutputSchema, structuredContent);
+        expectSchemaConformingStructuredContent(result, datasetItemsOutputSchema);
     });
 
     it('returns isError with a not-found message when listItems throws 404', async () => {

--- a/tests/unit/tools.get_dataset_schema.test.ts
+++ b/tests/unit/tools.get_dataset_schema.test.ts
@@ -8,7 +8,7 @@ import type * as SchemaGenModule from '../../src/utils/schema_generation.js';
 import { generateSchemaFromItems } from '../../src/utils/schema_generation.js';
 import {
     expectSoftFailInvalidInput,
-    expectStructuredContentMatchesSchema,
+    expectSchemaConformingStructuredContent,
     stubToolCallContext,
     type TextToolResult,
     type ToolTelemetrySnapshot,
@@ -93,7 +93,7 @@ describe('get-dataset-schema', () => {
         expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
         expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
         // The required `schema` is still present (empty object) and the emit conforms to the schema.
-        expectStructuredContentMatchesSchema(datasetSchemaOutputSchema, structuredContent);
+        expectSchemaConformingStructuredContent(result, datasetSchemaOutputSchema);
     });
 
     it('returns isError with a not-found message when listItems throws 404', async () => {

--- a/tests/unit/tools.get_dataset_schema.test.ts
+++ b/tests/unit/tools.get_dataset_schema.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../src/const.js';
 import { getDatasetSchema } from '../../src/tools/storage/get_dataset_schema.js';
+import { datasetSchemaOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import type * as SchemaGenModule from '../../src/utils/schema_generation.js';
 import { generateSchemaFromItems } from '../../src/utils/schema_generation.js';
 import {
     expectSoftFailInvalidInput,
+    expectStructuredContentMatchesSchema,
     stubToolCallContext,
     type TextToolResult,
     type ToolTelemetrySnapshot,
@@ -90,6 +92,8 @@ describe('get-dataset-schema', () => {
         expect(structuredContent.summary).toBe("Dataset 'ds-1' is empty; no schema to infer.");
         expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
         expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
+        // The required `schema` is still present (empty object) and the emit conforms to the schema.
+        expectStructuredContentMatchesSchema(datasetSchemaOutputSchema, structuredContent);
     });
 
     it('returns isError with a not-found message when listItems throws 404', async () => {
@@ -97,9 +101,10 @@ describe('get-dataset-schema', () => {
         const result = await (getDatasetSchema as HelperTool).call(
             stubToolCallContext({ datasetId: 'missing' }, stubApifyClientThrowing(notFound)),
         );
-        const { content } = result as TextToolResult;
+        const { content, structuredContent } = result as TextToolResult & { structuredContent?: unknown };
 
         expectSoftFailInvalidInput(result);
+        expect(structuredContent).toBeUndefined();
         expect(content[0].text).toContain("Dataset 'missing' not found");
     });
 

--- a/tests/unit/tools.get_key_value_store.test.ts
+++ b/tests/unit/tools.get_key_value_store.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
 import { getKeyValueStore } from '../../src/tools/storage/get_key_value_store.js';
+import { keyValueStoreOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     expectSoftFailInvalidInput,
+    expectStructuredContentMatchesSchema,
     mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
@@ -65,13 +67,23 @@ describe('get-key-value-store', () => {
         expect(structuredContent.summary).toBe("Key-value store 'my-store' holds 2048 bytes.");
     });
 
+    it('emits structuredContent that validates against the outputSchema for an unnamed store', async () => {
+        const result = await (getKeyValueStore as HelperTool).call(
+            stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient({ ...MOCK_STORE, name: null })),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expectStructuredContentMatchesSchema(keyValueStoreOutputSchema, structuredContent);
+    });
+
     it('returns isError with a not-found message when the store does not exist', async () => {
         const result = await (getKeyValueStore as HelperTool).call(
             stubToolCallContext({ keyValueStoreId: 'missing' }, stubApifyClient(undefined)),
         );
-        const { content } = result as TextToolResult;
+        const { content, structuredContent } = result as TextToolResult & { structuredContent?: unknown };
 
         expectSoftFailInvalidInput(result);
+        expect(structuredContent).toBeUndefined();
         expect(content[0].text).toContain("Key-value store 'missing' not found");
     });
 

--- a/tests/unit/tools.get_key_value_store.test.ts
+++ b/tests/unit/tools.get_key_value_store.test.ts
@@ -8,7 +8,7 @@ import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     expectSoftFailInvalidInput,
-    expectStructuredContentMatchesSchema,
+    expectSchemaConformingStructuredContent,
     mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
@@ -71,9 +71,7 @@ describe('get-key-value-store', () => {
         const result = await (getKeyValueStore as HelperTool).call(
             stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient({ ...MOCK_STORE, name: null })),
         );
-        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
-
-        expectStructuredContentMatchesSchema(keyValueStoreOutputSchema, structuredContent);
+        expectSchemaConformingStructuredContent(result, keyValueStoreOutputSchema);
     });
 
     it('returns isError with a not-found message when the store does not exist', async () => {

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -9,7 +9,7 @@ import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     decodeFencedToolText,
     expectSoftFailInvalidInput,
-    expectStructuredContentMatchesSchema,
+    expectSchemaConformingStructuredContent,
     mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
@@ -80,9 +80,7 @@ describe('get-key-value-store-keys', () => {
         const result = await (getKeyValueStoreKeys as HelperTool).call(
             stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(listKeysSpy)),
         );
-        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
-
-        expectStructuredContentMatchesSchema(keyValueStoreKeysOutputSchema, structuredContent);
+        expectSchemaConformingStructuredContent(result, keyValueStoreKeysOutputSchema);
     });
 
     it('flags truncation in the summary and points to the next page when more keys are available', async () => {

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -1,4 +1,3 @@
-import Ajv from 'ajv';
 import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
@@ -10,6 +9,7 @@ import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
     decodeFencedToolText,
     expectSoftFailInvalidInput,
+    expectStructuredContentMatchesSchema,
     mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
@@ -76,14 +76,13 @@ describe('get-key-value-store-keys', () => {
         // Validated with a strict AJV (no coercion) to mirror the SDK's output-schema check; the
         // repo's lenient `compileSchema` coerces types and would hide the mismatch.
         const listKeysSpy = vi.fn().mockResolvedValue({ ...MOCK_KEYS, nextExclusiveStartKey: null });
-        const validate = new Ajv({ strict: false }).compile(keyValueStoreKeysOutputSchema);
 
         const result = await (getKeyValueStoreKeys as HelperTool).call(
             stubToolCallContext({ keyValueStoreId: 'kv-1' }, stubApifyClient(listKeysSpy)),
         );
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
 
-        expect(validate(structuredContent)).toBe(true);
+        expectStructuredContentMatchesSchema(keyValueStoreKeysOutputSchema, structuredContent);
     });
 
     it('flags truncation in the summary and points to the next page when more keys are available', async () => {

--- a/tests/unit/tools.get_key_value_store_record.test.ts
+++ b/tests/unit/tools.get_key_value_store_record.test.ts
@@ -9,26 +9,15 @@ import { HelperTools, KV_RECORD_MAX_INLINE_BYTES } from '../../src/const.js';
 import { getKeyValueStoreRecord } from '../../src/tools/storage/get_key_value_store_record.js';
 import { keyValueStoreRecordOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { compileSchema } from '../../src/utils/ajv.js';
 import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
 import {
+    expectSchemaConformingStructuredContent,
     expectSoftFailInvalidInput,
     mockUserInfo,
     stubToolCallContext,
     type TextToolResult,
 } from './helpers/tool_context.js';
-
-// Mirrors the official MCP SDK client: any tool with an outputSchema MUST return structuredContent
-// that validates against the schema, or callTool throws (client/index.js).
-const validateRecordOutput = compileSchema(keyValueStoreRecordOutputSchema as unknown as Record<string, unknown>);
-function expectSchemaConformingStructuredContent(result: unknown) {
-    const { structuredContent, isError } = result as { structuredContent?: unknown; isError?: boolean };
-    expect(isError).not.toBe(true);
-    expect(structuredContent).toBeDefined();
-    const valid = validateRecordOutput(structuredClone(structuredContent));
-    expect(valid, JSON.stringify(validateRecordOutput.errors)).toBe(true);
-}
 
 // Only Console UI token sessions reach the users/me lookup.
 vi.mock('../../src/utils/userid_cache.js', () => ({
@@ -110,7 +99,7 @@ describe('get-key-value-store-record', () => {
                 stubApifyClient({ record: { key: 'OUTPUT', value: undefined, contentType: 'application/json' } }),
             ),
         );
-        expectSchemaConformingStructuredContent(result);
+        expectSchemaConformingStructuredContent(result, keyValueStoreRecordOutputSchema);
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
         expect(structuredContent).toMatchObject({ keyValueStoreId: 'kv-1', key: 'OUTPUT', value: '' });
     });
@@ -296,7 +285,7 @@ describe('get-key-value-store-record', () => {
                         stubApifyClient({ record: { key: recordKey, value, contentType } }),
                     ),
                 );
-                expectSchemaConformingStructuredContent(result);
+                expectSchemaConformingStructuredContent(result, keyValueStoreRecordOutputSchema);
                 const { structuredContent } = result as { structuredContent: Record<string, unknown> };
                 expect(structuredContent).toMatchObject({ keyValueStoreId: 'kv-1', key: recordKey, contentType });
             });

--- a/tests/unit/tools.key_value_store_collection.test.ts
+++ b/tests/unit/tools.key_value_store_collection.test.ts
@@ -6,7 +6,7 @@ import { storageListOutputSchema } from '../../src/tools/structured_output_schem
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import {
     decodeFencedToolText,
-    expectStructuredContentMatchesSchema,
+    expectSchemaConformingStructuredContent,
     stubToolCallContext,
     type TextToolResult,
 } from './helpers/tool_context.js';
@@ -102,7 +102,7 @@ describe('get-key-value-store-list', () => {
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
 
         expect(structuredContent).toHaveProperty('count', 0);
-        expectStructuredContentMatchesSchema(storageListOutputSchema, structuredContent);
+        expectSchemaConformingStructuredContent(result, storageListOutputSchema);
     });
 
     it('rejects limit above 10 via ajv validation', () => {

--- a/tests/unit/tools.key_value_store_collection.test.ts
+++ b/tests/unit/tools.key_value_store_collection.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { HelperTools } from '../../src/const.js';
 import { getUserKeyValueStoresList } from '../../src/tools/storage/key_value_store_collection.js';
+import { storageListOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { decodeFencedToolText, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import {
+    decodeFencedToolText,
+    expectStructuredContentMatchesSchema,
+    stubToolCallContext,
+    type TextToolResult,
+} from './helpers/tool_context.js';
 
 const MOCK_LIST = {
     total: 2,
@@ -85,6 +91,18 @@ describe('get-key-value-store-list', () => {
         await (getUserKeyValueStoresList as HelperTool).call(stubToolCallContext({}, stubApifyClient(listSpy)));
 
         expect(listSpy).toHaveBeenCalledWith({ limit: 10, offset: 0, desc: false, unnamed: false });
+    });
+
+    it('emits structuredContent that validates against the outputSchema for the last/empty page', async () => {
+        const listSpy = vi.fn().mockResolvedValue({ ...MOCK_LIST, total: 0, count: 0, items: [] });
+
+        const result = await (getUserKeyValueStoresList as HelperTool).call(
+            stubToolCallContext({}, stubApifyClient(listSpy)),
+        );
+        const { structuredContent } = result as { structuredContent: Record<string, unknown> };
+
+        expect(structuredContent).toHaveProperty('count', 0);
+        expectStructuredContentMatchesSchema(storageListOutputSchema, structuredContent);
     });
 
     it('rejects limit above 10 via ajv validation', () => {


### PR DESCRIPTION
## What we're solving

Closes #886 (under umbrella #784). "Spec compliant" for the storage tools means: each tool's emitted `structuredContent` must validate against its declared `outputSchema` — the non-coercing check a spec-compliant MCP client runs on tool results (a result with a schema but non-conforming output is rejected).

All 8 storage tools already declare an `outputSchema` and emit `structuredContent`, and a static audit of every success/error branch found **no mismatch at HEAD**. But only `get-key-value-store-keys` and `get-key-value-store-record` had a test proving conformance. For the other six tools, a future schema/output drift could ship undetected. This is a **tests-only** change.

## MCP conformance suite — cross-check (no code impact)

Ran the official `@modelcontextprotocol/conformance` suite (`server` mode over HTTP) against the local dev server as an independent cross-check. **11 passed, 21 failed**, but the failures are expected and do not indicate a defect:

- The suite tests **protocol conformance**, not tool behavior. To exercise `tools/call`, `prompts/get`, etc. it requires the server to implement its own **fixed test fixtures** (`test_simple_text`, `test_simple_prompt`, …). This server exposes real tools (`search-actors`, `call-actor`, `get-dataset-items`, …), so those scenarios fail with "tool/prompt not found" — a fixture mismatch, not a violation.
- The server **passes every scenario that maps to a capability it declares**: `initialize`, `ping`, `logging/setLevel`, `tools/list`, `resources/list`, `resources/read` (text), `resources/templates`, `prompts/list`, SSE multi-stream, and the valid-Host check.
- Optional capabilities the server does not advertise (`completion/complete`, `resources/subscribe`) are reported as failures by the suite but are not required.
- One genuine finding — the dev server does not validate the `Host`/`Origin` header (DNS-rebinding). **Out of scope here**: `src/dev_server.ts` is the dev/standby server only; the production Streamable-HTTP transport and its security live in `apify-mcp-server-internal`.
- 
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D4Lyju2prcnEiw4hPAZhK