### PR TITLE
fix: Flush Segment telemetry on stdio shutdown

### DIFF
--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -34,7 +34,7 @@ import { ApifyClient } from './apify_client.js';
 import { DEFAULT_TELEMETRY_ENV, TELEMETRY_ENV } from './const.js';
 import { processInput } from './input.js';
 import { ActorsMcpServer } from './mcp/server.js';
-import { getTelemetryEnv } from './telemetry.js';
+import { closeAnalyticsClient, getTelemetryEnv } from './telemetry.js';
 import type { ApifyRequestParams, Input, ServerModeOption, TelemetryEnv, ToolSelector } from './types.js';
 import { isApiTokenRequired } from './utils/auth.js';
 import { parseCommaSeparatedList } from './utils/generic.js';
@@ -234,6 +234,13 @@ async function main() {
     const mcpSessionId = randomUUID();
 
     await mcpServer.connect(transport);
+
+    // Flush buffered Segment events before the process exits (dominant path: the client closes
+    // stdin, the transport ends, the loop empties). Mirrors the Sentry beforeExit cleanup in
+    // instrument.ts. No-op when telemetry is off (no client was ever created).
+    process.on('beforeExit', async () => {
+        await closeAnalyticsClient();
+    });
 
     const sdkOnMessage = transport.onmessage;
     transport.onmessage = (message) => {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -64,6 +64,22 @@ export function getOrInitAnalyticsClient(telemetryEnv: TelemetryEnv): Analytics 
 }
 
 /**
+ * Flushes buffered events and closes the Segment client. Terminal — the client cannot be reused
+ * afterwards, so call this only at process shutdown (stdio). Without it, events produced in the last
+ * `SEGMENT_FLUSH_INTERVAL_MS` window are lost when the process exits. No-op if no client exists.
+ */
+export async function closeAnalyticsClient(): Promise<void> {
+    if (!analyticsClient) return;
+    try {
+        await analyticsClient.closeAndFlush();
+    } catch (error) {
+        log.error('Failed to flush Segment analytics client', { error });
+    } finally {
+        analyticsClient = null;
+    }
+}
+
+/**
  * Tracks a tool call event to Segment.
  * Segment requires either userId OR anonymousId, but not both. When the Apify user is known, use
  * userId; otherwise fall back to mcp_session_id so every unauthenticated call in the same session

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { trackToolCall } from '../../src/telemetry.js';
+import { closeAnalyticsClient, trackToolCall } from '../../src/telemetry.js';
 
 // Mock the Segment Analytics client
 const mockTrack = vi.fn();
+const mockCloseAndFlush = vi.fn();
 vi.mock('@segment/analytics-node', () => ({
     // Vitest 4 constructs mocked classes via `Reflect.construct`, which requires a
     // constructable implementation. An arrow function has no [[Construct]], so it must
@@ -11,6 +12,7 @@ vi.mock('@segment/analytics-node', () => ({
     Analytics: vi.fn().mockImplementation(function () {
         return {
             track: mockTrack,
+            closeAndFlush: mockCloseAndFlush,
         };
     }),
 }));
@@ -133,5 +135,44 @@ describe('telemetry', () => {
             event: 'MCP Tool Call',
             properties,
         });
+    });
+});
+
+describe('closeAnalyticsClient()', () => {
+    const properties = {
+        app: 'mcp' as const,
+        app_version: '0.5.6',
+        mcp_client_name: 'test-client',
+        mcp_client_version: '1.0.0',
+        mcp_protocol_version: '2024-11-05',
+        mcp_client_capabilities: {},
+        mcp_session_id: 'session-123',
+        transport_type: 'stdio',
+        tool_name: 'test-tool',
+        tool_status: 'SUCCEEDED' as const,
+        tool_exec_time_ms: 100,
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('flushes and closes the Segment client', async () => {
+        // A track call lazily creates the singleton client; closing it must flush.
+        trackToolCall('user', 'DEV', properties);
+
+        await closeAnalyticsClient();
+
+        expect(mockCloseAndFlush).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op when there is no active client', async () => {
+        // First close nulls the client; a second close must not touch it.
+        await closeAnalyticsClient();
+        mockCloseAndFlush.mockClear();
+
+        await closeAnalyticsClient();
+
+        expect(mockCloseAndFlush).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Problem

The Segment analytics client batches events (`flushAt: 50`, `flushInterval: 5s`). On stdio shutdown the process can exit before the interval timer fires, dropping any events produced in the final window — e.g. `MCP Tool Call`.

## Fix

- **`src/telemetry.ts`** — new `closeAnalyticsClient()`: a terminal `closeAndFlush()`, guarded to no-op when no client exists, nulling the singleton (idempotent).
- **`src/stdio.ts`** — runs it on `process.on('beforeExit')`, mirroring the existing Sentry cleanup in `instrument.ts`.
- **`tests/unit/telemetry.test.ts`** — flushes when a client exists; no-op when none.

Deliberately kept out of `ActorsMcpServer.close()` and the SIGINT handler — those are shared with HTTP mode, where the process-level Segment client is shared across sessions and a terminal flush would break other sessions.

## Known gaps

- **SIGINT (Ctrl-C) not covered** — that path `process.exit(0)`s and skips `beforeExit`, same as Sentry's cleanup already does. Covering it needs a broader change to the shared handler; out of scope here.
- **Not exercised end-to-end** — unit tests cover the flush logic; real Segment delivery on a live shutdown isn't observable without a write key/network.