### PR TITLE
chore: Split vitest timeout per suite (unit 30s, integration 120s)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,23 @@ export default defineConfig({
     test: {
         globals: true,
         environment: 'node',
-        include: ['tests/**/*.test.ts'],
-        testTimeout: 120_000,
+        projects: [
+            {
+                extends: true,
+                test: {
+                    name: 'unit',
+                    include: ['tests/unit/**/*.test.ts'],
+                    testTimeout: 30_000,
+                },
+            },
+            {
+                extends: true,
+                test: {
+                    name: 'integration',
+                    include: ['tests/integration/**/*.test.ts'],
+                    testTimeout: 120_000,
+                },
+            },
+        ],
     },
 });


### PR DESCRIPTION
Part of #1066 (checkbox: split the vitest timeout).

## What we're solving

`vitest.config.ts` applied one global `testTimeout` of 120_000 ms — sized for integration tests, which hit the live Apify API and can legitimately run long — to *every* test. Unit tests finish in ~7s, so a hung unit test took two minutes to surface instead of failing fast.

## How

Replace the flat `test` block with `test.projects`:
- `unit` project — `tests/unit/**`, `testTimeout: 30_000`
- `integration` project — `tests/integration/**`, `testTimeout: 120_000`

Each uses `extends: true` to inherit the shared `globals`/`environment`. No `package.json` changes — `test:unit` and `test:integration` keep running only their own suites.

## Alternatives considered

- Per-script CLI `--testTimeout` flag — rejected; the split would live only in `package.json` and silently fall back to 120s for any invocation not going through that exact script (IDE, watch mode, bare `vitest run`).
- A second config file — rejected; two files to keep in sync, duplicated shared settings.

## Verification

- `pnpm run test:unit`: 70 files / 959 passed / 2 skipped — matches the pre-change baseline, no double-run.
- Project labels correctly separated: `[unit]` (959 tests) / `[integration]` (230 tests).
- Probe: a unit test sleeping 35s fails with `Test timed out in 30000ms`; an integration probe passes at 35.5s — confirming the 30s vs 120s split is live per project.
- Oracle green: type-check clean, lint 0 errors, check:agents passed, format no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pXZvhEoE6Lz3DpBSL3n1Y

---
_Generated by [Claude Code](https://claude.ai/code/session_016pXZvhEoE6Lz3DpBSL3n1Y)_