### PR TITLE
test(integration): cover array-index collapse in dataset.fields

### DIFF
--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2206,6 +2206,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const fields = sc?.storages?.datasets?.default?.fields ?? [];
                 expect(fields).toEqual(expect.arrayContaining(['firstNumber', 'secondNumber', 'sum']));
 
+                // #911/#894: the actor emits `math.fibonacci: [..]`, which Apify reports index-expanded
+                // (`math/fibonacci/0`, `/1`, `/2`). The server must collapse those to a single
+                // `math.fibonacci` on the wire. `math.fibonacci` present proves collapse fired (not a
+                // flat-only no-op); no entry keeps an array index; no duplicates survive collapse.
+                expect(fields).toEqual(expect.arrayContaining(['math.fibonacci']));
+                expect(fields.some((f) => /\.\d+(\.|$)/.test(f))).toBe(false);
+                expect(new Set(fields).size).toBe(fields.length);
+
                 const outputResult = await client.callTool({
                     name: HelperTools.DATASET_GET_ITEMS,
                     arguments: {


### PR DESCRIPTION
## What we're solving

The server collapses Apify's index-expanded `dataset.fields` (`math/fibonacci/0,1,2` → `math.fibonacci`) before they reach MCP clients (#904, closes #894), but no integration test pinned this on the wire.

#911 assumed this needed a new array-shaped fixture actor. That's stale: `apify/normal-mode-test-actor` now emits `math.fibonacci: [..]` in its default dataset, so the collapse path runs end-to-end today — no new fixture needed.

## Alternatives considered

- A dedicated test — rejected: would add a second slow actor run for data the existing test already fetches.
- Extending the shared `expectNormalModeTestStructuredContent` helper — rejected: the check is specific to `math.fibonacci`, not a generic shape invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6wzYWnX5zhAKPgSKxyKqd