### PR TITLE
refactor: Convert web UI interfaces to type (#643 Phase 5)

### DIFF
--- a/src/web/src/types.ts
+++ b/src/web/src/types.ts
@@ -32,13 +32,13 @@ export type StructuredPricingInfo = {
     eventDescriptionsNote?: string;
 };
 
-export interface ActorStats {
+export type ActorStats = {
     totalUsers: number;
     actorReviewRating: number;
     actorReviewCount: number;
-}
+};
 
-export interface ActorDetails {
+export type ActorDetails = {
     actorInfo: Actor;
     actorCard: string;
     readme: string;
@@ -46,9 +46,9 @@ export interface ActorDetails {
         type: string;
         properties: Record<string, unknown>;
     };
-}
+};
 
-export interface Actor {
+export type Actor = {
     id: string;
     name: string;
     username: string;
@@ -59,4 +59,4 @@ export interface Actor {
     pictureUrl?: string;
     stats?: ActorStats;
     currentPricingInfo?: StructuredPricingInfo;
-}
+};


### PR DESCRIPTION
## What we're solving

`src/web/src/types.ts` declared `ActorStats`, `ActorDetails`, and `Actor` with `interface` where the project convention is `type`. This is Phase 5 of #643 (const & type convention alignment).

---

Part of #643. No internal-repo impact (web-frontend types, not re-exported via `index_internals.ts`). Verified: `type-check`, `lint`, `format:check`, `test:unit` (999 passed), `check:agents` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2sHxyNZxqyQmgMUsesmZu

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2sHxyNZxqyQmgMUsesmZu)_