### PR TITLE
fix(tools): return structured {found:false} envelope for missing key-value store records

### DIFF
--- a/src/tools/storage/get_key_value_store_record.ts
+++ b/src/tools/storage/get_key_value_store_record.ts
@@ -59,10 +59,27 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
         if (record === undefined) {
             // getRecord returns undefined for both missing-store and missing-key; disambiguate.
             const storeInfo = await store.get();
-            const text = storeInfo
-                ? `Record '${recordKey}' not found in key-value store '${keyValueStoreId}'.`
-                : `Key-value store '${keyValueStoreId}' not found.`;
-            return buildStorageNotFound(text);
+            if (!storeInfo) {
+                // Missing store is a real bad input — keep the soft-fail so telemetry flags it.
+                return buildStorageNotFound(`Key-value store '${keyValueStoreId}' not found.`);
+            }
+            // Store exists but the key doesn't. This is a legitimate branch case (e.g. a checkpoint
+            // that has been cleared on success); returning `isError: true` forces callers to regex
+            // the text envelope to distinguish it from a real error. Emit a structured
+            // `{found: false, ...}` envelope so agents can branch on the boolean instead.
+            const apifyConsoleUrl = buildConsoleKeyValueStoreUrl(
+                await getConsoleLinkContext(apifyToken, client),
+                keyValueStoreId,
+            );
+            return buildStorageResponse({
+                structuredContent: {
+                    found: false,
+                    keyValueStoreId,
+                    recordKey,
+                },
+                summary: `Record '${recordKey}' not found in key-value store '${keyValueStoreId}'.`,
+                apifyConsoleUrl,
+            });
         }
         const apifyConsoleUrl = buildConsoleKeyValueStoreUrl(
             await getConsoleLinkContext(apifyToken, client),

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -677,15 +677,22 @@ export const keyValueStoreKeysOutputSchema = {
 
 /**
  * Schema for a single record (get-key-value-store-record). Terminal: no nextStep.
+ *
+ * `found` disambiguates the "store exists but the key does not" case from a hit — callers can
+ * branch on the boolean instead of regex-matching a not-found text envelope. On a hit, `found`
+ * is omitted (existing shape preserved) and `key` + `value` are populated. On a miss, `found`
+ * is `false`, `recordKey` echoes the requested key, and `key`/`value` are absent.
  */
 export const keyValueStoreRecordOutputSchema = {
     type: 'object' as const,
     properties: {
+        found: { type: 'boolean', description: 'False when the store exists but the requested key does not. Omitted on a hit.' },
         keyValueStoreId: { type: 'string', description: 'Key-value store ID' },
-        key: { type: 'string', description: 'Record key' },
-        value: { description: 'The stored value (JSON, text, or binary)' },
+        recordKey: { type: 'string', description: 'The requested record key (present when found=false).' },
+        key: { type: 'string', description: 'Record key (present on a hit).' },
+        value: { description: 'The stored value (JSON, text, or binary). Present on a hit.' },
         contentType: { type: 'string', description: 'MIME type of the stored value' },
         summary: summaryProperty,
     },
-    required: ['keyValueStoreId', 'key', 'value', 'summary'],
+    required: ['keyValueStoreId', 'summary'],
 };

--- a/tests/unit/tools.get_key_value_store_record.test.ts
+++ b/tests/unit/tools.get_key_value_store_record.test.ts
@@ -225,17 +225,30 @@ describe('get-key-value-store-record', () => {
         });
     });
 
-    it('returns isError "record not found" when getRecord is undefined but the store exists', async () => {
+    it('returns a structured {found: false} envelope when the store exists but the key does not', async () => {
+        // Missing record in an existing store is a legitimate branch case (a checkpoint that has been
+        // cleared on success, a probe for optional metadata) — it must not surface as isError, because
+        // callers would have to regex the text envelope to distinguish it from a real error.
         const result = await (getKeyValueStoreRecord as HelperTool).call(
             stubToolCallContext(
                 { keyValueStoreId: 'kv-1', recordKey: 'MISSING' },
                 stubApifyClient({ record: undefined, store: MOCK_STORE }),
             ),
         );
-        const { content } = result as TextToolResult;
+        expectSchemaConformingStructuredContent(result, keyValueStoreRecordOutputSchema);
+        const { isError, structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
 
-        expectSoftFailInvalidInput(result);
-        expect(content[0].text).toContain("Record 'MISSING' not found in key-value store 'kv-1'");
+        expect(isError).not.toBe(true);
+        expect(structuredContent).toMatchObject({
+            found: false,
+            keyValueStoreId: 'kv-1',
+            recordKey: 'MISSING',
+        });
+        expect(structuredContent).not.toHaveProperty('key');
+        expect(structuredContent).not.toHaveProperty('value');
+        expect(structuredContent.summary).toBe("Record 'MISSING' not found in key-value store 'kv-1'.");
     });
 
     it('returns isError "store not found" when both getRecord and store get are undefined', async () => {


### PR DESCRIPTION
## Summary

`get-key-value-store-record` currently returns `isError: true` with a text-only `Record 'X' not found in key-value store 'Y'.` envelope (and no `structuredContent`) when the store exists but the requested key does not. Callers that treat "key missing" as a legitimate branch (probing whether a checkpoint has been cleared, checking for optional metadata, feature-flag records) have to regex-match that text to distinguish it from a real error.

This PR splits the not-found path:

- **Store missing** (`.get()` also returns `undefined`) — unchanged. Still soft-fails with `isError: true` + `INVALID_INPUT` telemetry, because that is a bad input.
- **Key missing in an existing store** — now returns a structured envelope with no `isError`:
  ```json
  { "found": false, "keyValueStoreId": "kv-1", "recordKey": "CHECKPOINT" }
  ```
  The human-readable line ("`Record 'X' not found in key-value store 'Y'.`") is preserved as the tool `summary`, so clients that only render text see the same message.
- **Hit** — unchanged shape.

## Rationale

Consider a common agent pattern: "check whether a checkpoint exists; if it does, resume from there; otherwise start fresh." Under the current behavior, the checkpoint being absent (which is the healthy fast path when work was completed and the checkpoint cleared) surfaces as `isError: true`. Downstream orchestration that fails on tool errors then treats a successful clear as a fault, and text-envelope callers must regex the message to recover.

A boolean `found` in `structuredContent` lets programmatic consumers branch without touching prose, and keeps the "real bad input" (missing store) as a genuine error.

## Evidence

Before this change, a call for a missing key in an existing store yielded (`kv-1` exists, `CHECKPOINT` does not):

```
isError: true
content: [{ type: 'text', text: "Record 'CHECKPOINT' not found in key-value store 'kv-1'." }]
```

with no `structuredContent`. After:

```
isError: (unset)
structuredContent: {
  found: false,
  keyValueStoreId: 'kv-1',
  recordKey: 'CHECKPOINT',
  summary: "Record 'CHECKPOINT' not found in key-value store 'kv-1'."
}
```

Missing-store still returns `isError: true` (see the `returns isError "store not found"` unit test).

## Output schema change

`keyValueStoreRecordOutputSchema` gains an optional `found: boolean` and an optional `recordKey: string`. `key` and `value` are dropped from `required` (they remain present on a hit; they are absent on a miss). This is additive for hit consumers and only removes required-ness — no existing hit response shape changes.

## Test plan

- [x] Existing "record on a hit" tests pass unchanged (JSON, text, empty, binary/image/audio/PDF, over-inline-limit link).
- [x] Renamed unit test asserts the structured miss envelope: `found: false`, `keyValueStoreId`, `recordKey`, no `key`/`value`, summary preserved.
- [x] Existing store-missing soft-fail test remains untouched.
- [x] `pnpm run type-check`, `pnpm run lint`, `pnpm run test:unit` all green.

_Surfaced during an evaluation of Apify surfaces for agent-driven Actor development._