### PR TITLE
feat: add experimental Code Mode tools (run-code + get-code-docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ Upon launching, the Inspector will display a URL that you can open in your brows
 ## Unauthenticated access
 
 When the `tools` query parameter includes only tools explicitly enabled for unauthenticated use, the hosted server allows access without an API token.
-Currently allowed tools: `search-actors`, `fetch-actor-details`, `search-apify-docs`, `fetch-apify-docs`.
+Currently allowed tools: `search-actors`, `fetch-actor-details`, `search-apify-docs`, `fetch-apify-docs`, `get-code-docs`.
 Example: `https://mcp.apify.com?tools=search-actors`.
 
 ## 🐦 Canary PR releases

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Here is an overview list of all the tools provided by the Apify MCP Server.
 
 Legend for the **Enabled by default** column:
 - ✅ — in the default tool set.
-- ⚡ — auto-injected when `call-actor`, `add-actor`, an Actor tool, or `get-actor-run` is present (which is true in the default configuration).
+- ⚡ — auto-injected when `call-actor`, `add-actor`, `run-code`, an Actor tool, or `get-actor-run` is present (which is true in the default configuration).
 
 | Tool name | Category | Description | Enabled by default |
 | :--- | :--- | :--- | :---: |
@@ -265,10 +265,12 @@ Legend for the **Enabled by default** column:
 | `get-dataset-list` | storage | List all available datasets for the user. |  |
 | `get-key-value-store-list`| storage | List all available key-value stores for the user. |  |
 | `add-actor` | experimental | Add an Actor as a new tool for the user to call. |  |
+| `run-code` | experimental | Run MCP in Code mode and orchestrate actions through code in one go. Execute JS/TS script in a sandboxed Actor. |  |
+| `get-code-docs` | experimental | Read the Code Mode guide for writing run-code scripts. |  |
 
 > **Note:**
 >
-> When `call-actor`, `add-actor`, an Actor tool, or `get-actor-run` is present, the server auto-injects `get-actor-run`, `get-dataset-items`, `get-key-value-store-record`, and `abort-actor-run`.
+> When `call-actor`, `add-actor`, `run-code`, an Actor tool, or `get-actor-run` is present, the server auto-injects `get-actor-run`, `get-dataset-items`, `get-key-value-store-record`, and `abort-actor-run`.
 >
 > When you call an Actor — through `call-actor` or directly via an Actor tool (e.g., `apify--rag-web-browser`) — the response contains run metadata, storage IDs, and a `summary` + `nextStep`, but no dataset items. To fetch items, follow `nextStep` and call `get-dataset-items` (auto-injected), passing the `datasetId` returned from the call.
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -54,8 +54,13 @@ export const HELPER_TOOLS = {
     STORE_SEARCH_WIDGET: 'search-actors-widget',
     DOCS_SEARCH: 'search-apify-docs',
     DOCS_FETCH: 'fetch-apify-docs',
+    CODE_RUN: 'run-code',
+    CODE_DOCS: 'get-code-docs',
 } as const;
 export type HelperToolName = (typeof HELPER_TOOLS)[keyof typeof HELPER_TOOLS];
+
+/** Actor backing Code Mode's run-code tool. Runs a user script in a workerd sandbox. */
+export const APIFY_CODE_RUNTIME_ACTOR = 'apify/code-runtime';
 
 export const RAG_WEB_BROWSER = 'apify/rag-web-browser';
 export const RAG_WEB_BROWSER_WHITELISTED_FIELDS = ['query', 'maxResults', 'outputFormats'];

--- a/src/tools/actors/code_docs_content.ts
+++ b/src/tools/actors/code_docs_content.ts
@@ -37,11 +37,12 @@ returns the same Actor record at runtime.)
 ## Returning results
 - \`console.log\` / \`console.info\` go to stdout; \`console.error\` / \`console.warn\` go to stderr.
 - When the script finishes, both are stored in the run's default dataset as a single item
-  \`{ stdout, stderr }\`, which the caller reads with ${HELPER_TOOLS.DATASET_GET_ITEMS}.
+  \`{ stdout, stderr, exitCode }\`, which the caller reads with ${HELPER_TOOLS.DATASET_GET_ITEMS}.
 - Your answer = what you print. Print a concise, JSON-stringified summary of the distilled result —
   never dump entire datasets (that wastes tokens and context).
-- If your script throws, the error is captured to stderr and the run still SUCCEEDS, so failures are
-  observable in the output.
+- If your script throws, the error is captured to stderr, \`exitCode\` is 1, and the run still
+  SUCCEEDS. Check \`exitCode\` (0 = ok, 1 = the script threw) to detect a failed script — not stderr,
+  which is also written by ordinary \`console.error\` / \`console.warn\` logging.
 - For long scripts, the run may still be RUNNING when \`${HELPER_TOOLS.CODE_RUN}\`'s wait cap (waitSecs)
   elapses — the caller then polls ${HELPER_TOOLS.ACTOR_RUNS_GET} until it finishes.
 

--- a/src/tools/actors/code_docs_content.ts
+++ b/src/tools/actors/code_docs_content.ts
@@ -1,0 +1,163 @@
+/**
+ * Manpage-style guide for writing Code Mode scripts (the `run-code` tool). Each page is a single
+ * focused unit; `get-code-docs` serves one page at a time. Keep pages reasonably sized — exhaustive
+ * per-method detail lives in the linked actor-code-runtime API reference.
+ */
+
+import { HELPER_TOOLS } from '../../const.js';
+
+/** Ordered page names; `overview` is the default/index page. */
+export const CODE_DOCS_PAGE_NAMES = ['overview', 'api', 'recipes'] as const;
+
+export type CodeDocsPage = (typeof CODE_DOCS_PAGE_NAMES)[number];
+
+/** Identical navigation footer appended to every page; the page list comes from the single source. */
+const SEE_ALSO = `## SEE ALSO
+Other Code Mode guide pages (call ${HELPER_TOOLS.CODE_DOCS} with page=<name>): ${CODE_DOCS_PAGE_NAMES.join(', ')}.`;
+
+const OVERVIEW = `# Code Mode — runtime & result contract
+
+\`${HELPER_TOOLS.CODE_RUN}\` executes one async JavaScript/TypeScript script in a sandboxed Apify Actor. Use it to do
+many operations in a single run — search, run and chain Actors, read datasets, then
+filter/aggregate locally — instead of sending every intermediate result back through the model.
+
+## Execution
+- Your code is an async script body with top-level \`await\`.
+- Two globals are injected: \`apify\` (the Apify binding) and \`console\`.
+- Sandbox: no filesystem, no package imports (no \`require\`/\`import\`), outbound \`fetch\` limited to the
+  apify.com domain and its subdomains (\`*.apify.com\`) only, limited permissions, single-use container
+  (nothing persists between runs).
+
+## Before using an Actor
+For every Actor you plan to run from your script, FIRST call the \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` tool to read
+its input and output schemas. Use it to build valid \`input\` and to know which output fields the run
+produces, so your code reads the right ones. (In-script, \`apify.actor.getDetails({ actorId })\`
+returns the same Actor record at runtime.)
+
+## Returning results
+- \`console.log\` / \`console.info\` go to stdout; \`console.error\` / \`console.warn\` go to stderr.
+- When the script finishes, both are stored in the run's default dataset as a single item
+  \`{ stdout, stderr }\`, which the caller reads with ${HELPER_TOOLS.DATASET_GET_ITEMS}.
+- Your answer = what you print. Print a concise, JSON-stringified summary of the distilled result —
+  never dump entire datasets (that wastes tokens and context).
+- If your script throws, the error is captured to stderr and the run still SUCCEEDS, so failures are
+  observable in the output.
+- For long scripts, the run may still be RUNNING when \`${HELPER_TOOLS.CODE_RUN}\`'s wait cap (waitSecs)
+  elapses — the caller then polls ${HELPER_TOOLS.ACTOR_RUNS_GET} until it finishes.
+
+## Save storage IDs before you process
+Actor runs cost money and the post-run processing is what usually breaks. As each run finishes,
+\`console.log\` its \`run.id\` / \`defaultDatasetId\` / \`defaultKeyValueStoreId\` BEFORE processing — if the
+script then throws, re-run reading those existing storages instead of paying to run the Actors again.
+
+${SEE_ALSO}`;
+
+const API = `# The \`apify\` binding
+
+A global \`apify\` object exposes a typed subset of the Apify API, authenticated with the run's token.
+Every method is async, takes one options object, and returns parsed JSON.
+
+## Actors
+apify.actor.search({ query, limit?, category? })            // → actors[]
+apify.actor.getDetails({ actorId })                         // → actor (incl. input schema)
+apify.actor.start({ actorId, input?, memoryMbytes?, timeoutSecs?, maxTotalChargeUsd?, maxItems? })  // → run (async)
+apify.actor.run({ actorId, input?, waitForFinishSecs = 60, ...startOpts })   // → run (waits, cap 60s)
+apify.actor.runAndGetItems({ actorId, input?, fields?, limit?, ...runOpts })  // → { run, items }
+
+## Runs
+apify.run.get({ runId })                                    // → run
+apify.run.wait({ runId, waitForFinishSecs = 60 })           // → run
+apify.run.abort({ runId })                                  // → run
+apify.run.getLog({ runId, limit? })                         // → string
+
+## Datasets
+apify.dataset.create({ name? })                             // → dataset
+apify.dataset.pushItems({ datasetId, items })               // → void
+apify.dataset.listItems({ datasetId, fields?, omit?, limit?, offset?, clean?, desc? })  // → items[]
+apify.dataset.iterate({ datasetId, batchSize = 1000, ...filters })  // → async iterable
+apify.dataset.getSchema({ datasetId, sample = 5 })          // → { itemCount, sampleSize, fields[] }
+
+## Key-value stores
+apify.kvs.create({ name? })                                 // → store
+apify.kvs.set({ storeId, key, value, contentType? })        // → void
+apify.kvs.get({ storeId, key })                             // → value | null (null when missing)
+apify.kvs.list({ storeId, limit?, exclusiveStartKey? })     // → { items: [{ key, size }] }
+
+Full per-method reference: https://github.com/apify/actor-code-runtime/blob/master/docs/API.md
+
+${SEE_ALSO}`;
+
+const RECIPES = `# Recipes — calling Actors & working with storages
+
+## Discover and inspect
+const found = await apify.actor.search({ query: 'instagram', limit: 5 });
+const details = await apify.actor.getDetails({ actorId: 'apify/instagram-scraper' });
+// details includes the input schema — build a valid \`input\` from it.
+
+## Run: sync vs async
+- apify.actor.run({ actorId, input, waitForFinishSecs }) starts and waits (cap 60s/call) → run.
+- apify.actor.start({ actorId, input }) returns immediately (status READY/RUNNING).
+- apify.actor.runAndGetItems({ actorId, input, limit }) runs then returns { run, items }.
+- Each run is billed — bound cost with the Actor's own input limits and callOptions (maxItems for
+  pay-per-result, maxTotalChargeUsd for pay-per-event).
+
+## Runs longer than 60s: start, then poll until terminal
+let run = await apify.actor.start({ actorId, input });
+const TERMINAL = ['SUCCEEDED', 'FAILED', 'ABORTED', 'TIMED-OUT'];
+while (!TERMINAL.includes(run.status)) {
+    run = await apify.run.wait({ runId: run.id, waitForFinishSecs: 60 });
+}
+
+## Chain Actors (one run's output → next run's input)
+const { items } = await apify.actor.runAndGetItems({
+    actorId: 'apify/google-search-scraper', input: { queries: 'apify' }, limit: 10,
+});
+const startUrls = items.flatMap((i) => i.organicResults ?? []).map((r) => ({ url: r.url }));
+const { items: pages } = await apify.actor.runAndGetItems({
+    actorId: 'apify/website-content-crawler', input: { startUrls },
+});
+
+## Run many inputs, keep going on errors
+const inputs = [{ query: 'a' }, { query: 'b' }, { query: 'c' }];
+const collected = [];
+for (const input of inputs) {
+    try {
+        const { items } = await apify.actor.runAndGetItems({ actorId: 'apify/rag-web-browser', input, limit: 5 });
+        collected.push(...items);
+    } catch (err) {
+        console.error('failed input ' + JSON.stringify(input) + ': ' + err.message);
+    }
+}
+
+## Datasets
+- Read one page: const items = await apify.dataset.listItems({ datasetId, limit: 50, fields: ['title', 'url'] });
+- Iterate everything (auto-pages): for await (const item of apify.dataset.iterate({ datasetId })) { /* ... */ }
+- Write your own results: const ds = await apify.dataset.create(); await apify.dataset.pushItems({ datasetId: ds.id, items: [{ a: 1 }] });
+- Inspect shape/count: const schema = await apify.dataset.getSchema({ datasetId });
+A run's results live in run.defaultDatasetId; use \`fields\` and \`limit\` to keep payloads small.
+
+## Key-value stores (non-tabular blobs, intermediate state)
+const kv = await apify.kvs.create();
+await apify.kvs.set({ storeId: kv.id, key: 'state', value: { seen: [] } }); // object → JSON
+const state = await apify.kvs.get({ storeId: kv.id, key: 'state' });        // → object, or null if missing
+\`kvs.get\` returns null (not an error) for a missing key, so lookup-or-default needs no try/catch.
+Read type follows the stored content type: JSON → object, text/* → string, else Uint8Array.
+
+## Aggregate locally, return little
+Do the data-wrangling in JS and print only the distilled result:
+const { items } = await apify.actor.runAndGetItems({
+    actorId: 'apify/google-search-scraper', input: { queries: 'web scraping' }, limit: 50,
+});
+const top = items
+    .flatMap((i) => i.organicResults ?? [])
+    .slice(0, 5)
+    .map((r) => ({ title: r.title, url: r.url }));
+console.log(JSON.stringify(top)); // 5 rows back to the model, not 50 pages of raw output
+
+${SEE_ALSO}`;
+
+export const CODE_DOCS_PAGES: Record<CodeDocsPage, string> = {
+    overview: OVERVIEW,
+    api: API,
+    recipes: RECIPES,
+};

--- a/src/tools/actors/code_docs_content.ts
+++ b/src/tools/actors/code_docs_content.ts
@@ -24,9 +24,10 @@ filter/aggregate locally — instead of sending every intermediate result back t
 ## Execution
 - Your code is an async script body with top-level \`await\`.
 - Two globals are injected: \`apify\` (the Apify binding) and \`console\`.
-- Sandbox: no filesystem, no package imports (no \`require\`/\`import\`), outbound \`fetch\` limited to the
-  apify.com domain and its subdomains (\`*.apify.com\`) only, limited permissions, single-use container
-  (nothing persists between runs).
+- Sandbox: no filesystem, no imports at all (no \`require\`/\`import\` — neither npm packages nor Node
+  \`node:*\` built-ins are available), outbound \`fetch\` limited to the apify.com domain and its
+  subdomains (\`*.apify.com\`) only, limited permissions, single-use container (nothing persists
+  between runs).
 
 ## Before using an Actor
 For every Actor you plan to run from your script, FIRST call the \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` tool to read

--- a/src/tools/actors/get_code_docs.ts
+++ b/src/tools/actors/get_code_docs.ts
@@ -1,0 +1,72 @@
+import dedent from 'dedent';
+import { z } from 'zod';
+
+import { HELPER_TOOLS } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
+import { compileSchema, fixZodSchemaRequired } from '../../utils/ajv.js';
+import { buildMCPResponse } from '../../utils/mcp.js';
+import { CODE_DOCS_PAGE_NAMES, CODE_DOCS_PAGES, type CodeDocsPage } from './code_docs_content.js';
+
+const DEFAULT_PAGE: CodeDocsPage = 'overview';
+
+const getCodeDocsArgs = z.object({
+    page: z
+        .enum(CODE_DOCS_PAGE_NAMES)
+        .default(DEFAULT_PAGE)
+        .optional()
+        .describe(
+            `Which guide page to return. One of: ${CODE_DOCS_PAGE_NAMES.join(', ')}. Defaults to "${DEFAULT_PAGE}".`,
+        ),
+});
+
+const getCodeDocsInputSchema = fixZodSchemaRequired(z.toJSONSchema(getCodeDocsArgs)) as ToolInputSchema;
+
+const getCodeDocsOutputSchema = {
+    type: 'object' as const,
+    properties: {
+        page: { type: 'string', description: 'The guide page name that was returned' },
+        content: { type: 'string', description: 'Markdown content of the guide page' },
+    },
+    required: ['page', 'content'],
+};
+
+const GET_CODE_DOCS_DESCRIPTION = dedent`
+    Read the Code Mode guide for writing ${HELPER_TOOLS.CODE_RUN} scripts. The guide is split into
+    manpage-style pages; this tool returns one page at a time.
+
+    Call this BEFORE ${HELPER_TOOLS.CODE_RUN} to learn the \`apify\` binding and the orchestration
+    patterns, then write your script.
+
+    Pages (pass via \`page\`):
+    - overview — runtime model, sandbox limits, and how results come back (the default page)
+    - api      — the \`apify\` binding method reference
+    - recipes  — worked examples: calling & chaining Actors, storages, local aggregation
+`;
+
+/** Code Mode `get-code-docs` — static, paginated guide. No token or network required. */
+export const getCodeDocs: ToolEntry = Object.freeze({
+    type: TOOL_TYPE.INTERNAL,
+    name: HELPER_TOOLS.CODE_DOCS,
+    title: 'Get code docs',
+    description: GET_CODE_DOCS_DESCRIPTION,
+    inputSchema: getCodeDocsInputSchema,
+    outputSchema: getCodeDocsOutputSchema,
+    ajvValidate: compileSchema(z.toJSONSchema(getCodeDocsArgs)),
+    annotations: {
+        title: 'Get code docs',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+    },
+    call: async (toolArgs: InternalToolArgs) => {
+        const parsed = getCodeDocsArgs.parse(toolArgs.args);
+        const page = (parsed.page ?? DEFAULT_PAGE) as CodeDocsPage;
+        const content = CODE_DOCS_PAGES[page];
+        return buildMCPResponse({
+            texts: [content],
+            structuredContent: { page, content },
+        });
+    },
+} as const);

--- a/src/tools/actors/run_code.ts
+++ b/src/tools/actors/run_code.ts
@@ -34,9 +34,13 @@ export const runCodeArgs = z.object({
         .describe(
             `Seconds to wait for the run to finish. Range 0–${WAIT_SECS_MAX}; ${WAIT_SECS_MAX} is the MAXIMUM — values above ${WAIT_SECS_MAX} (e.g. 60) are rejected. Default ${CALL_ACTOR_WAIT_SECS_DEFAULT}. If the run isn't terminal within waitSecs, returns the current run status; use 0 to start and return immediately for long scripts.`,
         ),
+    // code-runtime is a platform-usage Actor, so the pay-per-event / pay-per-result caps
+    // (maxTotalChargeUsd, maxItems) are silently ignored by the platform — expose only the
+    // options that actually apply. See PR #1044 for the removed cost cap.
     callOptions: callOptionsSchema
+        .pick({ memory: true, timeout: true })
         .optional()
-        .describe('Optional run config: memory (MB), timeout (s), maxTotalChargeUsd (cost cap).'),
+        .describe('Optional run config: memory (MB), timeout (s).'),
 });
 
 const runCodeInputSchema = z.toJSONSchema(runCodeArgs) as ToolInputSchema;

--- a/src/tools/actors/run_code.ts
+++ b/src/tools/actors/run_code.ts
@@ -56,8 +56,9 @@ const RUN_CODE_DESCRIPTION = dedent`
     one script here — not as separate ${HELPER_TOOLS.ACTOR_CALL} / ${HELPER_TOOLS.DATASET_GET_ITEMS} calls.
     One script is faster, cheaper, and keeps large intermediate data out of the model context.
 
-    OUTPUT: the script's { stdout, stderr } is written to the run's default dataset; follow the
-    nextStep and read it with ${HELPER_TOOLS.DATASET_GET_ITEMS} using the returned datasetId.
+    OUTPUT: the script's { stdout, stderr, exitCode } is written to the run's default dataset; follow
+    the nextStep and read it with ${HELPER_TOOLS.DATASET_GET_ITEMS} using the returned datasetId.
+    exitCode is 0 on success, 1 if the script threw (check it, not stderr, to detect a failed script).
 
     WORKFLOW: (1) call ${HELPER_TOOLS.CODE_DOCS} (overview page) to learn the binding, and
     ${HELPER_TOOLS.ACTOR_GET_DETAILS} for each Actor you'll use to get its input/output schemas;

--- a/src/tools/actors/run_code.ts
+++ b/src/tools/actors/run_code.ts
@@ -1,0 +1,139 @@
+import dedent from 'dedent';
+import { z } from 'zod';
+
+import log from '@apify/log';
+
+import { APIFY_CODE_RUNTIME_ACTOR, HELPER_TOOLS } from '../../const.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
+import { TOOL_TYPE } from '../../types.js';
+import { compileSchema } from '../../utils/ajv.js';
+import { getConsoleLinkContext } from '../../utils/console_link.js';
+import { buildGetActorRunSuccessResponse } from '../runs/get_actor_run.js';
+import { actorRunOutputSchema } from '../structured_output_schemas.js';
+import {
+    abortRunOnSignal,
+    buildStartRunResponse,
+    CALL_ACTOR_WAIT_SECS_DEFAULT,
+    fetchActorRunData,
+    WAIT_SECS_MAX,
+} from './actor_run_response.js';
+import { buildCallActorErrorResponse, callOptionsSchema } from './call_actor.js';
+
+export const runCodeArgs = z.object({
+    code: z
+        .string()
+        .min(1)
+        .describe(`The JavaScript/TypeScript to run. Call ${HELPER_TOOLS.CODE_DOCS} to learn how to write it.`),
+    waitSecs: z
+        .number()
+        .int()
+        .min(0, 'waitSecs must be 0 or greater')
+        .max(WAIT_SECS_MAX, `waitSecs cannot exceed ${WAIT_SECS_MAX}`)
+        .default(CALL_ACTOR_WAIT_SECS_DEFAULT)
+        .optional()
+        .describe(
+            `Seconds to wait for the run to finish. Range 0–${WAIT_SECS_MAX}; ${WAIT_SECS_MAX} is the MAXIMUM — values above ${WAIT_SECS_MAX} (e.g. 60) are rejected. Default ${CALL_ACTOR_WAIT_SECS_DEFAULT}. If the run isn't terminal within waitSecs, returns the current run status; use 0 to start and return immediately for long scripts.`,
+        ),
+    callOptions: callOptionsSchema
+        .optional()
+        .describe('Optional run config: memory (MB), timeout (s), maxTotalChargeUsd (cost cap).'),
+});
+
+const runCodeInputSchema = z.toJSONSchema(runCodeArgs) as ToolInputSchema;
+
+const RUN_CODE_DESCRIPTION = dedent`
+    Run a JavaScript/TypeScript script in a sandboxed Apify Actor (${APIFY_CODE_RUNTIME_ACTOR}) with an
+    \`apify\` binding (search/run Actors, read/write datasets and key-value stores), then return the run
+    result. Limited permissions: no filesystem, no imports, outbound network limited to the apify.com
+    domain and its subdomains (*.apify.com) only.
+
+    USE THIS FIRST FOR ANY MULTI-STEP TASK. If the request needs 2+ Actor runs, feeds one Actor's output
+    into another, or filters/transforms/joins/aggregates Actor results before answering, do it all in
+    one script here — not as separate ${HELPER_TOOLS.ACTOR_CALL} / ${HELPER_TOOLS.DATASET_GET_ITEMS} calls.
+    One script is faster, cheaper, and keeps large intermediate data out of the model context.
+
+    OUTPUT: the script's { stdout, stderr } is written to the run's default dataset; follow the
+    nextStep and read it with ${HELPER_TOOLS.DATASET_GET_ITEMS} using the returned datasetId.
+
+    WORKFLOW: (1) call ${HELPER_TOOLS.CODE_DOCS} (overview page) to learn the binding, and
+    ${HELPER_TOOLS.ACTOR_GET_DETAILS} for each Actor you'll use to get its input/output schemas;
+    (2) call this tool with your \`code\`.
+`;
+
+/**
+ * Code Mode `run-code` — thin wrapper over the canonical call-actor start→wait→respond pipeline,
+ * hardcoded to the ${APIFY_CODE_RUNTIME_ACTOR} Actor with `{ code }` as input.
+ */
+export const runCode: ToolEntry = Object.freeze({
+    type: TOOL_TYPE.INTERNAL,
+    name: HELPER_TOOLS.CODE_RUN,
+    title: 'Run code',
+    description: RUN_CODE_DESCRIPTION,
+    inputSchema: runCodeInputSchema,
+    outputSchema: actorRunOutputSchema,
+    ajvValidate: compileSchema(runCodeInputSchema),
+    paymentRequired: true,
+    annotations: {
+        title: 'Run code',
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+    },
+    execution: {
+        // Scripts can orchestrate long-running Actors.
+        taskSupport: 'optional',
+    },
+    call: async (toolArgs: InternalToolArgs) => {
+        const { apifyClient, apifyToken, args, extra, mcpSessionId, progressTracker, taskMode } = toolArgs;
+        const parsed = runCodeArgs.parse(args);
+        // Task mode waits until terminal (SDK default); otherwise block up to waitSecs.
+        const waitSecs = taskMode ? undefined : parsed.waitSecs;
+        const abortSignal = extra?.signal;
+
+        try {
+            if (abortSignal?.aborted) return {};
+
+            const actorRun = await apifyClient
+                .actor(APIFY_CODE_RUNTIME_ACTOR)
+                .start({ code: parsed.code }, parsed.callOptions);
+            log.debug('Started code-runtime run', { runId: actorRun.id, mcpSessionId, waitSecs });
+
+            // Abort can arrive while start() was in flight — abort the newly created run.
+            if (abortSignal?.aborted) {
+                await abortRunOnSignal(actorRun.id, apifyClient);
+                return {};
+            }
+
+            const linkContext = await getConsoleLinkContext(apifyToken, apifyClient);
+
+            // waitSecs:0 means "fire and forget" — start() already returned the full run, skip re-fetch.
+            if (waitSecs === 0) {
+                return buildStartRunResponse({ actorName: APIFY_CODE_RUNTIME_ACTOR, actorRun, linkContext });
+            }
+
+            const fetchResult = await fetchActorRunData({
+                runId: actorRun.id,
+                waitSecs,
+                actorName: APIFY_CODE_RUNTIME_ACTOR,
+                client: apifyClient,
+                progressTracker,
+                abortSignal,
+                mcpSessionId,
+                onAbort: abortRunOnSignal,
+            });
+
+            if ('aborted' in fetchResult) return {};
+            if ('error' in fetchResult) return fetchResult.error;
+
+            return buildGetActorRunSuccessResponse({ ...fetchResult.result, widget: false, linkContext });
+        } catch (error) {
+            return buildCallActorErrorResponse({
+                actorName: APIFY_CODE_RUNTIME_ACTOR,
+                error,
+                mcpSessionId,
+                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
+            });
+        }
+    },
+} as const);

--- a/src/tools/actors/run_code.ts
+++ b/src/tools/actors/run_code.ts
@@ -48,8 +48,8 @@ const runCodeInputSchema = z.toJSONSchema(runCodeArgs) as ToolInputSchema;
 const RUN_CODE_DESCRIPTION = dedent`
     Run a JavaScript/TypeScript script in a sandboxed Apify Actor (${APIFY_CODE_RUNTIME_ACTOR}) with an
     \`apify\` binding (search/run Actors, read/write datasets and key-value stores), then return the run
-    result. Limited permissions: no filesystem, no imports, outbound network limited to the apify.com
-    domain and its subdomains (*.apify.com) only.
+    result. Limited permissions: no filesystem, no imports (neither npm packages nor Node node:*
+    built-ins), outbound network limited to the apify.com domain and its subdomains (*.apify.com) only.
 
     USE THIS FIRST FOR ANY MULTI-STEP TASK. If the request needs 2+ Actor runs, feeds one Actor's output
     into another, or filters/transforms/joins/aggregates Actor results before answering, do it all in

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,11 @@ export const unauthEnabledTools: string[] = [
     HELPER_TOOLS.DOCS_FETCH,
     HELPER_TOOLS.STORE_SEARCH,
     HELPER_TOOLS.ACTOR_GET_DETAILS,
+    // get-code-docs serves a fully static guide (no token, no network), so a
+    // docs-only server can start unauthenticated. run-code (paired with it by
+    // the loader) still needs a token, but the token gate keys off the tools the
+    // caller explicitly requested, so requesting get-code-docs alone stays unauth.
+    HELPER_TOOLS.CODE_DOCS,
 ];
 
 // Re-export from registry.ts

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -25,6 +25,8 @@ import { SERVER_MODE } from '../types.js';
 import { addActor } from './actors/add_actor.js';
 import { callActorApps, callActorDefault } from './actors/call_actor.js';
 import { fetchActorDetails } from './actors/fetch_actor_details.js';
+import { getCodeDocs } from './actors/get_code_docs.js';
+import { runCode } from './actors/run_code.js';
 import { searchActors } from './actors/search_actors.js';
 import { fetchApifyDocs } from './docs/fetch_apify_docs.js';
 import { searchApifyDocs } from './docs/search_apify_docs.js';
@@ -64,7 +66,7 @@ function isModeMap(entry: CategoryToolEntry): entry is ModeMap {
  * Use {@link getCategoryTools} to resolve entries into concrete ToolEntry arrays for a given mode.
  */
 export const toolCategories = {
-    experimental: [addActor],
+    experimental: [addActor, runCode, getCodeDocs],
     actors: [
         searchActors,
         fetchActorDetails,

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -10,6 +10,8 @@ import log from '@apify/log';
 import { defaults, HELPER_TOOLS, type HelperToolName } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { addActor } from '../tools/actors/add_actor.js';
+import { getCodeDocs } from '../tools/actors/get_code_docs.js';
+import { runCode } from '../tools/actors/run_code.js';
 import { getActorsAsTools } from '../tools/index.js';
 import {
     CATEGORY_NAME_SET,
@@ -261,6 +263,14 @@ export function getToolsForServerMode(
         result.push(...actorTools);
     }
 
+    // Code Mode tools are a pair: get-code-docs teaches how to write the script that run-code runs.
+    // Selecting either alone is a mistake, so load both when the caller selected just one. Done before
+    // the auto-inject block below so a lone get-code-docs still pulls in run-code's run/storage helpers.
+    const selectedRunCode = result.some((entry) => entry.name === HELPER_TOOLS.CODE_RUN);
+    const selectedCodeDocs = result.some((entry) => entry.name === HELPER_TOOLS.CODE_DOCS);
+    if (selectedRunCode && !selectedCodeDocs) result.push(getCodeDocs);
+    if (selectedCodeDocs && !selectedRunCode) result.push(runCode);
+
     /**
      * Auto-inject run-status and storage tools when call-actor, actor tools, or add-actor are present.
      * Insert them right after call-actor (or appended at the end when call-actor is absent) so the
@@ -275,10 +285,13 @@ export function getToolsForServerMode(
     // and the apps-mode widget calls `get-dataset-items` to fetch its preview. A runs-only session
     // (e.g. `tools: ['runs']`) would otherwise land on an unrecommendable tool / empty widget.
     const hasGetActorRun = result.some((entry) => entry.name === HELPER_TOOLS.ACTOR_RUNS_GET);
+    // run-code starts an Actor and writes its { stdout, stderr } to a dataset; its nextStep points
+    // at get-dataset-items, so it needs the same run/storage helpers injected.
+    const hasRunCode = result.some((entry) => entry.name === HELPER_TOOLS.CODE_RUN);
 
     // Inject run-workflow helpers whenever any actor-running entrypoint is present; de-dup pass below drops repeats.
     const toolsToInject: ToolEntry[] = [];
-    if (hasCallActor || hasActorTools || hasAddActorTool || hasGetActorRun) {
+    if (hasCallActor || hasActorTools || hasAddActorTool || hasGetActorRun || hasRunCode) {
         toolsToInject.push(...AUTO_INJECTED_TOOLS);
     }
 

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -319,9 +319,12 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ enableAddingActors: false, tools: ['experimental'] });
 
                 const names = getToolNames(await client.listTools());
-                // experimental category provides add-actor + auto-injected helpers (get-actor-run, storage, abort).
-                expect(names).toHaveLength(1 + AUTO_INJECTED_TOOL_NAMES.length);
+                // experimental category provides add-actor + Code Mode tools (run-code, get-code-docs)
+                // + auto-injected helpers (get-actor-run, storage, abort).
+                expect(names).toHaveLength(3 + AUTO_INJECTED_TOOL_NAMES.length);
                 expect(names).toContain('add-actor');
+                expect(names).toContain(HELPER_TOOLS.CODE_RUN);
+                expect(names).toContain(HELPER_TOOLS.CODE_DOCS);
                 expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
 
                 await client.close();

--- a/tests/unit/tools.get_code_docs.test.ts
+++ b/tests/unit/tools.get_code_docs.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { HELPER_TOOLS } from '../../src/const.js';
+import { CODE_DOCS_PAGE_NAMES } from '../../src/tools/actors/code_docs_content.js';
+import { getCodeDocs } from '../../src/tools/actors/get_code_docs.js';
+import type { HelperTool, InternalToolArgs } from '../../src/types.js';
+import { stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+
+type DocsResult = TextToolResult & { structuredContent?: { page: string; content: string } };
+
+async function getPage(args: Record<string, unknown>): Promise<DocsResult> {
+    const client = {} as unknown as InternalToolArgs['apifyClient'];
+    return (await (getCodeDocs as HelperTool).call(stubToolCallContext(args, client))) as DocsResult;
+}
+
+describe('get-code-docs', () => {
+    it('defaults to the overview page and indexes the other pages', async () => {
+        const result = await getPage({});
+
+        expect(result.structuredContent?.page).toBe('overview');
+        const text = result.content.map((c) => c.text).join('\n');
+        expect(text).toContain('Code Mode');
+        for (const name of CODE_DOCS_PAGE_NAMES) {
+            if (name !== 'overview') expect(text).toContain(name);
+        }
+    });
+
+    it('returns each named page with non-empty content', async () => {
+        for (const page of CODE_DOCS_PAGE_NAMES) {
+            const result = await getPage({ page });
+            expect(result.structuredContent?.page).toBe(page);
+            expect((result.structuredContent?.content ?? '').length).toBeGreaterThan(50);
+        }
+    });
+
+    it('api page lists the apify binding namespaces', async () => {
+        const result = await getPage({ page: 'api' });
+        const text = result.content.map((c) => c.text).join('\n');
+        expect(text).toContain('apify.actor.');
+        expect(text).toContain('apify.dataset.');
+        expect(text).toContain('apify.kvs.');
+    });
+
+    it('overview recommends logging storage IDs to avoid re-running the Actor', async () => {
+        const result = await getPage({});
+        const text = result.content.map((c) => c.text).join('\n');
+        expect(text).toContain('defaultDatasetId');
+    });
+
+    it("overview tells the agent to fetch each Actor's details for its schemas", async () => {
+        const result = await getPage({});
+        const text = result.content.map((c) => c.text).join('\n');
+        expect(text).toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
+    });
+});

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -31,8 +31,9 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
 
     describe('per-mode tool lists', () => {
         it('should have correct tools in experimental category (both modes)', () => {
-            expect(toolNames(defaultCategories.experimental)).toEqual([HELPER_TOOLS.ACTOR_ADD]);
-            expect(toolNames(appsCategories.experimental)).toEqual([HELPER_TOOLS.ACTOR_ADD]);
+            const expectedExperimental = [HELPER_TOOLS.ACTOR_ADD, HELPER_TOOLS.CODE_RUN, HELPER_TOOLS.CODE_DOCS];
+            expect(toolNames(defaultCategories.experimental)).toEqual(expectedExperimental);
+            expect(toolNames(appsCategories.experimental)).toEqual(expectedExperimental);
         });
 
         it('should have correct tools in actors category (both modes)', () => {
@@ -274,10 +275,12 @@ describe('taskSupport contract across tool categories', () => {
                 }
             }
 
-            // Only call-actor is expected to declare taskSupport among static internal tools.
-            // (Dynamically-created Actor tools from actor_tools_factory also declare it, but those
-            // are not returned by getCategoryTools.)
-            expect(toolsWithTaskSupport.map((t) => t.name)).toEqual([HELPER_TOOLS.ACTOR_CALL]);
+            // call-actor and run-code declare taskSupport among static internal tools — both can
+            // orchestrate long-running Actor runs. Order follows CATEGORY_NAMES (experimental, which
+            // holds run-code, is iterated before actors, which holds call-actor). Dynamically-created
+            // Actor tools from actor_tools_factory also declare it, but those aren't returned by
+            // getCategoryTools.
+            expect(toolsWithTaskSupport.map((t) => t.name)).toEqual([HELPER_TOOLS.CODE_RUN, HELPER_TOOLS.ACTOR_CALL]);
 
             for (const { value } of toolsWithTaskSupport) {
                 expect(ALLOWED_TASK_TOOL_EXECUTION_MODES).toContain(value);

--- a/tests/unit/tools.run_code.test.ts
+++ b/tests/unit/tools.run_code.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import { APIFY_CODE_RUNTIME_ACTOR, HELPER_TOOLS } from '../../src/const.js';
+import type { RunResponse } from '../../src/tools/actors/actor_run_response.js';
+import { runCode } from '../../src/tools/actors/run_code.js';
+import type { HelperTool, InternalToolArgs } from '../../src/types.js';
+import { stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+
+function mockRun(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'code-run-1',
+        actId: 'code-runtime-actor-id',
+        status: 'READY',
+        startedAt: new Date('2026-06-25T10:00:00.000Z'),
+        defaultDatasetId: 'ds-1',
+        defaultKeyValueStoreId: 'kv-1',
+        storageIds: { datasets: { default: 'ds-1' }, keyValueStores: { default: 'kv-1' } },
+        ...overrides,
+    };
+}
+
+function stubClient(opts: {
+    run: unknown;
+    onStart?: (input: unknown, options: unknown, id: string) => void;
+    startThrows?: unknown;
+    dataset?: unknown;
+}): InternalToolArgs['apifyClient'] {
+    const { run, onStart, startThrows, dataset } = opts;
+    return {
+        actor: (id: string) => ({
+            start: async (input: unknown, options: unknown) => {
+                onStart?.(input, options, id);
+                if (startThrows) throw startThrows;
+                return run;
+            },
+        }),
+        run: (_id: string) => ({
+            get: async () => run,
+            waitForFinish: async () => run,
+            abort: async () => undefined,
+        }),
+        dataset: (_id: string) => ({
+            get: async () => dataset ?? null,
+            listItems: async () => ({ items: [], total: 0 }),
+        }),
+        keyValueStore: (_id: string) => ({
+            listKeys: async () => ({ items: [], count: 0, isTruncated: false, limit: 50 }),
+        }),
+    } as unknown as InternalToolArgs['apifyClient'];
+}
+
+type RunCodeResult = TextToolResult & {
+    structuredContent?: RunResponse;
+    isError?: boolean;
+};
+
+async function callRunCode(
+    args: Record<string, unknown>,
+    client: InternalToolArgs['apifyClient'],
+): Promise<RunCodeResult> {
+    return (await (runCode as HelperTool).call(stubToolCallContext(args, client))) as RunCodeResult;
+}
+
+describe('run-code', () => {
+    it('waitSecs:0 starts apify/code-runtime with { code } and returns the start run response', async () => {
+        let captured: { input: unknown; id: string } | undefined;
+        const client = stubClient({
+            run: mockRun(),
+            onStart: (input, _options, id) => {
+                captured = { input, id };
+            },
+        });
+
+        const result = await callRunCode({ code: 'console.log(1)', waitSecs: 0 }, client);
+
+        expect(captured?.id).toBe(APIFY_CODE_RUNTIME_ACTOR);
+        expect(captured?.input).toEqual({ code: 'console.log(1)' });
+        expect(result.structuredContent?.runId).toBe('code-run-1');
+        expect(result.structuredContent?.status).toBe('READY');
+        // Storage IDs are surfaced so the caller can later fetch { stdout, stderr }.
+        expect(result.structuredContent?.storages.datasets?.default.id).toBe('ds-1');
+    });
+
+    it('forwards callOptions to the Actor start call', async () => {
+        let capturedOptions: unknown;
+        const client = stubClient({
+            run: mockRun(),
+            onStart: (_input, options) => {
+                capturedOptions = options;
+            },
+        });
+
+        await callRunCode({ code: 'x', waitSecs: 0, callOptions: { memory: 512, timeout: 120 } }, client);
+
+        expect(capturedOptions).toEqual({ memory: 512, timeout: 120 });
+    });
+
+    it('waits and returns SUCCEEDED with a get-dataset-items nextStep', async () => {
+        const run = mockRun({
+            status: 'SUCCEEDED',
+            finishedAt: new Date('2026-06-25T10:00:05.000Z'),
+            stats: { runTimeSecs: 5 },
+        });
+        const dataset = { id: 'ds-1', itemCount: 1, fields: ['stdout', 'stderr'] };
+        const client = stubClient({ run, dataset });
+
+        const result = await callRunCode({ code: 'x', waitSecs: 30 }, client);
+
+        expect(result.structuredContent?.status).toBe('SUCCEEDED');
+        const text = result.content.map((c) => c.text).join('\n');
+        expect(text).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
+        expect(text).toContain('ds-1');
+    });
+
+    it('returns an error response when starting the Actor fails', async () => {
+        const client = stubClient({
+            run: mockRun(),
+            startThrows: Object.assign(new Error('boom'), { statusCode: 500 }),
+        });
+
+        const result = await callRunCode({ code: 'x', waitSecs: 0 }, client);
+
+        expect(result.isError).toBe(true);
+        const text = result.content.map((c) => c.text).join('\n');
+        expect(text).toContain(APIFY_CODE_RUNTIME_ACTOR);
+    });
+});

--- a/tests/unit/utils.auth.test.ts
+++ b/tests/unit/utils.auth.test.ts
@@ -32,12 +32,26 @@ describe('isApiTokenRequired', () => {
                 toolCategoryKeys: ['search-actors', 'fetch-actor-details'],
             }),
         ).toBe(false);
+
+        // get-code-docs serves a static guide, so a docs-only server needs no token.
+        expect(
+            isApiTokenRequired({
+                toolCategoryKeys: ['get-code-docs'],
+            }),
+        ).toBe(false);
     });
 
     it('should require token if any private tool is included', () => {
         expect(
             isApiTokenRequired({
                 toolCategoryKeys: ['search-actors', 'call-actor'],
+            }),
+        ).toBe(true);
+
+        // run-code starts an Actor, so it needs a token even paired with get-code-docs.
+        expect(
+            isApiTokenRequired({
+                toolCategoryKeys: ['get-code-docs', 'run-code'],
             }),
         ).toBe(true);
     });

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -170,3 +170,23 @@ describe('loadToolsFromInput explicit widget selection', () => {
         expect(toolNames.filter((n) => n === HELPER_TOOLS.STORE_SEARCH)).toHaveLength(1);
     });
 });
+
+describe('Code Mode tool pairing', () => {
+    const apifyClient = new ApifyClient({ token: 'test-token' });
+
+    it('adds get-code-docs and the run/storage helpers when only run-code is selected', async () => {
+        const tools = await loadToolsFromInput({ tools: [HELPER_TOOLS.CODE_RUN] }, apifyClient);
+        const toolNames = tools.map((t) => t.name);
+        expect(toolNames).toContain(HELPER_TOOLS.CODE_RUN);
+        expect(toolNames).toContain(HELPER_TOOLS.CODE_DOCS);
+        for (const name of AUTO_INJECTED_TOOL_NAMES) expect(toolNames).toContain(name);
+    });
+
+    it('adds run-code (and its helpers) when only get-code-docs is selected', async () => {
+        const tools = await loadToolsFromInput({ tools: [HELPER_TOOLS.CODE_DOCS] }, apifyClient);
+        const toolNames = tools.map((t) => t.name);
+        expect(toolNames).toContain(HELPER_TOOLS.CODE_RUN);
+        expect(toolNames).toContain(HELPER_TOOLS.CODE_DOCS);
+        for (const name of AUTO_INJECTED_TOOL_NAMES) expect(toolNames).toContain(name);
+    });
+});


### PR DESCRIPTION
The Actor is deployed https://apify.com/apify/code-runtime and lives in github.com/apify/actor-code-runtime/ (currently PR https://github.com/apify/actor-code-runtime/pull/1)

## What
Add two experimental tools. `run-code` runs a JS/TS script in a sandboxed `apify/code-runtime` Actor exposing an `apify` binding (search/run Actors, read/write datasets & key-value stores); it reuses the existing `call-actor` start→wait→respond pipeline and returns the run plus a `nextStep` pointing at `get-dataset-items` for the script's `{ stdout, stderr }` output. `get-code-docs` serves a paginated guide for writing those scripts. Selecting either Code Mode tool loads both (loader pairing), and when present the run/storage helpers are auto-injected (same as `call-actor`).

## Why
Multi-step Actor work (chain Actors, then filter/aggregate) otherwise costs many separate tool calls and round-trips every intermediate dataset through the model. One Code Mode script does it in a single run, keeping large intermediate data out of context. Implements #1017; the sandbox is the `apify/code-runtime` Actor (repo `apify/actor-code-runtime`), which runs with limited permissions (no filesystem, no imports, outbound network limited to `*.apify.com`).

### Note on concurrency
The guide shows a plain sequential loop for running an Actor over many inputs and does not hint at parallel fan-out. This avoids nudging agents into spinning up many concurrent runs by default, which free-tier accounts can hit as concurrent-run/memory limits. It does not forbid parallelism either — the guide stays neutral.

## Testing
- Unit tests: `tools.run_code.test.ts`, `tools.get_code_docs.test.ts`, loader-pairing cases in `utils.tools_loader.test.ts`; updated `tools.mode_contract.test.ts` and integration `suite.ts` (experimental tool count).
- Full gate green: `type-check`, `lint` (0/0), `test:unit` 1018 pass / 2 skip, `format`, `check:agents`.
- Backing Actor deployed and exercised end-to-end separately (18/18 binding smoke).

Configurator wiring (web tool selector): apify/apify-mcp-server-internal#628 — merges after the package bump that includes this PR.
