### PR TITLE
refactor: HelperTools and ServerMode enums to SNAKE_CASE as const

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Breaking changes must be coordinated; check whether updates are needed in `apify
 
 - **Follow [CONTRIBUTING.md](./CONTRIBUTING.md) for all naming and coding standards.** It is the single source of truth for naming rules (function verbs, boolean prefixes, type suffixes, enumerations, file names, etc.), string formatting, parameters, error handling, and anti-patterns. Read it before writing code.
 - **Validate tool inputs with Zod.** No ad-hoc shape checks.
-- **Reference tool names via the `HelperTools` enum**, not hardcoded strings (exception: integration tests).
+- **Reference tool names via the `HELPER_TOOLS` `as const` object**, not hardcoded strings (exception: integration tests).
 - **Apps vs default mode**: only `*-widget` tools differ between modes. All non-widget tools (`call-actor`, `get-actor-run`, direct actor tools, `search-actors`, `fetch-actor-details`) share a single implementation across modes.
 - Per-directory detail lives in the child `AGENTS.md` files (see Child docs below).
 - Always follow the latest [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25) and [MCP Apps spec](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,7 +278,7 @@ Use comments to guide reviewers:
     * **Error responses**: Return user-friendly error messages with suggestions.
     * **Input validation**: Always validate tool inputs with Zod before processing.
     * **Caching**: Use TTL-based caching for Actor schemas and details (see `src/utils/ttl_lru.ts`).
-    * **Constants and tool names**: Always use constants and never hardcoded values. When referring to tools, ALWAYS use the `HelperTools` enum.
+    * **Constants and tool names**: Always use constants and never hardcoded values. When referring to tools, ALWAYS use the `HELPER_TOOLS` `as const` object.
         * Exception: Integration tests (`tests/integration/`) must use hardcoded strings for tool names. This ensures tests fail if a tool is renamed, preventing accidental breaking changes.
 
 *   **Anti-patterns:**

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,8 +38,8 @@ Key entry points:
 Tool loading is intentionally split into two phases in [`src/utils/tools_loader.ts`](./src/utils/tools_loader.ts):
 
 - `getActors()` — async, mode-agnostic. Fetches Actor metadata and preserves the caller's requested tool/actor selection without choosing any mode-dependent tool variants.
-- `getToolsForServerMode()` — sync, mode-dependent. Takes the pre-fetched sources plus a resolved `ServerMode` and produces the concrete tool entries to expose to the client.
-- `loadToolsFromInput()` in `tools_loader.ts` — convenience wrapper running both phases back-to-back with an explicit `ServerMode`. **Not to be confused with** `ActorsMcpServer.loadToolsFromInput()` (the public method), which queues sources when mode is still `'auto'` and registers them onto the server — call the server method from transport entry points, the plain function only when you already have a resolved mode.
+- `getToolsForServerMode()` — sync, mode-dependent. Takes the pre-fetched sources plus a resolved `SERVER_MODE` and produces the concrete tool entries to expose to the client.
+- `loadToolsFromInput()` in `tools_loader.ts` — convenience wrapper running both phases back-to-back with an explicit `SERVER_MODE`. **Not to be confused with** `ActorsMcpServer.loadToolsFromInput()` (the public method), which queues sources when mode is still `'auto'` and registers them onto the server — call the server method from transport entry points, the plain function only when you already have a resolved mode.
 
 This split matters for `serverMode: 'auto'`.
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -31,30 +31,31 @@ export const SERVER_MODE_AUTO_DETECTION_ENABLED = true;
 
 export const SERVER_NAME = 'apify-mcp-server';
 export const SERVER_TITLE = 'Apify MCP Server';
-export enum HelperTools {
-    ACTOR_ADD = 'add-actor',
-    ACTOR_CALL = 'call-actor',
-    ACTOR_CALL_WIDGET = 'call-actor-widget',
-    ACTOR_GET_DETAILS = 'fetch-actor-details',
-    ACTOR_GET_DETAILS_WIDGET = 'fetch-actor-details-widget',
-    ACTOR_RUNS_ABORT = 'abort-actor-run',
-    ACTOR_RUNS_GET = 'get-actor-run',
-    ACTOR_RUNS_GET_WIDGET = 'get-actor-run-widget',
-    ACTOR_RUNS_LOG = 'get-actor-log',
-    ACTOR_RUN_LIST_GET = 'get-actor-run-list',
-    DATASET_GET = 'get-dataset',
-    DATASET_LIST_GET = 'get-dataset-list',
-    DATASET_GET_ITEMS = 'get-dataset-items',
-    DATASET_SCHEMA_GET = 'get-dataset-schema',
-    KEY_VALUE_STORE_LIST_GET = 'get-key-value-store-list',
-    KEY_VALUE_STORE_GET = 'get-key-value-store',
-    KEY_VALUE_STORE_KEYS_GET = 'get-key-value-store-keys',
-    KEY_VALUE_STORE_RECORD_GET = 'get-key-value-store-record',
-    STORE_SEARCH = 'search-actors',
-    STORE_SEARCH_WIDGET = 'search-actors-widget',
-    DOCS_SEARCH = 'search-apify-docs',
-    DOCS_FETCH = 'fetch-apify-docs',
-}
+export const HELPER_TOOLS = {
+    ACTOR_ADD: 'add-actor',
+    ACTOR_CALL: 'call-actor',
+    ACTOR_CALL_WIDGET: 'call-actor-widget',
+    ACTOR_GET_DETAILS: 'fetch-actor-details',
+    ACTOR_GET_DETAILS_WIDGET: 'fetch-actor-details-widget',
+    ACTOR_RUNS_ABORT: 'abort-actor-run',
+    ACTOR_RUNS_GET: 'get-actor-run',
+    ACTOR_RUNS_GET_WIDGET: 'get-actor-run-widget',
+    ACTOR_RUNS_LOG: 'get-actor-log',
+    ACTOR_RUN_LIST_GET: 'get-actor-run-list',
+    DATASET_GET: 'get-dataset',
+    DATASET_LIST_GET: 'get-dataset-list',
+    DATASET_GET_ITEMS: 'get-dataset-items',
+    DATASET_SCHEMA_GET: 'get-dataset-schema',
+    KEY_VALUE_STORE_LIST_GET: 'get-key-value-store-list',
+    KEY_VALUE_STORE_GET: 'get-key-value-store',
+    KEY_VALUE_STORE_KEYS_GET: 'get-key-value-store-keys',
+    KEY_VALUE_STORE_RECORD_GET: 'get-key-value-store-record',
+    STORE_SEARCH: 'search-actors',
+    STORE_SEARCH_WIDGET: 'search-actors-widget',
+    DOCS_SEARCH: 'search-apify-docs',
+    DOCS_FETCH: 'fetch-apify-docs',
+} as const;
+export type HelperToolName = (typeof HELPER_TOOLS)[keyof typeof HELPER_TOOLS];
 
 export const RAG_WEB_BROWSER = 'apify/rag-web-browser';
 export const RAG_WEB_BROWSER_WHITELISTED_FIELDS = ['query', 'maxResults', 'outputFormats'];

--- a/src/const.ts
+++ b/src/const.ts
@@ -26,7 +26,7 @@ export const DATASET_SIZE_HINT_BYTES = 50000;
 export const NARROW_OUTPUT_HINT = 'narrow with fields= or page with offset';
 
 // MCP Server
-/** When `false`, `resolveServerMode('auto', ...)` forces {@link ServerMode.DEFAULT} regardless of client capabilities. */
+/** When `false`, `resolveServerMode('auto', ...)` forces {@link SERVER_MODE.DEFAULT} regardless of client capabilities. */
 export const SERVER_MODE_AUTO_DETECTION_ENABLED = true;
 
 export const SERVER_NAME = 'apify-mcp-server';

--- a/src/index_internals.ts
+++ b/src/index_internals.ts
@@ -3,7 +3,7 @@
 */
 
 import { ApifyClient } from './apify_client.js';
-import { APIFY_FAVICON_URL, defaults, HelperTools, SERVER_NAME, SERVER_TITLE } from './const.js';
+import { APIFY_FAVICON_URL, defaults, HELPER_TOOLS, type HelperToolName, SERVER_NAME, SERVER_TITLE } from './const.js';
 import { processParamsGetTools } from './mcp/utils.js';
 import { resolvePaymentProvider } from './payments/index.js';
 import type { PaymentProvider } from './payments/types.js';
@@ -32,7 +32,8 @@ export {
     getServerCard,
     TTLLRUCache,
     actorNameToToolName,
-    HelperTools,
+    HELPER_TOOLS,
+    type HelperToolName,
     SERVER_NAME,
     SERVER_TITLE,
     defaults,
@@ -62,3 +63,8 @@ export {
      */
     redactSkyfirePayId,
 };
+
+/** @deprecated Use HELPER_TOOLS / HelperToolName. Kept for backward compatibility with apify-mcp-server-internal. */
+export const HelperTools = HELPER_TOOLS;
+/** @deprecated Use HelperToolName. */
+export type HelperTools = HelperToolName;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -80,7 +80,7 @@ import type {
     ToolEntry,
     ToolStatus,
 } from '../types.js';
-import { ServerMode, TOOL_TYPE } from '../types.js';
+import { SERVER_MODE, TOOL_TYPE } from '../types.js';
 import { isPermissionApprovalError, remoteMcpFailureDetail } from '../utils/apify_errors.js';
 import { getHttpStatusCode, isMcpClientFaultMessage, logHttpError, sanitizeMezmoMessage } from '../utils/logging.js';
 import {
@@ -183,7 +183,7 @@ export class ActorsMcpServer {
      * Finalized inside the `initialize` request handler (see constructor) once the
      * client's capabilities are known. Effectively set-once per connection.
      */
-    public serverMode: ServerMode;
+    public serverMode: SERVER_MODE;
     /**
      * Raw option captured from `options.serverMode` (or the legacy `uiMode`). Re-resolved
      * inside the initialize handler when set to `'auto'`; explicit `'default'`/`'apps'`
@@ -1856,7 +1856,7 @@ export class ActorsMcpServer {
      * Resolves widgets and determines which ones are ready to be served.
      */
     private async resolveWidgets(): Promise<void> {
-        if (this.serverMode !== ServerMode.APPS) {
+        if (this.serverMode !== SERVER_MODE.APPS) {
             return;
         }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -53,7 +53,7 @@ import {
     DEFAULT_TELEMETRY_ENABLED,
     DEFAULT_TELEMETRY_ENV,
     FAILURE_CATEGORY,
-    HelperTools,
+    HELPER_TOOLS,
     TOOL_STATUS,
 } from '../const.js';
 import { prepareToolCallContext } from '../payments/helpers.js';
@@ -927,7 +927,7 @@ export class ActorsMcpServer {
                     await failInvalidParams(
                         dedent`
                     Missing arguments for tool "${name}".
-                    Please provide the required arguments for this tool. Check the tool's input schema using ${HelperTools.ACTOR_GET_DETAILS} tool to see what parameters are required.
+                    Please provide the required arguments for this tool. Check the tool's input schema using ${HELPER_TOOLS.ACTOR_GET_DETAILS} tool to see what parameters are required.
                 `,
                         {
                             failure_category: FAILURE_CATEGORY.INVALID_INPUT,
@@ -970,7 +970,7 @@ export class ActorsMcpServer {
                         dedent`
                     Invalid arguments for tool "${tool.name}".
                     Validation errors: ${errorMessages}.
-                    Please check the tool's input schema using ${HelperTools.ACTOR_GET_DETAILS} tool and ensure all required parameters are provided with correct types and values.
+                    Please check the tool's input schema using ${HELPER_TOOLS.ACTOR_GET_DETAILS} tool and ensure all required parameters are provided with correct types and values.
                 `,
                         {
                             failure_category: FAILURE_CATEGORY.INVALID_INPUT,
@@ -1004,7 +1004,7 @@ export class ActorsMcpServer {
                 // `taskSupport: 'optional'`, so without this both paths would 402 by default.
                 const { paymentProvider } = this.options;
                 const isCallActorTool =
-                    tool.name === HelperTools.ACTOR_CALL || tool.name === HelperTools.ACTOR_CALL_WIDGET;
+                    tool.name === HELPER_TOOLS.ACTOR_CALL || tool.name === HELPER_TOOLS.ACTOR_CALL_WIDGET;
                 const actorArg = (toolArgs as { actor?: unknown } | undefined)?.actor;
 
                 const standbyRejection =
@@ -1089,7 +1089,7 @@ export class ActorsMcpServer {
                     // Tools that may emit notifications/progress during a sync wait must be opted in here.
                     // call-actor: emits during start+waitForFinish. get-actor-run: emits when waitSecs > 0.
                     const progressTrackerOptIn =
-                        tool.name === HelperTools.ACTOR_CALL || tool.name === HelperTools.ACTOR_RUNS_GET;
+                        tool.name === HELPER_TOOLS.ACTOR_CALL || tool.name === HELPER_TOOLS.ACTOR_RUNS_GET;
                     const progressTracker = progressTrackerOptIn
                         ? createProgressTracker(progressToken, extra.sendNotification)
                         : null;

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -7,7 +7,7 @@ import log from '@apify/log';
 
 import { processInput } from '../input.js';
 import type { ActorStore, Input } from '../types.js';
-import { ServerMode } from '../types.js';
+import { SERVER_MODE } from '../types.js';
 import { loadToolsFromInput } from '../utils/tools_loader.js';
 
 /**
@@ -21,7 +21,7 @@ import { loadToolsFromInput } from '../utils/tools_loader.js';
 export async function processParamsGetTools(
     url: string,
     apifyClient: ApifyClient,
-    mode: ServerMode = ServerMode.DEFAULT,
+    mode: SERVER_MODE = SERVER_MODE.DEFAULT,
     actorStore?: ActorStore,
 ) {
     const input = parseInputParamsFromUrl(url);

--- a/src/payments/const.ts
+++ b/src/payments/const.ts
@@ -1,4 +1,4 @@
-import { HelperTools } from '../const.js';
+import { HELPER_TOOLS, type HelperToolName } from '../const.js';
 
 export const PAYMENT_PROTOCOL_HEADER = 'x-apify-payment-protocol';
 
@@ -15,15 +15,15 @@ export const SKYFIRE_README_CONTENT = `The Apify MCP Server allows clients to in
  * Set of internal tool names that require Skyfire PAY token ID in Skyfire mode.
  * These tools interact with Actor runs, datasets, or key-value stores and need billing support.
  */
-export const SKYFIRE_ENABLED_TOOLS = new Set([
-    HelperTools.ACTOR_CALL,
-    HelperTools.ACTOR_RUNS_GET,
-    HelperTools.ACTOR_RUNS_LOG,
-    HelperTools.ACTOR_RUNS_ABORT,
-    HelperTools.DATASET_GET,
-    HelperTools.DATASET_GET_ITEMS,
-    HelperTools.DATASET_SCHEMA_GET,
-    HelperTools.KEY_VALUE_STORE_GET,
-    HelperTools.KEY_VALUE_STORE_KEYS_GET,
-    HelperTools.KEY_VALUE_STORE_RECORD_GET,
+export const SKYFIRE_ENABLED_TOOLS = new Set<HelperToolName>([
+    HELPER_TOOLS.ACTOR_CALL,
+    HELPER_TOOLS.ACTOR_RUNS_GET,
+    HELPER_TOOLS.ACTOR_RUNS_LOG,
+    HELPER_TOOLS.ACTOR_RUNS_ABORT,
+    HELPER_TOOLS.DATASET_GET,
+    HELPER_TOOLS.DATASET_GET_ITEMS,
+    HELPER_TOOLS.DATASET_SCHEMA_GET,
+    HELPER_TOOLS.KEY_VALUE_STORE_GET,
+    HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET,
+    HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET,
 ]);

--- a/src/resources/resource_service.ts
+++ b/src/resources/resource_service.ts
@@ -9,7 +9,7 @@ import type {
 import log from '@apify/log';
 
 import type { PaymentProvider } from '../payments/types.js';
-import { ServerMode } from '../types.js';
+import { SERVER_MODE } from '../types.js';
 import type { AvailableWidget } from './widgets.js';
 import { RESOURCE_MIME_TYPE } from './widgets.js';
 
@@ -37,7 +37,7 @@ type ResourceServiceOptions = {
      * client capabilities, and a captured value would freeze resource listings to
      * the preliminary mode.
      */
-    getMode: () => ServerMode;
+    getMode: () => SERVER_MODE;
     getAvailableWidgets: () => Map<string, AvailableWidget>;
 };
 
@@ -58,7 +58,7 @@ export function createResourceService(options: ResourceServiceOptions): Resource
             });
         }
 
-        if (getMode() === ServerMode.APPS) {
+        if (getMode() === SERVER_MODE.APPS) {
             for (const widget of getAvailableWidgets().values()) {
                 if (!widget.exists) {
                     continue;
@@ -90,7 +90,7 @@ export function createResourceService(options: ResourceServiceOptions): Resource
             };
         }
 
-        if (getMode() === ServerMode.APPS && uri.startsWith('ui://widget/')) {
+        if (getMode() === SERVER_MODE.APPS && uri.startsWith('ui://widget/')) {
             const widget = getAvailableWidgets().get(uri);
 
             if (!widget || !widget.exists) {

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -27,7 +27,7 @@ direct actor tools, `search-actors`, `fetch-actor-details`) is mode-agnostic.
 
 - **Validate inputs with Zod**; no ad-hoc shape checks. AJV + Zod already validate
   before a tool runs — don't re-check the same constraint inside the tool body.
-- **Reference tool names via the `HelperTools` enum**, never hardcoded strings
+- **Reference tool names via the `HELPER_TOOLS` `as const` object**, never hardcoded strings
   (exception: integration tests).
 - Keep a new tool mode-agnostic unless it is genuinely a widget variant.
 

--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -6,7 +6,7 @@ import type { ApifyClient } from '../../apify_client.js';
 import {
     DATASET_SIZE_HINT_BYTES,
     FAILURE_CATEGORY,
-    HelperTools,
+    HELPER_TOOLS,
     NARROW_OUTPUT_HINT,
     TOOL_STATUS,
 } from '../../const.js';
@@ -411,7 +411,7 @@ function elapsedSecs(run: ActorRun): number {
 }
 
 function pollHint(runId: string): string {
-    return `Use ${HelperTools.ACTOR_RUNS_GET} with runId=${runId} and waitSecs=${POLL_HINT_WAIT_SECS} to`;
+    return `Use ${HELPER_TOOLS.ACTOR_RUNS_GET} with runId=${runId} and waitSecs=${POLL_HINT_WAIT_SECS} to`;
 }
 
 /**
@@ -492,7 +492,7 @@ function buildSucceededSummaryNextStep(
         const fields = dataset?.fields ?? [];
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. ${itemCount} ${itemCount === 1 ? 'item' : 'items'}; ${fields.length} fields available.${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to fetch items (${itemCount} total).${datasetSizeNextStepHint(dataset?.inflatedBytes)}${fieldsProjectionHint(fields)}`,
+            nextStep: `Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to fetch items (${itemCount} total).${datasetSizeNextStepHint(dataset?.inflatedBytes)}${fieldsProjectionHint(fields)}`,
         };
     }
 
@@ -501,7 +501,7 @@ function buildSucceededSummaryNextStep(
     if (itemCount === undefined && datasetId) {
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. Dataset metadata unavailable.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to inspect output.`,
+            nextStep: `Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to inspect output.`,
         };
     }
 
@@ -510,7 +510,7 @@ function buildSucceededSummaryNextStep(
     if (itemCount === 0 && datasetId) {
         return {
             summary: `SUCCEEDED in ${runTimeSecs}s. No dataset items found.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to verify output (metadata reports 0 items).${fieldsProjectionHint(dataset?.fields)}`,
+            nextStep: `Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to verify output (metadata reports 0 items).${fieldsProjectionHint(dataset?.fields)}`,
         };
     }
 
@@ -542,7 +542,7 @@ function buildTimedOutSummaryNextStep(
         const fields = dataset?.fields ?? [];
         return {
             summary: `TIMED-OUT after ${runTimeSecs}s.${kv.summarySuffix}`,
-            nextStep: `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to fetch any partial output (${itemCount} ${itemCount === 1 ? 'item' : 'items'} written). Available fields: ${fields.length > 0 ? fields.join(', ') : 'none'}.`,
+            nextStep: `Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to fetch any partial output (${itemCount} ${itemCount === 1 ? 'item' : 'items'} written). Available fields: ${fields.length > 0 ? fields.join(', ') : 'none'}.`,
         };
     }
 

--- a/src/tools/actors/actor_tools_factory.ts
+++ b/src/tools/actors/actor_tools_factory.ts
@@ -3,7 +3,12 @@ import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import log from '@apify/log';
 
 import type { ApifyClient } from '../../apify_client.js';
-import { ACTOR_MAX_MEMORY_MBYTES, HelperTools, RAG_WEB_BROWSER, RAG_WEB_BROWSER_ADDITIONAL_DESC } from '../../const.js';
+import {
+    ACTOR_MAX_MEMORY_MBYTES,
+    HELPER_TOOLS,
+    RAG_WEB_BROWSER,
+    RAG_WEB_BROWSER_ADDITIONAL_DESC,
+} from '../../const.js';
 import { ActorLoadError } from '../../errors.js';
 import { getActorMCPServerPath, getActorMCPServerURL } from '../../mcp/actors.js';
 import { connectMCPClient } from '../../mcp/client.js';
@@ -46,7 +51,7 @@ const WAIT_SECS_INPUT_PROPERTY = {
     description:
         `Max seconds (0–45, default ${CALL_ACTOR_WAIT_SECS_DEFAULT}) to cap the wait for the Actor run to reach terminal state. ` +
         'For long-running Actors the response returns at the cap with the current run status; ' +
-        `follow \`nextStep\` to poll via ${HelperTools.ACTOR_RUNS_GET}. Set to 0 to fire-and-forget.`,
+        `follow \`nextStep\` to poll via ${HELPER_TOOLS.ACTOR_RUNS_GET}. Set to 0 to fire-and-forget.`,
 } as const;
 
 /**
@@ -127,7 +132,7 @@ export async function getNormalActorsAsTools(
         };
 
         let description = `This tool calls the Actor "${definition.actorFullName}" and retrieves its output results.
-Use this tool instead of the "${HelperTools.ACTOR_CALL}" if user requests this specific Actor.
+Use this tool instead of the "${HELPER_TOOLS.ACTOR_CALL}" if user requests this specific Actor.
 Actor description: ${definition.description}`;
         if (isRag) {
             description += RAG_WEB_BROWSER_ADDITIONAL_DESC;

--- a/src/tools/actors/add_actor.ts
+++ b/src/tools/actors/add_actor.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { ApifyClient } from '../../apify_client.js';
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -15,12 +15,12 @@ export const addToolArgsSchema = z.object({
 });
 export const addActor: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.ACTOR_ADD,
+    name: HELPER_TOOLS.ACTOR_ADD,
     title: 'Add tool',
     description: `Add an Actor or MCP server to the Apify MCP Server as an available tool.
 This does not execute the Actor; it only registers it so it can be called later.
 
-You can first discover Actors using the ${HelperTools.STORE_SEARCH} tool, then add the selected Actor as a tool.
+You can first discover Actors using the ${HELPER_TOOLS.STORE_SEARCH} tool, then add the selected Actor as a tool.
 
 USAGE:
 - Use when a user has chosen an Actor to work with and you need to make it available as a callable tool.

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -11,7 +11,7 @@ import {
     APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED,
     APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED,
     FAILURE_CATEGORY,
-    HelperTools,
+    HELPER_TOOLS,
     TOOL_STATUS,
 } from '../../const.js';
 import { ACTOR_LOAD_ERROR_KIND, ActorLoadError } from '../../errors.js';
@@ -60,7 +60,7 @@ export const CALL_ACTOR_MCP_SERVER_SECTION = `For MCP server Actors:
 /** Shared "two ways to run" + USAGE section — identical in both modes. */
 export const CALL_ACTOR_USAGE_SECTION = `There are two ways to run Actors:
 1. Dedicated Actor tools (e.g., ${RAG_WEB_BROWSER_TOOL}): These are pre-configured tools, offering a simpler and more direct experience.
-2. Generic call-actor tool (${HelperTools.ACTOR_CALL}): Use this when a dedicated tool is not available or when you want to run any Actor dynamically. This tool is especially useful if you do not want to add specific tools or your client does not support dynamic tool registration.
+2. Generic call-actor tool (${HELPER_TOOLS.ACTOR_CALL}): Use this when a dedicated tool is not available or when you want to run any Actor dynamically. This tool is especially useful if you do not want to add specific tools or your client does not support dynamic tool registration.
 
 USAGE:
 - Always use dedicated tools when available (e.g., ${RAG_WEB_BROWSER_TOOL})
@@ -75,13 +75,13 @@ type CallActorErrorResponseParams = {
     error: unknown;
     actorId?: string;
     mcpSessionId?: string;
-    actorGetDetailsTool: HelperTools.ACTOR_GET_DETAILS;
+    actorGetDetailsTool: typeof HELPER_TOOLS.ACTOR_GET_DETAILS;
 };
 
 const WIDGET_ADDENDUM = dedent`
     WIDGET ALTERNATIVE (apps mode):
-    - If the user explicitly asks to see live progress, call ${HelperTools.ACTOR_CALL_WIDGET} instead — it renders an interactive UI that tracks the run.
-    - For silent name resolution before this call, use ${HelperTools.STORE_SEARCH} (not ${HelperTools.STORE_SEARCH_WIDGET}, which renders UI).
+    - If the user explicitly asks to see live progress, call ${HELPER_TOOLS.ACTOR_CALL_WIDGET} instead — it renders an interactive UI that tracks the run.
+    - For silent name resolution before this call, use ${HELPER_TOOLS.STORE_SEARCH} (not ${HELPER_TOOLS.STORE_SEARCH_WIDGET}, which renders UI).
 `;
 
 function buildCallActorDescriptionSections(includeWidget: boolean): string {
@@ -89,16 +89,16 @@ function buildCallActorDescriptionSections(includeWidget: boolean): string {
         'Call any Actor from the Apify Store.',
         dedent`
             WORKFLOW:
-            1. Use ${HelperTools.ACTOR_GET_DETAILS} to get the Actor's input schema
+            1. Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} to get the Actor's input schema
             2. Call this tool with the actor name and proper input based on the schema
 
-            If the actor name is not in "username/name" format and ${HelperTools.STORE_SEARCH} is available in this session, use it to resolve the correct Actor first.
+            If the actor name is not in "username/name" format and ${HELPER_TOOLS.STORE_SEARCH} is available in this session, use it to resolve the correct Actor first.
         `,
         CALL_ACTOR_MCP_SERVER_SECTION,
         dedent`
             IMPORTANT:
             - Waits up to waitSecs (default 30s) for completion; returns run status, storage IDs, and field metadata
-            - Use ${HelperTools.DATASET_GET_ITEMS} with the datasetId to fetch results; non-terminal runs include a nextStep with polling instructions
+            - Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with the datasetId to fetch results; non-terminal runs include a nextStep with polling instructions
             - Use dedicated Actor tools when available for better experience
         `,
         CALL_ACTOR_USAGE_SECTION,
@@ -202,7 +202,7 @@ export function buildCallActorErrorResponse(params: CallActorErrorResponseParams
             `Failed to call Actor '${actorName}': ${errMsg}`,
             `Please verify the Actor name, input parameters, and ensure the Actor exists.`,
             // "if available" — search-actors may not be loaded in apps-mode partial tool selections.
-            `If ${HelperTools.STORE_SEARCH} is available in this session, you can use it to search for available Actors, or get Actor details using: ${actorGetDetailsTool}.`,
+            `If ${HELPER_TOOLS.STORE_SEARCH} is available in this session, you can use it to search for available Actors, or get Actor details using: ${actorGetDetailsTool}.`,
         ],
         isError: true,
         telemetry,
@@ -455,7 +455,7 @@ export async function resolveAndValidateActor(params: {
                     dedent`
                     Actor '${actorName}' was not found.
                     Please verify Actor ID or name format (e.g., "username/name" like "apify/rag-web-browser") and ensure that the Actor exists.
-                    You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
+                    You can search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}.
                 `,
                 ],
                 isError: true,
@@ -608,7 +608,7 @@ export async function callActorPreExecute(
  * `taskMode` is honored — when true, `waitSecs` is ignored and the SDK waits until terminal.
  */
 export async function executeCallActor(toolArgs: InternalToolArgs): Promise<object> {
-    const preResult = await callActorPreExecute(toolArgs, { route: HelperTools.ACTOR_CALL });
+    const preResult = await callActorPreExecute(toolArgs, { route: HELPER_TOOLS.ACTOR_CALL });
     if ('earlyResponse' in preResult) {
         return preResult.earlyResponse;
     }
@@ -682,7 +682,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<obje
             error,
             actorId: resolvedActorId,
             mcpSessionId: toolArgs.mcpSessionId,
-            actorGetDetailsTool: HelperTools.ACTOR_GET_DETAILS,
+            actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
         });
     }
 }
@@ -694,7 +694,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<obje
 function createCallActorTool(description: string): ToolEntry {
     return Object.freeze({
         type: TOOL_TYPE.INTERNAL,
-        name: HelperTools.ACTOR_CALL,
+        name: HELPER_TOOLS.ACTOR_CALL,
         title: 'Call Actor',
         description,
         inputSchema: callActorInputSchema,

--- a/src/tools/actors/fetch_actor_details.ts
+++ b/src/tools/actors/fetch_actor_details.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
+import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../const.js';
 import type { ConsoleLinkContext, HelperTool, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import {
@@ -123,7 +123,7 @@ EXAMPLES:
  */
 export const fetchActorDetailsMetadata: Omit<HelperTool, 'call'> = {
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.ACTOR_GET_DETAILS,
+    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
     title: 'Fetch Actor details',
     description: FETCH_ACTOR_DETAILS_DESCRIPTION,
     inputSchema: z.toJSONSchema(fetchActorDetailsToolArgsSchema) as ToolInputSchema,
@@ -147,7 +147,7 @@ export function buildActorNotFoundResponse(actorName: string): ReturnType<typeof
             dedent`
             Actor information for '${actorName}' was not found.
             Please verify Actor ID or name format and ensure that the Actor exists.
-            You can search for available Actors using the tool: ${HelperTools.STORE_SEARCH}.
+            You can search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}.
         `,
         ],
         isError: true,
@@ -242,7 +242,7 @@ export async function buildFetchActorDetailsResult(
 ): Promise<ReturnType<typeof buildMCPResponse>> {
     const { args, apifyToken, apifyClient, apifyMcpServer, mcpSessionId } = toolArgs;
     const parsed = fetchActorDetailsToolArgsSchema.parse(args);
-    const actorName = fixActorNameInputAndLog(parsed.actor, { mcpSessionId, route: HelperTools.ACTOR_GET_DETAILS });
+    const actorName = fixActorNameInputAndLog(parsed.actor, { mcpSessionId, route: HELPER_TOOLS.ACTOR_GET_DETAILS });
 
     const resolvedOutput = resolveOutputOptions(parsed.output);
     // Skip the /users/me round-trip when pricing isn't rendered (e.g. inputSchema-only

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, MAX_LIMIT_WITH_INPUT_SCHEMA } from '../../const.js';
+import { HELPER_TOOLS, MAX_LIMIT_WITH_INPUT_SCHEMA } from '../../const.js';
 import type {
     ActorStoreList,
     ConsoleLinkContext,
@@ -84,8 +84,8 @@ Usage:
 - You MUST always do at least two searches: first with broad keywords, then optionally with more specific terms if needed.
 
 Important limitations: This tool does not return full Actor documentation or detailed usage instructions - only summary information.
-Each result lists the Actor's input fields with their types (e.g. \`url: string, maxResults?: number\`) so you can construct an Actor call directly without a separate ${HelperTools.ACTOR_GET_DETAILS} round-trip.
-For complete Actor details (per-field descriptions, defaults, README), use the ${HelperTools.ACTOR_GET_DETAILS} tool.
+Each result lists the Actor's input fields with their types (e.g. \`url: string, maxResults?: number\`) so you can construct an Actor call directly without a separate ${HELPER_TOOLS.ACTOR_GET_DETAILS} round-trip.
+For complete Actor details (per-field descriptions, defaults, README), use the ${HELPER_TOOLS.ACTOR_GET_DETAILS} tool.
 The search is limited to publicly available Actors and excludes rental and restricted Actors.
 
 Returns list of Actor cards with the following info:
@@ -107,7 +107,7 @@ Returns list of Actor cards with the following info:
  */
 export const searchActorsMetadata: Omit<HelperTool, 'call'> = {
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.STORE_SEARCH,
+    name: HELPER_TOOLS.STORE_SEARCH,
     title: 'Search Actors',
     description: SEARCH_ACTORS_DESCRIPTION,
     inputSchema: z.toJSONSchema(searchActorsBaseArgsSchema) as ToolInputSchema,
@@ -189,7 +189,7 @@ export const searchActors: ToolEntry = Object.freeze({
             userTier: userPlanTier,
             instructions: dedent`
                 If you need more detailed information about any of these Actors, including their
-                input schemas and usage instructions, please use the ${HelperTools.ACTOR_GET_DETAILS}
+                input schemas and usage instructions, please use the ${HELPER_TOOLS.ACTOR_GET_DETAILS}
                 tool with the specific Actor name.
                 IMPORTANT: You MUST always do a second search with broader, more generic keywords
                 (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
@@ -210,7 +210,7 @@ export const searchActors: ToolEntry = Object.freeze({
         `;
         const footer = dedent`
             If you need more detailed information about any of these Actors, including their input
-            schemas and usage instructions, use the ${HelperTools.ACTOR_GET_DETAILS} tool with the
+            schemas and usage instructions, use the ${HELPER_TOOLS.ACTOR_GET_DETAILS} tool with the
             specific Actor name.
             IMPORTANT: You MUST always do a second search with broader, more generic keywords
             (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure

--- a/src/tools/docs/fetch_apify_docs.ts
+++ b/src/tools/docs/fetch_apify_docs.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import log from '@apify/log';
 
-import { ALLOWED_DOC_DOMAINS, FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
+import { ALLOWED_DOC_DOMAINS, FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../const.js';
 import { fetchApifyDocsCache } from '../../state.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
@@ -54,15 +54,15 @@ export function isAllowedDocsUrl(url: string): boolean {
 function buildFetchErrorMessage(url: string, detail: string): string {
     return `Failed to fetch the documentation page at "${url}". ${detail} \
 Please verify the URL is correct and accessible. \
-You can search for available documentation pages using the ${HelperTools.DOCS_SEARCH} tool.`;
+You can search for available documentation pages using the ${HELPER_TOOLS.DOCS_SEARCH} tool.`;
 }
 
 export const fetchApifyDocs: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.DOCS_FETCH,
+    name: HELPER_TOOLS.DOCS_FETCH,
     title: 'Fetch Apify docs',
     description: `Fetch the full content of an Apify or Crawlee documentation page by its URL.
-Use this after finding a relevant page with the ${HelperTools.DOCS_SEARCH} tool.
+Use this after finding a relevant page with the ${HELPER_TOOLS.DOCS_SEARCH} tool.
 
 USAGE:
 - Use when you need the complete content of a specific docs page for detailed answers.
@@ -98,7 +98,7 @@ USAGE EXAMPLES:
 Only documentation URLs from Apify and Crawlee are allowed \
 (starting with ${ALLOWED_DOC_DOMAINS.map((d) => `"${d}"`).join(' or ')}). \
 Please provide a valid documentation URL. \
-You can find documentation URLs using the ${HelperTools.DOCS_SEARCH} tool.`,
+You can find documentation URLs using the ${HELPER_TOOLS.DOCS_SEARCH} tool.`,
                 ],
                 isError: true,
                 telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },

--- a/src/tools/docs/search_apify_docs.ts
+++ b/src/tools/docs/search_apify_docs.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { DOCS_SOURCES, HelperTools } from '../../const.js';
+import { DOCS_SOURCES, HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -36,7 +36,7 @@ ${sources}
 The results will include the URL of the documentation page (which may include an anchor),
 and a limited piece of content that matches the search query.
 
-Fetch the full content of the document using the ${HelperTools.DOCS_FETCH} tool by providing the URL.
+Fetch the full content of the document using the ${HELPER_TOOLS.DOCS_FETCH} tool by providing the URL.
 
 ${PLATFORM_DOCS_PREFERENCE}`;
 }
@@ -70,7 +70,7 @@ const searchApifyDocsToolInputSchema = z.toJSONSchema(searchApifyDocsToolArgsSch
 
 export const searchApifyDocs: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.DOCS_SEARCH,
+    name: HELPER_TOOLS.DOCS_SEARCH,
     title: 'Search Apify docs',
     description: buildToolDescription(),
     inputSchema: searchApifyDocsToolInputSchema,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,4 @@
-import { HelperTools } from '../const.js';
+import { HELPER_TOOLS } from '../const.js';
 import type { ToolCategory, ToolEntry } from '../types.js';
 import { ServerMode } from '../types.js';
 import { getExpectedToolsByCategories } from '../utils/tool_categories_helpers.js';
@@ -14,10 +14,10 @@ import {
 
 // Use string constants instead of tool object imports to avoid circular dependencies
 export const unauthEnabledTools: string[] = [
-    HelperTools.DOCS_SEARCH,
-    HelperTools.DOCS_FETCH,
-    HelperTools.STORE_SEARCH,
-    HelperTools.ACTOR_GET_DETAILS,
+    HELPER_TOOLS.DOCS_SEARCH,
+    HELPER_TOOLS.DOCS_FETCH,
+    HELPER_TOOLS.STORE_SEARCH,
+    HELPER_TOOLS.ACTOR_GET_DETAILS,
 ];
 
 // Re-export from registry.ts

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,6 @@
 import { HELPER_TOOLS } from '../const.js';
 import type { ToolCategory, ToolEntry } from '../types.js';
-import { ServerMode } from '../types.js';
+import { SERVER_MODE } from '../types.js';
 import { getExpectedToolsByCategories } from '../utils/tool_categories_helpers.js';
 import { getActorsAsTools } from './actors/actor_tools_factory.js';
 import type { ActorsAsToolsResult } from './actors/actor_tools_factory.js';
@@ -28,7 +28,7 @@ export { CATEGORY_NAME_SET, CATEGORY_NAMES, getCategoryTools, toolCategories, to
  * Returns the tool entries for the default-enabled categories resolved for the given mode.
  * Computed here (not in helper file) to avoid module initialization issues.
  */
-export function getDefaultTools(mode: ServerMode = ServerMode.DEFAULT): ToolEntry[] {
+export function getDefaultTools(mode: SERVER_MODE = SERVER_MODE.DEFAULT): ToolEntry[] {
     return getExpectedToolsByCategories(toolCategoriesEnabledByDefault, mode);
 }
 
@@ -39,7 +39,7 @@ export function getDefaultTools(mode: ServerMode = ServerMode.DEFAULT): ToolEntr
  */
 export function getUnauthEnabledToolCategories(): ToolCategory[] {
     const unauthEnabledToolsSet = new Set(unauthEnabledTools);
-    const categories = getCategoryTools(ServerMode.DEFAULT);
+    const categories = getCategoryTools(SERVER_MODE.DEFAULT);
     return (Object.entries(categories) as [ToolCategory, ToolEntry[]][])
         .filter(([, tools]) => tools.every((tool) => unauthEnabledToolsSet.has(tool.name)))
         .map(([category]) => category);

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -19,7 +19,7 @@
  * tools, `search-actors`, `fetch-actor-details`) share a single implementation across modes.
  * Do NOT add per-mode runtime variants for non-widget tools.
  */
-import { HelperTools } from '../const.js';
+import { HELPER_TOOLS, type HelperToolName } from '../const.js';
 import type { ToolEntry } from '../types.js';
 import { ServerMode } from '../types.js';
 import { addActor } from './actors/add_actor.js';
@@ -145,9 +145,9 @@ export const toolCategoriesEnabledByDefault: (typeof CATEGORY_NAMES)[number][] =
  * does NOT auto-bring its base; callers asking for widget-only get a UI without
  * the programmatic data tool. To get both, select the base (or both explicitly).
  */
-export const WIDGET_BY_BASE_TOOL: ReadonlyMap<HelperTools, ToolEntry> = new Map([
-    [HelperTools.STORE_SEARCH, searchActorsWidget],
-    [HelperTools.ACTOR_GET_DETAILS, fetchActorDetailsWidget],
-    [HelperTools.ACTOR_CALL, callActorWidget],
-    [HelperTools.ACTOR_RUNS_GET, getActorRunWidget],
+export const WIDGET_BY_BASE_TOOL: ReadonlyMap<HelperToolName, ToolEntry> = new Map([
+    [HELPER_TOOLS.STORE_SEARCH, searchActorsWidget],
+    [HELPER_TOOLS.ACTOR_GET_DETAILS, fetchActorDetailsWidget],
+    [HELPER_TOOLS.ACTOR_CALL, callActorWidget],
+    [HELPER_TOOLS.ACTOR_RUNS_GET, getActorRunWidget],
 ]);

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -21,7 +21,7 @@
  */
 import { HELPER_TOOLS, type HelperToolName } from '../const.js';
 import type { ToolEntry } from '../types.js';
-import { ServerMode } from '../types.js';
+import { SERVER_MODE } from '../types.js';
 import { addActor } from './actors/add_actor.js';
 import { callActorApps, callActorDefault } from './actors/call_actor.js';
 import { fetchActorDetails } from './actors/fetch_actor_details.js';
@@ -45,7 +45,7 @@ import { fetchActorDetailsWidget } from './widgets/fetch_actor_details_widget.js
 import { getActorRunWidget } from './widgets/get_actor_run_widget.js';
 import { searchActorsWidget } from './widgets/search_actors_widget.js';
 
-type ModeMap = Partial<Record<ServerMode, ToolEntry>>;
+type ModeMap = Partial<Record<SERVER_MODE, ToolEntry>>;
 
 /** A category tool entry: plain ToolEntry (mode-independent) or a mode map. */
 type CategoryToolEntry = ToolEntry | ModeMap;
@@ -59,7 +59,7 @@ function isModeMap(entry: CategoryToolEntry): entry is ModeMap {
  * Unified tool category definitions — single source of truth.
  *
  * Each entry is either a plain ToolEntry (mode-independent) or a mode map
- * with ServerMode keys mapping to their ToolEntry variant.
+ * with SERVER_MODE keys mapping to their ToolEntry variant.
  *
  * Use {@link getCategoryTools} to resolve entries into concrete ToolEntry arrays for a given mode.
  */
@@ -104,7 +104,7 @@ export type ToolCategoryMap = Record<(typeof CATEGORY_NAMES)[number], ToolEntry[
  * - Plain ToolEntry (has `name`) → always included, mode-independent
  * - ModeMap → look up `entry[mode]`; included only if the mode key exists
  */
-function resolveCategoryEntries(entries: readonly CategoryToolEntry[], mode: ServerMode): ToolEntry[] {
+function resolveCategoryEntries(entries: readonly CategoryToolEntry[], mode: SERVER_MODE): ToolEntry[] {
     const result: ToolEntry[] = [];
     for (const entry of entries) {
         if (isModeMap(entry)) {
@@ -126,9 +126,9 @@ function resolveCategoryEntries(entries: readonly CategoryToolEntry[], mode: Ser
  * (async execution, widget metadata), default mode gets standard implementations.
  * Apps-only tools are excluded in default mode.
  *
- * @param mode - Optional. Use `'default'` or `'apps'`. Defaults to `ServerMode.DEFAULT` when omitted.
+ * @param mode - Optional. Use `'default'` or `'apps'`. Defaults to `SERVER_MODE.DEFAULT` when omitted.
  */
-export function getCategoryTools(mode: ServerMode = ServerMode.DEFAULT): ToolCategoryMap {
+export function getCategoryTools(mode: SERVER_MODE = SERVER_MODE.DEFAULT): ToolCategoryMap {
     return Object.fromEntries(
         CATEGORY_NAMES.map((name) => [name, resolveCategoryEntries(toolCategories[name], mode)]),
     ) as ToolCategoryMap;

--- a/src/tools/runs/abort_actor_run.ts
+++ b/src/tools/runs/abort_actor_run.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -21,7 +21,7 @@ const abortRunArgs = z.object({
  */
 export const abortActorRun: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.ACTOR_RUNS_ABORT,
+    name: HELPER_TOOLS.ACTOR_RUNS_ABORT,
     title: 'Abort Actor run',
     description: `Abort an Actor run that is currently starting or running.
 For runs with status FINISHED, FAILED, ABORTING, or TIMED-OUT, this call has no effect.

--- a/src/tools/runs/get_actor_run.ts
+++ b/src/tools/runs/get_actor_run.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, TOOL_STATUS } from '../../const.js';
+import { HELPER_TOOLS, TOOL_STATUS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { ConsoleLinkContext, HelperTool, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
@@ -40,9 +40,9 @@ Returns run result: status, storages (datasets/keyValueStores alias map), stats,
 - waitSecs (0–${WAIT_SECS_MAX}, default ${WAIT_SECS_DEFAULT}) waits up to that many seconds for terminal status before returning.
 
 USAGE:
-- Use to check the status of a run started with ${HelperTools.ACTOR_CALL}.
+- Use to check the status of a run started with ${HELPER_TOOLS.ACTOR_CALL}.
 - Pass waitSecs > 0 to block until terminal (or until the cap elapses).
-- If \`${HelperTools.ACTOR_CALL_WIDGET}\` or \`${HelperTools.ACTOR_RUNS_GET_WIDGET}\` rendered a widget for this run, do NOT poll here — the widget self-polls.
+- If \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` or \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` rendered a widget for this run, do NOT poll here — the widget self-polls.
 
 USAGE EXAMPLES:
 - user_input: Show details of run y2h7sK3Wc
@@ -54,7 +54,7 @@ USAGE EXAMPLES:
  */
 export const getActorRunMetadata: Omit<HelperTool, 'call'> = {
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.ACTOR_RUNS_GET,
+    name: HELPER_TOOLS.ACTOR_RUNS_GET,
     title: 'Get Actor run',
     description: GET_ACTOR_RUN_DESCRIPTION,
     // `fixZodSchemaRequired` strips fields with a real `default` from `required` so MCP clients

--- a/src/tools/runs/get_actor_run_list.ts
+++ b/src/tools/runs/get_actor_run_list.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { ApifyClient } from '../../apify_client.js';
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -35,7 +35,7 @@ const getUserRunsListArgs = z.object({
  */
 export const getActorRunList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.ACTOR_RUN_LIST_GET,
+    name: HELPER_TOOLS.ACTOR_RUN_LIST_GET,
     title: 'Get user runs list',
     description: `List Actor runs for the authenticated user with optional filtering and sorting.
 The results will include run details (including datasetId and keyValueStoreId) and can be filtered by status.

--- a/src/tools/runs/get_actor_run_log.ts
+++ b/src/tools/runs/get_actor_run_log.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -16,7 +16,7 @@ const GetRunLogArgs = z.object({
  */
 export const getActorRunLog: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.ACTOR_RUNS_LOG,
+    name: HELPER_TOOLS.ACTOR_RUNS_LOG,
     title: 'Get Actor run log',
     description: `Retrieve recent log lines for a specific Actor run.
 The results will include the last N lines of the run's log output (plain text).

--- a/src/tools/storage/get_dataset.ts
+++ b/src/tools/storage/get_dataset.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -21,12 +21,12 @@ const getDatasetArgs = z.object({
  */
 export const getDataset: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.DATASET_GET,
+    name: HELPER_TOOLS.DATASET_GET,
     title: 'Get dataset',
     description: dedent`
         Get metadata for a dataset (collection of structured data created by an Actor run).
         The results will include dataset details such as itemCount, fields, and stats.
-        Use fields to understand structure for filtering with ${HelperTools.DATASET_GET_ITEMS}.
+        Use fields to understand structure for filtering with ${HELPER_TOOLS.DATASET_GET_ITEMS}.
         stats.inflatedBytes (when present) is the approximate uncompressed byte size — use it with itemCount to pick a safe limit and fields before fetching.
         Note: itemCount updates may be delayed by up to ~5 seconds.
 
@@ -75,7 +75,7 @@ export const getDataset: ToolEntry = Object.freeze({
         // response today (only the dataset-list endpoint returns it), so read it defensively.
         const inflatedBytes = (dataset.stats as { inflatedBytes?: number } | undefined)?.inflatedBytes;
         const summary = `Dataset '${normalized.name ?? datasetId}' has ${normalized.itemCount ?? 0} items${fieldCount !== undefined ? `, ${fieldCount} fields` : ''}.`;
-        const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to fetch items.${datasetSizeNextStepHint(inflatedBytes)}`;
+        const nextStep = `Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to fetch items.${datasetSizeNextStepHint(inflatedBytes)}`;
         return buildStorageResponse({
             structuredContent: normalized as unknown as Record<string, unknown>,
             summary,

--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
+import { HELPER_TOOLS, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -64,11 +64,11 @@ const getDatasetItemsArgs = z.object({
  */
 export const getDatasetItems: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.DATASET_GET_ITEMS,
+    name: HELPER_TOOLS.DATASET_GET_ITEMS,
     title: 'Get dataset items',
     description: dedent`
         Retrieve dataset items with pagination, sorting, and field selection.
-        Items can be large; when you only need specific columns, pass fields to reduce response size (use ${HelperTools.DATASET_GET} first if you don't know the field names).
+        Items can be large; when you only need specific columns, pass fields to reduce response size (use ${HELPER_TOOLS.DATASET_GET} first if you don't know the field names).
         For nested fields use dot notation (e.g., fields="metadata.url") — the server auto-flattens parent prefixes.
         Defaults limit to ${DEFAULT_DATASET_ITEMS_LIMIT}. Use clean=true to skip empty items and hidden fields.
 

--- a/src/tools/storage/get_dataset_list.ts
+++ b/src/tools/storage/get_dataset_list.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -35,7 +35,7 @@ const getUserDatasetsListArgs = z.object({
  */
 export const getDatasetList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.DATASET_LIST_GET,
+    name: HELPER_TOOLS.DATASET_LIST_GET,
     title: 'Get user datasets list',
     description: dedent`
         List datasets (collections of Actor run data) for the authenticated user.
@@ -75,8 +75,8 @@ export const getDatasetList: ToolEntry = Object.freeze({
             total: datasets.total,
             offset: datasets.offset,
             noun: 'datasets',
-            listToolName: HelperTools.DATASET_LIST_GET,
-            inspectHint: `Use ${HelperTools.DATASET_GET} with a datasetId from the list to inspect a dataset.`,
+            listToolName: HELPER_TOOLS.DATASET_LIST_GET,
+            inspectHint: `Use ${HELPER_TOOLS.DATASET_GET} with a datasetId from the list to inspect a dataset.`,
         });
         return buildStorageResponse({
             structuredContent: datasets as unknown as Record<string, unknown>,

--- a/src/tools/storage/get_dataset_schema.ts
+++ b/src/tools/storage/get_dataset_schema.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, HTTP_NOT_FOUND, TOOL_STATUS } from '../../const.js';
+import { HELPER_TOOLS, HTTP_NOT_FOUND, TOOL_STATUS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -26,7 +26,7 @@ const getDatasetSchemaArgs = z.object({
  */
 export const getDatasetSchema: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.DATASET_SCHEMA_GET,
+    name: HELPER_TOOLS.DATASET_SCHEMA_GET,
     title: 'Get dataset schema',
     description: dedent`
         Generate a JSON schema from a sample of dataset items.
@@ -77,7 +77,7 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
             // Empty dataset: no items to infer from, but still emit a schema-conforming
             // response (empty schema = "any") rather than bare text.
             const summary = `Dataset '${datasetId}' is empty; no schema to infer.`;
-            const nextStep = `Use ${HelperTools.DATASET_GET} with datasetId=${datasetId} to check itemCount and stats.`;
+            const nextStep = `Use ${HELPER_TOOLS.DATASET_GET} with datasetId=${datasetId} to check itemCount and stats.`;
             return buildStorageResponse({ structuredContent: { datasetId, schema: {} }, summary, nextStep });
         }
 
@@ -98,7 +98,7 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
 
         const fieldCount = Object.keys(schema.items.properties ?? {}).length;
         const summary = `Schema inferred from ${datasetItems.length} ${datasetItems.length === 1 ? 'item' : 'items'}, ${fieldCount} ${fieldCount === 1 ? 'field' : 'fields'}.`;
-        const nextStep = `Use ${HelperTools.DATASET_GET_ITEMS} with datasetId=${datasetId} and fields="..." to project specific fields.`;
+        const nextStep = `Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with datasetId=${datasetId} and fields="..." to project specific fields.`;
         return buildStorageResponse({ structuredContent: { datasetId, schema }, summary, nextStep });
     },
 } as const);

--- a/src/tools/storage/get_key_value_store.ts
+++ b/src/tools/storage/get_key_value_store.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -19,7 +19,7 @@ const getKeyValueStoreArgs = z.object({
  */
 export const getKeyValueStore: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.KEY_VALUE_STORE_GET,
+    name: HELPER_TOOLS.KEY_VALUE_STORE_GET,
     title: 'Get key-value store',
     description: dedent`
         Get details about a key-value store by ID or username~store-name.
@@ -53,7 +53,7 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
         const linkContext = await getConsoleLinkContext(apifyToken, client);
         const bytes = (kvStore.stats as { storageBytes?: number } | undefined)?.storageBytes;
         const summary = `Key-value store '${kvStore.name ?? keyValueStoreId}'${bytes !== undefined ? ` holds ${bytes} bytes` : ''}.`;
-        const nextStep = `Use ${HelperTools.KEY_VALUE_STORE_KEYS_GET} with keyValueStoreId=${keyValueStoreId} to list keys.`;
+        const nextStep = `Use ${HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET} with keyValueStoreId=${keyValueStoreId} to list keys.`;
         return buildStorageResponse({
             structuredContent: kvStore as unknown as Record<string, unknown>,
             summary,

--- a/src/tools/storage/get_key_value_store_keys.ts
+++ b/src/tools/storage/get_key_value_store_keys.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, HTTP_NOT_FOUND } from '../../const.js';
+import { HELPER_TOOLS, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -25,7 +25,7 @@ const getKeyValueStoreKeysArgs = z.object({
  */
 export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.KEY_VALUE_STORE_KEYS_GET,
+    name: HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET,
     title: 'Get key-value store keys',
     description: dedent`
         List keys in a key-value store with optional pagination.

--- a/src/tools/storage/get_key_value_store_list.ts
+++ b/src/tools/storage/get_key_value_store_list.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -37,7 +37,7 @@ const getUserKeyValueStoresListArgs = z.object({
  */
 export const getKeyValueStoreList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.KEY_VALUE_STORE_LIST_GET,
+    name: HELPER_TOOLS.KEY_VALUE_STORE_LIST_GET,
     title: 'Get user key-value stores list',
     description: dedent`
         List key-value stores owned by the authenticated user.
@@ -76,8 +76,8 @@ export const getKeyValueStoreList: ToolEntry = Object.freeze({
             total: stores.total,
             offset: stores.offset,
             noun: 'key-value stores',
-            listToolName: HelperTools.KEY_VALUE_STORE_LIST_GET,
-            inspectHint: `Use ${HelperTools.KEY_VALUE_STORE_GET} with a keyValueStoreId from the list to inspect a store.`,
+            listToolName: HELPER_TOOLS.KEY_VALUE_STORE_LIST_GET,
+            inspectHint: `Use ${HELPER_TOOLS.KEY_VALUE_STORE_GET} with a keyValueStoreId from the list to inspect a store.`,
         });
         return buildStorageResponse({
             structuredContent: stores as unknown as Record<string, unknown>,

--- a/src/tools/storage/get_key_value_store_record.ts
+++ b/src/tools/storage/get_key_value_store_record.ts
@@ -2,7 +2,7 @@ import type { AudioContent, EmbeddedResource, ImageContent, ResourceLink } from 
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools, KV_RECORD_MAX_INLINE_BYTES } from '../../const.js';
+import { HELPER_TOOLS, KV_RECORD_MAX_INLINE_BYTES } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -26,7 +26,7 @@ const getKeyValueStoreRecordArgs = z.object({
  */
 export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.KEY_VALUE_STORE_RECORD_GET,
+    name: HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET,
     title: 'Get key-value store record',
     description: dedent`
         Get a value stored in a key-value store under a specific key.

--- a/src/tools/storage/storage_helpers.ts
+++ b/src/tools/storage/storage_helpers.ts
@@ -1,4 +1,4 @@
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../const.js';
+import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../const.js';
 import { VERBATIM_LINKS_NUDGE } from '../../utils/console_link.js';
 import { encodeToon } from '../../utils/encode_text.js';
 import { QUOTE_WRAPPER_CHARS } from '../../utils/generic.js';
@@ -109,7 +109,7 @@ export function buildDatasetItemsSummaryNextStep(params: {
     if (offset + itemCount < totalItemCount) {
         return {
             summary: `Fetched ${itemCount} of ${totalItemCount} items (offset=${offset}).`,
-            nextStep: `Call ${HelperTools.DATASET_GET_ITEMS} again with offset=${offset + itemCount} to fetch the next page.`,
+            nextStep: `Call ${HELPER_TOOLS.DATASET_GET_ITEMS} again with offset=${offset + itemCount} to fetch the next page.`,
         };
     }
     const summary =
@@ -118,8 +118,8 @@ export function buildDatasetItemsSummaryNextStep(params: {
             : `Fetched ${itemCount} of ${totalItemCount} items (offset=${offset}); no more pages.`;
     return {
         summary,
-        nextStep: suggestTool(HelperTools.DATASET_GET, loadedToolNames)
-            ? `Use ${HelperTools.DATASET_GET} with datasetId=${datasetId} to see the field list if you need the data structure.`
+        nextStep: suggestTool(HELPER_TOOLS.DATASET_GET, loadedToolNames)
+            ? `Use ${HELPER_TOOLS.DATASET_GET} with datasetId=${datasetId} to see the field list if you need the data structure.`
             : `No more pages. Inspect the returned items directly.`,
     };
 }
@@ -141,14 +141,14 @@ export function buildKvsKeysSummaryNextStep(params: {
     if (isTruncated && nextExclusiveStartKey) {
         return {
             summary,
-            nextStep: `Call ${HelperTools.KEY_VALUE_STORE_KEYS_GET} again with exclusiveStartKey=${nextExclusiveStartKey} to fetch the next page.`,
+            nextStep: `Call ${HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET} again with exclusiveStartKey=${nextExclusiveStartKey} to fetch the next page.`,
         };
     }
     return {
         summary,
         nextStep: firstKey
-            ? `Use ${HelperTools.KEY_VALUE_STORE_RECORD_GET} with keyValueStoreId=${keyValueStoreId} and recordKey=${firstKey} to read a value.`
-            : `Use ${HelperTools.KEY_VALUE_STORE_GET} with keyValueStoreId=${keyValueStoreId} to inspect the store.`,
+            ? `Use ${HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET} with keyValueStoreId=${keyValueStoreId} and recordKey=${firstKey} to read a value.`
+            : `Use ${HELPER_TOOLS.KEY_VALUE_STORE_GET} with keyValueStoreId=${keyValueStoreId} to inspect the store.`,
     };
 }
 

--- a/src/tools/widgets/call_actor_widget.ts
+++ b/src/tools/widgets/call_actor_widget.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import log from '@apify/log';
 
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
@@ -52,21 +52,21 @@ const CALL_ACTOR_WIDGET_DESCRIPTION = dedent`
     completion — do NOT poll or call any other tool after this.
 
     For silent async starts where no UI is needed (e.g., "start this in the background",
-    or when your next step is to fetch results via ${HelperTools.DATASET_GET_ITEMS}), use
-    ${HelperTools.ACTOR_CALL} instead — it returns the same runId without rendering a widget.
+    or when your next step is to fetch results via ${HELPER_TOOLS.DATASET_GET_ITEMS}), use
+    ${HELPER_TOOLS.ACTOR_CALL} instead — it returns the same runId without rendering a widget.
 
     WORKFLOW:
-    1. Use ${HelperTools.ACTOR_GET_DETAILS} to get the Actor's input schema
+    1. Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} to get the Actor's input schema
     2. Call this tool with the actor name and proper input based on the schema
 
-    If the actor name is not in "username/name" format, use ${HelperTools.STORE_SEARCH} to resolve the correct Actor first.
+    If the actor name is not in "username/name" format, use ${HELPER_TOOLS.STORE_SEARCH} to resolve the correct Actor first.
 
     Input: actor name and input JSON; callOptions (memory, timeout) are optional.
 `;
 
 export const callActorWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.ACTOR_CALL_WIDGET,
+    name: HELPER_TOOLS.ACTOR_CALL_WIDGET,
     title: 'Call Actor (widget)',
     description: CALL_ACTOR_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(callActorWidgetArgsSchema) as ToolInputSchema,
@@ -87,14 +87,14 @@ export const callActorWidget: ToolEntry = Object.freeze({
         if (typeof rawActor === 'string' && rawActor.includes(':')) {
             return buildMCPResponse({
                 texts: [
-                    `${HelperTools.ACTOR_CALL_WIDGET} does not render widgets for MCP tool calls.`,
-                    `Use ${HelperTools.ACTOR_CALL} for the "actorName:toolName" syntax.`,
+                    `${HELPER_TOOLS.ACTOR_CALL_WIDGET} does not render widgets for MCP tool calls.`,
+                    `Use ${HELPER_TOOLS.ACTOR_CALL} for the "actorName:toolName" syntax.`,
                 ],
                 isError: true,
             });
         }
 
-        const preResult = await callActorPreExecute(toolArgs, { route: HelperTools.ACTOR_CALL_WIDGET });
+        const preResult = await callActorPreExecute(toolArgs, { route: HELPER_TOOLS.ACTOR_CALL_WIDGET });
         if ('earlyResponse' in preResult) {
             return preResult.earlyResponse;
         }
@@ -134,7 +134,7 @@ export const callActorWidget: ToolEntry = Object.freeze({
                 error,
                 actorId: resolvedActorId,
                 mcpSessionId: toolArgs.mcpSessionId,
-                actorGetDetailsTool: HelperTools.ACTOR_GET_DETAILS,
+                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
             });
         }
     },

--- a/src/tools/widgets/fetch_actor_details_widget.ts
+++ b/src/tools/widgets/fetch_actor_details_widget.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
@@ -38,7 +38,7 @@ const FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION = dedent`
     The response renders as an interactive widget the user can view directly.
 
     For silent data lookups (e.g., fetching the input schema before calling an Actor, inspecting README
-    for decision making), use ${HelperTools.ACTOR_GET_DETAILS} instead — it returns the same data
+    for decision making), use ${HELPER_TOOLS.ACTOR_GET_DETAILS} instead — it returns the same data
     without rendering a widget.
 
     Input: the Actor ID or full name only. Output fields are fixed by the widget contract.
@@ -46,7 +46,7 @@ const FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION = dedent`
 
 export const fetchActorDetailsWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.ACTOR_GET_DETAILS_WIDGET,
+    name: HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET,
     title: 'Fetch Actor details (widget)',
     description: FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(fetchActorDetailsWidgetArgsSchema) as ToolInputSchema,
@@ -68,7 +68,7 @@ export const fetchActorDetailsWidget: ToolEntry = Object.freeze({
         const parsed = fetchActorDetailsWidgetArgsSchema.parse(toolArgs.args);
         const actorName = fixActorNameInputAndLog(parsed.actor, {
             mcpSessionId,
-            route: HelperTools.ACTOR_GET_DETAILS_WIDGET,
+            route: HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET,
         });
 
         const { userPlanTier } = await getUserInfoCached(apifyToken, apifyClient);

--- a/src/tools/widgets/get_actor_run_widget.ts
+++ b/src/tools/widgets/get_actor_run_widget.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
@@ -32,12 +32,12 @@ const GET_ACTOR_RUN_WIDGET_DESCRIPTION = dedent`
     (e.g., "show progress for run y2h7sK3Wc", "display the status of that run").
 
     For silent data lookups (run status, dataset IDs, stats, resource IDs), use
-    ${HelperTools.ACTOR_RUNS_GET} instead — it returns the same data without rendering a widget.
+    ${HELPER_TOOLS.ACTOR_RUNS_GET} instead — it returns the same data without rendering a widget.
 `;
 
 export const getActorRunWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.ACTOR_RUNS_GET_WIDGET,
+    name: HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET,
     title: 'Get Actor run (widget)',
     description: GET_ACTOR_RUN_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(getActorRunWidgetArgsSchema) as ToolInputSchema,

--- a/src/tools/widgets/search_actors_widget.ts
+++ b/src/tools/widgets/search_actors_widget.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HelperTools } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
@@ -29,7 +29,7 @@ const SEARCH_ACTORS_WIDGET_DESCRIPTION = dedent`
     The response renders as an interactive widget the user can view directly.
 
     For silent name resolution before running an Actor (e.g., "scrape google maps" — you need to
-    find the right Actor first, then fetch its schema and call it), use ${HelperTools.STORE_SEARCH}
+    find the right Actor first, then fetch its schema and call it), use ${HELPER_TOOLS.STORE_SEARCH}
     instead — it returns the same data without rendering a widget.
 
     Input: keywords (plus optional limit/offset). Output fields are fixed by the widget contract.
@@ -37,7 +37,7 @@ const SEARCH_ACTORS_WIDGET_DESCRIPTION = dedent`
 
 export const searchActorsWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
-    name: HelperTools.STORE_SEARCH_WIDGET,
+    name: HELPER_TOOLS.STORE_SEARCH_WIDGET,
     title: 'Search Actors (widget)',
     description: SEARCH_ACTORS_WIDGET_DESCRIPTION,
     inputSchema: z.toJSONSchema(searchActorsWidgetArgsSchema) as ToolInputSchema,

--- a/src/types.ts
+++ b/src/types.ts
@@ -440,20 +440,20 @@ export type CallDiagnostics = Pick<
  * OpenAI-specific; `'openai'` is kept as a deprecated alias at CLI/env ingestion
  * (see {@link parseServerMode}) and is silently normalized to `'apps'`.
  */
-export const ServerMode = {
+export const SERVER_MODE = {
     DEFAULT: 'default',
     APPS: 'apps',
 } as const;
-export type ServerMode = (typeof ServerMode)[keyof typeof ServerMode];
+export type SERVER_MODE = (typeof SERVER_MODE)[keyof typeof SERVER_MODE];
 
 /** All valid server modes, for iteration in tests and caches. */
-export const SERVER_MODES: readonly ServerMode[] = Object.values(ServerMode);
+export const SERVER_MODES: readonly SERVER_MODE[] = Object.values(SERVER_MODE);
 
 /**
- * Server mode option — a concrete {@link ServerMode} or `'auto'` to resolve from
+ * Server mode option — a concrete {@link SERVER_MODE} or `'auto'` to resolve from
  * the client's `initialize` capabilities at connection time.
  */
-export type ServerModeOption = ServerMode | 'auto';
+export type ServerModeOption = SERVER_MODE | 'auto';
 
 /**
  * Parameters for executing a direct actor tool ({@link TOOL_TYPE.ACTOR}).
@@ -609,7 +609,7 @@ export type ActorsMcpServerOptions = {
      */
     token?: string;
     /**
-     * Server mode — controls tool variants and response formats. See {@link ServerMode}.
+     * Server mode — controls tool variants and response formats. See {@link SERVER_MODE}.
      * Pass `'auto'` (or omit) to resolve from the client's `initialize` capabilities;
      * pass `'default'` or `'apps'` to force a specific mode and skip auto-detect.
      * Defaults to `'auto'` when unset.

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -7,7 +7,7 @@
  * avoiding hallucinated calls to tools absent from `tools/list`.
  */
 
-import { HelperTools, RAG_WEB_BROWSER } from '../../const.js';
+import { HELPER_TOOLS, RAG_WEB_BROWSER } from '../../const.js';
 import { ServerMode } from '../../types.js';
 
 /**
@@ -50,16 +50,16 @@ ${
 ## Widget workflow (applies when tool responses include widget metadata)
 Some clients render widget-backed Actor tools: the response includes a live UI that automatically polls run status. When a widget is rendered, follow-up status polling by the model is a forbidden duplicate.
 
-- **After \`${HelperTools.ACTOR_CALL_WIDGET}\` or \`${HelperTools.ACTOR_RUNS_GET_WIDGET}\`, never call \`${HelperTools.ACTOR_RUNS_GET}\` or \`${HelperTools.ACTOR_RUNS_GET_WIDGET}\` for the same run.** Both widgets render live progress and poll themselves — stop after the widget response and defer to it for run status. Re-rendering the same run via \`${HelperTools.ACTOR_RUNS_GET_WIDGET}\` is a duplicate.
-- Polling \`${HelperTools.ACTOR_RUNS_GET}\` after \`${HelperTools.ACTOR_CALL}\` is fine — that tool renders no UI, so polling is expected when the run is non-terminal and you need the latest status.
+- **After \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` or \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\`, never call \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` or \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` for the same run.** Both widgets render live progress and poll themselves — stop after the widget response and defer to it for run status. Re-rendering the same run via \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` is a duplicate.
+- Polling \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` after \`${HELPER_TOOLS.ACTOR_CALL}\` is fine — that tool renders no UI, so polling is expected when the run is non-terminal and you need the latest status.
 `
         : ''
 }
 ## Tool dependencies and disambiguation
 
 ### Tool dependencies
-- \`${HelperTools.ACTOR_CALL}\`:
-  - Use \`${HelperTools.ACTOR_GET_DETAILS}\` first to obtain the Actor's input schema.
+- \`${HELPER_TOOLS.ACTOR_CALL}\`:
+  - Use \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` first to obtain the Actor's input schema.
   - Then call with proper input to execute the Actor.
   - For MCP server Actors, use format "actorName:toolName" to call specific tools.
   - Supports a \`waitSecs\` parameter (default 30, max 45):
@@ -67,21 +67,21 @@ Some clients render widget-backed Actor tools: the response includes a live UI t
     - \`waitSecs > 0\`: waits up to that many seconds for the run to complete, then returns the result.
 
 ### Tool disambiguation
-- **\`${HelperTools.STORE_SEARCH}\` vs \`${HelperTools.ACTOR_GET_DETAILS}\`:**
-  \`${HelperTools.STORE_SEARCH}\` finds Actors; \`${HelperTools.ACTOR_GET_DETAILS}\` retrieves detailed info, README, and schema for a specific Actor.
+- **\`${HELPER_TOOLS.STORE_SEARCH}\` vs \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\`:**
+  \`${HELPER_TOOLS.STORE_SEARCH}\` finds Actors; \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` retrieves detailed info, README, and schema for a specific Actor.
 ${
     isApps
         ? `- **Data vs widget Actor tools (when the client supports widgets):**
-  - \`${HelperTools.STORE_SEARCH}\` is a silent data lookup (Actor list for name resolution) with no UI; \`${HelperTools.STORE_SEARCH_WIDGET}\` renders an interactive UI element (widget) with Actor search results for the user to browse — use it only when the user explicitly asks to search or discover Actors.
-  - \`${HelperTools.ACTOR_GET_DETAILS}\` is a silent data lookup (input schema, README, metadata) with no UI; \`${HelperTools.ACTOR_GET_DETAILS_WIDGET}\` renders an interactive UI element (widget) with Actor details — use it only when the user explicitly asks to see or browse the Actor.
-  - \`${HelperTools.ACTOR_CALL}\` runs the Actor and returns its result (no UI); \`${HelperTools.ACTOR_CALL_WIDGET}\` renders an interactive UI element (widget) that tracks live Actor run progress — use it only when the user explicitly asks to see progress.
-  - \`${HelperTools.ACTOR_RUNS_GET}\` is a silent data lookup (run status, dataset IDs, stats) with no UI; \`${HelperTools.ACTOR_RUNS_GET_WIDGET}\` renders an interactive UI element (widget) showing live run progress for the user — use it only when the user explicitly asks to see run progress.
-  - When the next step is running an Actor, prefer silent lookups (\`${HelperTools.STORE_SEARCH}\`, \`${HelperTools.ACTOR_GET_DETAILS}\`) over widget-backed variants.
+  - \`${HELPER_TOOLS.STORE_SEARCH}\` is a silent data lookup (Actor list for name resolution) with no UI; \`${HELPER_TOOLS.STORE_SEARCH_WIDGET}\` renders an interactive UI element (widget) with Actor search results for the user to browse — use it only when the user explicitly asks to search or discover Actors.
+  - \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` is a silent data lookup (input schema, README, metadata) with no UI; \`${HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET}\` renders an interactive UI element (widget) with Actor details — use it only when the user explicitly asks to see or browse the Actor.
+  - \`${HELPER_TOOLS.ACTOR_CALL}\` runs the Actor and returns its result (no UI); \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` renders an interactive UI element (widget) that tracks live Actor run progress — use it only when the user explicitly asks to see progress.
+  - \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` is a silent data lookup (run status, dataset IDs, stats) with no UI; \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` renders an interactive UI element (widget) showing live run progress for the user — use it only when the user explicitly asks to see run progress.
+  - When the next step is running an Actor, prefer silent lookups (\`${HELPER_TOOLS.STORE_SEARCH}\`, \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\`) over widget-backed variants.
 `
         : ''
-}- **\`${HelperTools.STORE_SEARCH}\` vs ${RAG_WEB_BROWSER}:**
-  \`${HelperTools.STORE_SEARCH}\` finds robust and reliable Actors for specific websites; ${RAG_WEB_BROWSER} is a general and versatile web scraping tool.
-- **Dedicated Actor tools (e.g. ${RAG_WEB_BROWSER}) vs \`${HelperTools.ACTOR_CALL}\`:**
-  Prefer dedicated tools when available; use \`${HelperTools.ACTOR_CALL}\` only when no specialized tool exists in the Apify store.
+}- **\`${HELPER_TOOLS.STORE_SEARCH}\` vs ${RAG_WEB_BROWSER}:**
+  \`${HELPER_TOOLS.STORE_SEARCH}\` finds robust and reliable Actors for specific websites; ${RAG_WEB_BROWSER} is a general and versatile web scraping tool.
+- **Dedicated Actor tools (e.g. ${RAG_WEB_BROWSER}) vs \`${HELPER_TOOLS.ACTOR_CALL}\`:**
+  Prefer dedicated tools when available; use \`${HELPER_TOOLS.ACTOR_CALL}\` only when no specialized tool exists in the Apify store.
 `;
 }

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { HELPER_TOOLS, RAG_WEB_BROWSER } from '../../const.js';
-import { ServerMode } from '../../types.js';
+import { SERVER_MODE } from '../../types.js';
 
 /**
  * Build server instructions for the given mode.
@@ -16,8 +16,8 @@ import { ServerMode } from '../../types.js';
  * Apps-only sections are omitted in default mode to prevent models from
  * attempting to call widget tools that are not registered.
  */
-export function getServerInstructions(mode: ServerMode = ServerMode.DEFAULT): string {
-    const isApps = mode === ServerMode.APPS;
+export function getServerInstructions(mode: SERVER_MODE = SERVER_MODE.DEFAULT): string {
+    const isApps = mode === SERVER_MODE.APPS;
 
     return `
 Apify is the world's largest marketplace of tools for web scraping, data extraction, and web automation.

--- a/src/utils/server_mode.ts
+++ b/src/utils/server_mode.ts
@@ -1,5 +1,5 @@
 import { SERVER_MODE_AUTO_DETECTION_ENABLED } from '../const.js';
-import { ServerMode, type ServerModeOption } from '../types.js';
+import { SERVER_MODE, type ServerModeOption } from '../types.js';
 
 /**
  * Parse an untrusted raw mode string (from CLI flag, env var, or URL param) into a {@link ServerModeOption}.
@@ -15,19 +15,19 @@ import { ServerMode, type ServerModeOption } from '../types.js';
  */
 export function parseServerMode(rawMode: string | null | undefined): ServerModeOption {
     if (!rawMode) return 'auto';
-    if (rawMode === 'true' || rawMode === 'on' || rawMode === ServerMode.APPS || rawMode === 'openai')
-        return ServerMode.APPS;
-    if (rawMode === 'false' || rawMode === 'off' || rawMode === ServerMode.DEFAULT) return ServerMode.DEFAULT;
+    if (rawMode === 'true' || rawMode === 'on' || rawMode === SERVER_MODE.APPS || rawMode === 'openai')
+        return SERVER_MODE.APPS;
+    if (rawMode === 'false' || rawMode === 'off' || rawMode === SERVER_MODE.DEFAULT) return SERVER_MODE.DEFAULT;
     return 'auto';
 }
 
 /**
- * Resolve a {@link ServerModeOption} to a concrete {@link ServerMode}.
- * Concrete modes are returned as-is. `'auto'` resolves to {@link ServerMode.APPS}
- * when the client advertises MCP Apps UI support, {@link ServerMode.DEFAULT} otherwise.
+ * Resolve a {@link ServerModeOption} to a concrete {@link SERVER_MODE}.
+ * Concrete modes are returned as-is. `'auto'` resolves to {@link SERVER_MODE.APPS}
+ * when the client advertises MCP Apps UI support, {@link SERVER_MODE.DEFAULT} otherwise.
  */
-export function resolveServerMode(option: ServerModeOption, clientSupportsUi: boolean): ServerMode {
+export function resolveServerMode(option: ServerModeOption, clientSupportsUi: boolean): SERVER_MODE {
     if (option !== 'auto') return option;
-    if (!SERVER_MODE_AUTO_DETECTION_ENABLED) return ServerMode.DEFAULT;
-    return clientSupportsUi ? ServerMode.APPS : ServerMode.DEFAULT;
+    if (!SERVER_MODE_AUTO_DETECTION_ENABLED) return SERVER_MODE.DEFAULT;
+    return clientSupportsUi ? SERVER_MODE.APPS : SERVER_MODE.DEFAULT;
 }

--- a/src/utils/tool_categories_helpers.ts
+++ b/src/utils/tool_categories_helpers.ts
@@ -3,12 +3,12 @@
  * Separated from tools.ts to break circular dependency: tools/index.ts → utils/tools.ts → tools/registry.ts → tools/index.ts
  */
 import { getCategoryTools } from '../tools/registry.js';
-import type { ServerMode, ToolCategory, ToolEntry } from '../types.js';
+import type { SERVER_MODE, ToolCategory, ToolEntry } from '../types.js';
 
 /**
  * Returns the tool objects for the given category names resolved for the specified mode.
  */
-export function getExpectedToolsByCategories(categories: ToolCategory[], mode: ServerMode): ToolEntry[] {
+export function getExpectedToolsByCategories(categories: ToolCategory[], mode: SERVER_MODE): ToolEntry[] {
     const resolved = getCategoryTools(mode);
     return categories.flatMap((category) => resolved[category] || []);
 }

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,4 +1,4 @@
-import { type HelperTools } from '../const.js';
+import { type HelperToolName } from '../const.js';
 import {
     SKYFIRE_ENABLED_TOOLS,
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
@@ -145,7 +145,7 @@ export function cloneToolEntry(toolEntry: ToolEntry): ToolEntry {
 function isSkyfireEligible(tool: ToolEntry): boolean {
     return (
         tool.type === TOOL_TYPE.ACTOR ||
-        (tool.type === TOOL_TYPE.INTERNAL && SKYFIRE_ENABLED_TOOLS.has(tool.name as HelperTools))
+        (tool.type === TOOL_TYPE.INTERNAL && SKYFIRE_ENABLED_TOOLS.has(tool.name as HelperToolName))
     );
 }
 

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -5,7 +5,7 @@ import {
     SKYFIRE_TOOL_INSTRUCTIONS,
 } from '../payments/const.js';
 import type { CallDiagnostics, HelperTool, ToolBase, ToolEntry, ToolInputSchema } from '../types.js';
-import { ServerMode, TOOL_TYPE } from '../types.js';
+import { SERVER_MODE, TOOL_TYPE } from '../types.js';
 import { fixZodSchemaRequired } from './ajv.js';
 
 /**
@@ -65,7 +65,7 @@ export function extractActorName(tool: ToolEntry, args?: Record<string, unknown>
 }
 
 type ToolPublicFieldOptions = {
-    mode?: ServerMode;
+    mode?: SERVER_MODE;
     filterWidgetMeta?: boolean;
 };
 
@@ -100,7 +100,7 @@ function fixZodInputSchemaRequired(inputSchema: ToolBase['inputSchema']): ToolBa
  */
 export function getToolPublicFieldOnly(tool: ToolBase, options: ToolPublicFieldOptions = {}) {
     const { mode, filterWidgetMeta = false } = options;
-    const meta = filterWidgetMeta && mode !== ServerMode.APPS ? stripWidgetMeta(tool._meta) : tool._meta;
+    const meta = filterWidgetMeta && mode !== SERVER_MODE.APPS ? stripWidgetMeta(tool._meta) : tool._meta;
 
     return {
         name: tool.name,

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -7,7 +7,7 @@ import type { ApifyClient } from 'apify-client';
 
 import log from '@apify/log';
 
-import { defaults, HelperTools } from '../const.js';
+import { defaults, HELPER_TOOLS, type HelperToolName } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { addActor } from '../tools/actors/add_actor.js';
 import { getActorsAsTools } from '../tools/index.js';
@@ -211,7 +211,7 @@ export function getToolsForServerMode(
             if (sel === 'preview') {
                 // 'preview' category is deprecated. It contained `call-actor` which is now default.
                 log.warning('Tool category "preview" is deprecated');
-                const callActorTool = toolsByName.get(HelperTools.ACTOR_CALL);
+                const callActorTool = toolsByName.get(HELPER_TOOLS.ACTOR_CALL);
                 if (callActorTool) internalSelections.push(callActorTool);
                 continue;
             }
@@ -268,13 +268,13 @@ export function getToolsForServerMode(
      * get-key-value-store-record → abort-actor-run. If the user explicitly selected these tools
      * via category before `actors`, the de-dup pass below preserves their selector order.
      */
-    const hasCallActor = result.some((entry) => entry.name === HelperTools.ACTOR_CALL);
+    const hasCallActor = result.some((entry) => entry.name === HELPER_TOOLS.ACTOR_CALL);
     const hasActorTools = result.some((entry) => entry.type === TOOL_TYPE.ACTOR);
-    const hasAddActorTool = result.some((entry) => entry.name === HelperTools.ACTOR_ADD);
+    const hasAddActorTool = result.some((entry) => entry.name === HELPER_TOOLS.ACTOR_ADD);
     // `get-actor-run`'s nextStep templates point at `get-dataset-items` / `get-key-value-store-record`,
     // and the apps-mode widget calls `get-dataset-items` to fetch its preview. A runs-only session
     // (e.g. `tools: ['runs']`) would otherwise land on an unrecommendable tool / empty widget.
-    const hasGetActorRun = result.some((entry) => entry.name === HelperTools.ACTOR_RUNS_GET);
+    const hasGetActorRun = result.some((entry) => entry.name === HELPER_TOOLS.ACTOR_RUNS_GET);
 
     // Inject run-workflow helpers whenever any actor-running entrypoint is present; de-dup pass below drops repeats.
     const toolsToInject: ToolEntry[] = [];
@@ -283,7 +283,7 @@ export function getToolsForServerMode(
     }
 
     if (toolsToInject.length > 0) {
-        const callActorIndex = result.findIndex((entry) => entry.name === HelperTools.ACTOR_CALL);
+        const callActorIndex = result.findIndex((entry) => entry.name === HELPER_TOOLS.ACTOR_CALL);
         if (callActorIndex !== -1) {
             result.splice(callActorIndex + 1, 0, ...toolsToInject);
         } else {
@@ -296,7 +296,7 @@ export function getToolsForServerMode(
     // brings its widget sibling.
     if (mode === ServerMode.APPS) {
         for (const entry of [...result]) {
-            const widget = WIDGET_BY_BASE_TOOL.get(entry.name as HelperTools);
+            const widget = WIDGET_BY_BASE_TOOL.get(entry.name as HelperToolName);
             // Push unconditionally; any duplicates are stripped by the de-dup pass below.
             if (widget) result.push(widget);
         }

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -23,7 +23,7 @@ import { getActorRun } from '../tools/runs/get_actor_run.js';
 import { getDatasetItems } from '../tools/storage/get_dataset_items.js';
 import { getKeyValueStoreRecord } from '../tools/storage/get_key_value_store_record.js';
 import type { ActorStore, Input, ToolCategory, ToolEntry } from '../types.js';
-import { SERVER_MODES, ServerMode, TOOL_TYPE } from '../types.js';
+import { SERVER_MODES, SERVER_MODE, TOOL_TYPE } from '../types.js';
 
 /**
  * Tools auto-injected alongside any actor-running tool (call-actor / direct
@@ -90,7 +90,7 @@ function normalizeInput(input: Input): NormalizedInput {
 /**
  * Resolve the list of Actor names (`username/name`) to fetch from the input.
  *
- * **Mode-agnostic** — the result does NOT depend on `ServerMode`. An Actor tool
+ * **Mode-agnostic** — the result does NOT depend on `SERVER_MODE`. An Actor tool
  * is identified by name, and the same Actor entry is reused across modes; only
  * the *internal* tool variants around it differ by mode.
  *
@@ -181,7 +181,7 @@ export function toolNamesToInput(toolNames: string[]): Input {
 export function getToolsForServerMode(
     input: Input,
     actorTools: ToolEntry[],
-    mode: ServerMode = ServerMode.DEFAULT,
+    mode: SERVER_MODE = SERVER_MODE.DEFAULT,
 ): ToolEntry[] {
     // Build mode-resolved categories — tools are already the correct variant for this mode
     const categories = getCategoryTools(mode);
@@ -197,7 +197,7 @@ export function getToolsForServerMode(
         }
     }
     // Widgets are apps-only and not in any category; include it for direct selection
-    if (mode === ServerMode.APPS) {
+    if (mode === SERVER_MODE.APPS) {
         for (const widget of WIDGET_BY_BASE_TOOL.values()) {
             toolsByName.set(widget.name, widget);
         }
@@ -294,7 +294,7 @@ export function getToolsForServerMode(
     // Apps mode: append a widget tool for each base tool already in the result.
     // Runs after the get-actor-run auto-inject, so an auto-injected base still
     // brings its widget sibling.
-    if (mode === ServerMode.APPS) {
+    if (mode === SERVER_MODE.APPS) {
         for (const entry of [...result]) {
             const widget = WIDGET_BY_BASE_TOOL.get(entry.name as HelperToolName);
             // Push unconditionally; any duplicates are stripped by the de-dup pass below.
@@ -311,7 +311,7 @@ export function getToolsForServerMode(
 export async function loadToolsFromInput(
     input: Input,
     apifyClient: ApifyClient,
-    mode: ServerMode = ServerMode.DEFAULT,
+    mode: SERVER_MODE = SERVER_MODE.DEFAULT,
     actorStore?: ActorStore,
 ): Promise<ToolEntry[]> {
     const actorTools = await getActors(input, apifyClient, { actorStore });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -4,7 +4,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import type { ClientCapabilities } from '@modelcontextprotocol/sdk/types.js';
 import { expect } from 'vitest';
 
-import { HelperTools } from '../src/const.js';
+import { HELPER_TOOLS } from '../src/const.js';
 import type { TelemetryEnv, ToolCategory } from '../src/types.js';
 
 export type McpClientOptions = {
@@ -164,7 +164,7 @@ export async function createMcpStdioClient(options?: McpClientOptions): Promise<
  */
 export async function addActor(client: Client, actor: string): Promise<void> {
     await client.callTool({
-        name: HelperTools.ACTOR_ADD,
+        name: HELPER_TOOLS.ACTOR_ADD,
         arguments: {
             actor,
         },

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -9,7 +9,7 @@ import { addActor } from '../../src/tools/actors/add_actor.js';
 import { getActorsAsTools } from '../../src/tools/index.js';
 import { actorNameToToolName } from '../../src/tools/utils.js';
 import type { Input } from '../../src/types.js';
-import { ServerMode } from '../../src/types.js';
+import { SERVER_MODE } from '../../src/types.js';
 import { loadToolsFromInput } from '../../src/utils/tools_loader.js';
 import { ACTOR_NORMAL_MODE } from '../const.js';
 import { expectArrayWeakEquals } from '../helpers.js';
@@ -23,7 +23,7 @@ describe('MCP server internals integration tests', () => {
         const actorsMcpServer = new ActorsMcpServer({
             setupSigintHandler: false,
             taskStore: new InMemoryTaskStore(),
-            serverMode: ServerMode.DEFAULT,
+            serverMode: SERVER_MODE.DEFAULT,
         });
         const apifyClient = new ApifyClient({ token: process.env.APIFY_TOKEN });
         const initialTools = await loadToolsFromInput(
@@ -78,7 +78,7 @@ describe('MCP server internals integration tests', () => {
         const actorsMCPServer = new ActorsMcpServer({
             setupSigintHandler: false,
             taskStore: new InMemoryTaskStore(),
-            serverMode: ServerMode.DEFAULT,
+            serverMode: SERVER_MODE.DEFAULT,
         });
         const apifyClient = new ApifyClient({ token: process.env.APIFY_TOKEN });
         const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, apifyClient, 'default');
@@ -121,7 +121,7 @@ describe('MCP server internals integration tests', () => {
         const actorsMCPServer = new ActorsMcpServer({
             setupSigintHandler: false,
             taskStore: new InMemoryTaskStore(),
-            serverMode: ServerMode.DEFAULT,
+            serverMode: SERVER_MODE.DEFAULT,
         });
         const apifyClient = new ApifyClient({ token: process.env.APIFY_TOKEN });
         const seeded = await loadToolsFromInput({ enableAddingActors: true } as Input, apifyClient, 'default');

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -7,7 +7,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { ApifyClient } from '../../src/apify_client.js';
 import {
     defaults,
-    HelperTools,
+    HELPER_TOOLS,
     MAX_LIMIT_WITH_INPUT_SCHEMA,
     SERVER_MODE_AUTO_DETECTION_ENABLED,
 } from '../../src/const.js';
@@ -133,9 +133,9 @@ function validateStructuredOutputForTool(result: unknown, toolName: string, mode
 /** Validates that the listed tools have widget metadata (_meta) with MCP Apps ui.* keys. */
 function expectWidgetToolMeta(tools: { tools: { name: string; _meta?: Record<string, unknown> }[] }): void {
     const toolNames = [
-        HelperTools.STORE_SEARCH_WIDGET,
-        HelperTools.ACTOR_GET_DETAILS_WIDGET,
-        HelperTools.ACTOR_CALL_WIDGET,
+        HELPER_TOOLS.STORE_SEARCH_WIDGET,
+        HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET,
+        HELPER_TOOLS.ACTOR_CALL_WIDGET,
     ];
     for (const toolName of toolNames) {
         const tool = tools.tools.find((t) => t.name === toolName);
@@ -246,7 +246,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expectToolNamesToContain(names, getDefaultToolNames());
                 expectToolNamesToContain(names, DEFAULT_ACTOR_NAMES);
                 // get-actor-run + storage/abort helpers are auto-injected alongside call-actor.
-                expect(names).toContain(HelperTools.ACTOR_RUNS_GET);
+                expect(names).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
                 expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
                 await client.close();
             });
@@ -270,7 +270,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expectToolNamesToContain(names, expectedActors);
                 expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
                 // get-actor-run should be automatically included when call-actor is present
-                expect(names).toContain(HelperTools.ACTOR_RUNS_GET);
+                expect(names).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
 
                 await client.close();
             });
@@ -310,7 +310,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expectToolNamesToContain(names, DEFAULT_ACTOR_NAMES);
                 expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
                 // get-actor-run should be automatically included when call-actor is present
-                expect(names).toContain(HelperTools.ACTOR_RUNS_GET);
+                expect(names).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
 
                 await client.close();
             });
@@ -524,13 +524,13 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const numberOfTools = getCategoryTools('default').actors.length + 1 + AUTO_INJECTED_TOOL_NAMES.length;
                 expect(names).toHaveLength(numberOfTools);
                 // get-actor-run should be automatically included when call-actor is present
-                expect(names).toContain(HelperTools.ACTOR_RUNS_GET);
+                expect(names).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
                 expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
                 // Check that the Actor is not in the tools list
                 expect(names).not.toContain(selectedToolName);
 
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: {
@@ -557,7 +557,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 // Should fail without input (AJV validation error)
                 await expect(
                     client!.callTool({
-                        name: HelperTools.ACTOR_CALL,
+                        name: HELPER_TOOLS.ACTOR_CALL,
                         arguments: {
                             actor: ACTOR_NORMAL_MODE,
                         },
@@ -566,7 +566,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // Should succeed with input
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: { firstNumber: 1, secondNumber: 2 },
@@ -579,7 +579,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ tools: ['actors'] });
 
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: { firstNumber: 1, secondNumber: 2 },
@@ -588,7 +588,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     },
                 });
 
-                validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL, 'default');
+                validateStructuredOutputForTool(callResult, HELPER_TOOLS.ACTOR_CALL, 'default');
                 expectNormalModeTestStructuredContent(callResult);
 
                 const sc = (callResult as { structuredContent?: { status?: string; summary?: string } })
@@ -603,7 +603,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ tools: ['actors'] });
 
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: { firstNumber: 1, secondNumber: 2 },
@@ -611,7 +611,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     },
                 });
 
-                validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL, 'default');
+                validateStructuredOutputForTool(callResult, HELPER_TOOLS.ACTOR_CALL, 'default');
 
                 const sc = (callResult as { structuredContent?: { runId?: string; status?: string } })
                     .structuredContent;
@@ -624,7 +624,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ tools: ['actors'] });
 
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: { firstNumber: 1, secondNumber: 2 },
@@ -635,7 +635,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // previewOutput is deprecated and ignored; the response is the canonical RunResponse
                 // regardless of the flag. Validate the metadata is intact.
-                validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL, 'default');
+                validateStructuredOutputForTool(callResult, HELPER_TOOLS.ACTOR_CALL, 'default');
                 expectNormalModeTestStructuredContent(callResult);
             });
 
@@ -643,7 +643,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ tools: ['actors'] });
 
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: { firstNumber: 1, secondNumber: 2 },
@@ -669,7 +669,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ tools: ['actors'] });
 
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: { firstNumber: 1, secondNumber: 2 },
@@ -679,7 +679,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // The canonical response doesn't inline preview items — agents fetch them via
                 // get-dataset-items using the dataset id and the fields list surfaced here.
-                validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL, 'default');
+                validateStructuredOutputForTool(callResult, HELPER_TOOLS.ACTOR_CALL, 'default');
                 expectNormalModeTestStructuredContent(callResult);
 
                 const sc = (
@@ -698,7 +698,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ tools: ['actors'] });
 
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: { firstNumber: 1, secondNumber: 2 },
@@ -708,7 +708,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 expect(callResult.isError).not.toBe(true);
                 // Schema validation must accept the alias entries (additionalProperties: full dataset shape).
-                validateStructuredOutputForTool(callResult, HelperTools.ACTOR_CALL, 'default');
+                validateStructuredOutputForTool(callResult, HELPER_TOOLS.ACTOR_CALL, 'default');
                 const sc = (
                     callResult as {
                         structuredContent?: {
@@ -729,7 +729,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
 
                 const result = await client.callTool({
-                    name: HelperTools.STORE_SEARCH,
+                    name: HELPER_TOOLS.STORE_SEARCH,
                     arguments: {
                         keywords: query,
                         limit: 5,
@@ -746,7 +746,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn();
 
                 const result = await client.callTool({
-                    name: HelperTools.STORE_SEARCH,
+                    name: HELPER_TOOLS.STORE_SEARCH,
                     arguments: {
                         keywords: 'rental',
                         limit: MAX_LIMIT_WITH_INPUT_SCHEMA,
@@ -774,7 +774,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     }
                 });
                 // Add Actor dynamically
-                await client.callTool({ name: HelperTools.ACTOR_ADD, arguments: { actor: ACTOR_NORMAL_MODE } });
+                await client.callTool({ name: HELPER_TOOLS.ACTOR_ADD, arguments: { actor: ACTOR_NORMAL_MODE } });
 
                 expect(hasReceivedNotification).toBe(true);
             });
@@ -783,7 +783,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ enableAddingActors: true });
                 const nonExistentActor = 'apify/this-actor-does-not-exist';
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_ADD,
+                    name: HELPER_TOOLS.ACTOR_ADD,
                     arguments: { actor: nonExistentActor },
                 });
                 expect(result).toBeDefined();
@@ -798,7 +798,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 async () => {
                     client = await createClientFn({ enableAddingActors: true, payment: 'x402' });
                     const result = await client.callTool({
-                        name: HelperTools.ACTOR_ADD,
+                        name: HELPER_TOOLS.ACTOR_ADD,
                         arguments: { actor: ACTOR_EXAMPLE_MCP_SERVER },
                     });
                     expect(result).toBeDefined();
@@ -852,7 +852,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 await client.listTools();
 
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: `${ACTOR_EXAMPLE_MCP_SERVER}:add`,
                         input: { firstNumber: 2, secondNumber: 3 },
@@ -885,7 +885,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({
                     tools: ['docs'],
                 });
-                const toolName = HelperTools.DOCS_SEARCH;
+                const toolName = HELPER_TOOLS.DOCS_SEARCH;
 
                 const query = 'standby actor';
                 const result = await client.callTool({
@@ -911,7 +911,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 const documentUrl = 'https://docs.apify.com/academy/getting-started/creating-actors';
                 const result = await client.callTool({
-                    name: HelperTools.DOCS_FETCH,
+                    name: HELPER_TOOLS.DOCS_FETCH,
                     arguments: {
                         url: documentUrl,
                     },
@@ -929,7 +929,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 const forbiddenUrl = 'https://example.com/some-page';
                 const result = await client.callTool({
-                    name: HelperTools.DOCS_FETCH,
+                    name: HELPER_TOOLS.DOCS_FETCH,
                     arguments: {
                         url: forbiddenUrl,
                     },
@@ -952,7 +952,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 const crawleeDocsUrl = 'https://crawlee.dev/js/docs/quick-start';
                 const result = await client.callTool({
-                    name: HelperTools.DOCS_FETCH,
+                    name: HELPER_TOOLS.DOCS_FETCH,
                     arguments: {
                         url: crawleeDocsUrl,
                     },
@@ -970,7 +970,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({
                     tools: ['docs'],
                 });
-                const toolName = HelperTools.DOCS_SEARCH;
+                const toolName = HELPER_TOOLS.DOCS_SEARCH;
 
                 const query = 'standby actor';
                 const result = await client.callTool({
@@ -985,14 +985,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const content = result.content as { text: string; isError?: boolean }[];
                 expect(content.length).toBeGreaterThan(0);
 
-                validateStructuredOutputForTool(result, HelperTools.DOCS_SEARCH, 'default');
+                validateStructuredOutputForTool(result, HELPER_TOOLS.DOCS_SEARCH, 'default');
             });
 
             it('should return structured output for fetch-actor-details matching outputSchema', async () => {
                 client = await createClientFn({
                     tools: ['actors'],
                 });
-                const toolName = HelperTools.ACTOR_GET_DETAILS;
+                const toolName = HELPER_TOOLS.ACTOR_GET_DETAILS;
 
                 const result = await client.callTool({
                     name: toolName,
@@ -1004,7 +1004,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const content = result.content as { text: string; isError?: boolean }[];
                 expect(content.length).toBeGreaterThan(0);
 
-                validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(result, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
             });
 
             it('should return only input schema when output={ inputSchema: true }', async () => {
@@ -1013,7 +1013,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
 
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1041,7 +1041,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
 
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1069,7 +1069,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
 
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_EXAMPLE_MCP_SERVER,
                         output: {
@@ -1096,7 +1096,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
 
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1120,7 +1120,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({
                     tools: ['actors'],
                 });
-                const toolName = HelperTools.ACTOR_GET_DETAILS;
+                const toolName = HELPER_TOOLS.ACTOR_GET_DETAILS;
 
                 // Test with output={ mcpTools: true } - should validate against schema even with selective fields
                 const result = await client.callTool({
@@ -1144,14 +1144,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(content.length).toBeGreaterThan(0);
 
                 // This should validate successfully - structured output must match schema
-                validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(result, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
             });
 
             it('should return structured output for fetch-actor-details with output={ description: true, readme: true } matching outputSchema', async () => {
                 client = await createClientFn({
                     tools: ['actors'],
                 });
-                const toolName = HelperTools.ACTOR_GET_DETAILS;
+                const toolName = HELPER_TOOLS.ACTOR_GET_DETAILS;
 
                 // Test with output={ description: true, readme: true } - inputSchema should be undefined
                 const result = await client.callTool({
@@ -1175,7 +1175,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(content.length).toBeGreaterThan(0);
 
                 // This should validate successfully - structured output must match schema
-                validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(result, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
             });
 
             it('should return only pricing when output={ pricing: true }', async () => {
@@ -1184,7 +1184,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
 
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1207,7 +1207,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(content.some((item) => item.text.includes('Input schema'))).toBe(false);
 
                 // Validate structured output
-                validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(result, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
             });
 
             it('should return only readme when output={ readme: true }', async () => {
@@ -1216,7 +1216,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
 
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1239,7 +1239,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(content.some((item) => item.text.includes('Input schema'))).toBe(false);
 
                 // Validate structured output
-                validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(result, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
             });
 
             it('should return README content (summary or full) in text and structured response for fetch-actor-details', async () => {
@@ -1272,7 +1272,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 validateStructuredOutput(
                     result,
-                    findToolByName(HelperTools.ACTOR_GET_DETAILS, 'default')?.outputSchema,
+                    findToolByName(HELPER_TOOLS.ACTOR_GET_DETAILS, 'default')?.outputSchema,
                     'fetch-actor-details',
                 );
             });
@@ -1315,7 +1315,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // When output is not provided, all fields should default to their default values
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                     },
@@ -1335,7 +1335,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
 
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1366,7 +1366,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(resultWithStructured.structuredContent?.inputSchema).toBeDefined();
 
                 // Validate against schema
-                validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(result, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
             });
 
             it('should support granular output controls for rating and metadata', async () => {
@@ -1376,7 +1376,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // Test 1: Only pricing (should include pricing, NOT other sections)
                 const pricingOnlyResult = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1408,7 +1408,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // Test 2: Only rating
                 const ratingOnlyResult = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1441,7 +1441,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // Test 3: Only metadata (should include developer, categories, last modified, deprecation status)
                 const metadataOnlyResult = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1472,7 +1472,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // Test 4: Combination - pricing + rating + metadata (should exclude description, stats, readme, input-schema)
                 const combinationResult = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1504,10 +1504,10 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(combinationText).not.toContain('Input schema');
 
                 // Validate structured output for all test cases
-                validateStructuredOutputForTool(pricingOnlyResult, HelperTools.ACTOR_GET_DETAILS, 'default');
-                validateStructuredOutputForTool(ratingOnlyResult, HelperTools.ACTOR_GET_DETAILS, 'default');
-                validateStructuredOutputForTool(metadataOnlyResult, HelperTools.ACTOR_GET_DETAILS, 'default');
-                validateStructuredOutputForTool(combinationResult, HelperTools.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(pricingOnlyResult, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(ratingOnlyResult, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(metadataOnlyResult, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(combinationResult, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
             });
 
             it('should dynamically test all output options and verify section presence/absence', async () => {
@@ -1610,7 +1610,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 // Test each output option individually
                 for (const option of outputOptions) {
                     const result = await client.callTool({
-                        name: HelperTools.ACTOR_GET_DETAILS,
+                        name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                         arguments: {
                             actor: ACTOR_NORMAL_MODE,
                             output: {
@@ -1642,12 +1642,12 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     }
 
                     // Validate structured output
-                    validateStructuredOutputForTool(result, HelperTools.ACTOR_GET_DETAILS, 'default');
+                    validateStructuredOutputForTool(result, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
                 }
 
                 // Test a combination: all actor card sections (description, stats, pricing, rating, metadata)
                 const allCardSectionsResult = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         output: {
@@ -1680,14 +1680,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(allCardText).not.toContain('README');
                 expect(allCardText).not.toContain('Input schema');
 
-                validateStructuredOutputForTool(allCardSectionsResult, HelperTools.ACTOR_GET_DETAILS, 'default');
+                validateStructuredOutputForTool(allCardSectionsResult, HELPER_TOOLS.ACTOR_GET_DETAILS, 'default');
             });
 
             it('should return structured output for search-actors matching outputSchema', async () => {
                 client = await createClientFn({
                     tools: ['actors'],
                 });
-                const toolName = HelperTools.STORE_SEARCH;
+                const toolName = HELPER_TOOLS.STORE_SEARCH;
 
                 const result = await client.callTool({
                     name: toolName,
@@ -1701,14 +1701,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const content = result.content as { text: string; isError?: boolean }[];
                 expect(content.length).toBeGreaterThan(0);
 
-                validateStructuredOutputForTool(result, HelperTools.STORE_SEARCH, 'default');
+                validateStructuredOutputForTool(result, HELPER_TOOLS.STORE_SEARCH, 'default');
             });
 
             it('should return structured output for fetch-apify-docs matching outputSchema', async () => {
                 client = await createClientFn({
                     tools: ['docs'],
                 });
-                const toolName = HelperTools.DOCS_FETCH;
+                const toolName = HELPER_TOOLS.DOCS_FETCH;
 
                 const result = await client.callTool({
                     name: toolName,
@@ -1720,7 +1720,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const content = result.content as { text: string; isError?: boolean }[];
                 expect(content.length).toBeGreaterThan(0);
 
-                validateStructuredOutputForTool(result, HelperTools.DOCS_FETCH, 'default');
+                validateStructuredOutputForTool(result, HELPER_TOOLS.DOCS_FETCH, 'default');
             });
 
             it.for(Object.keys(getCategoryTools('default')))(
@@ -1750,20 +1750,20 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const loadedTools = await client.listTools();
                 const toolNames = getToolNames(loadedTools);
 
-                expect(toolNames).toContain(HelperTools.ACTOR_ADD);
+                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_ADD);
             });
 
             it('should include add-actor when enableAddingActors is false and add-actor is selected directly', async () => {
                 client = await createClientFn({
                     enableAddingActors: false,
-                    tools: [HelperTools.ACTOR_ADD],
+                    tools: [HELPER_TOOLS.ACTOR_ADD],
                 });
 
                 const loadedTools = await client.listTools();
                 const toolNames = getToolNames(loadedTools);
 
                 // Must include add-actor since it was selected directly
-                expect(toolNames).toContain(HelperTools.ACTOR_ADD);
+                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_ADD);
             });
 
             it('should handle multiple tool category keys input correctly', async () => {
@@ -1859,7 +1859,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                             {
                                 method: 'tools/call' as const,
                                 params: {
-                                    name: HelperTools.ACTOR_CALL,
+                                    name: HELPER_TOOLS.ACTOR_CALL,
                                     arguments: {
                                         actor: ACTOR_NORMAL_MODE,
                                         step: 'call',
@@ -1903,7 +1903,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     expectToolNamesToContain(names, DEFAULT_ACTOR_NAMES);
                     expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
                     // get-actor-run should be automatically included when call-actor is present
-                    expect(names).toContain(HelperTools.ACTOR_RUNS_GET);
+                    expect(names).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
 
                     await client.close();
                 },
@@ -1929,10 +1929,10 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     client = await createClientFn({ tools: ['docs'], useEnv: true });
                     const toolNames = getToolNames(await client.listTools());
 
-                    expect(toolNames).toContain(HelperTools.DOCS_SEARCH);
-                    expect(toolNames).toContain(HelperTools.DOCS_FETCH);
-                    expect(toolNames).not.toContain(HelperTools.ACTOR_CALL);
-                    expect(toolNames).not.toContain(HelperTools.ACTOR_RUNS_GET);
+                    expect(toolNames).toContain(HELPER_TOOLS.DOCS_SEARCH);
+                    expect(toolNames).toContain(HELPER_TOOLS.DOCS_FETCH);
+                    expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_CALL);
+                    expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
                 },
             );
 
@@ -1941,11 +1941,11 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const tools = await client.listTools();
                 const names = tools.tools.map((t) => t.name);
 
-                const callIndex = names.indexOf(HelperTools.ACTOR_CALL);
-                const runIndex = names.indexOf(HelperTools.ACTOR_RUNS_GET);
-                const datasetIndex = names.indexOf(HelperTools.DATASET_GET_ITEMS);
-                const kvIndex = names.indexOf(HelperTools.KEY_VALUE_STORE_RECORD_GET);
-                const abortIndex = names.indexOf(HelperTools.ACTOR_RUNS_ABORT);
+                const callIndex = names.indexOf(HELPER_TOOLS.ACTOR_CALL);
+                const runIndex = names.indexOf(HELPER_TOOLS.ACTOR_RUNS_GET);
+                const datasetIndex = names.indexOf(HELPER_TOOLS.DATASET_GET_ITEMS);
+                const kvIndex = names.indexOf(HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET);
+                const abortIndex = names.indexOf(HELPER_TOOLS.ACTOR_RUNS_ABORT);
 
                 expect(callIndex).toBeGreaterThanOrEqual(0);
                 expect(callIndex).toBeLessThan(runIndex);
@@ -1960,7 +1960,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ tools: ['docs'] });
                 const names = getToolNames(await client.listTools());
                 for (const name of AUTO_INJECTED_TOOL_NAMES) expect(names).not.toContain(name);
-                expect(names).not.toContain(HelperTools.ACTOR_RUNS_GET);
+                expect(names).not.toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
                 await client.close();
             });
 
@@ -1972,7 +1972,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 beforeAll(async () => {
                     const setupClient = await createClientFn({ tools: ['actors', 'storage'] });
                     const callResult = await setupClient.callTool({
-                        name: HelperTools.ACTOR_CALL,
+                        name: HELPER_TOOLS.ACTOR_CALL,
                         arguments: {
                             actor: ACTOR_NORMAL_MODE,
                             input: { firstNumber: 1, secondNumber: 2 },
@@ -2001,7 +2001,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 it('applies the default `limit` of 20 when omitted on get-dataset-items', async () => {
                     client = await createClientFn({ tools: ['storage'] });
                     const result = await client.callTool({
-                        name: HelperTools.DATASET_GET_ITEMS,
+                        name: HELPER_TOOLS.DATASET_GET_ITEMS,
                         arguments: { datasetId },
                     });
                     expect(result.isError).not.toBe(true);
@@ -2015,7 +2015,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 it("reads INPUT from the run's default KV store via get-actor-run + get-key-value-store-record", async () => {
                     client = await createClientFn({ tools: ['runs', 'storage'] });
                     const runResult = await client.callTool({
-                        name: HelperTools.ACTOR_RUNS_GET,
+                        name: HELPER_TOOLS.ACTOR_RUNS_GET,
                         arguments: { runId },
                     });
                     expect(runResult.isError).not.toBe(true);
@@ -2028,7 +2028,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     expect(kvId).toBeDefined();
 
                     const kvResult = await client.callTool({
-                        name: HelperTools.KEY_VALUE_STORE_RECORD_GET,
+                        name: HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET,
                         arguments: { keyValueStoreId: kvId!, recordKey: 'INPUT' },
                     });
                     expect(kvResult.isError).not.toBe(true);
@@ -2044,7 +2044,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 it('returns dataset metadata via get-dataset', async () => {
                     client = await createClientFn({ tools: ['storage'] });
                     const result = await client.callTool({
-                        name: HelperTools.DATASET_GET,
+                        name: HELPER_TOOLS.DATASET_GET,
                         arguments: { datasetId },
                     });
                     expect(result.isError).not.toBe(true);
@@ -2055,14 +2055,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     const sc = (result as { structuredContent?: { summary?: string; nextStep?: string } })
                         .structuredContent;
                     expect(sc?.summary).toContain('items');
-                    expect(sc?.nextStep).toContain(HelperTools.DATASET_GET_ITEMS);
+                    expect(sc?.nextStep).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
                     await client.close();
                 });
 
                 it('infers schema from dataset items via get-dataset-schema', async () => {
                     client = await createClientFn({ tools: ['storage'] });
                     const result = await client.callTool({
-                        name: HelperTools.DATASET_SCHEMA_GET,
+                        name: HELPER_TOOLS.DATASET_SCHEMA_GET,
                         arguments: { datasetId },
                     });
                     expect(result.isError).not.toBe(true);
@@ -2074,14 +2074,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     const sc = (result as { structuredContent?: { summary?: string; nextStep?: string } })
                         .structuredContent;
                     expect(sc?.summary).toContain('Schema inferred');
-                    expect(sc?.nextStep).toContain(HelperTools.DATASET_GET_ITEMS);
+                    expect(sc?.nextStep).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
                     await client.close();
                 });
 
                 it('lists user datasets and finds the run dataset via get-dataset-list', async () => {
                     client = await createClientFn({ tools: ['storage'] });
                     const result = await client.callTool({
-                        name: HelperTools.DATASET_LIST_GET,
+                        name: HELPER_TOOLS.DATASET_LIST_GET,
                         arguments: { desc: true, unnamed: true, limit: 20 },
                     });
                     expect(result.isError).not.toBe(true);
@@ -2096,21 +2096,21 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 it('returns key-value store metadata via get-key-value-store', async () => {
                     client = await createClientFn({ tools: ['storage'] });
                     const result = await client.callTool({
-                        name: HelperTools.KEY_VALUE_STORE_GET,
+                        name: HELPER_TOOLS.KEY_VALUE_STORE_GET,
                         arguments: { keyValueStoreId: defaultKvId },
                     });
                     expect(result.isError).not.toBe(true);
                     const { text } = (result.content as { text: string }[])[0];
                     expect(text).toContain(defaultKvId);
                     const sc = (result as { structuredContent?: { nextStep?: string } }).structuredContent;
-                    expect(sc?.nextStep).toContain(HelperTools.KEY_VALUE_STORE_KEYS_GET);
+                    expect(sc?.nextStep).toContain(HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET);
                     await client.close();
                 });
 
                 it('lists keys in the run KV store via get-key-value-store-keys', async () => {
                     client = await createClientFn({ tools: ['storage'] });
                     const result = await client.callTool({
-                        name: HelperTools.KEY_VALUE_STORE_KEYS_GET,
+                        name: HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET,
                         arguments: { keyValueStoreId: defaultKvId, limit: 10 },
                     });
                     expect(result.isError).not.toBe(true);
@@ -2123,14 +2123,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     const sc = (result as { structuredContent?: { summary?: string; nextStep?: string } })
                         .structuredContent;
                     expect(sc?.summary).toContain('keys');
-                    expect(sc?.nextStep).toContain(HelperTools.KEY_VALUE_STORE_RECORD_GET);
+                    expect(sc?.nextStep).toContain(HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET);
                     await client.close();
                 });
 
                 it('lists user key-value stores and finds the run KV store via get-key-value-store-list', async () => {
                     client = await createClientFn({ tools: ['storage'] });
                     const result = await client.callTool({
-                        name: HelperTools.KEY_VALUE_STORE_LIST_GET,
+                        name: HELPER_TOOLS.KEY_VALUE_STORE_LIST_GET,
                         arguments: { desc: true, unnamed: true, limit: 10 },
                     });
                     expect(result.isError).not.toBe(true);
@@ -2148,7 +2148,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 it('flattens 3-level nested fields via get-dataset-items', async () => {
                     client = await createClientFn({ tools: ['storage'] });
                     const result = await client.callTool({
-                        name: HelperTools.DATASET_GET_ITEMS,
+                        name: HELPER_TOOLS.DATASET_GET_ITEMS,
                         arguments: { datasetId, fields: 'math.factorial.first' },
                     });
                     expect(result.isError).not.toBe(true);
@@ -2167,7 +2167,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ tools: ['storage'] });
                 await expect(
                     client.callTool({
-                        name: HelperTools.KEY_VALUE_STORE_RECORD_GET,
+                        name: HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET,
                         arguments: { recordKey: 'INPUT' },
                     }),
                 ).rejects.toThrow(/must have required property 'keyValueStoreId'/);
@@ -2207,7 +2207,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(fields).toEqual(expect.arrayContaining(['firstNumber', 'secondNumber', 'sum']));
 
                 const outputResult = await client.callTool({
-                    name: HelperTools.DATASET_GET_ITEMS,
+                    name: HELPER_TOOLS.DATASET_GET_ITEMS,
                     arguments: {
                         datasetId: datasetId!,
                         fields: 'firstNumber,sum',
@@ -2256,14 +2256,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 // content[1] is the LLM-readable summary+nextStep; it must reference the datasetId
                 // and the follow-up tool name so the LLM can act on the result.
                 expect(content[1].text).toContain(datasetId);
-                expect(content[1].text).toContain(HelperTools.DATASET_GET_ITEMS);
+                expect(content[1].text).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
 
                 // Dataset field paths surface in `storages.datasets.default.fields`.
                 const fields = sc?.storages?.datasets?.default?.fields ?? [];
                 expect(fields).toEqual(expect.arrayContaining(['firstNumber', 'secondNumber', 'sum']));
 
                 const outputResult = await client.callTool({
-                    name: HelperTools.DATASET_GET_ITEMS,
+                    name: HELPER_TOOLS.DATASET_GET_ITEMS,
                     arguments: { datasetId: datasetId!, fields: 'sum' },
                 });
 
@@ -2273,7 +2273,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(items!.length).toBeGreaterThan(0);
                 expect(items![0]).toHaveProperty('sum', 10);
 
-                validateStructuredOutputForTool(outputResult, HelperTools.DATASET_GET_ITEMS, 'default');
+                validateStructuredOutputForTool(outputResult, HELPER_TOOLS.DATASET_GET_ITEMS, 'default');
 
                 await client.close();
             });
@@ -2306,7 +2306,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(datasetId).toBeDefined();
 
                 const outputResult = await client.callTool({
-                    name: HelperTools.DATASET_GET_ITEMS,
+                    name: HELPER_TOOLS.DATASET_GET_ITEMS,
                     arguments: { datasetId: datasetId! },
                 });
 
@@ -2318,7 +2318,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(items![0]).toHaveProperty('secondNumber', input.secondNumber);
                 expect(items![0]).toHaveProperty('sum', input.firstNumber + input.secondNumber);
 
-                validateStructuredOutputForTool(outputResult, HelperTools.DATASET_GET_ITEMS, 'default');
+                validateStructuredOutputForTool(outputResult, HELPER_TOOLS.DATASET_GET_ITEMS, 'default');
             });
 
             it('should return structured output for get-actor-run matching outputSchema', async () => {
@@ -2326,7 +2326,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // First, start an async actor run to get a runId
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: { firstNumber: 1, secondNumber: 2 },
@@ -2340,13 +2340,13 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // Now test get-actor-run
                 const runResult = await client.callTool({
-                    name: HelperTools.ACTOR_RUNS_GET,
+                    name: HELPER_TOOLS.ACTOR_RUNS_GET,
                     arguments: { runId },
                 });
 
                 expect(runResult.content).toBeDefined();
                 // Validate structured output for get-actor-run
-                validateStructuredOutputForTool(runResult, HelperTools.ACTOR_RUNS_GET, 'default');
+                validateStructuredOutputForTool(runResult, HELPER_TOOLS.ACTOR_RUNS_GET, 'default');
             });
 
             it('should return Actor details both for full Actor name and ID', async () => {
@@ -2381,7 +2381,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // First, run an actor to get a datasetId
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: { firstNumber: 3, secondNumber: 4 },
@@ -2398,13 +2398,13 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // Now test get-dataset-items
                 const datasetResult = await client.callTool({
-                    name: HelperTools.DATASET_GET_ITEMS,
+                    name: HELPER_TOOLS.DATASET_GET_ITEMS,
                     arguments: { datasetId },
                 });
 
                 expect(datasetResult.content).toBeDefined();
                 // Validate structured output for get-dataset-items
-                validateStructuredOutputForTool(datasetResult, HelperTools.DATASET_GET_ITEMS, 'default');
+                validateStructuredOutputForTool(datasetResult, HELPER_TOOLS.DATASET_GET_ITEMS, 'default');
 
                 // Validate structured content has items with actual results
                 const datasetWithStructured = datasetResult as {
@@ -2709,7 +2709,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 const stream = client.experimental.tasks.callToolStream(
                     {
-                        name: HelperTools.ACTOR_CALL,
+                        name: HELPER_TOOLS.ACTOR_CALL,
                         arguments: {
                             actor: ACTOR_NORMAL_MODE,
                             input: {
@@ -2770,7 +2770,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                     const stream = client.experimental.tasks.callToolStream(
                         {
-                            name: HelperTools.ACTOR_CALL,
+                            name: HELPER_TOOLS.ACTOR_CALL,
                             arguments: {
                                 actor: ACTOR_NORMAL_MODE,
                                 // waitSeconds keeps the run open long enough for the polling
@@ -2826,9 +2826,9 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     expect(tools.tools.length).toBeGreaterThan(0);
 
                     // Verify that apps-only internal tools are present in apps mode
-                    expect(toolNames).toContain(HelperTools.ACTOR_GET_DETAILS_WIDGET);
-                    expect(toolNames).toContain(HelperTools.STORE_SEARCH_WIDGET);
-                    expect(toolNames).toContain(HelperTools.ACTOR_CALL_WIDGET);
+                    expect(toolNames).toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
+                    expect(toolNames).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+                    expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
 
                     // Verify that tools have widget metadata when UI mode is enabled
                     expectWidgetToolMeta(tools);
@@ -2843,9 +2843,9 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const toolNames = getToolNames(tools);
                 expect(tools.tools.length).toBeGreaterThan(0);
 
-                expect(toolNames).toContain(HelperTools.ACTOR_GET_DETAILS_WIDGET);
-                expect(toolNames).toContain(HelperTools.STORE_SEARCH_WIDGET);
-                expect(toolNames).toContain(HelperTools.ACTOR_CALL_WIDGET);
+                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
+                expect(toolNames).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
 
                 // Verify that tools have widget metadata when UI mode is enabled via URL parameter
                 expectWidgetToolMeta(tools);
@@ -2860,9 +2860,9 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const toolNames = getToolNames(tools);
                 expect(tools.tools.length).toBeGreaterThan(0);
 
-                expect(toolNames).toContain(HelperTools.ACTOR_GET_DETAILS_WIDGET);
-                expect(toolNames).toContain(HelperTools.STORE_SEARCH_WIDGET);
-                expect(toolNames).toContain(HelperTools.ACTOR_CALL_WIDGET);
+                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
+                expect(toolNames).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
                 expectWidgetToolMeta(tools);
 
                 await client.close();
@@ -2874,8 +2874,8 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const toolNames = getToolNames(tools);
 
                 // When serverMode is enabled, default tools include call-actor, so get-actor-run should be included
-                expect(toolNames).toContain(HelperTools.ACTOR_CALL);
-                expect(toolNames).toContain(HelperTools.ACTOR_RUNS_GET);
+                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
+                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
 
                 await client.close();
             });
@@ -2886,13 +2886,13 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const toolNames = getToolNames(tools);
 
                 // No actor tools selected — get-actor-run and its widget must not appear
-                expect(toolNames).not.toContain(HelperTools.ACTOR_RUNS_GET);
-                expect(toolNames).not.toContain(HelperTools.ACTOR_RUNS_GET_WIDGET);
+                expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
+                expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
                 // Docs tools should be present
-                expect(toolNames).toContain(HelperTools.DOCS_SEARCH);
-                expect(toolNames).toContain(HelperTools.DOCS_FETCH);
+                expect(toolNames).toContain(HELPER_TOOLS.DOCS_SEARCH);
+                expect(toolNames).toContain(HELPER_TOOLS.DOCS_FETCH);
                 // call-actor should NOT be present since only 'docs' was selected
-                expect(toolNames).not.toContain(HelperTools.ACTOR_CALL);
+                expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_CALL);
 
                 await client.close();
             });
@@ -2920,12 +2920,12 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const tools = await client.listTools();
                 const toolNames = getToolNames(tools);
 
-                expect(toolNames).not.toContain(HelperTools.STORE_SEARCH_WIDGET);
-                expect(toolNames).not.toContain(HelperTools.ACTOR_GET_DETAILS_WIDGET);
+                expect(toolNames).not.toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+                expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
                 for (const toolName of [
-                    HelperTools.STORE_SEARCH,
-                    HelperTools.ACTOR_GET_DETAILS,
-                    HelperTools.ACTOR_CALL,
+                    HELPER_TOOLS.STORE_SEARCH,
+                    HELPER_TOOLS.ACTOR_GET_DETAILS,
+                    HELPER_TOOLS.ACTOR_CALL,
                 ]) {
                     const tool = tools.tools.find((t) => t.name === toolName);
                     expect(tool).toBeDefined();
@@ -2997,18 +2997,18 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     // Kept independent of any production constant so this test pins the expected paid set
                     // and any silent drift (e.g. a tool losing paymentRequired) is caught here.
                     const paidToolNames = [
-                        HelperTools.ACTOR_CALL,
-                        HelperTools.ACTOR_RUNS_GET,
-                        HelperTools.ACTOR_RUNS_LOG,
-                        HelperTools.ACTOR_RUNS_ABORT,
-                        HelperTools.DATASET_GET,
-                        HelperTools.DATASET_GET_ITEMS,
-                        HelperTools.DATASET_SCHEMA_GET,
-                        HelperTools.KEY_VALUE_STORE_GET,
-                        HelperTools.KEY_VALUE_STORE_KEYS_GET,
-                        HelperTools.KEY_VALUE_STORE_RECORD_GET,
+                        HELPER_TOOLS.ACTOR_CALL,
+                        HELPER_TOOLS.ACTOR_RUNS_GET,
+                        HELPER_TOOLS.ACTOR_RUNS_LOG,
+                        HELPER_TOOLS.ACTOR_RUNS_ABORT,
+                        HELPER_TOOLS.DATASET_GET,
+                        HELPER_TOOLS.DATASET_GET_ITEMS,
+                        HELPER_TOOLS.DATASET_SCHEMA_GET,
+                        HELPER_TOOLS.KEY_VALUE_STORE_GET,
+                        HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET,
+                        HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET,
                     ];
-                    const freeToolNames = [HelperTools.STORE_SEARCH, HelperTools.DOCS_SEARCH];
+                    const freeToolNames = [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.DOCS_SEARCH];
 
                     client = await createClientFn({
                         payment: 'x402',
@@ -3170,7 +3170,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     client = await createClientFn({ tools: ['actors'], payment: 'x402' });
 
                     const result = await client.callTool({
-                        name: HelperTools.ACTOR_CALL,
+                        name: HELPER_TOOLS.ACTOR_CALL,
                         arguments: {
                             actor: ACTOR_NORMAL_MODE,
                             input: { firstNumber: 1, secondNumber: 2 },
@@ -3197,7 +3197,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // First, start an async actor run to get a runId
                 const callResult = await client.callTool({
-                    name: HelperTools.ACTOR_CALL,
+                    name: HELPER_TOOLS.ACTOR_CALL,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                         input: { firstNumber: 1, secondNumber: 2 },
@@ -3210,7 +3210,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
 
                 // Now test get-actor-run with waitSecs to drive it to terminal state.
                 const runResult = await client.callTool({
-                    name: HelperTools.ACTOR_RUNS_GET,
+                    name: HELPER_TOOLS.ACTOR_RUNS_GET,
                     arguments: { runId, waitSecs: 30 },
                 });
 
@@ -3252,7 +3252,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 // assertion; the failure must come from waitSecs validation, not from run lookup.
                 await expect(
                     client.callTool({
-                        name: HelperTools.ACTOR_RUNS_GET,
+                        name: HELPER_TOOLS.ACTOR_RUNS_GET,
                         arguments: { runId: 'aaaaaaaaaaaaaaaaa', waitSecs: 46 },
                     }),
                 ).rejects.toThrow(/waitSecs|less than or equal to 45|<= 45/i);
@@ -3265,7 +3265,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
 
                 const result = await client.callTool({
-                    name: HelperTools.STORE_SEARCH_WIDGET,
+                    name: HELPER_TOOLS.STORE_SEARCH_WIDGET,
                     arguments: {
                         keywords: 'python',
                         limit: 5,
@@ -3302,7 +3302,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
 
                 const result = await client.callTool({
-                    name: HelperTools.ACTOR_GET_DETAILS_WIDGET,
+                    name: HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET,
                     arguments: {
                         actor: ACTOR_NORMAL_MODE,
                     },

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -18,7 +18,7 @@ import { CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG } from '../../src/tools/actors/cal
 import { getCategoryTools, getDefaultTools } from '../../src/tools/index.js';
 import { actorRunOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import { actorNameToToolName } from '../../src/tools/utils.js';
-import type { ServerMode, ToolCategory, ToolEntry } from '../../src/types.js';
+import type { SERVER_MODE, ToolCategory, ToolEntry } from '../../src/types.js';
 import { getExpectedToolNamesByCategories } from '../../src/utils/tool_categories_helpers.js';
 import { AUTO_INJECTED_TOOLS } from '../../src/utils/tools_loader.js';
 import { ACTOR_EXAMPLE_MCP_SERVER, ACTOR_NORMAL_MODE, DEFAULT_ACTOR_NAMES, getDefaultToolNames } from '../const.js';
@@ -30,7 +30,7 @@ const AUTO_INJECTED_TOOL_NAMES = AUTO_INJECTED_TOOLS.map((t) => t.name);
 // Helper to find tool by name, resolving categories for the given mode on each call.
 // This ensures we always validate against the correct mode-specific tool definition
 // (e.g. outputSchema may diverge between modes in the future).
-function findToolByName(name: string, mode: ServerMode): ToolEntry | undefined {
+function findToolByName(name: string, mode: SERVER_MODE): ToolEntry | undefined {
     const resolved = getCategoryTools(mode);
     for (const tools of Object.values(resolved)) {
         const tool = tools.find((t) => t.name === name);
@@ -126,7 +126,7 @@ function expectReadmeInStructuredContent(result: unknown, expectedActorFullName?
     expect(r.structuredContent?.inputSchema).toBeDefined();
 }
 
-function validateStructuredOutputForTool(result: unknown, toolName: string, mode: ServerMode): void {
+function validateStructuredOutputForTool(result: unknown, toolName: string, mode: SERVER_MODE): void {
     validateStructuredOutput(result, findToolByName(toolName, mode)?.outputSchema, toolName);
 }
 

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -3,7 +3,7 @@ import { decode as decodeToon } from '@toon-format/toon';
 import Ajv from 'ajv';
 import { expect } from 'vitest';
 
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../../src/const.js';
+import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../../src/const.js';
 import type { InternalToolArgs } from '../../../src/types.js';
 import { FENCES } from '../../../src/utils/encode_text.js';
 import type { CachedUserInfo } from '../../../src/utils/userid_cache.js';
@@ -55,7 +55,7 @@ export function stubToolCallContext(
         apifyClient: client,
         extra: {},
         mcpServer: {},
-        apifyMcpServer: { options: { paymentProvider: undefined }, listToolNames: () => Object.values(HelperTools) },
+        apifyMcpServer: { options: { paymentProvider: undefined }, listToolNames: () => Object.values(HELPER_TOOLS) },
     } as unknown as InternalToolArgs;
 }
 

--- a/tests/unit/mcp.server.capability_gating.test.ts
+++ b/tests/unit/mcp.server.capability_gating.test.ts
@@ -3,7 +3,7 @@ import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { ApifyClient } from 'apify-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { HelperTools, SERVER_MODE_AUTO_DETECTION_ENABLED } from '../../src/const.js';
+import { HELPER_TOOLS, SERVER_MODE_AUTO_DETECTION_ENABLED } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
 import { RESOURCE_MIME_TYPE } from '../../src/resources/widgets.js';
 import { callActorApps } from '../../src/tools/actors/call_actor.js';
@@ -97,17 +97,17 @@ describe('ActorsMcpServer initialize handler', () => {
             const server = track(makeServer('auto'));
             const apifyClient = new ApifyClient({ token: 'test-token' });
 
-            await server.loadToolsFromInput({ tools: [HelperTools.STORE_SEARCH] }, apifyClient);
+            await server.loadToolsFromInput({ tools: [HELPER_TOOLS.STORE_SEARCH] }, apifyClient);
 
             // Sources are pending — no tools visible yet
-            expect(server.tools.has(HelperTools.STORE_SEARCH)).toBe(false);
+            expect(server.tools.has(HELPER_TOOLS.STORE_SEARCH)).toBe(false);
 
             await dispatchInitialize(server, makeInitializeRequest(true));
 
             // After initialize (apps mode): composed with APPS-mode variants
             // search-actors is mode-independent (data-only); search-actors-widget is the apps-only UI variant auto-added in apps mode.
-            expect(server.tools.get(HelperTools.STORE_SEARCH)).toBe(searchActors);
-            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidget);
+            expect(server.tools.get(HELPER_TOOLS.STORE_SEARCH)).toBe(searchActors);
+            expect(server.tools.get(HELPER_TOOLS.STORE_SEARCH_WIDGET)).toBe(searchActorsWidget);
         },
     );
 
@@ -147,16 +147,16 @@ describe('ActorsMcpServer initialize handler', () => {
             const server = track(makeServer('auto'));
             const apifyClient = new ApifyClient({ token: 'test-token' });
 
-            await server.loadToolsByName([HelperTools.STORE_SEARCH, HelperTools.ACTOR_CALL], apifyClient);
+            await server.loadToolsByName([HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.ACTOR_CALL], apifyClient);
 
-            expect(server.tools.has(HelperTools.STORE_SEARCH)).toBe(false);
-            expect(server.tools.has(HelperTools.ACTOR_CALL)).toBe(false);
+            expect(server.tools.has(HELPER_TOOLS.STORE_SEARCH)).toBe(false);
+            expect(server.tools.has(HELPER_TOOLS.ACTOR_CALL)).toBe(false);
 
             await dispatchInitialize(server, makeInitializeRequest(true));
 
-            expect(server.tools.get(HelperTools.STORE_SEARCH)).toBe(searchActors);
-            expect(server.tools.get(HelperTools.ACTOR_CALL)).toBe(callActorApps);
-            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidget);
+            expect(server.tools.get(HELPER_TOOLS.STORE_SEARCH)).toBe(searchActors);
+            expect(server.tools.get(HELPER_TOOLS.ACTOR_CALL)).toBe(callActorApps);
+            expect(server.tools.get(HELPER_TOOLS.STORE_SEARCH_WIDGET)).toBe(searchActorsWidget);
         },
     );
 
@@ -169,14 +169,14 @@ describe('ActorsMcpServer initialize handler', () => {
                 .spyOn(server, 'loadActorsAsTools')
                 .mockResolvedValue({ tools: [], errors: [] });
 
-            await server.loadToolsByName([HelperTools.STORE_SEARCH_WIDGET], apifyClient);
+            await server.loadToolsByName([HELPER_TOOLS.STORE_SEARCH_WIDGET], apifyClient);
 
             expect(loadActorsAsTools).not.toHaveBeenCalled();
-            expect(server.tools.has(HelperTools.STORE_SEARCH_WIDGET)).toBe(false);
+            expect(server.tools.has(HELPER_TOOLS.STORE_SEARCH_WIDGET)).toBe(false);
 
             await dispatchInitialize(server, makeInitializeRequest(true));
 
-            expect(server.tools.get(HelperTools.STORE_SEARCH_WIDGET)).toBe(searchActorsWidget);
+            expect(server.tools.get(HELPER_TOOLS.STORE_SEARCH_WIDGET)).toBe(searchActorsWidget);
         },
     );
 });

--- a/tests/unit/mcp.server.capability_gating.test.ts
+++ b/tests/unit/mcp.server.capability_gating.test.ts
@@ -10,7 +10,7 @@ import { callActorApps } from '../../src/tools/actors/call_actor.js';
 import { searchActors } from '../../src/tools/actors/search_actors.js';
 import { searchActorsWidget } from '../../src/tools/widgets/search_actors_widget.js';
 import type { ServerModeOption } from '../../src/types.js';
-import { ServerMode } from '../../src/types.js';
+import { SERVER_MODE } from '../../src/types.js';
 
 type InitHandler = (req: InitializeRequest, ctx: unknown) => Promise<unknown>;
 
@@ -67,17 +67,17 @@ describe('ActorsMcpServer initialize handler', () => {
     };
 
     describe('mode resolution', () => {
-        const cases: { option: ServerModeOption; supportsUi: boolean; expectedMode: ServerMode }[] = [
-            { option: ServerMode.APPS, supportsUi: true, expectedMode: ServerMode.APPS },
-            { option: ServerMode.APPS, supportsUi: false, expectedMode: ServerMode.APPS },
-            { option: ServerMode.DEFAULT, supportsUi: true, expectedMode: ServerMode.DEFAULT },
-            { option: ServerMode.DEFAULT, supportsUi: false, expectedMode: ServerMode.DEFAULT },
+        const cases: { option: ServerModeOption; supportsUi: boolean; expectedMode: SERVER_MODE }[] = [
+            { option: SERVER_MODE.APPS, supportsUi: true, expectedMode: SERVER_MODE.APPS },
+            { option: SERVER_MODE.APPS, supportsUi: false, expectedMode: SERVER_MODE.APPS },
+            { option: SERVER_MODE.DEFAULT, supportsUi: true, expectedMode: SERVER_MODE.DEFAULT },
+            { option: SERVER_MODE.DEFAULT, supportsUi: false, expectedMode: SERVER_MODE.DEFAULT },
             {
                 option: 'auto',
                 supportsUi: true,
-                expectedMode: SERVER_MODE_AUTO_DETECTION_ENABLED ? ServerMode.APPS : ServerMode.DEFAULT,
+                expectedMode: SERVER_MODE_AUTO_DETECTION_ENABLED ? SERVER_MODE.APPS : SERVER_MODE.DEFAULT,
             },
-            { option: 'auto', supportsUi: false, expectedMode: ServerMode.DEFAULT },
+            { option: 'auto', supportsUi: false, expectedMode: SERVER_MODE.DEFAULT },
         ];
 
         for (const { option, supportsUi, expectedMode } of cases) {
@@ -113,20 +113,20 @@ describe('ActorsMcpServer initialize handler', () => {
 
     it('defaults to preliminary DEFAULT mode before initialize runs', () => {
         const server = track(makeServer('auto'));
-        expect(server.serverMode).toBe(ServerMode.DEFAULT);
+        expect(server.serverMode).toBe(SERVER_MODE.DEFAULT);
         expect(server.clientSupportsUi).toBe(false);
     });
 
     it('preliminary mode is APPS when option=apps, even before initialize', () => {
-        const server = track(makeServer(ServerMode.APPS));
-        expect(server.serverMode).toBe(ServerMode.APPS);
+        const server = track(makeServer(SERVER_MODE.APPS));
+        expect(server.serverMode).toBe(SERVER_MODE.APPS);
     });
 
     it('explicit option bypasses auto-detect — apps-capable client does not override default', async () => {
-        const server = track(makeServer(ServerMode.DEFAULT));
+        const server = track(makeServer(SERVER_MODE.DEFAULT));
         await dispatchInitialize(server, makeInitializeRequest(true));
 
-        expect(server.serverMode).toBe(ServerMode.DEFAULT);
+        expect(server.serverMode).toBe(SERVER_MODE.DEFAULT);
         expect(server.clientSupportsUi).toBe(true);
     });
 

--- a/tests/unit/mcp.server.progress_wiring.test.ts
+++ b/tests/unit/mcp.server.progress_wiring.test.ts
@@ -1,7 +1,7 @@
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import type { ActorsMcpServer } from '../../src/mcp/server.js';
 import type { InternalToolArgs, ToolEntry } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
@@ -84,7 +84,7 @@ async function runRecorder(toolName: string, meta: Record<string, unknown>) {
 
 describe('tools/call progressToken wiring', () => {
     it('creates a ProgressTracker for get-actor-run when _meta.progressToken is provided', async () => {
-        const received = await runRecorder(HelperTools.ACTOR_RUNS_GET, {
+        const received = await runRecorder(HELPER_TOOLS.ACTOR_RUNS_GET, {
             progressToken: 'tok-1',
             mcpSessionId: 'sess-1',
         });
@@ -92,7 +92,7 @@ describe('tools/call progressToken wiring', () => {
     });
 
     it('passes null progressTracker for get-actor-run when no progressToken is provided', async () => {
-        const received = await runRecorder(HelperTools.ACTOR_RUNS_GET, { mcpSessionId: 'sess-1' });
+        const received = await runRecorder(HELPER_TOOLS.ACTOR_RUNS_GET, { mcpSessionId: 'sess-1' });
         expect(received.progressTracker).toBeNull();
     });
 

--- a/tests/unit/tools.add_actor.test.ts
+++ b/tests/unit/tools.add_actor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import { addActor } from '../../src/tools/actors/add_actor.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import type { TextToolResult } from './helpers/tool_context.js';
@@ -44,7 +44,7 @@ function buildContext(
 
 describe('add-actor tool', () => {
     it('has the expected tool name', () => {
-        expect(addActor.name).toBe(HelperTools.ACTOR_ADD);
+        expect(addActor.name).toBe(HELPER_TOOLS.ACTOR_ADD);
     });
 
     it('sends list_changed and nudges the client to refresh via tools/list (#851)', async () => {

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -2,7 +2,12 @@ import { ApifyApiError } from 'apify-client';
 import type { AxiosResponse } from 'axios';
 import { describe, expect, it } from 'vitest';
 
-import { APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED, FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../src/const.js';
+import {
+    APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED,
+    FAILURE_CATEGORY,
+    HELPER_TOOLS,
+    TOOL_STATUS,
+} from '../../src/const.js';
 import {
     buildCallActorAppsDescription,
     buildCallActorDescription,
@@ -16,14 +21,14 @@ describe('call_actor_common', () => {
         it('builds the description with public helper tools and waitSecs guidance', () => {
             const description = buildCallActorDescription();
 
-            expect(description).toContain(`Use ${HelperTools.ACTOR_GET_DETAILS} to get the Actor's input schema`);
+            expect(description).toContain(`Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} to get the Actor's input schema`);
             expect(description).toContain(
-                `${HelperTools.STORE_SEARCH} is available in this session, use it to resolve the correct Actor first`,
+                `${HELPER_TOOLS.STORE_SEARCH} is available in this session, use it to resolve the correct Actor first`,
             );
             expect(description).toContain('waitSecs');
-            expect(description).toContain(HelperTools.DATASET_GET_ITEMS);
+            expect(description).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
             expect(description).not.toContain('always runs asynchronously');
-            expect(description).not.toContain(HelperTools.ACTOR_CALL_WIDGET);
+            expect(description).not.toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
         });
     });
 
@@ -31,10 +36,10 @@ describe('call_actor_common', () => {
         it('appends widget guidance to the shared description', () => {
             const description = buildCallActorAppsDescription();
 
-            expect(description).toContain(HelperTools.ACTOR_CALL_WIDGET);
-            expect(description).toContain(HelperTools.STORE_SEARCH_WIDGET);
+            expect(description).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
+            expect(description).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
             expect(description).toContain('waitSecs');
-            expect(description).toContain(HelperTools.DATASET_GET_ITEMS);
+            expect(description).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
         });
     });
 
@@ -47,13 +52,13 @@ describe('call_actor_common', () => {
                 error,
                 actorId: 'actor-123',
                 mcpSessionId: 'session-123',
-                actorGetDetailsTool: HelperTools.ACTOR_GET_DETAILS,
+                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
             });
 
             expect(response.isError).toBe(true);
             const allText = response.content.map((c) => c.text).join('\n');
-            expect(allText).toContain(`If ${HelperTools.STORE_SEARCH} is available in this session`);
-            expect(allText).toContain(`using: ${HelperTools.ACTOR_GET_DETAILS}`);
+            expect(allText).toContain(`If ${HELPER_TOOLS.STORE_SEARCH} is available in this session`);
+            expect(allText).toContain(`using: ${HELPER_TOOLS.ACTOR_GET_DETAILS}`);
             expect(response.toolTelemetry).toEqual(
                 expect.objectContaining({
                     toolStatus: TOOL_STATUS.SOFT_FAIL,
@@ -86,7 +91,7 @@ describe('call_actor_common', () => {
                 actorName: 'apify/some-actor',
                 error,
                 actorId: 'actor-456',
-                actorGetDetailsTool: HelperTools.ACTOR_GET_DETAILS,
+                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
             });
 
             expect(response.isError).toBe(true);
@@ -107,12 +112,12 @@ describe('call_actor_common', () => {
             const response = buildCallActorErrorResponse({
                 actorName: 'apify/rag-web-browser',
                 error: new Error('boom'),
-                actorGetDetailsTool: HelperTools.ACTOR_GET_DETAILS,
+                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
             });
 
             const allText = response.content.map((c) => c.text).join('\n');
-            expect(allText).toContain(`If ${HelperTools.STORE_SEARCH} is available in this session`);
-            expect(allText).toContain(`using: ${HelperTools.ACTOR_GET_DETAILS}`);
+            expect(allText).toContain(`If ${HELPER_TOOLS.STORE_SEARCH} is available in this session`);
+            expect(allText).toContain(`using: ${HELPER_TOOLS.ACTOR_GET_DETAILS}`);
             expect(response.toolTelemetry).toEqual(
                 expect.objectContaining({
                     toolStatus: TOOL_STATUS.FAILED,
@@ -141,7 +146,7 @@ describe('call_actor_common', () => {
                 actorName: 'compass/crawler-google-places',
                 error,
                 actorId: 'actor-789',
-                actorGetDetailsTool: HelperTools.ACTOR_GET_DETAILS,
+                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
             });
 
             expect(response.isError).toBe(true);
@@ -150,7 +155,7 @@ describe('call_actor_common', () => {
             expect(allText).toContain('Account memory quota exceeded');
             expect(allText).toContain('callOptions.memory');
             // Regression: must not nudge the LLM toward aborting unrelated runs to free capacity.
-            expect(allText).not.toContain(HelperTools.ACTOR_RUNS_ABORT);
+            expect(allText).not.toContain(HELPER_TOOLS.ACTOR_RUNS_ABORT);
             expect(allText).not.toContain('verify the Actor name');
         });
 
@@ -173,7 +178,7 @@ describe('call_actor_common', () => {
                 actorName: 'apify/instagram-scraper',
                 error,
                 actorId: 'actor-999',
-                actorGetDetailsTool: HelperTools.ACTOR_GET_DETAILS,
+                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
             });
 
             expect(response.isError).toBe(true);

--- a/tests/unit/tools.categories.test.ts
+++ b/tests/unit/tools.categories.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import { CATEGORY_NAMES, getCategoryTools, toolCategories } from '../../src/tools/index.js';
 import type { ToolCategory, ToolEntry } from '../../src/types.js';
 
@@ -50,8 +50,8 @@ describe('getCategoryTools', () => {
         // call-actor still has mode-specific variants — distinct objects differing only in
         // description (apps mode appends a widget addendum).
         // search-actors and fetch-actor-details are mode-independent and share the same object.
-        const defaultCallActor = defaultResult.actors.find((t: ToolEntry) => t.name === HelperTools.ACTOR_CALL);
-        const appsCallActor = appsResult.actors.find((t: ToolEntry) => t.name === HelperTools.ACTOR_CALL);
+        const defaultCallActor = defaultResult.actors.find((t: ToolEntry) => t.name === HELPER_TOOLS.ACTOR_CALL);
+        const appsCallActor = appsResult.actors.find((t: ToolEntry) => t.name === HELPER_TOOLS.ACTOR_CALL);
         expect(defaultCallActor).toBeDefined();
         expect(appsCallActor).toBeDefined();
         expect(defaultCallActor).not.toBe(appsCallActor);
@@ -61,8 +61,8 @@ describe('getCategoryTools', () => {
         const defaultResult = getCategoryTools('default');
         const appsResult = getCategoryTools('apps');
 
-        const defaultGetRun = defaultResult.runs.find((t: ToolEntry) => t.name === HelperTools.ACTOR_RUNS_GET);
-        const appsGetRun = appsResult.runs.find((t: ToolEntry) => t.name === HelperTools.ACTOR_RUNS_GET);
+        const defaultGetRun = defaultResult.runs.find((t: ToolEntry) => t.name === HELPER_TOOLS.ACTOR_RUNS_GET);
+        const appsGetRun = appsResult.runs.find((t: ToolEntry) => t.name === HELPER_TOOLS.ACTOR_RUNS_GET);
 
         expect(defaultGetRun).toBeDefined();
         expect(appsGetRun).toBeDefined();
@@ -85,6 +85,10 @@ describe('getCategoryTools', () => {
         const actorNames = result.actors.map((t: ToolEntry) => t.name);
 
         // Verify workflow order: search → details → call
-        expect(actorNames).toEqual([HelperTools.STORE_SEARCH, HelperTools.ACTOR_GET_DETAILS, HelperTools.ACTOR_CALL]);
+        expect(actorNames).toEqual([
+            HELPER_TOOLS.STORE_SEARCH,
+            HELPER_TOOLS.ACTOR_GET_DETAILS,
+            HELPER_TOOLS.ACTOR_CALL,
+        ]);
     });
 });

--- a/tests/unit/tools.get_actor_run_list.test.ts
+++ b/tests/unit/tools.get_actor_run_list.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import { getActorRunList } from '../../src/tools/runs/get_actor_run_list.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
 import { decodeFencedToolText, stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
@@ -37,7 +37,7 @@ const noClient = null as unknown as InternalToolArgs['apifyClient'];
 
 describe('get-actor-run-list', () => {
     it('has the expected tool name', () => {
-        expect(getActorRunList.name).toBe(HelperTools.ACTOR_RUN_LIST_GET);
+        expect(getActorRunList.name).toBe(HELPER_TOOLS.ACTOR_RUN_LIST_GET);
     });
 
     it('returns runs as fenced text (json or toon), mirrors them in structuredContent, and declares an outputSchema', async () => {

--- a/tests/unit/tools.get_dataset.test.ts
+++ b/tests/unit/tools.get_dataset.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import { getDataset } from '../../src/tools/storage/get_dataset.js';
 import { datasetMetadataOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
@@ -34,7 +34,7 @@ function stubApifyClient(dataset: unknown): InternalToolArgs['apifyClient'] {
 
 describe('get-dataset', () => {
     it('has the expected tool name', () => {
-        expect(getDataset.name).toBe(HelperTools.DATASET_GET);
+        expect(getDataset.name).toBe(HELPER_TOOLS.DATASET_GET);
     });
 
     it('returns dataset metadata plus a summary and nextStep in structuredContent', async () => {
@@ -49,7 +49,7 @@ describe('get-dataset', () => {
         // structuredContent preserves the metadata and adds the narrative fields.
         expect(structuredContent).toMatchObject(MOCK_DATASET);
         expect(structuredContent.summary).toBe("Dataset 'my-dataset' has 42 items, 2 fields.");
-        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET_ITEMS);
+        expect(structuredContent.nextStep).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
         expect(structuredContent.nextStep).toContain('datasetId=ds-1');
         // content[0] is the data-only JSON dump (no narrative); content[1] is the narrative.
         const { summary, nextStep, ...data } = structuredContent;

--- a/tests/unit/tools.get_dataset_items.test.ts
+++ b/tests/unit/tools.get_dataset_items.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import { extractDotPrefixes, getDatasetItems } from '../../src/tools/storage/get_dataset_items.js';
 import { datasetItemsOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
@@ -70,7 +70,7 @@ function stubApifyClientThrowing(err: unknown): InternalToolArgs['apifyClient'] 
 
 describe('get-dataset-items', () => {
     it('has the expected tool name', () => {
-        expect(getDatasetItems.name).toBe(HelperTools.DATASET_GET_ITEMS);
+        expect(getDatasetItems.name).toBe(HELPER_TOOLS.DATASET_GET_ITEMS);
     });
 
     it('returns dataset items in structuredContent on happy path', async () => {
@@ -230,7 +230,7 @@ describe('get-dataset-items', () => {
         };
 
         expect(structuredContent.summary).toBe('Fetched all 1 items.');
-        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
+        expect(structuredContent.nextStep).toContain(HELPER_TOOLS.DATASET_GET);
         expect(structuredContent.nextStep).toContain('datasetId=ds-1');
         // summary + nextStep ship as a separate text block after the fenced data.
         expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
@@ -247,7 +247,7 @@ describe('get-dataset-items', () => {
 
         expect(structuredContent.summary).toBe('Fetched 20 of 100 items (offset=0).');
         expect(structuredContent.nextStep).toBe(
-            `Call ${HelperTools.DATASET_GET_ITEMS} again with offset=20 to fetch the next page.`,
+            `Call ${HELPER_TOOLS.DATASET_GET_ITEMS} again with offset=20 to fetch the next page.`,
         );
     });
 

--- a/tests/unit/tools.get_dataset_list.test.ts
+++ b/tests/unit/tools.get_dataset_list.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import { getDatasetList } from '../../src/tools/storage/get_dataset_list.js';
 import { storageListOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
@@ -31,7 +31,7 @@ function stubApifyClient(listSpy: ReturnType<typeof vi.fn>): InternalToolArgs['a
 
 describe('get-dataset-list', () => {
     it('has the expected tool name', () => {
-        expect(getDatasetList.name).toBe(HelperTools.DATASET_LIST_GET);
+        expect(getDatasetList.name).toBe(HELPER_TOOLS.DATASET_LIST_GET);
     });
 
     it('returns the list response plus a summary and nextStep in structuredContent', async () => {
@@ -45,7 +45,7 @@ describe('get-dataset-list', () => {
         expect(structuredContent).toMatchObject(MOCK_LIST);
         expect(structuredContent.summary).toBe('Listed 2 of 2 datasets.');
         // Not truncated → nextStep points at inspecting a dataset, not pagination.
-        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
+        expect(structuredContent.nextStep).toContain(HELPER_TOOLS.DATASET_GET);
         // content[0] ships the TOON-fenced data; content[1] carries the prose summary + nextStep.
         const { summary, nextStep, ...data } = structuredContent;
         expect(decodeFencedToolText(content[0].text)).toEqual(data);
@@ -77,7 +77,7 @@ describe('get-dataset-list', () => {
 
         expect(structuredContent.summary).toBe('Listed 2 of 25 datasets.');
         expect(structuredContent.nextStep).toBe(
-            `Call ${HelperTools.DATASET_LIST_GET} again with offset=2 to fetch the next page.`,
+            `Call ${HELPER_TOOLS.DATASET_LIST_GET} again with offset=2 to fetch the next page.`,
         );
     });
 

--- a/tests/unit/tools.get_dataset_schema.test.ts
+++ b/tests/unit/tools.get_dataset_schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../src/const.js';
+import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../src/const.js';
 import { getDatasetSchema } from '../../src/tools/storage/get_dataset_schema.js';
 import { datasetSchemaOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
@@ -47,7 +47,7 @@ function stubApifyClientThrowing(err: unknown): InternalToolArgs['apifyClient'] 
 
 describe('get-dataset-schema', () => {
     it('has the expected tool name', () => {
-        expect(getDatasetSchema.name).toBe(HelperTools.DATASET_SCHEMA_GET);
+        expect(getDatasetSchema.name).toBe(HELPER_TOOLS.DATASET_SCHEMA_GET);
     });
 
     it('returns the inferred schema plus a summary and nextStep on the happy path', async () => {
@@ -63,7 +63,7 @@ describe('get-dataset-schema', () => {
         expect(structuredContent.schema).toMatchObject({ type: 'array' });
         // MOCK_ITEMS has 2 items, each with 2 fields (title, count).
         expect(structuredContent.summary).toBe('Schema inferred from 2 items, 2 fields.');
-        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET_ITEMS);
+        expect(structuredContent.nextStep).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
         expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
     });
 
@@ -90,7 +90,7 @@ describe('get-dataset-schema', () => {
         expect(structuredContent.datasetId).toBe('ds-1');
         expect(structuredContent.schema).toEqual({});
         expect(structuredContent.summary).toBe("Dataset 'ds-1' is empty; no schema to infer.");
-        expect(structuredContent.nextStep).toContain(HelperTools.DATASET_GET);
+        expect(structuredContent.nextStep).toContain(HELPER_TOOLS.DATASET_GET);
         expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
         // The required `schema` is still present (empty object) and the emit conforms to the schema.
         expectSchemaConformingStructuredContent(result, datasetSchemaOutputSchema);

--- a/tests/unit/tools.get_key_value_store.test.ts
+++ b/tests/unit/tools.get_key_value_store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import { getKeyValueStore } from '../../src/tools/storage/get_key_value_store.js';
 import { keyValueStoreOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
@@ -33,7 +33,7 @@ function stubApifyClient(store: unknown): InternalToolArgs['apifyClient'] {
 
 describe('get-key-value-store', () => {
     it('has the expected tool name', () => {
-        expect(getKeyValueStore.name).toBe(HelperTools.KEY_VALUE_STORE_GET);
+        expect(getKeyValueStore.name).toBe(HELPER_TOOLS.KEY_VALUE_STORE_GET);
     });
 
     it('returns store metadata plus a summary and nextStep in structuredContent', async () => {
@@ -47,7 +47,7 @@ describe('get-key-value-store', () => {
         expect(isError).not.toBe(true);
         expect(structuredContent).toMatchObject(MOCK_STORE);
         expect(structuredContent.summary).toBe("Key-value store 'my-store'.");
-        expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_KEYS_GET);
+        expect(structuredContent.nextStep).toContain(HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET);
         expect(structuredContent.nextStep).toContain('keyValueStoreId=kv-1');
         // content[0] is the data-only JSON dump (no narrative); content[1] is the narrative.
         const { summary, nextStep, ...data } = structuredContent;

--- a/tests/unit/tools.get_key_value_store_keys.test.ts
+++ b/tests/unit/tools.get_key_value_store_keys.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import { getKeyValueStoreKeys } from '../../src/tools/storage/get_key_value_store_keys.js';
 import { keyValueStoreKeysOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
@@ -45,7 +45,7 @@ function stubApifyClientThrowing(err: unknown): InternalToolArgs['apifyClient'] 
 
 describe('get-key-value-store-keys', () => {
     it('has the expected tool name', () => {
-        expect(getKeyValueStoreKeys.name).toBe(HelperTools.KEY_VALUE_STORE_KEYS_GET);
+        expect(getKeyValueStoreKeys.name).toBe(HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET);
     });
 
     it('returns the keys response plus a summary and read nextStep in structuredContent', async () => {
@@ -62,7 +62,7 @@ describe('get-key-value-store-keys', () => {
         expect(structuredContent.summary).toBe('Listed 2 keys.');
         // nextStep points at reading the first listed key.
         expect(structuredContent.nextStep).toBe(
-            `Use ${HelperTools.KEY_VALUE_STORE_RECORD_GET} with keyValueStoreId=kv-1 and recordKey=INPUT to read a value.`,
+            `Use ${HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET} with keyValueStoreId=kv-1 and recordKey=INPUT to read a value.`,
         );
         // content[0] ships the TOON-fenced data; content[1] carries the prose summary + nextStep.
         const { summary, nextStep, ...data } = structuredContent;
@@ -97,7 +97,7 @@ describe('get-key-value-store-keys', () => {
 
         expect(structuredContent.summary).toBe('Listed 2 keys (more available).');
         expect(structuredContent.nextStep).toBe(
-            `Call ${HelperTools.KEY_VALUE_STORE_KEYS_GET} again with exclusiveStartKey=OUTPUT to fetch the next page.`,
+            `Call ${HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET} again with exclusiveStartKey=OUTPUT to fetch the next page.`,
         );
     });
 
@@ -110,7 +110,7 @@ describe('get-key-value-store-keys', () => {
         const { structuredContent } = result as { structuredContent: Record<string, unknown> };
 
         expect(structuredContent.summary).toBe('Listed 0 keys.');
-        expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_GET);
+        expect(structuredContent.nextStep).toContain(HELPER_TOOLS.KEY_VALUE_STORE_GET);
     });
 
     it('forwards exclusiveStartKey and limit to listKeys', async () => {

--- a/tests/unit/tools.get_key_value_store_list.test.ts
+++ b/tests/unit/tools.get_key_value_store_list.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import { getKeyValueStoreList } from '../../src/tools/storage/get_key_value_store_list.js';
 import { storageListOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
@@ -31,7 +31,7 @@ function stubApifyClient(listSpy: ReturnType<typeof vi.fn>): InternalToolArgs['a
 
 describe('get-key-value-store-list', () => {
     it('has the expected tool name', () => {
-        expect(getKeyValueStoreList.name).toBe(HelperTools.KEY_VALUE_STORE_LIST_GET);
+        expect(getKeyValueStoreList.name).toBe(HELPER_TOOLS.KEY_VALUE_STORE_LIST_GET);
     });
 
     it('returns the list response plus a summary and nextStep in structuredContent', async () => {
@@ -46,7 +46,7 @@ describe('get-key-value-store-list', () => {
 
         expect(structuredContent).toMatchObject(MOCK_LIST);
         expect(structuredContent.summary).toBe('Listed 2 of 2 key-value stores.');
-        expect(structuredContent.nextStep).toContain(HelperTools.KEY_VALUE_STORE_GET);
+        expect(structuredContent.nextStep).toContain(HELPER_TOOLS.KEY_VALUE_STORE_GET);
         // content[0] ships the TOON-fenced data; content[1] carries the prose summary + nextStep.
         const { summary, nextStep, ...data } = structuredContent;
         expect(decodeFencedToolText(content[0].text)).toEqual(data);
@@ -63,7 +63,7 @@ describe('get-key-value-store-list', () => {
 
         expect(structuredContent.summary).toBe('Listed 2 of 30 key-value stores.');
         expect(structuredContent.nextStep).toBe(
-            `Call ${HelperTools.KEY_VALUE_STORE_LIST_GET} again with offset=2 to fetch the next page.`,
+            `Call ${HELPER_TOOLS.KEY_VALUE_STORE_LIST_GET} again with offset=2 to fetch the next page.`,
         );
     });
 

--- a/tests/unit/tools.get_key_value_store_record.test.ts
+++ b/tests/unit/tools.get_key_value_store_record.test.ts
@@ -5,7 +5,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools, KV_RECORD_MAX_INLINE_BYTES } from '../../src/const.js';
+import { HELPER_TOOLS, KV_RECORD_MAX_INLINE_BYTES } from '../../src/const.js';
 import { getKeyValueStoreRecord } from '../../src/tools/storage/get_key_value_store_record.js';
 import { keyValueStoreRecordOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
@@ -48,7 +48,7 @@ function stubApifyClient(opts: {
 
 describe('get-key-value-store-record', () => {
     it('has the expected tool name', () => {
-        expect(getKeyValueStoreRecord.name).toBe(HelperTools.KEY_VALUE_STORE_RECORD_GET);
+        expect(getKeyValueStoreRecord.name).toBe(HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET);
     });
 
     it('returns a JSON record plus a terminal summary (no nextStep) in structuredContent', async () => {

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-import { ALLOWED_TASK_TOOL_EXECUTION_MODES, HelperTools } from '../../src/const.js';
+import { ALLOWED_TASK_TOOL_EXECUTION_MODES, HELPER_TOOLS, type HelperToolName } from '../../src/const.js';
 import { searchActorsBaseArgsSchema } from '../../src/tools/actors/search_actors.js';
 import { searchApifyDocs } from '../../src/tools/docs/search_apify_docs.js';
 import { CATEGORY_NAMES, getCategoryTools } from '../../src/tools/index.js';
@@ -31,28 +31,28 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
 
     describe('per-mode tool lists', () => {
         it('should have correct tools in experimental category (both modes)', () => {
-            expect(toolNames(defaultCategories.experimental)).toEqual([HelperTools.ACTOR_ADD]);
-            expect(toolNames(appsCategories.experimental)).toEqual([HelperTools.ACTOR_ADD]);
+            expect(toolNames(defaultCategories.experimental)).toEqual([HELPER_TOOLS.ACTOR_ADD]);
+            expect(toolNames(appsCategories.experimental)).toEqual([HELPER_TOOLS.ACTOR_ADD]);
         });
 
         it('should have correct tools in actors category (both modes)', () => {
-            const expected = [HelperTools.STORE_SEARCH, HelperTools.ACTOR_GET_DETAILS, HelperTools.ACTOR_CALL];
+            const expected = [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.ACTOR_GET_DETAILS, HELPER_TOOLS.ACTOR_CALL];
             expect(toolNames(defaultCategories.actors)).toEqual(expected);
             expect(toolNames(appsCategories.actors)).toEqual(expected);
         });
 
         it('should have correct tools in docs category (both modes)', () => {
-            const expected = [HelperTools.DOCS_SEARCH, HelperTools.DOCS_FETCH];
+            const expected = [HELPER_TOOLS.DOCS_SEARCH, HELPER_TOOLS.DOCS_FETCH];
             expect(toolNames(defaultCategories.docs)).toEqual(expected);
             expect(toolNames(appsCategories.docs)).toEqual(expected);
         });
 
         it('should have correct tools in runs category (both modes)', () => {
             const expected = [
-                HelperTools.ACTOR_RUNS_GET,
-                HelperTools.ACTOR_RUN_LIST_GET,
-                HelperTools.ACTOR_RUNS_LOG,
-                HelperTools.ACTOR_RUNS_ABORT,
+                HELPER_TOOLS.ACTOR_RUNS_GET,
+                HELPER_TOOLS.ACTOR_RUN_LIST_GET,
+                HELPER_TOOLS.ACTOR_RUNS_LOG,
+                HELPER_TOOLS.ACTOR_RUNS_ABORT,
             ];
             expect(toolNames(defaultCategories.runs)).toEqual(expected);
             expect(toolNames(appsCategories.runs)).toEqual(expected);
@@ -60,14 +60,14 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
 
         it('should have correct tools in storage category (both modes)', () => {
             const expected = [
-                HelperTools.DATASET_GET,
-                HelperTools.DATASET_GET_ITEMS,
-                HelperTools.DATASET_SCHEMA_GET,
-                HelperTools.KEY_VALUE_STORE_GET,
-                HelperTools.KEY_VALUE_STORE_KEYS_GET,
-                HelperTools.KEY_VALUE_STORE_RECORD_GET,
-                HelperTools.DATASET_LIST_GET,
-                HelperTools.KEY_VALUE_STORE_LIST_GET,
+                HELPER_TOOLS.DATASET_GET,
+                HELPER_TOOLS.DATASET_GET_ITEMS,
+                HELPER_TOOLS.DATASET_SCHEMA_GET,
+                HELPER_TOOLS.KEY_VALUE_STORE_GET,
+                HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET,
+                HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET,
+                HELPER_TOOLS.DATASET_LIST_GET,
+                HELPER_TOOLS.KEY_VALUE_STORE_LIST_GET,
             ];
             expect(toolNames(defaultCategories.storage)).toEqual(expected);
             expect(toolNames(appsCategories.storage)).toEqual(expected);
@@ -98,11 +98,11 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
     });
 
     describe('base data tools have no widget meta in either mode', () => {
-        const baseTools: { name: HelperTools; category: keyof typeof defaultCategories }[] = [
-            { name: HelperTools.ACTOR_GET_DETAILS, category: 'actors' },
-            { name: HelperTools.STORE_SEARCH, category: 'actors' },
-            { name: HelperTools.ACTOR_CALL, category: 'actors' },
-            { name: HelperTools.ACTOR_RUNS_GET, category: 'runs' },
+        const baseTools: { name: HelperToolName; category: keyof typeof defaultCategories }[] = [
+            { name: HELPER_TOOLS.ACTOR_GET_DETAILS, category: 'actors' },
+            { name: HELPER_TOOLS.STORE_SEARCH, category: 'actors' },
+            { name: HELPER_TOOLS.ACTOR_CALL, category: 'actors' },
+            { name: HELPER_TOOLS.ACTOR_RUNS_GET, category: 'runs' },
         ];
         for (const mode of SERVER_MODES) {
             for (const { name, category } of baseTools) {
@@ -122,10 +122,10 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
 
     describe('inputSchema parity for mode-variant tools', () => {
         const modeVariantToolNames = [
-            HelperTools.STORE_SEARCH,
-            HelperTools.ACTOR_GET_DETAILS,
-            HelperTools.ACTOR_CALL,
-            HelperTools.ACTOR_RUNS_GET,
+            HELPER_TOOLS.STORE_SEARCH,
+            HELPER_TOOLS.ACTOR_GET_DETAILS,
+            HELPER_TOOLS.ACTOR_CALL,
+            HELPER_TOOLS.ACTOR_RUNS_GET,
         ];
 
         for (const name of modeVariantToolNames) {
@@ -144,26 +144,26 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
         // Locks the invariant that search-actors-widget reuses the shared base schema
         // verbatim (see #700). Prevents silent drift on limit/offset/keywords.
         it('should use searchActorsBaseArgsSchema.strict() for search-actors-widget inputSchema', () => {
-            const widgetTool = WIDGET_BY_BASE_TOOL.get(HelperTools.STORE_SEARCH);
+            const widgetTool = WIDGET_BY_BASE_TOOL.get(HELPER_TOOLS.STORE_SEARCH);
             expect(widgetTool).toBeDefined();
-            expect(widgetTool!.name).toBe(HelperTools.STORE_SEARCH_WIDGET);
+            expect(widgetTool!.name).toBe(HELPER_TOOLS.STORE_SEARCH_WIDGET);
             expect(widgetTool!.inputSchema).toEqual(z.toJSONSchema(searchActorsBaseArgsSchema.strict()));
         });
     });
 
     describe('mode-specific call-actor behavior guidance', () => {
         it('apps call-actor description points to the widget sibling and warns against search-actors-widget for name resolution', () => {
-            const appsCallActor = appsCategories.actors.find((t) => t.name === HelperTools.ACTOR_CALL);
-            const defaultCallActor = defaultCategories.actors.find((t) => t.name === HelperTools.ACTOR_CALL);
+            const appsCallActor = appsCategories.actors.find((t) => t.name === HELPER_TOOLS.ACTOR_CALL);
+            const defaultCallActor = defaultCategories.actors.find((t) => t.name === HELPER_TOOLS.ACTOR_CALL);
 
             expect(appsCallActor).toBeDefined();
-            expect(appsCallActor!.description).toContain(HelperTools.ACTOR_CALL_WIDGET);
-            expect(appsCallActor!.description).toContain(HelperTools.STORE_SEARCH_WIDGET);
+            expect(appsCallActor!.description).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
+            expect(appsCallActor!.description).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
 
             // Widget guidance must not leak into default mode where those tools don't exist.
             expect(defaultCallActor).toBeDefined();
-            expect(defaultCallActor!.description).not.toContain(HelperTools.ACTOR_CALL_WIDGET);
-            expect(defaultCallActor!.description).not.toContain(HelperTools.STORE_SEARCH_WIDGET);
+            expect(defaultCallActor!.description).not.toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
+            expect(defaultCallActor!.description).not.toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
         });
     });
 
@@ -187,24 +187,24 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
         }
     });
 
-    describe('all tool names match HelperTools enum values', () => {
-        const allHelperToolNames = new Set(Object.values(HelperTools));
+    describe('all tool names match HELPER_TOOLS values', () => {
+        const allHelperToolNames = new Set(Object.values(HELPER_TOOLS));
 
         for (const mode of SERVER_MODES) {
             const categories = getCategoryTools(mode);
 
             for (const categoryName of CATEGORY_NAMES) {
                 for (const tool of categories[categoryName]) {
-                    it(`${tool.name} (${mode} mode) should be a known HelperTools value`, () => {
-                        expect(allHelperToolNames.has(tool.name as HelperTools)).toBe(true);
+                    it(`${tool.name} (${mode} mode) should be a known HELPER_TOOLS value`, () => {
+                        expect(allHelperToolNames.has(tool.name as HelperToolName)).toBe(true);
                     });
                 }
             }
         }
 
         for (const widget of WIDGET_BY_BASE_TOOL.values()) {
-            it(`${widget.name} widget should be a known HelperTools value`, () => {
-                expect(allHelperToolNames.has(widget.name as HelperTools)).toBe(true);
+            it(`${widget.name} widget should be a known HELPER_TOOLS value`, () => {
+                expect(allHelperToolNames.has(widget.name as HelperToolName)).toBe(true);
             });
         }
     });
@@ -217,46 +217,46 @@ describe('apps-mode widget pairing in getToolsForServerMode', () => {
 
     it('tools: ["docs"] in apps mode includes no widget tools', () => {
         const names = namesFor({ tools: ['docs'] }, ServerMode.APPS);
-        expect(names).toContain(HelperTools.DOCS_SEARCH);
-        expect(names).toContain(HelperTools.DOCS_FETCH);
-        expect(names).not.toContain(HelperTools.STORE_SEARCH_WIDGET);
-        expect(names).not.toContain(HelperTools.ACTOR_GET_DETAILS_WIDGET);
-        expect(names).not.toContain(HelperTools.ACTOR_CALL_WIDGET);
-        expect(names).not.toContain(HelperTools.ACTOR_RUNS_GET_WIDGET);
+        expect(names).toContain(HELPER_TOOLS.DOCS_SEARCH);
+        expect(names).toContain(HELPER_TOOLS.DOCS_FETCH);
+        expect(names).not.toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
     });
 
     it('tools: ["search-actors"] in apps mode pairs only the search-actors widget', () => {
         const names = namesFor({ tools: ['search-actors'] }, ServerMode.APPS);
-        expect(names).toContain(HelperTools.STORE_SEARCH);
-        expect(names).toContain(HelperTools.STORE_SEARCH_WIDGET);
-        expect(names).not.toContain(HelperTools.ACTOR_GET_DETAILS_WIDGET);
-        expect(names).not.toContain(HelperTools.ACTOR_CALL_WIDGET);
+        expect(names).toContain(HELPER_TOOLS.STORE_SEARCH);
+        expect(names).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
     });
 
     it('tools: ["call-actor"] in apps mode pairs call-actor-widget and the auto-injected get-actor-run-widget', () => {
         const names = namesFor({ tools: ['call-actor'] }, ServerMode.APPS);
-        expect(names).toContain(HelperTools.ACTOR_CALL);
-        expect(names).toContain(HelperTools.ACTOR_CALL_WIDGET);
-        expect(names).toContain(HelperTools.ACTOR_RUNS_GET);
-        expect(names).toContain(HelperTools.ACTOR_RUNS_GET_WIDGET);
-        expect(names).not.toContain(HelperTools.STORE_SEARCH_WIDGET);
-        expect(names).not.toContain(HelperTools.ACTOR_GET_DETAILS_WIDGET);
+        expect(names).toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(names).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
+        expect(names).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
+        expect(names).toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
     });
 
     it('tools: ["actors"] category in apps mode pairs all four actor widgets', () => {
         const names = namesFor({ tools: ['actors'] }, ServerMode.APPS);
-        expect(names).toContain(HelperTools.STORE_SEARCH_WIDGET);
-        expect(names).toContain(HelperTools.ACTOR_GET_DETAILS_WIDGET);
-        expect(names).toContain(HelperTools.ACTOR_CALL_WIDGET);
-        expect(names).toContain(HelperTools.ACTOR_RUNS_GET_WIDGET);
+        expect(names).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+        expect(names).toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
+        expect(names).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
+        expect(names).toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
     });
 
     it('default mode adds no widget tools regardless of selection', () => {
         const names = namesFor({ tools: ['actors'] }, ServerMode.DEFAULT);
-        expect(names).not.toContain(HelperTools.STORE_SEARCH_WIDGET);
-        expect(names).not.toContain(HelperTools.ACTOR_GET_DETAILS_WIDGET);
-        expect(names).not.toContain(HelperTools.ACTOR_CALL_WIDGET);
-        expect(names).not.toContain(HelperTools.ACTOR_RUNS_GET_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
+        expect(names).not.toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
     });
 });
 
@@ -277,7 +277,7 @@ describe('taskSupport contract across tool categories', () => {
             // Only call-actor is expected to declare taskSupport among static internal tools.
             // (Dynamically-created Actor tools from actor_tools_factory also declare it, but those
             // are not returned by getCategoryTools.)
-            expect(toolsWithTaskSupport.map((t) => t.name)).toEqual([HelperTools.ACTOR_CALL]);
+            expect(toolsWithTaskSupport.map((t) => t.name)).toEqual([HELPER_TOOLS.ACTOR_CALL]);
 
             for (const { value } of toolsWithTaskSupport) {
                 expect(ALLOWED_TASK_TOOL_EXECUTION_MODES).toContain(value);

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -16,7 +16,7 @@ import { searchApifyDocs } from '../../src/tools/docs/search_apify_docs.js';
 import { CATEGORY_NAMES, getCategoryTools } from '../../src/tools/index.js';
 import { WIDGET_BY_BASE_TOOL } from '../../src/tools/registry.js';
 import type { Input, ToolBase, ToolEntry } from '../../src/types.js';
-import { SERVER_MODES, ServerMode } from '../../src/types.js';
+import { SERVER_MODES, SERVER_MODE } from '../../src/types.js';
 import { getToolPublicFieldOnly } from '../../src/utils/tools.js';
 import { getToolsForServerMode } from '../../src/utils/tools_loader.js';
 
@@ -211,12 +211,12 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
 });
 
 describe('apps-mode widget pairing in getToolsForServerMode', () => {
-    function namesFor(input: Input, mode: ServerMode): string[] {
+    function namesFor(input: Input, mode: SERVER_MODE): string[] {
         return getToolsForServerMode(input, [], mode).map((t) => t.name);
     }
 
     it('tools: ["docs"] in apps mode includes no widget tools', () => {
-        const names = namesFor({ tools: ['docs'] }, ServerMode.APPS);
+        const names = namesFor({ tools: ['docs'] }, SERVER_MODE.APPS);
         expect(names).toContain(HELPER_TOOLS.DOCS_SEARCH);
         expect(names).toContain(HELPER_TOOLS.DOCS_FETCH);
         expect(names).not.toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
@@ -226,7 +226,7 @@ describe('apps-mode widget pairing in getToolsForServerMode', () => {
     });
 
     it('tools: ["search-actors"] in apps mode pairs only the search-actors widget', () => {
-        const names = namesFor({ tools: ['search-actors'] }, ServerMode.APPS);
+        const names = namesFor({ tools: ['search-actors'] }, SERVER_MODE.APPS);
         expect(names).toContain(HELPER_TOOLS.STORE_SEARCH);
         expect(names).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
         expect(names).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
@@ -234,7 +234,7 @@ describe('apps-mode widget pairing in getToolsForServerMode', () => {
     });
 
     it('tools: ["call-actor"] in apps mode pairs call-actor-widget and the auto-injected get-actor-run-widget', () => {
-        const names = namesFor({ tools: ['call-actor'] }, ServerMode.APPS);
+        const names = namesFor({ tools: ['call-actor'] }, SERVER_MODE.APPS);
         expect(names).toContain(HELPER_TOOLS.ACTOR_CALL);
         expect(names).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
         expect(names).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
@@ -244,7 +244,7 @@ describe('apps-mode widget pairing in getToolsForServerMode', () => {
     });
 
     it('tools: ["actors"] category in apps mode pairs all four actor widgets', () => {
-        const names = namesFor({ tools: ['actors'] }, ServerMode.APPS);
+        const names = namesFor({ tools: ['actors'] }, SERVER_MODE.APPS);
         expect(names).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
         expect(names).toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
         expect(names).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
@@ -252,7 +252,7 @@ describe('apps-mode widget pairing in getToolsForServerMode', () => {
     });
 
     it('default mode adds no widget tools regardless of selection', () => {
-        const names = namesFor({ tools: ['actors'] }, ServerMode.DEFAULT);
+        const names = namesFor({ tools: ['actors'] }, SERVER_MODE.DEFAULT);
         expect(names).not.toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
         expect(names).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
         expect(names).not.toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);

--- a/tests/unit/tools.search_actors.default.response.test.ts
+++ b/tests/unit/tools.search_actors.default.response.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { APIFY_STORE_URL, HelperTools, MAX_INPUT_FIELDS_IN_ACTOR_CARD } from '../../src/const.js';
+import { APIFY_STORE_URL, HELPER_TOOLS, MAX_INPUT_FIELDS_IN_ACTOR_CARD } from '../../src/const.js';
 import { searchActors } from '../../src/tools/actors/search_actors.js';
 import { actorInfoSchema } from '../../src/tools/structured_output_schemas.js';
 import type { ActorStoreInputSchema, ActorStoreList, HelperTool } from '../../src/types.js';
@@ -82,7 +82,7 @@ describe('search-actors without widget (searchActors)', () => {
                 simplifyPricingForUserTier: true,
             }),
         );
-        expect(structuredContent.instructions).toContain(HelperTools.ACTOR_GET_DETAILS);
+        expect(structuredContent.instructions).toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
 
         expect(content).toHaveLength(1);
         expect((result as { _meta?: unknown })._meta).toBeUndefined();
@@ -92,7 +92,7 @@ describe('search-actors without widget (searchActors)', () => {
         expect(text).toContain(SEARCH_KEYWORDS);
         expect(text).toContain('Number of Actors found:** 1');
         expect(text).toContain('# Actors:');
-        expect(text).toContain(HelperTools.ACTOR_GET_DETAILS);
+        expect(text).toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
         expect(text).toContain(`## [${MOCK_STORE_ACTOR.title}](${APIFY_STORE_URL}/apify/web-scraper)`);
         expect(text).toContain('`apify/web-scraper`');
         expect(text).not.toContain('do NOT print or summarize');

--- a/tests/unit/tools.skyfire.test.ts
+++ b/tests/unit/tools.skyfire.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import {
     SKYFIRE_ENABLED_TOOLS,
     SKYFIRE_PAY_ID_PROPERTY_DESCRIPTION,
@@ -28,7 +28,7 @@ const MOCK_AJV_VALIDATE = vi.fn(() => true);
 
 function makeInternalTool(overrides: Partial<HelperTool> = {}): HelperTool {
     return {
-        name: HelperTools.ACTOR_CALL,
+        name: HELPER_TOOLS.ACTOR_CALL,
         description: 'Call an Actor',
         type: TOOL_TYPE.INTERNAL,
         inputSchema: {
@@ -78,7 +78,7 @@ function makeActorMcpTool(overrides: Partial<ActorMcpTool> = {}): ActorMcpTool {
 function makeNonEligibleInternalTool(): HelperTool {
     // search-apify-docs is NOT in SKYFIRE_ENABLED_TOOLS
     return makeInternalTool({
-        name: HelperTools.DOCS_SEARCH,
+        name: HELPER_TOOLS.DOCS_SEARCH,
         description: 'Search documentation',
     });
 }
@@ -147,7 +147,7 @@ describe('cloneToolEntry', () => {
 describe('applySkyfireAugmentation', () => {
     describe('eligible internal tools', () => {
         it('should augment an eligible internal tool', () => {
-            const original = makeInternalTool({ name: HelperTools.ACTOR_CALL });
+            const original = makeInternalTool({ name: HELPER_TOOLS.ACTOR_CALL });
             const result = applySkyfireAugmentation(original);
 
             // Returns a different object (cloned)
@@ -209,7 +209,7 @@ describe('applySkyfireAugmentation', () => {
 
     describe('idempotency', () => {
         it('should not double-append description when called twice', () => {
-            const original = makeInternalTool({ name: HelperTools.ACTOR_CALL });
+            const original = makeInternalTool({ name: HELPER_TOOLS.ACTOR_CALL });
             const firstPass = applySkyfireAugmentation(original);
             const secondPass = applySkyfireAugmentation(firstPass);
 
@@ -233,7 +233,7 @@ describe('applySkyfireAugmentation', () => {
 
     describe('frozen originals', () => {
         it('should not mutate a frozen internal tool', () => {
-            const original = Object.freeze(makeInternalTool({ name: HelperTools.ACTOR_CALL }));
+            const original = Object.freeze(makeInternalTool({ name: HELPER_TOOLS.ACTOR_CALL }));
             const result = applySkyfireAugmentation(original);
 
             // Result is augmented
@@ -263,7 +263,7 @@ describe('applySkyfireAugmentation', () => {
 
     describe('function preservation', () => {
         it('should preserve ajvValidate on augmented internal tool', () => {
-            const original = makeInternalTool({ name: HelperTools.ACTOR_CALL });
+            const original = makeInternalTool({ name: HELPER_TOOLS.ACTOR_CALL });
             const result = applySkyfireAugmentation(original) as HelperTool;
 
             expect(result.ajvValidate).toBe(original.ajvValidate);
@@ -271,7 +271,7 @@ describe('applySkyfireAugmentation', () => {
         });
 
         it('should preserve call function on augmented internal tool', () => {
-            const original = makeInternalTool({ name: HelperTools.ACTOR_CALL });
+            const original = makeInternalTool({ name: HELPER_TOOLS.ACTOR_CALL });
             const result = applySkyfireAugmentation(original) as HelperTool;
 
             expect(result.call).toBe(original.call);
@@ -289,7 +289,7 @@ describe('applySkyfireAugmentation', () => {
     describe('edge cases', () => {
         it('should handle tool with no description gracefully', () => {
             const original = makeInternalTool({
-                name: HelperTools.ACTOR_CALL,
+                name: HELPER_TOOLS.ACTOR_CALL,
                 description: undefined as unknown as string,
             });
             const result = applySkyfireAugmentation(original);
@@ -300,7 +300,7 @@ describe('applySkyfireAugmentation', () => {
 
         it('should handle tool with empty inputSchema properties', () => {
             const original = makeInternalTool({
-                name: HelperTools.ACTOR_CALL,
+                name: HELPER_TOOLS.ACTOR_CALL,
                 inputSchema: { type: 'object' as const, properties: {} },
             });
             const result = applySkyfireAugmentation(original);
@@ -318,12 +318,12 @@ describe('applySkyfireAugmentation', () => {
 describe('Skyfire eligibility matrix', () => {
     const testCases: { tool: ToolEntry; eligible: boolean; label: string }[] = [
         {
-            tool: makeInternalTool({ name: HelperTools.ACTOR_CALL }),
+            tool: makeInternalTool({ name: HELPER_TOOLS.ACTOR_CALL }),
             eligible: true,
             label: 'internal/eligible (call-actor)',
         },
         {
-            tool: makeInternalTool({ name: HelperTools.DATASET_GET_ITEMS }),
+            tool: makeInternalTool({ name: HELPER_TOOLS.DATASET_GET_ITEMS }),
             eligible: true,
             label: 'internal/eligible (get-dataset-items)',
         },

--- a/tests/unit/tools.storage_helpers.test.ts
+++ b/tests/unit/tools.storage_helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { FAILURE_CATEGORY, HelperTools, TOOL_STATUS } from '../../src/const.js';
+import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../src/const.js';
 import {
     buildDatasetItemsSummaryNextStep,
     buildStorageNotFound,
@@ -27,9 +27,9 @@ describe('buildDatasetItemsSummaryNextStep()', () => {
             itemCount: 5,
             totalItemCount: 5,
             offset: 0,
-            loadedToolNames: [HelperTools.DATASET_GET],
+            loadedToolNames: [HELPER_TOOLS.DATASET_GET],
         });
-        expect(t.nextStep).toContain(HelperTools.DATASET_GET);
+        expect(t.nextStep).toContain(HELPER_TOOLS.DATASET_GET);
         expect(t.nextStep).toContain('datasetId=ds-1');
     });
 
@@ -41,7 +41,7 @@ describe('buildDatasetItemsSummaryNextStep()', () => {
             offset: 0,
             loadedToolNames: [],
         });
-        expect(t.nextStep).not.toContain(HelperTools.DATASET_GET);
+        expect(t.nextStep).not.toContain(HELPER_TOOLS.DATASET_GET);
         expect(t.nextStep).toContain('No more pages');
     });
 
@@ -51,7 +51,7 @@ describe('buildDatasetItemsSummaryNextStep()', () => {
             itemCount: 20,
             totalItemCount: 100,
             offset: 0,
-            loadedToolNames: [HelperTools.DATASET_GET],
+            loadedToolNames: [HELPER_TOOLS.DATASET_GET],
         });
         const unloaded = buildDatasetItemsSummaryNextStep({
             datasetId: 'ds-1',
@@ -61,7 +61,7 @@ describe('buildDatasetItemsSummaryNextStep()', () => {
             loadedToolNames: [],
         });
         expect(loaded.nextStep).toBe(unloaded.nextStep);
-        expect(loaded.nextStep).toContain(HelperTools.DATASET_GET_ITEMS);
+        expect(loaded.nextStep).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
         expect(loaded.nextStep).toContain('offset=20');
     });
 });

--- a/tests/unit/utils.server_mode.parse.test.ts
+++ b/tests/unit/utils.server_mode.parse.test.ts
@@ -1,22 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
-import { ServerMode } from '../../src/types.js';
+import { SERVER_MODE } from '../../src/types.js';
 import { parseServerMode } from '../../src/utils/server_mode.js';
 
 describe('parseServerMode', () => {
     it.each([
-        ['true', ServerMode.APPS],
-        ['on', ServerMode.APPS],
-        [ServerMode.APPS, ServerMode.APPS],
-        ['openai', ServerMode.APPS],
+        ['true', SERVER_MODE.APPS],
+        ['on', SERVER_MODE.APPS],
+        [SERVER_MODE.APPS, SERVER_MODE.APPS],
+        ['openai', SERVER_MODE.APPS],
     ])('maps %s → apps', (input, expected) => {
         expect(parseServerMode(input)).toBe(expected);
     });
 
     it.each([
-        ['false', ServerMode.DEFAULT],
-        ['off', ServerMode.DEFAULT],
-        [ServerMode.DEFAULT, ServerMode.DEFAULT],
+        ['false', SERVER_MODE.DEFAULT],
+        ['off', SERVER_MODE.DEFAULT],
+        [SERVER_MODE.DEFAULT, SERVER_MODE.DEFAULT],
     ])('maps %s → default', (input, expected) => {
         expect(parseServerMode(input)).toBe(expected);
     });

--- a/tests/unit/utils.server_mode.resolve.test.ts
+++ b/tests/unit/utils.server_mode.resolve.test.ts
@@ -1,32 +1,32 @@
 import { describe, expect, it } from 'vitest';
 
 import { SERVER_MODE_AUTO_DETECTION_ENABLED } from '../../src/const.js';
-import { ServerMode } from '../../src/types.js';
+import { SERVER_MODE } from '../../src/types.js';
 import { resolveServerMode } from '../../src/utils/server_mode.js';
 
 describe('resolveServerMode', () => {
     it('returns concrete option as-is (capabilities ignored)', () => {
-        expect(resolveServerMode(ServerMode.APPS, false)).toBe(ServerMode.APPS);
-        expect(resolveServerMode(ServerMode.APPS, true)).toBe(ServerMode.APPS);
-        expect(resolveServerMode(ServerMode.DEFAULT, false)).toBe(ServerMode.DEFAULT);
-        expect(resolveServerMode(ServerMode.DEFAULT, true)).toBe(ServerMode.DEFAULT);
+        expect(resolveServerMode(SERVER_MODE.APPS, false)).toBe(SERVER_MODE.APPS);
+        expect(resolveServerMode(SERVER_MODE.APPS, true)).toBe(SERVER_MODE.APPS);
+        expect(resolveServerMode(SERVER_MODE.DEFAULT, false)).toBe(SERVER_MODE.DEFAULT);
+        expect(resolveServerMode(SERVER_MODE.DEFAULT, true)).toBe(SERVER_MODE.DEFAULT);
     });
 
     it('resolves auto to default when client does not support UI', () => {
-        expect(resolveServerMode('auto', false)).toBe(ServerMode.DEFAULT);
+        expect(resolveServerMode('auto', false)).toBe(SERVER_MODE.DEFAULT);
     });
 
     it.runIf(SERVER_MODE_AUTO_DETECTION_ENABLED)(
         'with auto-detection enabled, resolves auto to apps when client supports UI',
         () => {
-            expect(resolveServerMode('auto', true)).toBe(ServerMode.APPS);
+            expect(resolveServerMode('auto', true)).toBe(SERVER_MODE.APPS);
         },
     );
 
     it.runIf(!SERVER_MODE_AUTO_DETECTION_ENABLED)(
         'with auto-detection disabled, resolves auto to default regardless of client UI support',
         () => {
-            expect(resolveServerMode('auto', true)).toBe(ServerMode.DEFAULT);
+            expect(resolveServerMode('auto', true)).toBe(SERVER_MODE.DEFAULT);
         },
     );
 });

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -1,7 +1,7 @@
 import { ApifyClient } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
-import { HelperTools } from '../../src/const.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import type { ToolEntry } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
 import {
@@ -50,21 +50,21 @@ describe('loadToolsFromInput explicit-empty semantics', () => {
         );
 
         const toolNames = tools.map((tool) => tool.name);
-        expect(toolNames).toContain(HelperTools.DOCS_SEARCH);
-        expect(toolNames).toContain(HelperTools.DOCS_FETCH);
+        expect(toolNames).toContain(HELPER_TOOLS.DOCS_SEARCH);
+        expect(toolNames).toContain(HELPER_TOOLS.DOCS_FETCH);
         // get-actor-run is not requested and not triggered by call-actor, so no widgets appear
-        expect(toolNames).not.toContain(HelperTools.ACTOR_RUNS_GET);
-        expect(toolNames).not.toContain(HelperTools.ACTOR_RUNS_GET_WIDGET);
-        expect(toolNames).not.toContain(HelperTools.STORE_SEARCH_WIDGET);
-        expect(toolNames).not.toContain(HelperTools.ACTOR_GET_DETAILS_WIDGET);
-        expect(toolNames).not.toContain(HelperTools.ACTOR_CALL_WIDGET);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
+        expect(toolNames).not.toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
     });
 });
 
 describe('toolNamesToInput', () => {
     it('should keep internal tool names in tools and move actor names to actors', () => {
-        expect(toolNamesToInput([HelperTools.STORE_SEARCH, 'apify/rag-web-browser'])).toEqual({
-            tools: [HelperTools.STORE_SEARCH],
+        expect(toolNamesToInput([HELPER_TOOLS.STORE_SEARCH, 'apify/rag-web-browser'])).toEqual({
+            tools: [HELPER_TOOLS.STORE_SEARCH],
             actors: ['apify/rag-web-browser'],
         });
     });
@@ -77,8 +77,8 @@ describe('toolNamesToInput', () => {
     });
 
     it('should classify widget tool names as internal tools, not actor IDs', () => {
-        expect(toolNamesToInput([HelperTools.STORE_SEARCH_WIDGET])).toEqual({
-            tools: [HelperTools.STORE_SEARCH_WIDGET],
+        expect(toolNamesToInput([HELPER_TOOLS.STORE_SEARCH_WIDGET])).toEqual({
+            tools: [HELPER_TOOLS.STORE_SEARCH_WIDGET],
         });
     });
 });
@@ -90,15 +90,15 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
         const tools = await loadToolsFromInput({}, apifyClient);
         const toolNames = tools.map((t) => t.name);
 
-        expect(toolNames).toContain(HelperTools.ACTOR_CALL);
-        expect(toolNames).toContain(HelperTools.ACTOR_RUNS_GET);
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
         for (const name of AUTO_INJECTED_TOOL_NAMES) expect(toolNames).toContain(name);
 
-        const callIndex = toolNames.indexOf(HelperTools.ACTOR_CALL);
-        const runIndex = toolNames.indexOf(HelperTools.ACTOR_RUNS_GET);
-        const datasetIndex = toolNames.indexOf(HelperTools.DATASET_GET_ITEMS);
-        const kvIndex = toolNames.indexOf(HelperTools.KEY_VALUE_STORE_RECORD_GET);
-        const abortIndex = toolNames.indexOf(HelperTools.ACTOR_RUNS_ABORT);
+        const callIndex = toolNames.indexOf(HELPER_TOOLS.ACTOR_CALL);
+        const runIndex = toolNames.indexOf(HELPER_TOOLS.ACTOR_RUNS_GET);
+        const datasetIndex = toolNames.indexOf(HELPER_TOOLS.DATASET_GET_ITEMS);
+        const kvIndex = toolNames.indexOf(HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET);
+        const abortIndex = toolNames.indexOf(HELPER_TOOLS.ACTOR_RUNS_ABORT);
         expect(callIndex).toBeLessThan(runIndex);
         expect(runIndex).toBeLessThan(datasetIndex);
         expect(datasetIndex).toBeLessThan(kvIndex);
@@ -109,7 +109,7 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
         const tools = await loadToolsFromInput({ tools: ['docs'] }, apifyClient);
         const toolNames = tools.map((t) => t.name);
 
-        expect(toolNames).not.toContain(HelperTools.ACTOR_CALL);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_CALL);
         for (const name of AUTO_INJECTED_TOOL_NAMES) expect(toolNames).not.toContain(name);
     });
 
@@ -125,8 +125,8 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
         const tools = await loadToolsFromInput({ tools: ['runs'] }, apifyClient);
         const toolNames = tools.map((t) => t.name);
 
-        expect(toolNames).toContain(HelperTools.ACTOR_RUNS_GET);
-        expect(toolNames).not.toContain(HelperTools.ACTOR_CALL);
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_CALL);
         for (const name of AUTO_INJECTED_TOOL_NAMES) expect(toolNames).toContain(name);
     });
 
@@ -142,7 +142,7 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
             const toolNames = tools.map((t) => t.name);
 
             expect(toolNames).toContain('apify--rag-web-browser');
-            expect(toolNames).toContain(HelperTools.ACTOR_RUNS_GET);
+            expect(toolNames).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
             for (const name of AUTO_INJECTED_TOOL_NAMES) expect(toolNames).toContain(name);
         },
     );
@@ -152,21 +152,21 @@ describe('loadToolsFromInput explicit widget selection', () => {
     const apifyClient = new ApifyClient({ token: 'test-token' });
 
     it('should resolve an explicit widget name to the widget tool in apps mode', async () => {
-        const tools = await loadToolsFromInput({ tools: [HelperTools.STORE_SEARCH_WIDGET] }, apifyClient, 'apps');
+        const tools = await loadToolsFromInput({ tools: [HELPER_TOOLS.STORE_SEARCH_WIDGET] }, apifyClient, 'apps');
         const toolNames = tools.map((t) => t.name);
-        expect(toolNames).toContain(HelperTools.STORE_SEARCH_WIDGET);
+        expect(toolNames).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
     });
 
     it('should not duplicate the widget when both base and widget are explicitly selected', async () => {
         const tools = await loadToolsFromInput(
-            { tools: [HelperTools.STORE_SEARCH, HelperTools.STORE_SEARCH_WIDGET] },
+            { tools: [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.STORE_SEARCH_WIDGET] },
             apifyClient,
             'apps',
         );
         const toolNames = tools.map((t) => t.name);
         // Base selected explicitly + widget selected explicitly + pairing pass would push widget again.
         // The de-dup pass must collapse to exactly one widget entry.
-        expect(toolNames.filter((n) => n === HelperTools.STORE_SEARCH_WIDGET)).toHaveLength(1);
-        expect(toolNames.filter((n) => n === HelperTools.STORE_SEARCH)).toHaveLength(1);
+        expect(toolNames.filter((n) => n === HELPER_TOOLS.STORE_SEARCH_WIDGET)).toHaveLength(1);
+        expect(toolNames.filter((n) => n === HELPER_TOOLS.STORE_SEARCH)).toHaveLength(1);
     });
 });


### PR DESCRIPTION
Phases 6 and 7 of #643 — align the last two enumerations with the `as const` + uppercase `SNAKE_CASE` convention.

## What we're solving

- **`HelperTools`** was the last TypeScript `enum` (used in ~460 places, re-exported to the hosted server via `./internals`).
- **`ServerMode`** was already an `as const` object but `PascalCase`; the enumeration convention wants uppercase `SNAKE_CASE`. Spotted while doing the `HelperTools` work.

closes #643 

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W21qeHkur4U2qeFHCwVHAJ