### PR TITLE
refactor: Brand ToolResponse to lock tool-response contract (#938)

### DIFF
--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -796,7 +796,7 @@ export async function fetchActorRunData(params: {
     abortSignal?: AbortSignal;
     mcpSessionId?: string;
     onAbort?: (runId: string, client: ApifyClient) => Promise<void>;
-}): Promise<{ error: object } | { aborted: true } | { result: FetchActorRunResult }> {
+}): Promise<{ error: ToolResponse } | { aborted: true } | { result: FetchActorRunResult }> {
     const { runId, waitSecs, client, progressTracker, abortSignal, mcpSessionId, onAbort } = params;
 
     const waitResult = await waitForRunWithProgress({

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -1,4 +1,5 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { ContentBlock } from '@modelcontextprotocol/sdk/types.js';
 import type { ApifyApiError } from 'apify-client';
 import dedent from 'dedent';
 import { z } from 'zod';
@@ -30,7 +31,14 @@ import {
 import { getConsoleLinkContext } from '../../utils/console_link.js';
 import { wrapJsonText } from '../../utils/encode_text.js';
 import { logHttpError } from '../../utils/logging.js';
-import { respondErrorNoTelemetry, respondServerError, respondUserError, type ToolResponse } from '../../utils/mcp.js';
+import {
+    respondAborted,
+    respondErrorNoTelemetry,
+    respondRaw,
+    respondServerError,
+    respondUserError,
+    type ToolResponse,
+} from '../../utils/mcp.js';
 import { classifyFailureCategory, extractAjvErrorDetails } from '../../utils/tool_status.js';
 import { extractActorId } from '../../utils/tools.js';
 import { actorNameToToolName, isActorBlockedUnderPaymentProvider } from '../actor_tool_naming.js';
@@ -328,7 +336,7 @@ export async function handleMcpToolCall(params: {
     mcpServerUrl: string | false;
     apifyToken: string;
     mcpSessionId?: string;
-}): Promise<object | null> {
+}): Promise<ToolResponse | null> {
     const { baseActorName, mcpToolName, input, isActorMcpServer, mcpServerUrl, apifyToken, mcpSessionId } = params;
 
     if (!isActorMcpServer) {
@@ -359,8 +367,8 @@ export async function handleMcpToolCall(params: {
         // the remote tool's payload still flows through `content`. Also forward `isError` so a
         // failing remote tool surfaces as a failure here.
         const isErrorFromRemote = result.isError === true;
-        return {
-            content: result.content,
+        return respondRaw({
+            content: result.content as ContentBlock[],
             isError: isErrorFromRemote,
             structuredContent: {
                 runId: 'mcp-passthrough',
@@ -371,7 +379,7 @@ export async function handleMcpToolCall(params: {
                 summary: `Called MCP tool '${mcpToolName}' on '${baseActorName}'.`,
                 nextStep: 'Response content carries the remote MCP tool result; no Apify run was started.',
             },
-        };
+        });
     } catch (error) {
         logHttpError(error, `Failed to call MCP tool '${mcpToolName}' on Actor '${baseActorName}'`, {
             actorName: baseActorName,
@@ -393,7 +401,7 @@ export async function resolveAndValidateActor(params: {
     actorName: string;
     input: Record<string, unknown>;
     toolArgs: InternalToolArgs;
-}): Promise<{ error: object } | { actor: ToolEntry }> {
+}): Promise<{ error: ToolResponse } | { actor: ToolEntry }> {
     const { actorName, input, toolArgs } = params;
     const { apifyClient } = toolArgs;
 
@@ -493,7 +501,7 @@ export async function callActorPreExecute(
     toolArgs: InternalToolArgs,
     options: { route: string },
 ): Promise<
-    | { earlyResponse: object }
+    | { earlyResponse: ToolResponse }
     | {
           parsed: CallActorParsedArgs;
           baseActorName: string;
@@ -546,7 +554,7 @@ export async function callActorPreExecute(
  * Shared start-then-wait flow for call-actor variants (default + apps).
  * `taskMode` is honored — when true, `waitSecs` is ignored and the SDK waits until terminal.
  */
-export async function executeCallActor(toolArgs: InternalToolArgs): Promise<object> {
+export async function executeCallActor(toolArgs: InternalToolArgs): Promise<ToolResponse> {
     const preResult = await callActorPreExecute(toolArgs, { route: HELPER_TOOLS.ACTOR_CALL });
     if ('earlyResponse' in preResult) {
         return preResult.earlyResponse;
@@ -573,7 +581,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<obje
         const { apifyClient } = toolArgs;
         const abortSignal = toolArgs.extra.signal;
 
-        if (abortSignal?.aborted) return {};
+        if (abortSignal?.aborted) return respondAborted();
 
         const actorRun = await apifyClient.actor(baseActorName).start(input, callOptions);
         log.debug('Started Actor run', {
@@ -586,7 +594,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<obje
         // Abort can arrive while start() was in flight — abort the newly created run.
         if (abortSignal?.aborted) {
             await abortRunOnSignal(actorRun.id, apifyClient);
-            return {};
+            return respondAborted();
         }
 
         const linkContext = await getConsoleLinkContext(toolArgs.apifyToken, apifyClient);
@@ -608,7 +616,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<obje
             onAbort: abortRunOnSignal,
         });
 
-        if ('aborted' in fetchResult) return {};
+        if ('aborted' in fetchResult) return respondAborted();
         if ('error' in fetchResult) return fetchResult.error;
 
         return {

--- a/src/tools/runs/get_actor_run.ts
+++ b/src/tools/runs/get_actor_run.ts
@@ -8,7 +8,7 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema, fixZodSchemaRequired } from '../../utils/ajv.js';
 import { getConsoleLinkContext } from '../../utils/console_link.js';
 import { logHttpError } from '../../utils/logging.js';
-import { buildUsageMeta, respondOk, respondUserError, type ToolResponse } from '../../utils/mcp.js';
+import { buildUsageMeta, respondAborted, respondOk, respondUserError, type ToolResponse } from '../../utils/mcp.js';
 import {
     applyConsoleLinks,
     type FetchActorRunResult,
@@ -145,7 +145,7 @@ export const getActorRun: ToolEntry = Object.freeze({
 
             // Per MCP spec, receivers SHOULD NOT send a response for a cancelled request:
             // https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/cancellation
-            if ('aborted' in fetchResult) return {};
+            if ('aborted' in fetchResult) return respondAborted();
             if ('error' in fetchResult) return fetchResult.error;
 
             return buildGetActorRunSuccessResponse({

--- a/src/tools/runs/get_actor_run_list.ts
+++ b/src/tools/runs/get_actor_run_list.ts
@@ -5,6 +5,7 @@ import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { respondRaw } from '../../utils/mcp.js';
 import { actorRunListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserRunsListArgs = z.object({
@@ -63,6 +64,9 @@ USAGE EXAMPLES:
         const runs = await client
             .runs()
             .list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
-        return { content: [{ type: 'text', text: JSON.stringify(runs) }], structuredContent: runs };
+        return respondRaw({
+            content: [{ type: 'text', text: JSON.stringify(runs) }],
+            structuredContent: runs as unknown as Record<string, unknown>,
+        });
     },
 } as const);

--- a/src/tools/runs/get_actor_run_log.ts
+++ b/src/tools/runs/get_actor_run_log.ts
@@ -4,6 +4,7 @@ import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
+import { respondRaw } from '../../utils/mcp.js';
 
 const GetRunLogArgs = z.object({
     runId: z.string().describe('The ID of the Actor run.'),
@@ -44,6 +45,6 @@ USAGE EXAMPLES:
         const v = (await client.run(parsed.runId).log().get()) ?? '';
         const lines = v.split('\n');
         const text = lines.slice(lines.length - parsed.lines - 1, lines.length).join('\n');
-        return { content: [{ type: 'text', text }] };
+        return respondRaw({ content: [{ type: 'text', text }] });
     },
 } as const);

--- a/src/tools/storage/get_key_value_store_record.ts
+++ b/src/tools/storage/get_key_value_store_record.ts
@@ -8,7 +8,7 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleKeyValueStoreUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { computeValueBytes, stripQuoteWrappers } from '../../utils/generic.js';
-import { respondUserError } from '../../utils/mcp.js';
+import { respondRaw, respondUserError } from '../../utils/mcp.js';
 import { keyValueStoreRecordOutputSchema } from '../structured_output_schemas.js';
 import { buildConsoleLinkContent, buildStorageResponse, normalizeRecordKey } from './storage_helpers.js';
 
@@ -93,7 +93,7 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
             if (value.length > KV_RECORD_MAX_INLINE_BYTES) {
                 // base64-inlining a large binary would blow up the context window; return a link instead.
                 const uri = await store.getRecordPublicUrl(recordKey);
-                return {
+                return respondRaw({
                     structuredContent,
                     content: [
                         {
@@ -105,25 +105,25 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
                         } satisfies ResourceLink,
                         ...consoleLinkContent,
                     ],
-                };
+                });
             }
             const data = value.toString('base64');
             if (mimeType?.startsWith('image/')) {
-                return {
+                return respondRaw({
                     structuredContent,
                     content: [{ type: 'image', data, mimeType } satisfies ImageContent, ...consoleLinkContent],
-                };
+                });
             }
             if (mimeType?.startsWith('audio/')) {
-                return {
+                return respondRaw({
                     structuredContent,
                     content: [{ type: 'audio', data, mimeType } satisfies AudioContent, ...consoleLinkContent],
-                };
+                });
             }
             // The blob is inlined, so the uri is just an identifier — build it from the store's API
             // URL instead of getRecordPublicUrl, which fetches store metadata to sign a link nobody follows.
             const uri = `${store.url}/records/${recordKey}`;
-            return {
+            return respondRaw({
                 structuredContent,
                 content: [
                     {
@@ -132,7 +132,7 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
                     } satisfies EmbeddedResource,
                     ...consoleLinkContent,
                 ],
-            };
+            });
         }
         // Text/JSON values serialize cleanly — return them as structuredContent per the storage-tool contract.
         // apify-client maps an empty record body to `undefined`, which drops the schema-required `value` on

--- a/src/tools/widgets/get_actor_run_widget.ts
+++ b/src/tools/widgets/get_actor_run_widget.ts
@@ -7,6 +7,7 @@ import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.j
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
+import { respondAborted } from '../../utils/mcp.js';
 import { fetchActorRunData } from '../actors/actor_run_response.js';
 import { buildGetActorRunError, buildGetActorRunSuccessResponse } from '../runs/get_actor_run.js';
 import { actorRunOutputSchema } from '../structured_output_schemas.js';
@@ -68,7 +69,7 @@ export const getActorRunWidget: ToolEntry = Object.freeze({
 
             // Widget always passes waitSecs=0 with no abort signal, so 'aborted' is unreachable
             // here — the discriminator just keeps the type-checker happy.
-            if ('aborted' in fetchResult) return {};
+            if ('aborted' in fetchResult) return respondAborted();
             if ('error' in fetchResult) return fetchResult.error;
 
             return buildGetActorRunSuccessResponse({ ...fetchResult.result, widget: true });

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ import type { FAILURE_CATEGORY, TELEMETRY_ENV, TOOL_STATUS } from './const.js';
 import type { ActorsMcpServer } from './mcp/server.js';
 import type { PaymentProvider } from './payments/types.js';
 import type { CATEGORY_NAMES } from './tools/registry.js';
+import type { ToolResponse } from './utils/mcp.js';
 import type { PricingTier, StructuredPricingInfo } from './utils/pricing_info.js';
 import type { ProgressTracker } from './utils/progress.js';
 
@@ -184,7 +185,7 @@ export type HelperTool = ToolBase & {
      * @param toolArgs - Arguments and server references
      * @returns Promise resolving to the tool's output
      */
-    call: (toolArgs: InternalToolArgs) => Promise<object>;
+    call: (toolArgs: InternalToolArgs) => Promise<ToolResponse>;
 };
 
 /**

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -1,3 +1,5 @@
+import type { CallToolResult, ContentBlock } from '@modelcontextprotocol/sdk/types.js';
+
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
 import type { AjvErrorDetails, FailureCategory, ToolTelemetryContext } from '../types.js';
 import { ACTOR_RUN_LIMIT_MESSAGE, isActorRunLimitError } from './apify_errors.js';
@@ -50,14 +52,28 @@ function buildMCPResponse(options: {
         ...(telemetry && { toolTelemetry: telemetry }),
         ...(structuredContent !== undefined && { structuredContent }),
         ...(_meta !== undefined && { _meta }),
-    };
+    } as unknown as ToolResponse;
 }
 
 /**
- * Shared return type of the `respond*` constructors. Replaces the
- * `ReturnType<typeof buildMCPResponse>` annotations now that `buildMCPResponse` is private.
+ * Module-private brand. Phantom `declare`d symbol — never assigned or emitted at runtime, so it adds
+ * nothing to the wire. Its only job is to make `ToolResponse` unforgeable at compile time.
  */
-export type ToolResponse = ReturnType<typeof buildMCPResponse>;
+declare const toolResponseBrand: unique symbol;
+
+/**
+ * Shared return type of the `respond*` constructors and of every `HelperTool.call`. The required brand
+ * means a raw `{ content, isError }` literal (or a bare `{}`) fails to compile — the only way to produce a
+ * `ToolResponse` is a constructor here. `content` is the full MCP `ContentBlock` union so image/audio/
+ * resource returns type-check.
+ */
+export type ToolResponse = {
+    content: ContentBlock[];
+    isError: boolean;
+    toolTelemetry?: ToolTelemetryContext;
+    structuredContent?: unknown;
+    _meta?: Record<string, unknown>;
+} & { readonly [toolResponseBrand]: never };
 
 /** Normalise a `string | string[]` text argument to the array `buildMCPResponse` expects. */
 function toTexts(texts: string | string[]): string[] {
@@ -166,6 +182,24 @@ export function respondErrorNoTelemetry(
     opts?: { structuredContent?: unknown },
 ): ToolResponse {
     return { ...respondOk(texts, opts), isError: true };
+}
+
+/**
+ * Brands an already-well-formed MCP result without reshaping it — runtime identity. For content this
+ * module can't build: binary/resource blocks (image, audio, resource_link, embedded resource) and opaque
+ * remote tool results. Returns the exact object passed in (no `isError` injection, no key reorder), so the
+ * wire bytes stay identical.
+ */
+export function respondRaw(result: CallToolResult): ToolResponse {
+    return result as unknown as ToolResponse;
+}
+
+/**
+ * Empty response for MCP cancellation paths — per spec, receivers SHOULD NOT reply to a cancelled request.
+ * Returns runtime `{}`, branded.
+ */
+export function respondAborted(): ToolResponse {
+    return {} as unknown as ToolResponse;
 }
 
 /**

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -66,10 +66,14 @@ declare const toolResponseBrand: unique symbol;
  * means a raw `{ content, isError }` literal (or a bare `{}`) fails to compile — the only way to produce a
  * `ToolResponse` is a constructor here. `content` is the full MCP `ContentBlock` union so image/audio/
  * resource returns type-check.
+ *
+ * `content` and `isError` are optional because the escape hatches may omit them: `respondAborted()`
+ * returns `{}` (both absent) and `respondRaw()` passes a `CallToolResult` through unchanged (which may
+ * omit `isError`). Consumers reading either field must guard (`?.`, an `in` check, or the `textOf` helper).
  */
 export type ToolResponse = {
-    content: ContentBlock[];
-    isError: boolean;
+    content?: ContentBlock[];
+    isError?: boolean;
     toolTelemetry?: ToolTelemetryContext;
     structuredContent?: unknown;
     _meta?: Record<string, unknown>;

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -1,10 +1,15 @@
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, ContentBlock } from '@modelcontextprotocol/sdk/types.js';
 import Ajv from 'ajv';
 import { expect } from 'vitest';
 
 import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../../src/const.js';
 import type { InternalToolArgs } from '../../../src/types.js';
 import type { CachedUserInfo } from '../../../src/utils/userid_cache.js';
+
+/** Read the text off a content block; '' for non-text blocks. Keeps assertions on text responses tidy. */
+export function textOf(block: ContentBlock): string {
+    return 'text' in block ? block.text : '';
+}
 
 /** Default `CachedUserInfo` for tests that mock `getUserInfoCached`. */
 export function mockUserInfo(overrides: Partial<CachedUserInfo> = {}): CachedUserInfo {

--- a/tests/unit/mcp.server.progress_wiring.test.ts
+++ b/tests/unit/mcp.server.progress_wiring.test.ts
@@ -5,6 +5,7 @@ import { HELPER_TOOLS } from '../../src/const.js';
 import type { ActorsMcpServer } from '../../src/mcp/server.js';
 import type { InternalToolArgs, ToolEntry } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
+import { respondRaw } from '../../src/utils/mcp.js';
 import { ProgressTracker } from '../../src/utils/progress.js';
 
 /**
@@ -47,7 +48,7 @@ function makeRecorderTool(name: string): {
         annotations: {},
         call: async (toolArgs: InternalToolArgs) => {
             received.progressTracker = toolArgs.progressTracker;
-            return { content: [{ type: 'text', text: 'ok' }] };
+            return respondRaw({ content: [{ type: 'text', text: 'ok' }] });
         },
     } as ToolEntry;
     return { tool, received };

--- a/tests/unit/payments.helpers.test.ts
+++ b/tests/unit/payments.helpers.test.ts
@@ -15,6 +15,7 @@ import { prepareToolCallContext } from '../../src/payments/helpers.js';
 import type { PaymentProvider } from '../../src/payments/types.js';
 import type { HelperTool } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
+import { respondRaw } from '../../src/utils/mcp.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -30,7 +31,7 @@ function makeTool(paymentRequired = true): HelperTool {
         paymentRequired,
         inputSchema: { type: 'object', properties: { actor: { type: 'string' } } },
         ajvValidate: vi.fn(() => true) as never,
-        call: vi.fn(async () => ({ content: [] })),
+        call: vi.fn(async () => respondRaw({ content: [] })),
     };
 }
 

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -67,7 +67,7 @@ describe('call_actor_common', () => {
             });
 
             expect(response.isError).toBe(true);
-            const allText = response.content.map((c) => c.text).join('\n');
+            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
             expect(allText).toContain(`If ${HELPER_TOOLS.STORE_SEARCH} is available in this session`);
             expect(allText).toContain(`using: ${HELPER_TOOLS.ACTOR_GET_DETAILS}`);
             expect(response.toolTelemetry).toEqual(
@@ -106,7 +106,7 @@ describe('call_actor_common', () => {
             });
 
             expect(response.isError).toBe(true);
-            const allText = response.content.map((c) => c.text).join('\n');
+            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
             expect(allText).toContain('This Actor requires full access to your account');
             expect(allText).toContain(approvalUrl);
             expect(response.toolTelemetry).toEqual(
@@ -126,7 +126,7 @@ describe('call_actor_common', () => {
                 actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
             });
 
-            const allText = response.content.map((c) => c.text).join('\n');
+            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
             expect(allText).toContain(`If ${HELPER_TOOLS.STORE_SEARCH} is available in this session`);
             expect(allText).toContain(`using: ${HELPER_TOOLS.ACTOR_GET_DETAILS}`);
             expect(response.toolTelemetry).toEqual(
@@ -161,7 +161,7 @@ describe('call_actor_common', () => {
             });
 
             expect(response.isError).toBe(true);
-            const allText = response.content.map((c) => c.text).join('\n');
+            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
             expect(allText).toContain('memory limit of 8192MB');
             expect(allText).toContain('Account memory quota exceeded');
             expect(allText).toContain('callOptions.memory');
@@ -203,7 +203,7 @@ describe('call_actor_common', () => {
             });
 
             expect(response.isError).toBe(true);
-            const allText = response.content.map((c) => c.text).join('\n');
+            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
             expect(allText).toContain('account limit for concurrent Actor runs');
             expect(allText).toContain('console.apify.com/billing/subscription');
             // Run-limit must not fall through to the generic "verify the Actor name" hint.
@@ -269,7 +269,7 @@ describe('call_actor_common', () => {
             const response = buildPermissionApprovalResponse(makeError(approvalUrl));
 
             expect(response.isError).toBe(true);
-            const allText = response.content.map((c) => c.text).join('\n');
+            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
             expect(allText).toContain('This Actor requires full access to your account');
             expect(allText).toContain(approvalUrl);
         });
@@ -279,7 +279,10 @@ describe('call_actor_common', () => {
 
             expect(response.isError).toBe(true);
             expect(response.content).toHaveLength(1);
-            expect(response.content[0]?.text).toContain('This Actor requires full access to your account');
+            const firstBlock = response.content[0];
+            expect(firstBlock && 'text' in firstBlock ? firstBlock.text : undefined).toContain(
+                'This Actor requires full access to your account',
+            );
         });
     });
 

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../../src/tools/actors/call_actor.js';
 import type { InternalToolArgs, ToolEntry } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
-import type { TextToolResult } from './helpers/tool_context.js';
+import { textOf, type TextToolResult } from './helpers/tool_context.js';
 
 vi.mock('../../src/tools/actors/actor_tools_factory.js', async () => {
     const actual = await vi.importActual<Record<string, unknown>>('../../src/tools/actors/actor_tools_factory.js');
@@ -67,7 +67,7 @@ describe('call_actor_common', () => {
             });
 
             expect(response.isError).toBe(true);
-            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
+            const allText = (response.content ?? []).map(textOf).join('\n');
             expect(allText).toContain(`If ${HELPER_TOOLS.STORE_SEARCH} is available in this session`);
             expect(allText).toContain(`using: ${HELPER_TOOLS.ACTOR_GET_DETAILS}`);
             expect(response.toolTelemetry).toEqual(
@@ -106,7 +106,7 @@ describe('call_actor_common', () => {
             });
 
             expect(response.isError).toBe(true);
-            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
+            const allText = (response.content ?? []).map(textOf).join('\n');
             expect(allText).toContain('This Actor requires full access to your account');
             expect(allText).toContain(approvalUrl);
             expect(response.toolTelemetry).toEqual(
@@ -126,7 +126,7 @@ describe('call_actor_common', () => {
                 actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
             });
 
-            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
+            const allText = (response.content ?? []).map(textOf).join('\n');
             expect(allText).toContain(`If ${HELPER_TOOLS.STORE_SEARCH} is available in this session`);
             expect(allText).toContain(`using: ${HELPER_TOOLS.ACTOR_GET_DETAILS}`);
             expect(response.toolTelemetry).toEqual(
@@ -161,7 +161,7 @@ describe('call_actor_common', () => {
             });
 
             expect(response.isError).toBe(true);
-            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
+            const allText = (response.content ?? []).map(textOf).join('\n');
             expect(allText).toContain('memory limit of 8192MB');
             expect(allText).toContain('Account memory quota exceeded');
             expect(allText).toContain('callOptions.memory');
@@ -203,7 +203,7 @@ describe('call_actor_common', () => {
             });
 
             expect(response.isError).toBe(true);
-            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
+            const allText = (response.content ?? []).map(textOf).join('\n');
             expect(allText).toContain('account limit for concurrent Actor runs');
             expect(allText).toContain('console.apify.com/billing/subscription');
             // Run-limit must not fall through to the generic "verify the Actor name" hint.
@@ -269,7 +269,7 @@ describe('call_actor_common', () => {
             const response = buildPermissionApprovalResponse(makeError(approvalUrl));
 
             expect(response.isError).toBe(true);
-            const allText = response.content.map((c) => ('text' in c ? c.text : '')).join('\n');
+            const allText = (response.content ?? []).map(textOf).join('\n');
             expect(allText).toContain('This Actor requires full access to your account');
             expect(allText).toContain(approvalUrl);
         });
@@ -279,7 +279,7 @@ describe('call_actor_common', () => {
 
             expect(response.isError).toBe(true);
             expect(response.content).toHaveLength(1);
-            const firstBlock = response.content[0];
+            const firstBlock = (response.content ?? [])[0];
             expect(firstBlock && 'text' in firstBlock ? firstBlock.text : undefined).toContain(
                 'This Actor requires full access to your account',
             );

--- a/tests/unit/tools.clone.test.ts
+++ b/tests/unit/tools.clone.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HELPER_TOOLS } from '../../src/const.js';
 import type { ActorTool, HelperTool } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
+import { respondRaw } from '../../src/utils/mcp.js';
 import { cloneToolEntry } from '../../src/utils/tools.js';
 
 // ---------------------------------------------------------------------------
@@ -29,7 +30,7 @@ function makeInternalTool(overrides: Partial<HelperTool> = {}): HelperTool {
             properties: { actor: { type: 'string' } },
         },
         ajvValidate: MOCK_AJV_VALIDATE as never,
-        call: vi.fn(async () => ({ content: [] })),
+        call: vi.fn(async () => respondRaw({ content: [] })),
         ...overrides,
     };
 }

--- a/tests/unit/tools.x402.test.ts
+++ b/tests/unit/tools.x402.test.ts
@@ -14,6 +14,7 @@ import {
 import { actorRunOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
+import { respondRaw } from '../../src/utils/mcp.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -69,7 +70,7 @@ function makePaidTool(overrides: Partial<HelperTool> = {}): HelperTool {
         paymentRequired: true,
         inputSchema: { type: 'object' as const, properties: {} },
         ajvValidate: vi.fn(() => true) as never,
-        call: vi.fn(async () => ({ content: [] })),
+        call: vi.fn(async () => respondRaw({ content: [] })),
         ...overrides,
     };
 }

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, ContentBlock } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { ApifyApiError } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
@@ -17,11 +17,7 @@ import {
     respondUserError,
     type ToolResponse,
 } from '../../src/utils/mcp.js';
-
-/** Read the text off a content block; '' for non-text blocks. Keeps assertions on text responses tidy. */
-function textOf(block: ContentBlock): string {
-    return 'text' in block ? block.text : '';
-}
+import { textOf } from './helpers/tool_context.js';
 
 describe('respondOk()', () => {
     it('returns a success response with the raw text and no isError/telemetry', () => {
@@ -35,7 +31,7 @@ describe('respondOk()', () => {
     it('keeps bare JSON bare in content[0] (no fence) — the raw-JSON mirror channel', () => {
         const structuredContent = { runId: 'r1', status: 'RUNNING' };
         const result = respondOk([JSON.stringify(structuredContent), 'summary'], { structuredContent });
-        const firstText = textOf(result.content[0]);
+        const firstText = textOf((result.content ?? [])[0]);
         expect(firstText).toBe('{"runId":"r1","status":"RUNNING"}');
         expect(firstText.startsWith('```')).toBe(false);
         expect(result.structuredContent).toEqual(structuredContent);
@@ -52,7 +48,7 @@ describe('respondJson()', () => {
         const value = { a: 1, b: [2, 3] };
         const result = respondJson(value);
         expect(result.content).toEqual([{ type: 'text', text: wrapJsonText(value) }]);
-        expect(textOf(result.content[0]).startsWith('```json\n')).toBe(true);
+        expect(textOf((result.content ?? [])[0]).startsWith('```json\n')).toBe(true);
         expect(result.isError).toBe(false);
         expect('toolTelemetry' in result).toBe(false);
     });

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -1,17 +1,27 @@
+import type { CallToolResult, ContentBlock } from '@modelcontextprotocol/sdk/types.js';
 import { ApifyApiError } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
+import type { HelperTool } from '../../src/types.js';
 import { wrapJsonText } from '../../src/utils/encode_text.js';
 import {
     computeToolResponseBytes,
     getToolCallErrorUserText,
+    respondAborted,
     respondErrorNoTelemetry,
     respondJson,
     respondOk,
+    respondRaw,
     respondServerError,
     respondUserError,
+    type ToolResponse,
 } from '../../src/utils/mcp.js';
+
+/** Read the text off a content block; '' for non-text blocks. Keeps assertions on text responses tidy. */
+function textOf(block: ContentBlock): string {
+    return 'text' in block ? block.text : '';
+}
 
 describe('respondOk()', () => {
     it('returns a success response with the raw text and no isError/telemetry', () => {
@@ -25,8 +35,9 @@ describe('respondOk()', () => {
     it('keeps bare JSON bare in content[0] (no fence) — the raw-JSON mirror channel', () => {
         const structuredContent = { runId: 'r1', status: 'RUNNING' };
         const result = respondOk([JSON.stringify(structuredContent), 'summary'], { structuredContent });
-        expect(result.content[0].text).toBe('{"runId":"r1","status":"RUNNING"}');
-        expect(result.content[0].text.startsWith('```')).toBe(false);
+        const firstText = textOf(result.content[0]);
+        expect(firstText).toBe('{"runId":"r1","status":"RUNNING"}');
+        expect(firstText.startsWith('```')).toBe(false);
         expect(result.structuredContent).toEqual(structuredContent);
     });
 
@@ -41,7 +52,7 @@ describe('respondJson()', () => {
         const value = { a: 1, b: [2, 3] };
         const result = respondJson(value);
         expect(result.content).toEqual([{ type: 'text', text: wrapJsonText(value) }]);
-        expect(result.content[0].text.startsWith('```json\n')).toBe(true);
+        expect(textOf(result.content[0]).startsWith('```json\n')).toBe(true);
         expect(result.isError).toBe(false);
         expect('toolTelemetry' in result).toBe(false);
     });
@@ -271,5 +282,67 @@ describe('computeToolResponseBytes()', () => {
         circular.self = circular;
         const result = { structuredContent: circular };
         expect(computeToolResponseBytes(result)).toEqual({ contentBytes: 0, structuredContentBytes: 0, fileBytes: 0 });
+    });
+});
+
+describe('respondRaw()', () => {
+    it('returns the exact object passed in — runtime identity, no reshaping', () => {
+        const raw: CallToolResult = { content: [{ type: 'text', text: 'log line' }] };
+        const result = respondRaw(raw);
+        // Same reference: no isError injected, no key reorder, so the wire bytes stay identical.
+        expect(result).toBe(raw);
+        expect(JSON.stringify(result)).toBe('{"content":[{"type":"text","text":"log line"}]}');
+    });
+
+    it('passes binary/resource blocks through unchanged', () => {
+        const raw: CallToolResult = {
+            content: [{ type: 'image', data: 'AAAA', mimeType: 'image/png' }],
+            structuredContent: { key: 'INPUT' },
+        };
+        expect(respondRaw(raw)).toBe(raw);
+    });
+});
+
+describe('respondAborted()', () => {
+    it('returns an empty object with nothing on the wire', () => {
+        const result = respondAborted();
+        expect(result).toEqual({});
+        expect(JSON.stringify(result)).toBe('{}');
+    });
+});
+
+describe('ToolResponse brand', () => {
+    it('never serializes the phantom brand marker to the wire', () => {
+        // The brand is a declared symbol, never assigned at runtime — no symbol keys, no "brand" text.
+        const result = respondOk('all good');
+        expect(Object.getOwnPropertySymbols(result)).toHaveLength(0);
+        expect(JSON.stringify(result)).toBe('{"content":[{"type":"text","text":"all good"}],"isError":false}');
+    });
+
+    it('accepts respond* outputs as a HelperTool.call return but rejects raw literals (compile-time lock)', () => {
+        // Positive: every constructor output is a valid HelperTool.call return.
+        const okCall: HelperTool['call'] = async () => respondOk('ok');
+        const rawCall: HelperTool['call'] = async () => respondRaw({ content: [{ type: 'text', text: 'x' }] });
+        const abortedCall: HelperTool['call'] = async () => respondAborted();
+
+        // Negative: a hand-rolled { content, isError } literal is missing the brand.
+        // @ts-expect-error raw literal is not a branded ToolResponse
+        const badLiteralCall: HelperTool['call'] = async () => ({
+            content: [{ type: 'text', text: 'x' }],
+            isError: true,
+        });
+        // Negative: a bare {} is missing the brand.
+        // @ts-expect-error bare {} is not a branded ToolResponse
+        const badEmptyCall: HelperTool['call'] = async () => ({});
+
+        for (const call of [okCall, rawCall, abortedCall, badLiteralCall, badEmptyCall]) {
+            expect(typeof call).toBe('function');
+        }
+    });
+
+    it('rejects a raw literal assigned directly to ToolResponse', () => {
+        // @ts-expect-error a plausible-but-unclassified literal is not assignable — the brand is required
+        const bad: ToolResponse = { content: [{ type: 'text', text: 'x' }], isError: false };
+        expect('content' in bad).toBe(true);
     });
 });

--- a/tests/unit/utils.payment_errors.test.ts
+++ b/tests/unit/utils.payment_errors.test.ts
@@ -35,7 +35,7 @@ describe('buildPaymentRequiredResponse()', () => {
 
         expect(result.isError).toBe(true);
         expect(result.structuredContent).toEqual(SAMPLE_PAYMENT_REQUIRED);
-        expect(result.content[0]).toEqual({
+        expect((result.content ?? [])[0]).toEqual({
             type: 'text',
             text: JSON.stringify(SAMPLE_PAYMENT_REQUIRED),
         });
@@ -45,7 +45,7 @@ describe('buildPaymentRequiredResponse()', () => {
         const result = buildPaymentRequiredResponse(new Error('Payment required'), SAMPLE_PAYMENT_REQUIRED);
 
         expect(result.content).toHaveLength(2);
-        expect(result.content[1]).toEqual({
+        expect((result.content ?? [])[1]).toEqual({
             type: 'text',
             text: 'Payment required to run this Actor or access this resource.',
         });


### PR DESCRIPTION
## What we're solving

The `respond*` constructors landed in #937, but nothing forced handlers to use them: a hand-rolled `return { content, isError: true }` was an unclassified, telemetry-less response that compiled silently. This is the P4 lock — make that a **compile error**, so the tool-response contract is enforced by the type system instead of review discipline.

## How

`ToolResponse` now carries a module-private **required** brand (a `unique symbol`, never emitted), and `HelperTool.call` returns `Promise<ToolResponse>`. The only way to produce a `ToolResponse` is a `respond*` constructor. `respondRaw` applies the brand to pre-shaped remote/binary content as a pure identity pass-through; `respondAborted` covers cancellation returns. `content` is widened to the MCP `ContentBlock` union so non-text handlers (key-value-store record) keep compiling.

**Wire output is byte-identical** — the brand is a phantom symbol, never serialized; `respondRaw` returns its argument unchanged and the tightened return-type annotations are type-only.

## Alternatives considered

- **Optional brand** (`{ [brand]?: never }`, the issue's original snippet): rejected — `tsc` proves an optional symbol does not reject raw literals, so it fails its own acceptance criterion. A required brand is necessary.
- **A rebuilding constructor for binary blocks**: rejected — it would inject `isError` and reorder keys, changing serialized bytes. `respondRaw` preserves them exactly.
- `ToolResponse` is written as an explicit transcription of the wire shape rather than `ReturnType<typeof buildMCPResponse>`, because the builder now casts to `ToolResponse`, making that derivation circular.

#937 (PR #1045) has since merged to `master`; this PR is rebased onto `master` and contains only the #938 lock. Part of #935. Closes #938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLMFGqUuBGat7FPxWGhsRD