### PR TITLE
refactor: Extract catchNotFound storage helper

### DIFF
--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -1,16 +1,15 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HELPER_TOOLS, HTTP_NOT_FOUND } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleDatasetUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { parseCommaSeparatedList, stripQuoteWrappers } from '../../utils/generic.js';
-import { getHttpStatusCode } from '../../utils/logging.js';
 import { respondUserError } from '../../utils/mcp.js';
 import { datasetItemsOutputSchema } from '../structured_output_schemas.js';
-import { buildDatasetItemsSummaryNextStep, buildStorageResponse } from './storage_helpers.js';
+import { buildDatasetItemsSummaryNextStep, buildStorageResponse, catchNotFound } from './storage_helpers.js';
 
 export const DEFAULT_DATASET_ITEMS_LIMIT = 20;
 
@@ -103,12 +102,8 @@ export const getDatasetItems: ToolEntry = Object.freeze({
 
         const effectiveLimit = parsed.limit ?? DEFAULT_DATASET_ITEMS_LIMIT;
         const datasetId = stripQuoteWrappers(parsed.datasetId);
-        // `dataset(id).listItems()` throws ApifyApiError on a missing dataset
-        // instead of returning undefined (only `.get()` and `.getStatistics()`
-        // soft-catch 404 in the SDK), so translate 404 into a soft-fail.
-        const v = await client
-            .dataset(datasetId)
-            .listItems({
+        const v = await catchNotFound(
+            client.dataset(datasetId).listItems({
                 clean: parsed.clean,
                 offset: parsed.offset,
                 limit: effectiveLimit,
@@ -116,13 +111,8 @@ export const getDatasetItems: ToolEntry = Object.freeze({
                 omit,
                 desc: parsed.desc,
                 flatten,
-            })
-            .catch((err: unknown) => {
-                if (getHttpStatusCode(err) === HTTP_NOT_FOUND) {
-                    return null;
-                }
-                throw err;
-            });
+            }),
+        );
         if (!v) {
             return respondUserError(`Dataset '${datasetId}' not found.`);
         }

--- a/src/tools/storage/get_dataset_schema.ts
+++ b/src/tools/storage/get_dataset_schema.ts
@@ -1,16 +1,15 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HELPER_TOOLS, HTTP_NOT_FOUND } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { getHttpStatusCode } from '../../utils/logging.js';
 import { respondServerError, respondUserError } from '../../utils/mcp.js';
 import { generateSchemaFromItems } from '../../utils/schema_generation.js';
 import { datasetSchemaOutputSchema } from '../structured_output_schemas.js';
-import { buildStorageResponse } from './storage_helpers.js';
+import { buildStorageResponse, catchNotFound } from './storage_helpers.js';
 
 const getDatasetSchemaArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
@@ -55,17 +54,9 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
         const parsed = getDatasetSchemaArgs.parse(args);
         const datasetId = stripQuoteWrappers(parsed.datasetId);
 
-        // `listItems()` throws ApifyApiError on a missing dataset (the SDK only soft-catches
-        // 404 on `.get()` / `.getStatistics()`), so translate 404 into a soft-fail.
-        const datasetResponse = await client
-            .dataset(datasetId)
-            .listItems({ clean: parsed.clean, limit: parsed.limit })
-            .catch((err: unknown) => {
-                if (getHttpStatusCode(err) === HTTP_NOT_FOUND) {
-                    return null;
-                }
-                throw err;
-            });
+        const datasetResponse = await catchNotFound(
+            client.dataset(datasetId).listItems({ clean: parsed.clean, limit: parsed.limit }),
+        );
 
         if (!datasetResponse) {
             return respondUserError(`Dataset '${datasetId}' not found.`);

--- a/src/tools/storage/get_key_value_store_keys.ts
+++ b/src/tools/storage/get_key_value_store_keys.ts
@@ -1,16 +1,15 @@
 import dedent from 'dedent';
 import { z } from 'zod';
 
-import { HELPER_TOOLS, HTTP_NOT_FOUND } from '../../const.js';
+import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleKeyValueStoreUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
-import { getHttpStatusCode } from '../../utils/logging.js';
 import { respondUserError } from '../../utils/mcp.js';
 import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
-import { buildKvsKeysSummaryNextStep, buildStorageResponse } from './storage_helpers.js';
+import { buildKvsKeysSummaryNextStep, buildStorageResponse, catchNotFound } from './storage_helpers.js';
 
 const getKeyValueStoreKeysArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
@@ -54,17 +53,11 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
         const { args, apifyClient: client, apifyToken } = toolArgs;
         const parsed = getKeyValueStoreKeysArgs.parse(args);
         const keyValueStoreId = stripQuoteWrappers(parsed.keyValueStoreId);
-        // `listKeys()` throws ApifyApiError on a missing store (the SDK only soft-catches
-        // 404 on `.get()` / `.getRecord()`), so translate 404 into a soft-fail.
-        const keys = await client
-            .keyValueStore(keyValueStoreId)
-            .listKeys({ exclusiveStartKey: parsed.exclusiveStartKey, limit: parsed.limit })
-            .catch((err: unknown) => {
-                if (getHttpStatusCode(err) === HTTP_NOT_FOUND) {
-                    return null;
-                }
-                throw err;
-            });
+        const keys = await catchNotFound(
+            client
+                .keyValueStore(keyValueStoreId)
+                .listKeys({ exclusiveStartKey: parsed.exclusiveStartKey, limit: parsed.limit }),
+        );
         if (!keys) {
             return respondUserError(`Key-value store '${keyValueStoreId}' not found.`);
         }

--- a/src/tools/storage/storage_helpers.ts
+++ b/src/tools/storage/storage_helpers.ts
@@ -1,7 +1,28 @@
-import { HELPER_TOOLS } from '../../const.js';
+import { HELPER_TOOLS, HTTP_NOT_FOUND } from '../../const.js';
 import { VERBATIM_LINKS_NUDGE } from '../../utils/console_link.js';
 import { QUOTE_WRAPPER_CHARS } from '../../utils/generic.js';
+import { getHttpStatusCode } from '../../utils/logging.js';
 import { respondOk } from '../../utils/mcp.js';
+
+/**
+ * Wrap a storage SDK promise to convert a 404 rejection into null.
+ *
+ * The Apify SDK soft-catches 404 on `.get()`, `.getStatistics()`, and `.getRecord()` (returning
+ * falsy instead of throwing), but list methods like `.listItems()` and `.listKeys()` throw
+ * ApifyApiError on a missing storage. This helper wraps those list calls to provide consistent
+ * 404 handling: resolves with the promise's value, returns null if it rejects with a 404, or
+ * rethrows any other error. Call sites check `if (!result) return respondUserError(...)` as usual.
+ */
+export async function catchNotFound<T>(promise: Promise<T>): Promise<T | null> {
+    try {
+        return await promise;
+    } catch (err: unknown) {
+        if (getHttpStatusCode(err) === HTTP_NOT_FOUND) {
+            return null;
+        }
+        throw err;
+    }
+}
 
 function suggestTool(toolName: string, loadedToolNames: string[]): string | undefined {
     return loadedToolNames.includes(toolName) ? toolName : undefined;


### PR DESCRIPTION
Part of #1066 (checkbox: `catchNotFound(promise)` helper).

## What we're solving

Three storage tools — `get_dataset_items.ts`, `get_dataset_schema.ts`, `get_key_value_store_keys.ts` — each inlined the same 404→null `.catch` block plus a near-verbatim comment explaining an Apify SDK quirk: list methods (`listItems()`, `listKeys()`) throw `ApifyApiError` on a missing storage, unlike `.get()`/`.getStatistics()`/`.getRecord()` which soft-catch 404. Tuning the logic or the explanation meant editing three places in sync.

## How

Add a generic `catchNotFound<T>(promise: Promise<T>): Promise<T | null>` to `storage_helpers.ts`: resolves to the value, returns `null` on a 404, rethrows any other error. Each call site wraps its list call in `catchNotFound(...)` and keeps its existing `if (!x) return respondUserError('… not found.')` guard. The SDK-quirk explanation now lives once, in the helper's doc comment.

Behavior is unchanged — the existing 404 and non-404-rethrow unit tests for all three tools pass unmodified.

## Alternatives considered

- A generic `utils/` home — rejected; the quirk is storage-SDK-specific and `storage_helpers.ts` already exists as the shared home.
- Keeping a pointer comment at each call site — rejected; recreates the duplication being removed.

## Scope note

Only these three files duplicate the pattern. `get_dataset.ts`/`get_key_value_store_record.ts` call `.get()`/`.getRecord()`, which already soft-catch 404 in the SDK — nothing to convert.

## Verification

- Oracle green: type-check clean, lint 0/0, check:agents passed, `test:unit` 959 passed / 2 skipped (targeted 404 tests: 41 passed), format no-op.
- Scope: 4 source files, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pXZvhEoE6Lz3DpBSL3n1Y

---
_Generated by [Claude Code](https://claude.ai/code/session_016pXZvhEoE6Lz3DpBSL3n1Y)_