### PR TITLE
refactor: Extract getTaskOrThrow helper for task handlers

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,6 +19,7 @@ import type {
     InitializeResult,
     Notification,
     Request,
+    Task,
     TaskStatusNotification,
 } from '@modelcontextprotocol/sdk/types.js';
 import {
@@ -696,6 +697,19 @@ export class ActorsMcpServer {
     }
 
     /**
+     * Fetches a task by ID, softFail-logging and throwing a client-facing McpError if it doesn't exist.
+     */
+    private async getTaskOrThrow(taskId: string, mcpSessionId: string | undefined, logTag: string): Promise<Task> {
+        const task = await this.taskStore.getTask(taskId, mcpSessionId);
+        if (!task) {
+            // Client error (invalid/unknown taskId) — softFail to avoid polluting error logs.
+            log.softFail(`[${logTag}] Task not found`, { taskId, mcpSessionId, statusCode: 404 });
+            throw new McpError(ErrorCode.InvalidParams, `Task "${taskId}" not found`);
+        }
+        return task;
+    }
+
+    /**
      * Sets up MCP request handlers for long-running tasks.
      */
     private setupTaskHandlers(): void {
@@ -717,12 +731,7 @@ export class ActorsMcpServer {
             const { taskId } = params;
             const mcpSessionId = params._meta?.mcpSessionId;
             log.debug('[GetTaskRequestSchema] Getting task status', { taskId, mcpSessionId });
-            const task = await this.taskStore.getTask(taskId, mcpSessionId);
-            if (task) return task;
-
-            // Client error (invalid/unknown taskId) — softFail to avoid polluting error logs.
-            log.softFail('[GetTaskRequestSchema] Task not found', { taskId, mcpSessionId, statusCode: 404 });
-            throw new McpError(ErrorCode.InvalidParams, `Task "${taskId}" not found`);
+            return await this.getTaskOrThrow(taskId, mcpSessionId, 'GetTaskRequestSchema');
         });
 
         // Get task result payload
@@ -732,12 +741,7 @@ export class ActorsMcpServer {
             const { taskId } = params;
             const mcpSessionId = params._meta?.mcpSessionId;
             log.debug('[GetTaskPayloadRequestSchema] Getting task result', { taskId, mcpSessionId });
-            const task = await this.taskStore.getTask(taskId, mcpSessionId);
-            if (!task) {
-                // Client error (invalid/unknown taskId) — softFail to avoid polluting error logs.
-                log.softFail('[GetTaskPayloadRequestSchema] Task not found', { taskId, mcpSessionId, statusCode: 404 });
-                throw new McpError(ErrorCode.InvalidParams, `Task "${taskId}" not found`);
-            }
+            const task = await this.getTaskOrThrow(taskId, mcpSessionId, 'GetTaskPayloadRequestSchema');
             if (task.status !== 'completed' && task.status !== 'failed') {
                 throw new McpError(
                     ErrorCode.InvalidParams,
@@ -763,12 +767,7 @@ export class ActorsMcpServer {
             const mcpSessionId = params._meta?.mcpSessionId;
             log.debug('[CancelTaskRequestSchema] Cancelling task', { taskId, mcpSessionId });
 
-            const task = await this.taskStore.getTask(taskId, mcpSessionId);
-            if (!task) {
-                // Client error (invalid/unknown taskId) — softFail to avoid polluting error logs.
-                log.softFail('[CancelTaskRequestSchema] Task not found', { taskId, mcpSessionId, statusCode: 404 });
-                throw new McpError(ErrorCode.InvalidParams, `Task "${taskId}" not found`);
-            }
+            const task = await this.getTaskOrThrow(taskId, mcpSessionId, 'CancelTaskRequestSchema');
             if (task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled') {
                 // Client error (cancel on terminal task) — softFail to avoid polluting error logs.
                 log.softFail('[CancelTaskRequestSchema] Task already in terminal state', {


### PR DESCRIPTION
## Summary
- Addresses one item from the checklist in #1066 ("getTaskOrThrow helper").
- `GetTaskRequestSchema`, `GetTaskPayloadRequestSchema`, and `CancelTaskRequestSchema` each duplicated the same "fetch task, softFail + throw McpError if missing" block, differing only in the log tag used for the softFail call.
- Extracted a single private `getTaskOrThrow(taskId, mcpSessionId, logTag)` helper and call it from all three handlers.

No behavior change — same softFail log call, same error code/message, same control flow, just de-duplicated.

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm run lint` (0 warnings/errors)
- [x] `pnpm run test:unit` (1023 passed, 2 skipped)
- [x] `pnpm run format`
- [x] `pnpm run check:agents`