### PR TITLE
refactor: Adopt respond* response constructors across tools

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -85,10 +85,10 @@ import { SERVER_MODE, TOOL_TYPE } from '../types.js';
 import { isPermissionApprovalError, remoteMcpFailureDetail } from '../utils/apify_errors.js';
 import { getHttpStatusCode, isMcpClientFaultMessage, logHttpError, sanitizeMezmoMessage } from '../utils/logging.js';
 import {
-    buildMCPResponse,
-    buildResponseBytesTelemetry,
     computeToolResponseBytes,
     getToolCallErrorUserText,
+    respondErrorNoTelemetry,
+    respondOk,
 } from '../utils/mcp.js';
 import { buildPaymentRequiredResponse, isX402PaymentRequiredError } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
@@ -1131,7 +1131,7 @@ export class ActorsMcpServer {
                             await this.server.sendLoggingMessage({ level: 'error', data: msg });
                             toolStatus = TOOL_STATUS.SOFT_FAIL;
                             callDiagnostics = { ...callDiagnostics, failure_category: FAILURE_CATEGORY.INTERNAL_ERROR };
-                            return captureResult(buildMCPResponse({ texts: [msg], isError: true }));
+                            return captureResult(respondErrorNoTelemetry(msg));
                         }
 
                         // Only set up notification handlers if progressToken is provided by the client
@@ -1202,12 +1202,9 @@ export class ActorsMcpServer {
                             },
                         );
                         return captureResult(
-                            buildMCPResponse({
-                                texts: [
-                                    `Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}': ${remoteMcpFailureDetail(error)}`,
-                                ],
-                                isError: true,
-                            }),
+                            respondErrorNoTelemetry(
+                                `Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}': ${remoteMcpFailureDetail(error)}`,
+                            ),
                         );
                     } finally {
                         if (client) await client.close();
@@ -1314,13 +1311,15 @@ export class ActorsMcpServer {
                     validationMissingProperty: callDiagnostics.validation_missing_property,
                     validationAdditionalProperty: callDiagnostics.validation_additional_property,
                 });
-                return captureResult(
-                    buildMCPResponse({
-                        texts: [getToolCallErrorUserText(name, error)],
-                        isError: true,
-                        telemetry: { toolStatus },
-                    }),
-                );
+                // This framework outer-catch path bypasses extractToolTelemetry (returned via
+                // captureResult), so preserve the pre-existing wire shape { toolStatus } exactly:
+                // reuse the local ABORTED-aware toolStatus, do NOT re-derive from the error (which
+                // would drop ABORTED and leak failureCategory/failureHttpStatus onto the wire).
+                return captureResult({
+                    ...respondOk(getToolCallErrorUserText(name, error)),
+                    isError: true,
+                    toolTelemetry: { toolStatus },
+                });
             } finally {
                 if (shouldTrackTelemetry) {
                     this.logToolCallAndTelemetry({
@@ -1393,7 +1392,11 @@ export class ActorsMcpServer {
                 ...params.telemetryData,
                 tool_status: params.toolStatus,
                 tool_exec_time_ms: durationMs,
-                ...buildResponseBytesTelemetry(responseBytes),
+                ...(responseBytes && {
+                    tool_response_content_bytes: responseBytes.contentBytes,
+                    tool_response_structured_content_bytes: responseBytes.structuredContentBytes,
+                    tool_response_file_bytes: responseBytes.fileBytes,
+                }),
                 // Always include actor_name/actor_id; failure-specific fields are only present when callDiagnostics has them.
                 ...params.callDiagnostics,
                 // Resource ids are read once here from the args + the tool's public output; no tool

--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -3,13 +3,7 @@ import type { ActorRun, Dataset, KeyValueClientListKeysResult } from 'apify-clie
 import log from '@apify/log';
 
 import type { ApifyClient } from '../../apify_client.js';
-import {
-    DATASET_SIZE_HINT_BYTES,
-    FAILURE_CATEGORY,
-    HELPER_TOOLS,
-    NARROW_OUTPUT_HINT,
-    TOOL_STATUS,
-} from '../../const.js';
+import { DATASET_SIZE_HINT_BYTES, HELPER_TOOLS, NARROW_OUTPUT_HINT } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { ConsoleLinkContext } from '../../types.js';
 import {
@@ -19,7 +13,7 @@ import {
     VERBATIM_LINKS_NUDGE,
 } from '../../utils/console_link.js';
 import { logHttpError } from '../../utils/logging.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { respondOk, respondUserError, type ToolResponse } from '../../utils/mcp.js';
 import { formatRunStatusMessage, type ProgressTracker, TERMINAL_RUN_STATUSES } from '../../utils/progress.js';
 import { cleanEmptyProperties } from '../../utils/schema_generation.js';
 import { DEFAULT_DATASET_ITEMS_LIMIT } from '../storage/get_dataset_items.js';
@@ -723,7 +717,7 @@ export function buildStartRunResponse(params: {
     actorRun: ActorRun;
     widget?: boolean;
     linkContext?: ConsoleLinkContext;
-}): ReturnType<typeof buildMCPResponse> {
+}): ToolResponse {
     const { actorName, actorRun, widget, linkContext } = params;
 
     // Start path returns before any metadata fetch, so every entry — default and aliases — is id-only.
@@ -769,10 +763,9 @@ export function buildStartRunResponse(params: {
           }
         : undefined;
 
-    return buildMCPResponse({
-        texts: [JSON.stringify(structuredContent), `${summary}\n${nextStep}${consoleLinks}`],
+    return respondOk([JSON.stringify(structuredContent), `${summary}\n${nextStep}${consoleLinks}`], {
         structuredContent,
-        ...(widgetMeta && { _meta: widgetMeta }),
+        meta: widgetMeta,
     });
 }
 
@@ -819,11 +812,7 @@ export async function fetchActorRunData(params: {
     if (waitResult.kind === 'aborted') return { aborted: true };
     if (waitResult.kind === 'not-found') {
         return {
-            error: buildMCPResponse({
-                texts: [`Run with ID '${runId}' not found.`],
-                isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
-            }),
+            error: respondUserError(`Run with ID '${runId}' not found.`),
         };
     }
     const { run, actorName } = waitResult;

--- a/src/tools/actors/add_actor.ts
+++ b/src/tools/actors/add_actor.ts
@@ -5,7 +5,7 @@ import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { respondOk, respondServerError } from '../../utils/mcp.js';
 
 export const addToolArgsSchema = z.object({
     actor: z
@@ -47,9 +47,7 @@ USAGE EXAMPLES:
         } = toolArgs;
         const parsed = addToolArgsSchema.parse(args);
         if (apifyMcpServer.listAllToolNames().includes(parsed.actor)) {
-            return buildMCPResponse({
-                texts: [`Actor ${parsed.actor} is already available. No new tools were added.`],
-            });
+            return respondOk(`Actor ${parsed.actor} is already available. No new tools were added.`);
         }
 
         const apifyClient = new ApifyClient({ token: apifyToken });
@@ -57,21 +55,16 @@ USAGE EXAMPLES:
         // First error is the precise reason this Actor could not be added —
         // safe to forward verbatim (sanitized at source by ActorLoadError factories).
         if (errors[0]) {
-            return buildMCPResponse({
-                texts: [errors[0].message],
-                isError: true,
-            });
+            return respondServerError(errors[0].message);
         }
         await sendNotification({ method: 'notifications/tools/list_changed' });
         const toolNames = tools.map((t: ToolEntry) => t.name).join(', ');
         // Many MCP clients ignore `notifications/tools/list_changed`, so nudge the LLM to
         // re-list tools itself — otherwise the freshly added Actor stays invisible until the
         // client happens to refresh (apify-mcp-server#851).
-        return buildMCPResponse({
-            texts: [
-                `Actor ${parsed.actor} has been added. Newly available tools: ${toolNames}. ` +
-                    `If they are not visible yet, refresh the tool list using the tools/list request before calling them.`,
-            ],
-        });
+        return respondOk(
+            `Actor ${parsed.actor} has been added. Newly available tools: ${toolNames}. ` +
+                `If they are not visible yet, refresh the tool list using the tools/list request before calling them.`,
+        );
     },
 } as const);

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -12,7 +12,6 @@ import {
     APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED,
     FAILURE_CATEGORY,
     HELPER_TOOLS,
-    TOOL_STATUS,
 } from '../../const.js';
 import { ACTOR_LOAD_ERROR_KIND, ActorLoadError } from '../../errors.js';
 import { connectMCPClient } from '../../mcp/client.js';
@@ -29,9 +28,10 @@ import {
     remoteMcpFailureDetail,
 } from '../../utils/apify_errors.js';
 import { getConsoleLinkContext } from '../../utils/console_link.js';
-import { getHttpStatusCode, logHttpError } from '../../utils/logging.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
-import { classifyFailureCategory, extractAjvErrorDetails, getToolStatusFromError } from '../../utils/tool_status.js';
+import { wrapJsonText } from '../../utils/encode_text.js';
+import { logHttpError } from '../../utils/logging.js';
+import { respondErrorNoTelemetry, respondServerError, respondUserError, type ToolResponse } from '../../utils/mcp.js';
+import { classifyFailureCategory, extractAjvErrorDetails } from '../../utils/tool_status.js';
 import { extractActorId } from '../../utils/tools.js';
 import { actorNameToToolName, isActorBlockedUnderPaymentProvider } from '../actor_tool_naming.js';
 import { buildGetActorRunSuccessResponse } from '../runs/get_actor_run.js';
@@ -121,92 +121,70 @@ export function buildCallActorAppsDescription(): string {
     return buildCallActorDescriptionSections(true);
 }
 
-/** Exported for native actor tool error handling in server.ts — no logging, no telemetry. */
-export function buildPermissionApprovalResponse(error: ApifyApiError): ReturnType<typeof buildMCPResponse> {
+/** Text lines for a permission-approval response: the error message plus an optional approval URL. */
+function buildPermissionApprovalTexts(error: ApifyApiError): string[] {
     const approvalUrl = typeof error.data?.approvalUrl === 'string' ? error.data.approvalUrl : undefined;
-    return buildMCPResponse({
-        texts: [error.message, ...(approvalUrl ? [`Approve here: ${approvalUrl}`] : [])],
-        isError: true,
-    });
+    return [error.message, ...(approvalUrl ? [`Approve here: ${approvalUrl}`] : [])];
 }
 
-function buildPermissionApprovalErrorResponse(
-    actorName: string,
-    error: ApifyApiError,
-    actorId: string | undefined,
-    mcpSessionId: string | undefined,
-): ReturnType<typeof buildMCPResponse> {
-    logHttpError(error, 'Failed to call Actor — permission approval required', {
-        actorName,
-        mcpSessionId,
-        failureCategory: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
-    });
-    return {
-        ...buildPermissionApprovalResponse(error),
-        toolTelemetry: {
-            toolStatus: TOOL_STATUS.SOFT_FAIL,
-            failureCategory: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
-            failureHttpStatus: error.statusCode,
-            failureDetail: APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED,
-            actorId,
-        },
-    };
+/** Exported for native actor tool error handling in server.ts — no logging, no telemetry. */
+export function buildPermissionApprovalResponse(error: ApifyApiError): ToolResponse {
+    return respondErrorNoTelemetry(buildPermissionApprovalTexts(error));
 }
 
-export function buildCallActorErrorResponse(params: CallActorErrorResponseParams): ReturnType<typeof buildMCPResponse> {
+export function buildCallActorErrorResponse(params: CallActorErrorResponseParams): ToolResponse {
     const { actorName, error, actorId, mcpSessionId, actorGetDetailsTool } = params;
 
     if (isPermissionApprovalError(error)) {
-        return buildPermissionApprovalErrorResponse(actorName, error, actorId, mcpSessionId);
+        logHttpError(error, 'Failed to call Actor — permission approval required', {
+            actorName,
+            mcpSessionId,
+            failureCategory: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
+        });
+        return respondUserError(buildPermissionApprovalTexts(error), {
+            category: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
+            httpStatus: error.statusCode,
+            detail: APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED,
+            actorId,
+        });
     }
 
     const errMsg = error instanceof Error ? error.message : String(error);
-    const failureCategory = classifyFailureCategory(error);
     logHttpError(error, 'Failed to call Actor', {
         actorName,
         mcpSessionId,
-        failureCategory,
+        failureCategory: classifyFailureCategory(error),
     });
-
-    const telemetry = {
-        toolStatus: getToolStatusFromError(error, false),
-        failureCategory,
-        failureHttpStatus: getHttpStatusCode(error),
-        failureDetail: errMsg.slice(0, 200),
-        actorId,
-    };
 
     if (isMemoryQuotaError(error)) {
         // Deliberately do NOT mention actor-runs-abort as a recovery path — nudging the LLM
         // toward "free capacity" risks aborting unrelated in-flight runs the user cares about.
-        return buildMCPResponse({
-            texts: [
+        return respondServerError(
+            [
                 `Failed to call Actor '${actorName}': ${errMsg}`,
                 `Account memory quota exceeded for your plan. Retry with a smaller callOptions.memory, or wait for current runs to finish before retrying.`,
             ],
-            isError: true,
-            telemetry: { ...telemetry, failureDetail: APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED },
-        });
+            { error, detail: APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED, actorId },
+        );
     }
 
     if (isActorRunLimitError(error)) {
-        return buildMCPResponse({
-            texts: [`Failed to call Actor '${actorName}': ${errMsg}`, ACTOR_RUN_LIMIT_MESSAGE],
-            isError: true,
-            telemetry: { ...telemetry, failureDetail: APIFY_ERROR_TYPE_CANNOT_START_ACTOR_RUNS },
+        return respondServerError([`Failed to call Actor '${actorName}': ${errMsg}`, ACTOR_RUN_LIMIT_MESSAGE], {
+            error,
+            detail: APIFY_ERROR_TYPE_CANNOT_START_ACTOR_RUNS,
+            actorId,
         });
     }
 
-    return buildMCPResponse({
-        texts: [
+    return respondServerError(
+        [
             `Failed to call Actor '${actorName}': ${errMsg}`,
             `Please verify the Actor name, input parameters, and ensure the Actor exists.`,
             // "if available" — search-actors may not be loaded in apps-mode partial tool selections.
             `If ${HELPER_TOOLS.STORE_SEARCH} is available in this session, you can use it to search for available Actors, or get Actor details using: ${actorGetDetailsTool}.`,
         ],
-        isError: true,
-        telemetry,
-    });
+        { error, detail: errMsg.slice(0, 200), actorId },
+    );
 }
 
 export const callOptionsSchema = z.object({
@@ -317,11 +295,7 @@ export async function checkPaymentProviderStandbyConflict(params: {
         failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
     });
 
-    return buildMCPResponse({
-        texts: [ActorLoadError.standbyPaymentNotSupported(normalizedActorName).message],
-        isError: true,
-        telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
-    });
+    return respondUserError(ActorLoadError.standbyPaymentNotSupported(normalizedActorName).message);
 }
 
 /**
@@ -358,29 +332,20 @@ export async function handleMcpToolCall(params: {
     const { baseActorName, mcpToolName, input, isActorMcpServer, mcpServerUrl, apifyToken, mcpSessionId } = params;
 
     if (!isActorMcpServer) {
-        return buildMCPResponse({
-            texts: [`Actor '${baseActorName}' is not an MCP server.`],
-            isError: true,
-        });
+        return respondServerError(`Actor '${baseActorName}' is not an MCP server.`);
     }
 
     if (!input) {
-        return buildMCPResponse({
-            texts: [
-                `Input is required for MCP tool '${mcpToolName}'. Please provide the input parameter based on the tool's input schema.`,
-            ],
-            isError: true,
-        });
+        return respondServerError(
+            `Input is required for MCP tool '${mcpToolName}'. Please provide the input parameter based on the tool's input schema.`,
+        );
     }
 
     let client: Client | null = null;
     try {
         client = await connectMCPClient(mcpServerUrl as string, apifyToken, mcpSessionId);
         if (!client) {
-            return buildMCPResponse({
-                texts: [`Failed to connect to MCP server ${mcpServerUrl}`],
-                isError: true,
-            });
+            return respondServerError(`Failed to connect to MCP server ${mcpServerUrl}`);
         }
 
         const result = await client.callTool({
@@ -412,12 +377,9 @@ export async function handleMcpToolCall(params: {
             actorName: baseActorName,
             toolName: mcpToolName,
         });
-        return buildMCPResponse({
-            texts: [
-                `Failed to call MCP tool '${mcpToolName}' on Actor '${baseActorName}': ${remoteMcpFailureDetail(error)}`,
-            ],
-            isError: true,
-        });
+        return respondServerError(
+            `Failed to call MCP tool '${mcpToolName}' on Actor '${baseActorName}': ${remoteMcpFailureDetail(error)}`,
+        );
     } finally {
         if (client) await client.close();
     }
@@ -450,22 +412,14 @@ export async function resolveAndValidateActor(params: {
 
     if (!actor) {
         return {
-            error: buildMCPResponse({
-                texts: [
-                    dedent`
+            error: respondUserError(
+                dedent`
                     Actor '${actorName}' was not found.
                     Please verify Actor ID or name format (e.g., "username/name" like "apify/rag-web-browser") and ensure that the Actor exists.
                     You can search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}.
                 `,
-                ],
-                isError: true,
-                telemetry: {
-                    toolStatus: TOOL_STATUS.SOFT_FAIL,
-                    failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
-                    failureHttpStatus: 404,
-                    failureDetail: `Actor '${actorName}' was not found`,
-                },
-            }),
+                { httpStatus: 404, detail: `Actor '${actorName}' was not found` },
+            ),
         };
     }
 
@@ -478,20 +432,14 @@ export async function resolveAndValidateActor(params: {
             failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
         });
         return {
-            error: buildMCPResponse({
-                texts: [
+            error: respondUserError(
+                [
                     `Input is required for Actor '${actorName}'. Please provide the input parameter based on the Actor's input schema.`,
                     `The input schema for this Actor was retrieved and is shown below:`,
-                    `\`\`\`json\n${JSON.stringify(actor.inputSchema)}\n\`\`\``,
+                    wrapJsonText(actor.inputSchema),
                 ],
-                isError: true,
-                telemetry: {
-                    toolStatus: TOOL_STATUS.SOFT_FAIL,
-                    failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
-                    actorId,
-                    failureDetail: 'input is required',
-                },
-            }),
+                { actorId, detail: 'input is required' },
+            ),
         };
     }
 
@@ -511,22 +459,16 @@ export async function resolveAndValidateActor(params: {
 
         const content = [
             `Input validation failed for Actor '${actorName}'. Please ensure your input matches the Actor's input schema.`,
-            `Input schema:\n\`\`\`json\n${JSON.stringify(actor.inputSchema)}\n\`\`\``,
+            `Input schema:\n${wrapJsonText(actor.inputSchema)}`,
         ];
         if (validationSummary) {
             content.push(`Validation errors: ${validationSummary}`);
         }
         return {
-            error: buildMCPResponse({
-                texts: content,
-                isError: true,
-                telemetry: {
-                    toolStatus: TOOL_STATUS.SOFT_FAIL,
-                    failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
-                    actorId,
-                    failureDetail: validationSummary.slice(0, 200) || 'input validation failed',
-                    ajvErrorDetails: ajvDetails,
-                },
+            error: respondUserError(content, {
+                actorId,
+                detail: validationSummary.slice(0, 200) || 'input validation failed',
+                ajvErrorDetails: ajvDetails,
             }),
         };
     }
@@ -577,10 +519,7 @@ export async function callActorPreExecute(
     const isMcpToolNameInvalid = mcpToolName === undefined || mcpToolName.trim().length === 0;
     if (isActorMcpServer && isMcpToolNameInvalid) {
         return {
-            earlyResponse: buildMCPResponse({
-                texts: [CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG],
-                isError: true,
-            }),
+            earlyResponse: respondServerError(CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG),
         };
     }
 

--- a/src/tools/actors/fetch_actor_details.ts
+++ b/src/tools/actors/fetch_actor_details.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { ConsoleLinkContext, HelperTool, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import {
@@ -14,7 +14,8 @@ import {
 } from '../../utils/actor_details.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleActorUrl, getConsoleLinkContext, VERBATIM_LINKS_NUDGE } from '../../utils/console_link.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { wrapJsonText } from '../../utils/encode_text.js';
+import { respondOk, respondUserError, type ToolResponse } from '../../utils/mcp.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
 import { actorDetailsOutputSchema } from '../structured_output_schemas.js';
 import { fixActorNameInputAndLog } from './actor_tools_factory.js';
@@ -141,18 +142,12 @@ export const fetchActorDetailsMetadata: Omit<HelperTool, 'call'> = {
 /**
  * Build error response for when actor is not found.
  */
-export function buildActorNotFoundResponse(actorName: string): ReturnType<typeof buildMCPResponse> {
-    return buildMCPResponse({
-        texts: [
-            dedent`
-            Actor information for '${actorName}' was not found.
-            Please verify Actor ID or name format and ensure that the Actor exists.
-            You can search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}.
-        `,
-        ],
-        isError: true,
-        telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
-    });
+export function buildActorNotFoundResponse(actorName: string): ToolResponse {
+    return respondUserError(dedent`
+        Actor information for '${actorName}' was not found.
+        Please verify Actor ID or name format and ensure that the Actor exists.
+        You can search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}.
+    `);
 }
 
 /**
@@ -191,9 +186,7 @@ export function buildActorDetailsTextResponse(options: {
     if (output.inputSchema) {
         // Console has no /input sub-page — link to the Actor detail page instead.
         const inputSchemaUrl = linkContext ? actorUrl : `${actorUrl}/input`;
-        texts.push(
-            [`# [Input schema](${inputSchemaUrl})`, '```json', JSON.stringify(details.inputSchema), '```'].join('\n'),
-        );
+        texts.push(`# [Input schema](${inputSchemaUrl})\n${wrapJsonText(details.inputSchema)}`);
     }
 
     if (output.outputSchema) {
@@ -237,9 +230,7 @@ export function buildActorDetailsTextResponse(options: {
  * Shared handler for the base fetch-actor-details tool.
  * Returns the same text + structured response in both modes.
  */
-export async function buildFetchActorDetailsResult(
-    toolArgs: InternalToolArgs,
-): Promise<ReturnType<typeof buildMCPResponse>> {
+export async function buildFetchActorDetailsResult(toolArgs: InternalToolArgs): Promise<ToolResponse> {
     const { args, apifyToken, apifyClient, apifyMcpServer, mcpSessionId } = toolArgs;
     const parsed = fetchActorDetailsToolArgsSchema.parse(args);
     const actorName = fixActorNameInputAndLog(parsed.actor, { mcpSessionId, route: HELPER_TOOLS.ACTOR_GET_DETAILS });
@@ -286,7 +277,7 @@ export async function buildFetchActorDetailsResult(
         linkContext,
     });
 
-    return buildMCPResponse({ texts, structuredContent });
+    return respondOk(texts, { structuredContent });
 }
 
 /**

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -16,7 +16,7 @@ import { DEFAULT_CARD_OPTIONS, formatActorToActorCard, formatActorToStructuredCa
 import { searchAgentSafeActors } from '../../utils/actor_search.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { getConsoleLinkContext, VERBATIM_LINKS_NUDGE } from '../../utils/console_link.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { respondOk } from '../../utils/mcp.js';
 import type { PricingTier } from '../../utils/pricing_info.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
 import { actorSearchOutputSchema } from '../structured_output_schemas.js';
@@ -139,19 +139,6 @@ export function buildSearchActorsResult(
     };
 }
 
-export function buildSearchActorsEmptyResponse(query: string): ReturnType<typeof buildMCPResponse> {
-    const instructions = dedent`
-        No Actors were found for the search query "${query}".
-        You MUST retry with broader, more generic keywords - use just the platform name
-        (e.g., "TikTok" instead of "TikTok posts") before concluding no Actor exists.
-    `;
-
-    return buildMCPResponse({
-        texts: [instructions],
-        structuredContent: { actors: [], query, count: 0, instructions },
-    });
-}
-
 /**
  * Default mode search-actors tool.
  * Returns text-based Actor cards without widget metadata.
@@ -175,7 +162,14 @@ export const searchActors: ToolEntry = Object.freeze({
         ]);
 
         if (actors.length === 0) {
-            return buildSearchActorsEmptyResponse(parsed.keywords);
+            const instructions = dedent`
+                No Actors were found for the search query "${parsed.keywords}".
+                You MUST retry with broader, more generic keywords - use just the platform name
+                (e.g., "TikTok" instead of "TikTok posts") before concluding no Actor exists.
+            `;
+            return respondOk(instructions, {
+                structuredContent: { actors: [], query: parsed.keywords, count: 0, instructions },
+            });
         }
 
         // Cache hit — the Promise.all above already resolved users/me for this token.
@@ -216,7 +210,6 @@ export const searchActors: ToolEntry = Object.freeze({
             (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
             you haven't missed a better Actor.${verbatimLinksNudge}
         `;
-        const texts = [`${header}\n\n${actorCardText}\n\n${footer}`];
-        return buildMCPResponse({ texts, structuredContent });
+        return respondOk(`${header}\n\n${actorCardText}\n\n${footer}`, { structuredContent });
     },
 } as const);

--- a/src/tools/docs/fetch_apify_docs.ts
+++ b/src/tools/docs/fetch_apify_docs.ts
@@ -2,14 +2,13 @@ import { z } from 'zod';
 
 import log from '@apify/log';
 
-import { ALLOWED_DOC_DOMAINS, FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../const.js';
+import { ALLOWED_DOC_DOMAINS, HELPER_TOOLS } from '../../const.js';
 import { fetchApifyDocsCache } from '../../state.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
-import { classifyFailureCategory } from '../../utils/tool_status.js';
+import { respondOk, respondServerError, respondUserError } from '../../utils/mcp.js';
 import { fetchApifyDocsToolOutputSchema } from '../structured_output_schemas.js';
 
 const fetchApifyDocsToolArgsSchema = z.object({
@@ -92,17 +91,13 @@ USAGE EXAMPLES:
 
         if (!isAllowedDomain) {
             log.softFail(`[fetch-apify-docs] Invalid URL domain: ${url}`);
-            return buildMCPResponse({
-                texts: [
-                    `Invalid URL: "${url}". \
+            return respondUserError(
+                `Invalid URL: "${url}". \
 Only documentation URLs from Apify and Crawlee are allowed \
 (starting with ${ALLOWED_DOC_DOMAINS.map((d) => `"${d}"`).join(' or ')}). \
 Please provide a valid documentation URL. \
 You can find documentation URLs using the ${HELPER_TOOLS.DOCS_SEARCH} tool.`,
-                ],
-                isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
-            });
+            );
         }
 
         // Cache by URL without fragment to avoid fetching the same page multiple times
@@ -121,36 +116,24 @@ You can find documentation URLs using the ${HELPER_TOOLS.DOCS_SEARCH} tool.`,
                         url: mdUrl,
                         statusText: response.statusText,
                     });
-                    const isUserError = response.status >= 400 && response.status < 500;
-                    return buildMCPResponse({
-                        texts: [buildFetchErrorMessage(url, `HTTP Status: ${response.status} ${response.statusText}.`)],
-                        isError: true,
-                        telemetry: {
-                            toolStatus: isUserError ? TOOL_STATUS.SOFT_FAIL : TOOL_STATUS.FAILED,
-                            failureCategory: classifyFailureCategory(error),
-                            failureHttpStatus: response.status,
-                        },
-                    });
+                    return respondServerError(
+                        buildFetchErrorMessage(url, `HTTP Status: ${response.status} ${response.statusText}.`),
+                        { error },
+                    );
                 }
                 markdown = await response.text();
                 fetchApifyDocsCache.set(urlWithoutFragment, markdown);
             } catch (error) {
                 logHttpError(error, 'Failed to fetch the documentation page', { url: mdUrl });
-                return buildMCPResponse({
-                    texts: [
-                        buildFetchErrorMessage(
-                            url,
-                            `Error: ${error instanceof Error ? error.message : String(error)}.`,
-                        ),
-                    ],
-                    isError: true,
-                    telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR },
-                });
+                // A thrown fetch (network/DNS, no statusCode) is a server failure, so classify it FAILED + INTERNAL_ERROR.
+                return respondServerError(
+                    buildFetchErrorMessage(url, `Error: ${error instanceof Error ? error.message : String(error)}.`),
+                    { error },
+                );
             }
         }
 
-        return buildMCPResponse({
-            texts: [`Fetched content from ${url}:\n\n${markdown}`],
+        return respondOk(`Fetched content from ${url}:\n\n${markdown}`, {
             structuredContent: { url, content: markdown },
         });
     },

--- a/src/tools/docs/search_apify_docs.ts
+++ b/src/tools/docs/search_apify_docs.ts
@@ -5,7 +5,7 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { searchDocsBySourceCached } from '../../utils/apify_docs.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { respondOk } from '../../utils/mcp.js';
 import { searchApifyDocsToolOutputSchema } from '../structured_output_schemas.js';
 
 const PLATFORM_DOCS_PREFERENCE = `When results contain both platform documentation (\`docs.apify.com/platform\`) \
@@ -103,7 +103,7 @@ You can also try using more specific or alternative keywords related to your sea
                 count: 0,
                 instructions,
             };
-            return buildMCPResponse({ texts: [instructions], structuredContent });
+            return respondOk(instructions, { structuredContent });
         }
 
         // Instructions for LLM to use the docs fetch tool when retrieving full document content
@@ -131,6 +131,6 @@ ${results
             instructions,
         };
         // We put the instructions at the end so that they are more likely to be acknowledged by the LLM
-        return buildMCPResponse({ texts: [textResult, instructions], structuredContent });
+        return respondOk([textResult, instructions], { structuredContent });
     },
 } as const);

--- a/src/tools/runs/abort_actor_run.ts
+++ b/src/tools/runs/abort_actor_run.ts
@@ -4,7 +4,7 @@ import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { respondOk } from '../../utils/mcp.js';
 import { buildStats, buildStatusSummaryNextStep, type RunResponse, toIsoString } from '../actors/actor_run_response.js';
 import { actorRunOutputSchema } from '../structured_output_schemas.js';
 
@@ -69,9 +69,6 @@ USAGE EXAMPLES:
             nextStep,
         };
 
-        return buildMCPResponse({
-            texts: [JSON.stringify(structuredContent), `${summary}\n${nextStep}`],
-            structuredContent,
-        });
+        return respondOk([JSON.stringify(structuredContent), `${summary}\n${nextStep}`], { structuredContent });
     },
 } as const);

--- a/src/tools/runs/get_actor_run.ts
+++ b/src/tools/runs/get_actor_run.ts
@@ -1,14 +1,14 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HELPER_TOOLS, TOOL_STATUS } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { ConsoleLinkContext, HelperTool, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema, fixZodSchemaRequired } from '../../utils/ajv.js';
 import { getConsoleLinkContext } from '../../utils/console_link.js';
 import { logHttpError } from '../../utils/logging.js';
-import { buildMCPResponse, buildUsageMeta } from '../../utils/mcp.js';
+import { buildUsageMeta, respondOk, respondUserError, type ToolResponse } from '../../utils/mcp.js';
 import {
     applyConsoleLinks,
     type FetchActorRunResult,
@@ -76,18 +76,12 @@ export const getActorRunMetadata: Omit<HelperTool, 'call'> = {
 // Response builders
 // -----------------------------------------------------------------------------
 
-export function buildGetActorRunError(runId: string, error: unknown): ReturnType<typeof buildMCPResponse> {
+export function buildGetActorRunError(runId: string, error: unknown): ToolResponse {
     const errMsg = error instanceof Error ? error.message : String(error);
-    return buildMCPResponse({
-        texts: [
-            dedent`
-            Failed to get Actor run '${runId}': ${errMsg}.
-            Please verify the run ID and ensure that the run exists.
-        `,
-        ],
-        isError: true,
-        telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL },
-    });
+    return respondUserError(dedent`
+        Failed to get Actor run '${runId}': ${errMsg}.
+        Please verify the run ID and ensure that the run exists.
+    `);
 }
 
 /**
@@ -97,36 +91,37 @@ export function buildGetActorRunError(runId: string, error: unknown): ReturnType
  */
 export function buildGetActorRunSuccessResponse(
     params: FetchActorRunResult & { widget: boolean; linkContext?: ConsoleLinkContext },
-): ReturnType<typeof buildMCPResponse> {
+): ToolResponse {
     const { run, structuredContent, widget, linkContext } = params;
 
     if (!widget) {
         // Mints the `apifyConsoleUrl` fields onto structuredContent and returns the narrative suffix in one pass.
         const consoleLinks = applyConsoleLinks(structuredContent, linkContext);
-        return buildMCPResponse({
-            texts: [
+        return respondOk(
+            [
                 JSON.stringify(structuredContent),
                 `${structuredContent.summary}\n${structuredContent.nextStep}${consoleLinks}`,
             ],
-            structuredContent,
-            _meta: buildUsageMeta(run),
-        });
+            { structuredContent, meta: buildUsageMeta(run) },
+        );
     }
 
     // Override nextStep so the model reading structuredContent (content[0]) also sees no-poll guidance.
     const widgetContent = { ...structuredContent, nextStep: WIDGET_NO_POLL_NEXT_STEP };
-    return buildMCPResponse({
-        texts: [
+    return respondOk(
+        [
             JSON.stringify(widgetContent),
             `Actor run ${structuredContent.runId} status: ${structuredContent.status}. A run widget has been rendered.`,
         ],
-        structuredContent: widgetContent,
-        _meta: {
-            ...(getWidgetConfig(WIDGET_URIS.ACTOR_RUN)?.meta ?? {}),
-            ...(buildUsageMeta(run) ?? {}),
-            'openai/widgetDescription': `Actor run progress for ${structuredContent.actorName ?? structuredContent.runId}`,
+        {
+            structuredContent: widgetContent,
+            meta: {
+                ...(getWidgetConfig(WIDGET_URIS.ACTOR_RUN)?.meta ?? {}),
+                ...(buildUsageMeta(run) ?? {}),
+                'openai/widgetDescription': `Actor run progress for ${structuredContent.actorName ?? structuredContent.runId}`,
+            },
         },
-    });
+    );
 }
 
 /**

--- a/src/tools/storage/get_dataset.ts
+++ b/src/tools/storage/get_dataset.ts
@@ -7,10 +7,11 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleDatasetUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
+import { respondUserError } from '../../utils/mcp.js';
 import { datasetSizeNextStepHint, normalizeDatasetFields } from '../actors/actor_run_response.js';
 import { datasetMetadataOutputSchema } from '../structured_output_schemas.js';
 import { DEFAULT_DATASET_ITEMS_LIMIT } from './get_dataset_items.js';
-import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
+import { buildStorageResponse } from './storage_helpers.js';
 
 const getDatasetArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
@@ -53,7 +54,7 @@ export const getDataset: ToolEntry = Object.freeze({
         const datasetId = stripQuoteWrappers(parsed.datasetId);
         const dataset = await client.dataset(datasetId).get();
         if (!dataset) {
-            return buildStorageNotFound(`Dataset '${datasetId}' not found.`);
+            return respondUserError(`Dataset '${datasetId}' not found.`);
         }
         const linkContext = await getConsoleLinkContext(apifyToken, client);
         // The API also returns a raw `schema` (untyped in apify-client). It is 93–95% of the

--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -8,8 +8,9 @@ import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleDatasetUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { parseCommaSeparatedList, stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
+import { respondUserError } from '../../utils/mcp.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
-import { buildDatasetItemsSummaryNextStep, buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
+import { buildDatasetItemsSummaryNextStep, buildStorageResponse } from './storage_helpers.js';
 
 export const DEFAULT_DATASET_ITEMS_LIMIT = 20;
 
@@ -123,7 +124,7 @@ export const getDatasetItems: ToolEntry = Object.freeze({
                 throw err;
             });
         if (!v) {
-            return buildStorageNotFound(`Dataset '${datasetId}' not found.`);
+            return respondUserError(`Dataset '${datasetId}' not found.`);
         }
 
         const offset = parsed.offset ?? 0;

--- a/src/tools/storage/get_dataset_schema.ts
+++ b/src/tools/storage/get_dataset_schema.ts
@@ -1,16 +1,16 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HELPER_TOOLS, HTTP_NOT_FOUND, TOOL_STATUS } from '../../const.js';
+import { HELPER_TOOLS, HTTP_NOT_FOUND } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { respondServerError, respondUserError } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
 import { datasetSchemaOutputSchema } from '../structured_output_schemas.js';
-import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
+import { buildStorageResponse } from './storage_helpers.js';
 
 const getDatasetSchemaArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
@@ -68,7 +68,7 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
             });
 
         if (!datasetResponse) {
-            return buildStorageNotFound(`Dataset '${datasetId}' not found.`);
+            return respondUserError(`Dataset '${datasetId}' not found.`);
         }
 
         const datasetItems = datasetResponse.items;
@@ -88,12 +88,8 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
         });
 
         if (!schema) {
-            // Schema generation failure is typically a server/processing error, not a user error
-            return buildMCPResponse({
-                texts: [`Failed to generate schema for dataset '${datasetId}'.`],
-                isError: true,
-                telemetry: { toolStatus: TOOL_STATUS.FAILED },
-            });
+            // A schema-generation failure is a server/processing error, not a user error.
+            return respondServerError(`Failed to generate schema for dataset '${datasetId}'.`);
         }
 
         const fieldCount = Object.keys(schema.items.properties ?? {}).length;

--- a/src/tools/storage/get_key_value_store.ts
+++ b/src/tools/storage/get_key_value_store.ts
@@ -7,8 +7,9 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleKeyValueStoreUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
+import { respondUserError } from '../../utils/mcp.js';
 import { keyValueStoreOutputSchema } from '../structured_output_schemas.js';
-import { buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
+import { buildStorageResponse } from './storage_helpers.js';
 
 const getKeyValueStoreArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -48,7 +49,7 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
         const keyValueStoreId = stripQuoteWrappers(parsed.keyValueStoreId);
         const kvStore = await client.keyValueStore(keyValueStoreId).get();
         if (!kvStore) {
-            return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
+            return respondUserError(`Key-value store '${keyValueStoreId}' not found.`);
         }
         const linkContext = await getConsoleLinkContext(apifyToken, client);
         const bytes = (kvStore.stats as { storageBytes?: number } | undefined)?.storageBytes;

--- a/src/tools/storage/get_key_value_store_keys.ts
+++ b/src/tools/storage/get_key_value_store_keys.ts
@@ -8,8 +8,9 @@ import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleKeyValueStoreUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { getHttpStatusCode } from '../../utils/logging.js';
+import { respondUserError } from '../../utils/mcp.js';
 import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
-import { buildKvsKeysSummaryNextStep, buildStorageNotFound, buildStorageResponse } from './storage_helpers.js';
+import { buildKvsKeysSummaryNextStep, buildStorageResponse } from './storage_helpers.js';
 
 const getKeyValueStoreKeysArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -65,7 +66,7 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
                 throw err;
             });
         if (!keys) {
-            return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
+            return respondUserError(`Key-value store '${keyValueStoreId}' not found.`);
         }
         const linkContext = await getConsoleLinkContext(apifyToken, client);
         const { summary, nextStep } = buildKvsKeysSummaryNextStep({

--- a/src/tools/storage/get_key_value_store_record.ts
+++ b/src/tools/storage/get_key_value_store_record.ts
@@ -8,13 +8,9 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleKeyValueStoreUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { computeValueBytes, stripQuoteWrappers } from '../../utils/generic.js';
+import { respondUserError } from '../../utils/mcp.js';
 import { keyValueStoreRecordOutputSchema } from '../structured_output_schemas.js';
-import {
-    buildConsoleLinkContent,
-    buildStorageNotFound,
-    buildStorageResponse,
-    normalizeRecordKey,
-} from './storage_helpers.js';
+import { buildConsoleLinkContent, buildStorageResponse, normalizeRecordKey } from './storage_helpers.js';
 
 const getKeyValueStoreRecordArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -62,7 +58,7 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
             const text = storeInfo
                 ? `Record '${recordKey}' not found in key-value store '${keyValueStoreId}'.`
                 : `Key-value store '${keyValueStoreId}' not found.`;
-            return buildStorageNotFound(text);
+            return respondUserError(text);
         }
         const apifyConsoleUrl = buildConsoleKeyValueStoreUrl(
             await getConsoleLinkContext(apifyToken, client),

--- a/src/tools/storage/storage_helpers.ts
+++ b/src/tools/storage/storage_helpers.ts
@@ -1,8 +1,8 @@
-import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import { VERBATIM_LINKS_NUDGE } from '../../utils/console_link.js';
 import { encodeToon } from '../../utils/encode_text.js';
 import { QUOTE_WRAPPER_CHARS } from '../../utils/generic.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { respondOk } from '../../utils/mcp.js';
 
 function suggestTool(toolName: string, loadedToolNames: string[]): string | undefined {
     return loadedToolNames.includes(toolName) ? toolName : undefined;
@@ -25,19 +25,6 @@ export function apifyConsoleLinkText(apifyConsoleUrl: string | undefined): strin
 export function buildConsoleLinkContent(apifyConsoleUrl: string | undefined): { type: 'text'; text: string }[] {
     const text = apifyConsoleLinkText(apifyConsoleUrl);
     return text ? [{ type: 'text', text }] : [];
-}
-
-/**
- * Soft-fail not-found response for storage tools. Centralizes
- * `isError: true` + SOFT_FAIL/INVALID_INPUT telemetry so call sites
- * only supply the message.
- */
-export function buildStorageNotFound(text: string) {
-    return buildMCPResponse({
-        texts: [text],
-        isError: true,
-        telemetry: { toolStatus: TOOL_STATUS.SOFT_FAIL, failureCategory: FAILURE_CATEGORY.INVALID_INPUT },
-    });
 }
 
 /**
@@ -65,8 +52,7 @@ export function buildStorageResponse(params: {
     const summaryText = nextStep !== undefined ? `${summary}\n${nextStep}` : summary;
     const dataText = toon ? encodeToon(structuredContent) : JSON.stringify(structuredContent);
     const consoleLinkText = apifyConsoleLinkText(apifyConsoleUrl);
-    return buildMCPResponse({
-        texts: [dataText, summaryText, ...(consoleLinkText ? [consoleLinkText] : [])],
+    return respondOk([dataText, summaryText, ...(consoleLinkText ? [consoleLinkText] : [])], {
         structuredContent: full,
     });
 }

--- a/src/tools/widgets/call_actor_widget.ts
+++ b/src/tools/widgets/call_actor_widget.ts
@@ -8,7 +8,7 @@ import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { respondServerError } from '../../utils/mcp.js';
 import { extractActorId } from '../../utils/tools.js';
 import { buildStartRunResponse } from '../actors/actor_run_response.js';
 import {
@@ -85,13 +85,10 @@ export const callActorWidget: ToolEntry = Object.freeze({
     call: async (toolArgs: InternalToolArgs) => {
         const rawActor = toolArgs.args?.actor;
         if (typeof rawActor === 'string' && rawActor.includes(':')) {
-            return buildMCPResponse({
-                texts: [
-                    `${HELPER_TOOLS.ACTOR_CALL_WIDGET} does not render widgets for MCP tool calls.`,
-                    `Use ${HELPER_TOOLS.ACTOR_CALL} for the "actorName:toolName" syntax.`,
-                ],
-                isError: true,
-            });
+            return respondServerError([
+                `${HELPER_TOOLS.ACTOR_CALL_WIDGET} does not render widgets for MCP tool calls.`,
+                `Use ${HELPER_TOOLS.ACTOR_CALL} for the "actorName:toolName" syntax.`,
+            ]);
         }
 
         const preResult = await callActorPreExecute(toolArgs, { route: HELPER_TOOLS.ACTOR_CALL_WIDGET });

--- a/src/tools/widgets/fetch_actor_details_widget.ts
+++ b/src/tools/widgets/fetch_actor_details_widget.ts
@@ -7,7 +7,7 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { buildActorDetailsForWidget, buildCardOptions, fetchActorDetails } from '../../utils/actor_details.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { respondOk } from '../../utils/mcp.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
 import { fixActorNameInputAndLog } from '../actors/actor_tools_factory.js';
 import { actorDetailsOutputDefaults, buildActorNotFoundResponse } from '../actors/fetch_actor_details.js';
@@ -97,11 +97,10 @@ export const fetchActorDetailsWidget: ToolEntry = Object.freeze({
         `,
         ];
 
-        return buildMCPResponse({
-            texts,
+        return respondOk(texts, {
             structuredContent,
             // Response-level meta; only returned in apps mode (this handler is apps-only).
-            _meta: {
+            meta: {
                 ...widgetConfig?.meta,
                 'openai/widgetDescription': `Actor details for ${actorName} from Apify Store`,
             },

--- a/src/tools/widgets/search_actors_widget.ts
+++ b/src/tools/widgets/search_actors_widget.ts
@@ -8,7 +8,7 @@ import { TOOL_TYPE } from '../../types.js';
 import { formatActorForWidget } from '../../utils/actor_card.js';
 import { searchAgentSafeActors } from '../../utils/actor_search.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { buildMCPResponse } from '../../utils/mcp.js';
+import { respondOk } from '../../utils/mcp.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
 import { buildSearchActorsResult, searchActorsBaseArgsSchema } from '../actors/search_actors.js';
 import { actorSearchWidgetOutputSchema } from '../structured_output_schemas.js';
@@ -78,8 +78,7 @@ export const searchActorsWidget: ToolEntry = Object.freeze({
                 You MUST retry with broader, more generic keywords - use just the platform name
                 (e.g., "TikTok" instead of "TikTok posts") before concluding no Actor exists.
             `;
-            return buildMCPResponse({
-                texts: [instructions],
+            return respondOk(instructions, {
                 structuredContent: {
                     actors: [],
                     query: parsed.keywords,
@@ -111,11 +110,10 @@ export const searchActorsWidget: ToolEntry = Object.freeze({
         ];
 
         const widgetConfig = getWidgetConfig(WIDGET_URIS.SEARCH_ACTORS);
-        return buildMCPResponse({
-            texts,
+        return respondOk(texts, {
             structuredContent,
             // Response-level meta; only returned in apps mode (this handler is apps-only).
-            _meta: {
+            meta: {
                 ...widgetConfig?.meta,
                 'openai/widgetDescription': `Interactive actor search results showing ${actors.length} ${actors.length === 1 ? 'actor' : 'actors'} from Apify Store`,
             },

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -1,6 +1,9 @@
-import type { ToolCallTelemetryProperties, ToolTelemetryContext } from '../types.js';
+import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
+import type { AjvErrorDetails, FailureCategory, ToolTelemetryContext } from '../types.js';
 import { ACTOR_RUN_LIMIT_MESSAGE, isActorRunLimitError } from './apify_errors.js';
+import { wrapJsonText } from './encode_text.js';
 import { getHttpStatusCode } from './logging.js';
+import { classifyFailureCategory, getToolStatusFromError } from './tool_status.js';
 
 /** MCP `_meta` key for Apify Actor run information. Namespaced per MCP spec. */
 export const APIFY_ACTOR_RUN_META_KEY = 'com.apify/ActorRun';
@@ -32,7 +35,7 @@ export function buildUsageMeta(source: {
  *   then stripped by `extractToolTelemetry()` before the response reaches the client.
  *   Contains tool outcome (toolStatus, failureCategory, etc.) used for Segment telemetry.
  */
-export function buildMCPResponse(options: {
+function buildMCPResponse(options: {
     texts: string[];
     isError?: boolean;
     telemetry?: ToolTelemetryContext;
@@ -48,6 +51,121 @@ export function buildMCPResponse(options: {
         ...(structuredContent !== undefined && { structuredContent }),
         ...(_meta !== undefined && { _meta }),
     };
+}
+
+/**
+ * Shared return type of the `respond*` constructors. Replaces the
+ * `ReturnType<typeof buildMCPResponse>` annotations now that `buildMCPResponse` is private.
+ */
+export type ToolResponse = ReturnType<typeof buildMCPResponse>;
+
+/** Normalise a `string | string[]` text argument to the array `buildMCPResponse` expects. */
+function toTexts(texts: string | string[]): string[] {
+    return Array.isArray(texts) ? texts : [texts];
+}
+
+/**
+ * Success response carrying caller-supplied text. `content[0]` is the raw text verbatim — bare JSON
+ * stays bare (the raw-JSON mirror channel), so use this (not `respondJson`) for unfenced JSON payloads.
+ */
+export function respondOk(
+    texts: string | string[],
+    opts?: { structuredContent?: unknown; meta?: Record<string, unknown> },
+): ToolResponse {
+    return buildMCPResponse({
+        texts: toTexts(texts),
+        structuredContent: opts?.structuredContent,
+        _meta: opts?.meta,
+    });
+}
+
+/**
+ * Success response carrying a JSON value in a ```json code fence. Owns the fence by delegating to
+ * `wrapJsonText` — use only where the byte output already leads with a ```json fence.
+ */
+export function respondJson(
+    value: unknown,
+    opts?: { structuredContent?: unknown; meta?: Record<string, unknown> },
+): ToolResponse {
+    return buildMCPResponse({
+        texts: [wrapJsonText(value)],
+        structuredContent: opts?.structuredContent,
+        _meta: opts?.meta,
+    });
+}
+
+/**
+ * User-error response (`SOFT_FAIL`). `category` defaults to `INVALID_INPUT`; the type excludes
+ * `INTERNAL_ERROR` (a server category — use `respondServerError` for that).
+ */
+export function respondUserError(
+    texts: string | string[],
+    opts?: {
+        category?: Exclude<FailureCategory, 'INTERNAL_ERROR'>;
+        httpStatus?: number;
+        detail?: string;
+        actorId?: string;
+        ajvErrorDetails?: AjvErrorDetails;
+        structuredContent?: unknown;
+    },
+): ToolResponse {
+    return buildMCPResponse({
+        texts: toTexts(texts),
+        isError: true,
+        telemetry: {
+            toolStatus: TOOL_STATUS.SOFT_FAIL,
+            failureCategory: opts?.category ?? FAILURE_CATEGORY.INVALID_INPUT,
+            ...(opts?.httpStatus !== undefined && { failureHttpStatus: opts.httpStatus }),
+            ...(opts?.detail !== undefined && { failureDetail: opts.detail }),
+            ...(opts?.actorId !== undefined && { actorId: opts.actorId }),
+            ...(opts?.ajvErrorDetails !== undefined && { ajvErrorDetails: opts.ajvErrorDetails }),
+        },
+        structuredContent: opts?.structuredContent,
+    });
+}
+
+/**
+ * Server-error response. Derives `toolStatus`/`failureCategory`/`failureHttpStatus` from the caught
+ * error (so a 4xx yields `SOFT_FAIL`, not `FAILED`); with no error → `FAILED` + `INTERNAL_ERROR`.
+ */
+export function respondServerError(
+    texts: string | string[],
+    opts?: {
+        error?: unknown;
+        detail?: string;
+        actorId?: string;
+        structuredContent?: unknown;
+        meta?: Record<string, unknown>;
+    },
+): ToolResponse {
+    const { error } = opts ?? {};
+    const httpStatus = getHttpStatusCode(error);
+    return buildMCPResponse({
+        texts: toTexts(texts),
+        isError: true,
+        telemetry: {
+            toolStatus: error === undefined ? TOOL_STATUS.FAILED : getToolStatusFromError(error, false),
+            failureCategory: error === undefined ? FAILURE_CATEGORY.INTERNAL_ERROR : classifyFailureCategory(error),
+            ...(httpStatus !== undefined && { failureHttpStatus: httpStatus }),
+            ...(opts?.detail !== undefined && { failureDetail: opts.detail }),
+            ...(opts?.actorId !== undefined && { actorId: opts.actorId }),
+        },
+        structuredContent: opts?.structuredContent,
+        _meta: opts?.meta,
+    });
+}
+
+/**
+ * Error response for framework paths (native-tool handling and the outer catch in `server.ts`, the
+ * x402 path) that record telemetry on local vars and bypass `extractToolTelemetry`. Carries no
+ * `toolTelemetry` key, so nothing leaks onto the wire. Tool handlers must NOT use this — they return
+ * a `respond*` error so telemetry is attached and then stripped by `extractToolTelemetry`.
+ */
+export function respondErrorNoTelemetry(
+    texts: string | string[],
+    opts?: { structuredContent?: unknown },
+): ToolResponse {
+    return { ...respondOk(texts, opts), isError: true };
 }
 
 /**
@@ -97,26 +215,6 @@ export function computeToolResponseBytes(result: unknown): {
         }
     }
     return { contentBytes, structuredContentBytes, fileBytes };
-}
-
-/**
- * Maps computed response byte counts to their `tool_response_*_bytes` telemetry fields.
- * Single source of truth for the field set, so adding a byte metric touches only
- * `computeToolResponseBytes` and this mapping. Returns `{}` when bytes weren't computed
- * (e.g. telemetry-disabled path) so callers can spread it unconditionally.
- */
-export function buildResponseBytesTelemetry(
-    responseBytes?: ReturnType<typeof computeToolResponseBytes>,
-): Pick<
-    ToolCallTelemetryProperties,
-    'tool_response_content_bytes' | 'tool_response_structured_content_bytes' | 'tool_response_file_bytes'
-> {
-    if (!responseBytes) return {};
-    return {
-        tool_response_content_bytes: responseBytes.contentBytes,
-        tool_response_structured_content_bytes: responseBytes.structuredContentBytes,
-        tool_response_file_bytes: responseBytes.fileBytes,
-    };
 }
 
 /** User-facing error text for tool execution failures with HTTP-aware hints. */

--- a/src/utils/payment_errors.ts
+++ b/src/utils/payment_errors.ts
@@ -6,7 +6,7 @@ import type { ApifyClient } from '../apify_client.js';
 import { HTTP_PAYMENT_REQUIRED } from '../const.js';
 import { isActorRunLimitError } from './apify_errors.js';
 import { getHttpStatusCode } from './logging.js';
-import { buildMCPResponse } from './mcp.js';
+import { respondErrorNoTelemetry } from './mcp.js';
 
 const PAYMENT_REQUIRED_HEADER = 'payment-required';
 
@@ -121,5 +121,5 @@ export function buildPaymentRequiredResponse(errorOrMessage: unknown, precompute
         ? [JSON.stringify(paymentData), 'Payment required to run this Actor or access this resource.']
         : [message];
 
-    return buildMCPResponse({ texts, isError: true, structuredContent: paymentData });
+    return respondErrorNoTelemetry(texts, { structuredContent: paymentData });
 }

--- a/tests/unit/mcp.server.error_handling.test.ts
+++ b/tests/unit/mcp.server.error_handling.test.ts
@@ -3,7 +3,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import log from '@apify/log';
 
+import { TOOL_STATUS } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
+import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../src/types.js';
+import { TOOL_TYPE } from '../../src/types.js';
+import { compileSchema } from '../../src/utils/ajv.js';
+import { getToolCallErrorUserText } from '../../src/utils/mcp.js';
 
 /**
  * Covers the `server.onerror` wiring in `setupErrorHandling()`: client faults softFail with a
@@ -35,5 +40,81 @@ describe('ActorsMcpServer onerror', () => {
         } finally {
             await server.close();
         }
+    });
+});
+
+/**
+ * Covers the tool-dispatch outer `catch` in the `CallToolRequestSchema` handler (server.ts).
+ * That response is returned via `captureResult` and never passes through `extractToolTelemetry`,
+ * so it must preserve the pre-computed, ABORTED-aware `toolStatus` and emit only `{ toolStatus }`
+ * in `toolTelemetry` — no `failureCategory`/`failureHttpStatus` (which would leak onto the wire).
+ */
+describe('CallToolRequestSchema handler outer catch', () => {
+    type HandlerFn = (req: Record<string, unknown>, extra: Record<string, unknown>) => Promise<Record<string, unknown>>;
+
+    // A synthetic internal tool whose call throws a plain (non-McpError) error, so dispatch falls
+    // through to the outer catch. An empty input schema validates against `{}`.
+    function makeThrowingTool(): ToolEntry {
+        return {
+            type: TOOL_TYPE.INTERNAL,
+            name: 'test-throwing-tool',
+            description: 'throws',
+            inputSchema: { type: 'object', properties: {} } as ToolInputSchema,
+            ajvValidate: compileSchema({ type: 'object', properties: {} }),
+            call: async (_toolArgs: InternalToolArgs) => {
+                throw new Error('boom');
+            },
+        };
+    }
+
+    function getToolCallHandler(server: ActorsMcpServer): HandlerFn {
+        // eslint-disable-next-line no-underscore-dangle
+        const handler = (
+            server as unknown as { server: { _requestHandlers: Map<string, HandlerFn> } }
+        ).server._requestHandlers.get('tools/call');
+        if (!handler) throw new Error('tools/call handler not registered');
+        return handler;
+    }
+
+    async function dispatchThrow(aborted: boolean) {
+        const server = new ActorsMcpServer({
+            taskStore: new InMemoryTaskStore(),
+            setupSigintHandler: false,
+            telemetry: { enabled: false },
+            token: 'fake-token',
+        });
+        try {
+            vi.spyOn(log, 'error').mockImplementation(() => log);
+            vi.spyOn(log, 'exception').mockImplementation(() => log);
+            server.upsertTools([makeThrowingTool()]);
+            const handler = getToolCallHandler(server);
+            return await handler(
+                {
+                    method: 'tools/call',
+                    params: { name: 'test-throwing-tool', arguments: {}, _meta: { mcpSessionId: 's1' } },
+                },
+                { signal: { aborted }, sendNotification: vi.fn() },
+            );
+        } finally {
+            await server.close();
+        }
+    }
+
+    it('preserves ABORTED toolStatus and emits only { toolStatus } when the request was aborted', async () => {
+        const result = await dispatchThrow(true);
+
+        expect(result.isError).toBe(true);
+        expect(result.content).toEqual([
+            { type: 'text', text: getToolCallErrorUserText('test-throwing-tool', new Error('boom')) },
+        ]);
+        // Only toolStatus — no failureCategory/failureHttpStatus leaking onto the wire.
+        expect(result.toolTelemetry).toEqual({ toolStatus: TOOL_STATUS.ABORTED });
+    });
+
+    it('emits only { toolStatus } (derived FAILED) when the request was not aborted', async () => {
+        const result = await dispatchThrow(false);
+
+        expect(result.isError).toBe(true);
+        expect(result.toolTelemetry).toEqual({ toolStatus: TOOL_STATUS.FAILED });
     });
 });

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -1,6 +1,6 @@
 import { ApifyApiError } from 'apify-client';
 import type { AxiosResponse } from 'axios';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
     APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED,
@@ -14,7 +14,18 @@ import {
     buildCallActorErrorResponse,
     buildPermissionApprovalResponse,
     callActorArgs,
+    resolveAndValidateActor,
 } from '../../src/tools/actors/call_actor.js';
+import type { InternalToolArgs, ToolEntry } from '../../src/types.js';
+import { TOOL_TYPE } from '../../src/types.js';
+import type { TextToolResult } from './helpers/tool_context.js';
+
+vi.mock('../../src/tools/actors/actor_tools_factory.js', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../src/tools/actors/actor_tools_factory.js');
+    return { ...actual, getActorsAsTools: vi.fn() };
+});
+
+const { getActorsAsTools } = await import('../../src/tools/actors/actor_tools_factory.js');
 
 describe('call_actor_common', () => {
     describe('buildCallActorDescription', () => {
@@ -157,6 +168,16 @@ describe('call_actor_common', () => {
             // Regression: must not nudge the LLM toward aborting unrelated runs to free capacity.
             expect(allText).not.toContain(HELPER_TOOLS.ACTOR_RUNS_ABORT);
             expect(allText).not.toContain('verify the Actor name');
+            // 402 memory-limit derives SOFT_FAIL (4xx) with the memory-limit failureDetail.
+            expect(response.toolTelemetry).toEqual(
+                expect.objectContaining({
+                    toolStatus: TOOL_STATUS.SOFT_FAIL,
+                    failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                    failureHttpStatus: 402,
+                    failureDetail: APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED,
+                    actorId: 'actor-789',
+                }),
+            );
         });
 
         it('returns the concurrent-run-limit billing hint for cannot-start-actor-runs errors', () => {
@@ -187,8 +208,14 @@ describe('call_actor_common', () => {
             expect(allText).toContain('console.apify.com/billing/subscription');
             // Run-limit must not fall through to the generic "verify the Actor name" hint.
             expect(allText).not.toContain('verify the Actor name');
+            // Run-limit derives SOFT_FAIL even though it arrives as 402/5xx (billing condition).
             expect(response.toolTelemetry).toEqual(
-                expect.objectContaining({ failureDetail: 'cannot-start-actor-runs', actorId: 'actor-999' }),
+                expect.objectContaining({
+                    toolStatus: TOOL_STATUS.SOFT_FAIL,
+                    failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                    failureDetail: 'cannot-start-actor-runs',
+                    actorId: 'actor-999',
+                }),
             );
         });
     });
@@ -253,6 +280,92 @@ describe('call_actor_common', () => {
             expect(response.isError).toBe(true);
             expect(response.content).toHaveLength(1);
             expect(response.content[0]?.text).toContain('This Actor requires full access to your account');
+        });
+    });
+
+    describe('resolveAndValidateActor', () => {
+        const INPUT_SCHEMA = { type: 'object', properties: { query: { type: 'string' } } };
+        const stubToolArgs = { apifyClient: {}, mcpSessionId: 'session-1' } as unknown as InternalToolArgs;
+
+        beforeEach(() => {
+            vi.mocked(getActorsAsTools).mockReset();
+        });
+
+        function mockActorTool(ajvValidate: ((input: unknown) => boolean) & { errors?: unknown }): void {
+            const tool = {
+                type: TOOL_TYPE.ACTOR,
+                name: 'apify--rag-web-browser',
+                actorId: 'actor-id-rag',
+                actorFullName: 'apify/rag-web-browser',
+                inputSchema: INPUT_SCHEMA,
+                ajvValidate,
+            } as unknown as ToolEntry;
+            vi.mocked(getActorsAsTools).mockResolvedValue({ tools: [tool], errors: [] });
+        }
+
+        it('returns a SOFT_FAIL/404 not-found error when the Actor is missing', async () => {
+            vi.mocked(getActorsAsTools).mockResolvedValue({ tools: [], errors: [] });
+
+            const resolution = await resolveAndValidateActor({
+                actorName: 'apify/missing',
+                input: { query: 'x' },
+                toolArgs: stubToolArgs,
+            });
+
+            expect('error' in resolution).toBe(true);
+            const { error } = resolution as { error: TextToolResult & { toolTelemetry?: unknown } };
+            expect(error.isError).toBe(true);
+            expect(error.content[0].text).toContain("Actor 'apify/missing' was not found");
+            expect(error.toolTelemetry).toEqual({
+                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                failureHttpStatus: 404,
+                failureDetail: "Actor 'apify/missing' was not found",
+            });
+        });
+
+        // Byte-identity guard for #937: the input-required error embeds the input schema in a
+        // ```json fence built via wrapJsonText — the exact bytes of the former hand-rolled fence.
+        it('embeds the input schema in an unchanged ```json fence for the input-required error', async () => {
+            mockActorTool((() => true) as never);
+
+            const resolution = await resolveAndValidateActor({
+                actorName: 'apify/rag-web-browser',
+                input: null as unknown as Record<string, unknown>,
+                toolArgs: stubToolArgs,
+            });
+
+            const { error } = resolution as { error: TextToolResult & { toolTelemetry?: Record<string, unknown> } };
+            expect(error.content[2].text).toBe(`\`\`\`json\n${JSON.stringify(INPUT_SCHEMA)}\n\`\`\``);
+            expect(error.toolTelemetry).toEqual({
+                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                failureDetail: 'input is required',
+                actorId: 'actor-id-rag',
+            });
+        });
+
+        // Byte-identity guard for #937: the validation-failed error keeps the `Input schema:\n`
+        // prefix before the wrapJsonText fence.
+        it('embeds the input schema in an unchanged ```json fence for the validation-failed error', async () => {
+            const ajvValidate = Object.assign(() => false, {
+                errors: [{ message: 'must have required property query' }],
+            });
+            mockActorTool(ajvValidate as never);
+
+            const resolution = await resolveAndValidateActor({
+                actorName: 'apify/rag-web-browser',
+                input: { wrong: 1 },
+                toolArgs: stubToolArgs,
+            });
+
+            const { error } = resolution as { error: TextToolResult & { toolTelemetry?: Record<string, unknown> } };
+            expect(error.content[1].text).toBe(`Input schema:\n\`\`\`json\n${JSON.stringify(INPUT_SCHEMA)}\n\`\`\``);
+            expect(error.toolTelemetry).toMatchObject({
+                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                actorId: 'actor-id-rag',
+            });
         });
     });
 });

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -132,6 +132,20 @@ describe('buildActorDetailsTextResponse()', () => {
             expect(texts[0]).not.toContain('/input)');
         });
 
+        // Byte-identity guard for #937: the embedded ```json fence (formerly hand-rolled via
+        // ['```json', JSON.stringify(...), '```'].join('\n')) now comes from wrapJsonText — the
+        // exact same bytes. The fence must stay embedded in the text element, not become respondJson.
+        it('embeds the input schema in an unchanged ```json fence (R5)', () => {
+            const { texts } = buildActorDetailsTextResponse({
+                details: MOCK_DETAILS,
+                output: inputSchemaOnlyOutput,
+                linkContext,
+            });
+            expect(texts[0]).toBe(
+                `# [Input schema](https://console.apify.com/actors/actor-id-1)\n\`\`\`json\n${JSON.stringify(MOCK_DETAILS.inputSchema)}\n\`\`\``,
+            );
+        });
+
         it('appends the verbatim-links nudge as the last text', () => {
             const { texts } = buildActorDetailsTextResponse({
                 details: MOCK_DETAILS,

--- a/tests/unit/tools.storage_helpers.test.ts
+++ b/tests/unit/tools.storage_helpers.test.ts
@@ -1,24 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../src/const.js';
-import {
-    buildDatasetItemsSummaryNextStep,
-    buildStorageNotFound,
-    normalizeRecordKey,
-} from '../../src/tools/storage/storage_helpers.js';
+import { HELPER_TOOLS } from '../../src/const.js';
+import { buildDatasetItemsSummaryNextStep, normalizeRecordKey } from '../../src/tools/storage/storage_helpers.js';
 
-describe('buildStorageNotFound()', () => {
-    it('returns a SOFT_FAIL / INVALID_INPUT response with the supplied message', () => {
-        const result = buildStorageNotFound("Dataset 'ds-1' not found.");
-
-        expect(result.isError).toBe(true);
-        expect(result.content).toEqual([{ type: 'text', text: "Dataset 'ds-1' not found." }]);
-        expect(result.toolTelemetry).toEqual({
-            toolStatus: TOOL_STATUS.SOFT_FAIL,
-            failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
-        });
-    });
-});
+// `buildStorageNotFound` was deleted in #937 — its six call sites call `respondUserError(text)`
+// directly. The SOFT_FAIL + INVALID_INPUT contract it guarded is now covered by the `respondUserError`
+// unit test in `tests/unit/utils.mcp.test.ts`.
 
 describe('buildDatasetItemsSummaryNextStep()', () => {
     it('suggests get-dataset on the terminal page when loaded', () => {

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -1,10 +1,183 @@
+import { ApifyApiError } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
+import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
+import { wrapJsonText } from '../../src/utils/encode_text.js';
 import {
-    buildResponseBytesTelemetry,
     computeToolResponseBytes,
     getToolCallErrorUserText,
+    respondErrorNoTelemetry,
+    respondJson,
+    respondOk,
+    respondServerError,
+    respondUserError,
 } from '../../src/utils/mcp.js';
+
+describe('respondOk()', () => {
+    it('returns a success response with the raw text and no isError/telemetry', () => {
+        const result = respondOk('all good');
+        expect(result).toEqual({ content: [{ type: 'text', text: 'all good' }], isError: false });
+        expect('toolTelemetry' in result).toBe(false);
+        expect('structuredContent' in result).toBe(false);
+        expect('_meta' in result).toBe(false);
+    });
+
+    it('keeps bare JSON bare in content[0] (no fence) — the raw-JSON mirror channel', () => {
+        const structuredContent = { runId: 'r1', status: 'RUNNING' };
+        const result = respondOk([JSON.stringify(structuredContent), 'summary'], { structuredContent });
+        expect(result.content[0].text).toBe('{"runId":"r1","status":"RUNNING"}');
+        expect(result.content[0].text.startsWith('```')).toBe(false);
+        expect(result.structuredContent).toEqual(structuredContent);
+    });
+
+    it('maps meta to _meta and omits it when undefined', () => {
+        expect(respondOk('x', { meta: { 'openai/foo': 1 } })._meta).toEqual({ 'openai/foo': 1 });
+        expect('_meta' in respondOk('x', { meta: undefined })).toBe(false);
+    });
+});
+
+describe('respondJson()', () => {
+    it('wraps the value in a ```json fence via wrapJsonText', () => {
+        const value = { a: 1, b: [2, 3] };
+        const result = respondJson(value);
+        expect(result.content).toEqual([{ type: 'text', text: wrapJsonText(value) }]);
+        expect(result.content[0].text.startsWith('```json\n')).toBe(true);
+        expect(result.isError).toBe(false);
+        expect('toolTelemetry' in result).toBe(false);
+    });
+
+    it('carries structuredContent and meta when provided', () => {
+        const result = respondJson({ a: 1 }, { structuredContent: { a: 1 }, meta: { k: 'v' } });
+        expect(result.structuredContent).toEqual({ a: 1 });
+        expect(result._meta).toEqual({ k: 'v' });
+    });
+});
+
+describe('respondErrorNoTelemetry()', () => {
+    it('returns an isError response with no toolTelemetry (framework paths)', () => {
+        const result = respondErrorNoTelemetry('failed');
+        expect(result).toEqual({ content: [{ type: 'text', text: 'failed' }], isError: true });
+        expect('toolTelemetry' in result).toBe(false);
+    });
+
+    it('carries structuredContent when provided, still no telemetry', () => {
+        const result = respondErrorNoTelemetry(['{"x":1}', 'note'], { structuredContent: { x: 1 } });
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toEqual({ x: 1 });
+        expect('toolTelemetry' in result).toBe(false);
+    });
+});
+
+describe('respondUserError()', () => {
+    it('defaults to SOFT_FAIL + INVALID_INPUT with only those telemetry fields', () => {
+        const result = respondUserError('bad input');
+        expect(result.isError).toBe(true);
+        expect(result.content).toEqual([{ type: 'text', text: 'bad input' }]);
+        expect(result.toolTelemetry).toEqual({
+            toolStatus: TOOL_STATUS.SOFT_FAIL,
+            failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+        });
+    });
+
+    it('accepts an explicit non-internal category (PERMISSION_APPROVAL_REQUIRED)', () => {
+        const result = respondUserError(['line1', 'line2'], {
+            category: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
+            httpStatus: 403,
+            detail: 'full-permission-actor-not-approved',
+            actorId: 'actor-1',
+        });
+        expect(result.content).toHaveLength(2);
+        expect(result.toolTelemetry).toEqual({
+            toolStatus: TOOL_STATUS.SOFT_FAIL,
+            failureCategory: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
+            failureHttpStatus: 403,
+            failureDetail: 'full-permission-actor-not-approved',
+            actorId: 'actor-1',
+        });
+    });
+
+    it('omits each optional telemetry field when undefined', () => {
+        const result = respondUserError('x', { httpStatus: 404 });
+        expect(result.toolTelemetry).toEqual({
+            toolStatus: TOOL_STATUS.SOFT_FAIL,
+            failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+            failureHttpStatus: 404,
+        });
+        expect('failureDetail' in (result.toolTelemetry ?? {})).toBe(false);
+        expect('actorId' in (result.toolTelemetry ?? {})).toBe(false);
+        expect('ajvErrorDetails' in (result.toolTelemetry ?? {})).toBe(false);
+    });
+
+    it('carries structuredContent when provided', () => {
+        const result = respondUserError('x', { structuredContent: { foo: 1 } });
+        expect(result.structuredContent).toEqual({ foo: 1 });
+    });
+});
+
+describe('respondServerError()', () => {
+    it('derives FAILED + INTERNAL_ERROR when given no error', () => {
+        const result = respondServerError('server broke');
+        expect(result.isError).toBe(true);
+        expect(result.content).toEqual([{ type: 'text', text: 'server broke' }]);
+        expect(result.toolTelemetry).toMatchObject({
+            toolStatus: TOOL_STATUS.FAILED,
+            failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR,
+        });
+    });
+
+    it('derives SOFT_FAIL + INVALID_INPUT for a 404 error', () => {
+        const error = Object.assign(new Error('Not found'), { statusCode: 404 });
+        expect(respondServerError('x', { error }).toolTelemetry).toMatchObject({
+            toolStatus: TOOL_STATUS.SOFT_FAIL,
+            failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+            failureHttpStatus: 404,
+        });
+    });
+
+    it('derives SOFT_FAIL + INVALID_INPUT for a run-limit error wrapped as 5xx', () => {
+        const error = Object.assign(new Error('Streamable HTTP error: cannot-start-actor-runs'), { statusCode: 500 });
+        expect(respondServerError('x', { error }).toolTelemetry).toMatchObject({
+            toolStatus: TOOL_STATUS.SOFT_FAIL,
+            failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+        });
+    });
+
+    it('derives FAILED + INTERNAL_ERROR for a 5xx error', () => {
+        const error = Object.assign(new Error('Internal'), { statusCode: 500 });
+        expect(respondServerError('x', { error }).toolTelemetry).toMatchObject({
+            toolStatus: TOOL_STATUS.FAILED,
+            failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR,
+            failureHttpStatus: 500,
+        });
+    });
+
+    it('adds detail and actorId to telemetry when provided, omits them otherwise', () => {
+        const error = Object.assign(new Error('boom'), { statusCode: 500 });
+        const withOpts = respondServerError('x', { error, detail: 'memory-limit-exceeded', actorId: 'a1' });
+        expect(withOpts.toolTelemetry).toMatchObject({ failureDetail: 'memory-limit-exceeded', actorId: 'a1' });
+
+        const withoutOpts = respondServerError('x', { error });
+        expect('failureDetail' in (withoutOpts.toolTelemetry ?? {})).toBe(false);
+        expect('actorId' in (withoutOpts.toolTelemetry ?? {})).toBe(false);
+    });
+
+    it('reproduces the generic buildCallActorErrorResponse telemetry shape byte-for-byte', () => {
+        // The generic call-actor error branch is `respondServerError(texts, { error, detail, actorId })`.
+        const error = new ApifyApiError({ data: { error: { type: 'x', message: 'boom' } }, status: 500 } as never, 1);
+        const result = respondServerError(['Failed to call Actor', 'verify'], {
+            error,
+            detail: 'boom',
+            actorId: 'actor-1',
+        });
+        expect(result.toolTelemetry).toEqual({
+            toolStatus: TOOL_STATUS.FAILED,
+            failureCategory: FAILURE_CATEGORY.INTERNAL_ERROR,
+            failureHttpStatus: 500,
+            failureDetail: 'boom',
+            actorId: 'actor-1',
+        });
+    });
+});
 
 describe('getToolCallErrorUserText()', () => {
     it('returns the concurrent-run-limit hint when a direct Actor tool hits the limit', () => {
@@ -98,20 +271,5 @@ describe('computeToolResponseBytes()', () => {
         circular.self = circular;
         const result = { structuredContent: circular };
         expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 0, structuredContentBytes: 0, fileBytes: 0 });
-    });
-});
-
-describe('buildResponseBytesTelemetry()', () => {
-    it('returns an empty object when no bytes are provided', () => {
-        expect(buildResponseBytesTelemetry()).toEqual({});
-        expect(buildResponseBytesTelemetry(undefined)).toEqual({});
-    });
-
-    it('maps byte counts to their telemetry fields', () => {
-        expect(buildResponseBytesTelemetry({ contentBytes: 10, structuredContentBytes: 20, fileBytes: 30 })).toEqual({
-            tool_response_content_bytes: 10,
-            tool_response_structured_content_bytes: 20,
-            tool_response_file_bytes: 30,
-        });
     });
 });


### PR DESCRIPTION
I'm sorry for a bulky PR but there was no other way.
This PR helps to create a boundary between tool response and MCP response. 

> 📄 **Visual summary:** [The `respond*` response contract](https://claude.ai/code/artifact/384caccf-53c8-413e-8a2b-3ae9031e344c) — a one-screen brief.

Tool handlers built MCP responses by hand, so failure classification was opt-in and telemetry unreliable: `get_dataset_schema` failures carried no `failureCategory` (P2), and the `SOFT_FAIL + INVALID_INPUT` telemetry literal was duplicated across handlers (P3), alongside redundant domain builders and hand-rolled JSON code fences.

## How

A `respond*` family — `respondOk`, `respondJson`, `respondUserError`, `respondServerError`, plus a `respondErrorNoTelemetry` helper for framework paths — is now the only public way to build a tool response. `buildMCPResponse` is un-exported (private to `utils/mcp.ts`); an exported `ToolResponse` alias replaces the `ReturnType` annotations. `respondServerError` derives `toolStatus` / `failureCategory` / `httpStatus` from the caught error; `respondJson` owns the ` ```json ` fence via the existing `wrapJsonText` helper. `buildPermissionApprovalErrorResponse` and `buildStorageNotFound` are deleted and the single-call-site `buildSearchActorsEmptyResponse` is inlined; three helpers with two call sites each (base tool + widget) are kept but now route through `respond*`.

**Client-facing wire output is byte-identical** except the intended telemetry corrections:
- **P2** — `get_dataset_schema` failure is now classified `INTERNAL_ERROR` (was category-less).
- **P3** — the duplicated `SOFT_FAIL + INVALID_INPUT` literal collapses into `respondUserError`.
- Two coherence fixes to previously incoherent status/category pairings: `fetch-apify-docs` thrown-fetch (`SOFT_FAIL` → `FAILED`) and `get-actor-run` error (now carries `INVALID_INPUT`).

## Alternatives considered

Deleting all six domain builders and inlining every call site (the issue's literal wording) would duplicate multi-branch logic across each base+widget pair; keeping the multi-call-site helpers routed through `respond*` preserves DRY while still removing the hand-rolled response bodies. The brand + `ToolEntry.call` narrowing (the compile-time lock) is deferred to a separate sub-issue — `call` is unchanged here.

## Note for `apify-mcp-server-internal`

Removing the `buildMCPResponse` export and the P2/coherence telemetry changes touch what the hosted server consumes (telemetry shape). Internal consumes only the stripped wire shape, which is unchanged; no import of `buildMCPResponse` exists there. The internal contract suite may want a matching case for the corrected failure categories.

Part of #935. Closes #937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLiBdJ2Q7jRFFyZxtYuWhj