### PR TITLE
feat: Cap search-apify-docs output with Algolia snippeting

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -125,6 +125,22 @@ export const DOCS_SOURCES = [
     },
 ] as const;
 
+/**
+ * Word window for Algolia `attributesToSnippet` in `search-apify-docs`. Bounds each hit to a
+ * match-centered snippet instead of the full indexed `content` attribute — API-reference records
+ * inline the whole OpenAPI schema (~34.5k chars each), so 20 hits returned ~173k tokens. The agent
+ * fetches full pages via `fetch-apify-docs`.
+ */
+export const DOCS_SNIPPET_MAX_WORDS = 100;
+
+/**
+ * Sentinel used as Algolia `highlightPreTag`/`highlightPostTag` for docs snippets, stripped before
+ * returning. An empty-string tag is treated as "unset" and falls back to Algolia's default
+ * `<span class="algolia-docsearch-suggestion--highlight">` markup, so we set a private-use
+ * character (U+E000) and remove it.
+ */
+export const DOCS_SNIPPET_HIGHLIGHT_TAG = '\uE000';
+
 export const ALLOWED_DOC_DOMAINS = ['https://docs.apify.com', 'https://crawlee.dev'] as const;
 
 export const APIFY_STORE_URL = 'https://apify.com';

--- a/src/utils/apify_docs.ts
+++ b/src/utils/apify_docs.ts
@@ -85,9 +85,9 @@ function prepareAlgoliaRequest(
     }
 
     // Return a bounded, match-centered snippet of `content` rather than the full indexed attribute
-    // (API-reference records inline the whole ~34.5k-char OpenAPI schema). Highlight markup is
-    // injected around matches with a strippable sentinel; skip full-content highlighting and the
-    // full-content attribute to keep the response small.
+    // (see DOCS_SNIPPET_MAX_WORDS for why). Highlight markup is injected around matches with a
+    // strippable sentinel; skip full-content highlighting and the full-content attribute to keep
+    // the response small.
     searchRequest.attributesToSnippet = [`content:${DOCS_SNIPPET_MAX_WORDS}`];
     searchRequest.snippetEllipsisText = '…';
     searchRequest.highlightPreTag = DOCS_SNIPPET_HIGHLIGHT_TAG;

--- a/src/utils/apify_docs.ts
+++ b/src/utils/apify_docs.ts
@@ -9,7 +9,7 @@ import { algoliasearch } from 'algoliasearch';
 
 import log from '@apify/log';
 
-import { DOCS_SOURCES } from '../const.js';
+import { DOCS_SNIPPET_HIGHLIGHT_TAG, DOCS_SNIPPET_MAX_WORDS, DOCS_SOURCES } from '../const.js';
 import { searchApifyDocsCache } from '../state.js';
 import type { ApifyDocsSearchResult } from '../types.js';
 
@@ -34,6 +34,8 @@ type AlgoliaResultHit = {
     content?: string | null;
     type?: string;
     hierarchy?: Record<string, string | null>;
+    /** Bounded, match-centered snippet of `content`; produced by `attributesToSnippet`. */
+    _snippetResult?: { content?: { value?: string } };
 };
 
 /**
@@ -82,6 +84,17 @@ function prepareAlgoliaRequest(
         searchRequest.facetFilters = indexConfig.facetFilters;
     }
 
+    // Return a bounded, match-centered snippet of `content` rather than the full indexed attribute
+    // (API-reference records inline the whole ~34.5k-char OpenAPI schema). Highlight markup is
+    // injected around matches with a strippable sentinel; skip full-content highlighting and the
+    // full-content attribute to keep the response small.
+    searchRequest.attributesToSnippet = [`content:${DOCS_SNIPPET_MAX_WORDS}`];
+    searchRequest.snippetEllipsisText = '…';
+    searchRequest.highlightPreTag = DOCS_SNIPPET_HIGHLIGHT_TAG;
+    searchRequest.highlightPostTag = DOCS_SNIPPET_HIGHLIGHT_TAG;
+    searchRequest.attributesToHighlight = [];
+    searchRequest.attributesToRetrieve = ['url_without_anchor', 'anchor'];
+
     return searchRequest;
 }
 
@@ -110,9 +123,12 @@ function processAlgoliaResponse(results: AlgoliaResult[]): ApifyDocsSearchResult
                 url += `#${hit.anchor}`;
             }
 
+            // Bounded, match-centered snippet with the injected highlight sentinels stripped
+            // (see DOCS_SNIPPET_HIGHLIGHT_TAG). `content` isn't retrieved, so the snippet is the only source.
+            const content = hit._snippetResult?.content?.value?.split(DOCS_SNIPPET_HIGHLIGHT_TAG).join('');
             searchResults.push({
                 url,
-                ...(hit.content ? { content: hit.content } : {}),
+                ...(content ? { content } : {}),
             });
         }
     }

--- a/tests/unit/utils.apify_docs.test.ts
+++ b/tests/unit/utils.apify_docs.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DOCS_SNIPPET_HIGHLIGHT_TAG, DOCS_SNIPPET_MAX_WORDS } from '../../src/const.js';
+import { searchDocsBySource } from '../../src/utils/apify_docs.js';
+
+const searchMock = vi.fn();
+
+vi.mock('algoliasearch', () => ({
+    // Return a client whose `search` is our spy so we can assert the request and stub hits.
+    algoliasearch: vi.fn(() => ({ search: searchMock })),
+}));
+
+describe('searchDocsBySource()', () => {
+    beforeEach(() => {
+        searchMock.mockReset();
+        searchMock.mockResolvedValue({ results: [{ hits: [] }] });
+    });
+
+    describe('Algolia request', () => {
+        it('asks Algolia for a bounded, match-centered content snippet', async () => {
+            await searchDocsBySource('apify', 'standby actor');
+
+            const request = searchMock.mock.calls[0]?.[0]?.requests?.[0];
+            expect(request.attributesToSnippet).toEqual([`content:${DOCS_SNIPPET_MAX_WORDS}`]);
+            // Highlight markup must use a strippable sentinel, not Algolia's default <span>.
+            expect(request.highlightPreTag).toBe(DOCS_SNIPPET_HIGHLIGHT_TAG);
+            expect(request.highlightPostTag).toBe(DOCS_SNIPPET_HIGHLIGHT_TAG);
+        });
+
+        it('preserves the source filters alongside the snippet params', async () => {
+            await searchDocsBySource('apify', 'standby actor');
+
+            const request = searchMock.mock.calls[0]?.[0]?.requests?.[0];
+            expect(request.filters).toBe('version:latest');
+        });
+    });
+
+    describe('result processing', () => {
+        it('returns the snippet with highlight sentinels stripped, not the full content attribute', async () => {
+            const tag = DOCS_SNIPPET_HIGHLIGHT_TAG;
+            searchMock.mockResolvedValue({
+                results: [
+                    {
+                        hits: [
+                            {
+                                url_without_anchor: 'https://docs.apify.com/platform/actors/running/standby',
+                                anchor: 'how-do-i-authenticate-my-requests',
+                                content: 'FULL 34k-char indexed attribute that must not be returned',
+                                _snippetResult: {
+                                    content: { value: `authenticate your ${tag}standby${tag} requests…` },
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            const results = await searchDocsBySource('apify', 'standby authenticate');
+
+            expect(results).toEqual([
+                {
+                    url: 'https://docs.apify.com/platform/actors/running/standby#how-do-i-authenticate-my-requests',
+                    content: 'authenticate your standby requests…',
+                },
+            ]);
+        });
+
+        it('omits content for hits without a snippet (e.g. crawlee lvl1 records)', async () => {
+            searchMock.mockResolvedValue({
+                results: [{ hits: [{ url_without_anchor: 'https://crawlee.dev/js/docs/guides/request-storage' }] }],
+            });
+
+            const results = await searchDocsBySource('crawlee-js', 'request storage');
+
+            expect(results).toEqual([{ url: 'https://crawlee.dev/js/docs/guides/request-storage' }]);
+        });
+    });
+});


### PR DESCRIPTION
## Problem
`search-apify-docs` returned the full Algolia `content` attribute per hit. API-reference records inline the entire schema (~34.5K chars each, byte-identical across endpoints), so a `limit: 20` search returned **~173K tokens** — mostly duplicated boilerplate — overrunning limited-context agents (Apify AI hit hardest). Part of Context Bloating problem.

## Fix
Bound each hit at the source with query-time Algolia snippeting in `prepareAlgoliaRequest`:
- `attributesToSnippet: ['content:100']` — a 100-word, match-centered window instead of the full attribute.
- Matched terms come wrapped in highlight markup; we strip it via a private-use sentinel tag (`DOCS_SNIPPET_HIGHLIGHT_TAG`). An empty tag is treated as "unset" and falls back to Algolia's verbose default `<span>`, so a sentinel is required.
- `attributesToHighlight: []` + `attributesToRetrieve: ['url_without_anchor','anchor']` shrink the wire response (1.43 MB → 27 KB).

`processAlgoliaResponse` reads `_snippetResult.content.value` and strips the sentinel.

## Why it's safe (no ranking/relevance change)
The diff only adds display/retrieval params; it never touches the ranking inputs (`query` / `filters` / `typeFilter` / `facetFilters`), so Algolia ranking is unchanged by construction. Verified two ways:
- **Actual `master` build vs this branch, via mcpc → live Algolia** (5 queries): identical URLs + order for every query.
- **Before/after eval** (13 queries): identical results, ~90% content reduction, latency unchanged (~49 → ~48 ms).

Measured reductions (master → branch output): `create webhook` 217,793 → 11,390 B (**−95%**); `actor input schema` 27,496 → 15,362 B. **crawlee-js/py are byte-identical** — their `lvl1` records have no `content`, so the change is a no-op there.

## Tests
`tests/unit/utils.apify_docs.test.ts` (mocked Algolia): the request carries the snippet params; result processing prefers and strips the snippet; hits without a snippet (crawlee) stay url-only.

## Scope
Bounds `search-apify-docs` only. `fetch-apify-docs` is unchanged — it serves the full page on demand (a deliberate single-page pull), which is the right tool for full context.

## Relationship to #1029
This is an **alternative** to #1029's `search-apify-docs` cap (`clipSnippet`, a 1000-char head-slice) — the two are **mutually exclusive for search and should not both be merged**. Snippeting is match-centered (vs a head-slice of the boilerplate top) and also shrinks the Algolia wire payload. #1029's other caps (dataset / key-value-store / call-actor) are independent and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
