### PR TITLE
test: Pin sync/task tool-call contracts before dispatch dedup

### DIFF
--- a/tests/unit/helpers/mcp_server.ts
+++ b/tests/unit/helpers/mcp_server.ts
@@ -1,7 +1,7 @@
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 
 import type { ALLOWED_TASK_TOOL_EXECUTION_MODES } from '../../../src/const.js';
-import type { ActorsMcpServer } from '../../../src/mcp/server.js';
+import { ActorsMcpServer } from '../../../src/mcp/server.js';
 import type { ActorsMcpServerOptions, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../../src/types.js';
 import { TOOL_TYPE } from '../../../src/types.js';
 import { compileSchema } from '../../../src/utils/ajv.js';
@@ -40,7 +40,6 @@ export async function withServer<T>(
     run: (server: ActorsMcpServer) => Promise<T>,
     options?: Partial<ActorsMcpServerOptions>,
 ): Promise<T> {
-    const { ActorsMcpServer } = await import('../../../src/mcp/server.js');
     const server = new ActorsMcpServer({
         taskStore: new InMemoryTaskStore(),
         setupSigintHandler: false,

--- a/tests/unit/helpers/mcp_server.ts
+++ b/tests/unit/helpers/mcp_server.ts
@@ -1,0 +1,107 @@
+import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
+
+import type { ALLOWED_TASK_TOOL_EXECUTION_MODES } from '../../../src/const.js';
+import type { ActorsMcpServer } from '../../../src/mcp/server.js';
+import type { ActorsMcpServerOptions, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../../src/types.js';
+import { TOOL_TYPE } from '../../../src/types.js';
+import { compileSchema } from '../../../src/utils/ajv.js';
+import { respondRaw } from '../../../src/utils/mcp.js';
+
+/**
+ * Signature of an SDK request handler reached via the private `_requestHandlers` map. The
+ * `mcp.server.*` tests drive these handlers directly (no transport, no `server.request()`).
+ */
+export type HandlerFn = (
+    req: Record<string, unknown>,
+    extra: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+/**
+ * Returns the real request handler the SDK registered for `method` (e.g. 'tools/call',
+ * 'tasks/result'), reached through the server's private `_requestHandlers` map so a test can invoke
+ * it directly. Throws if the handler is not registered. This reach into an SDK-internal seam is
+ * centralized here so an SDK upgrade only needs one fix.
+ */
+export function getRequestHandler(server: unknown, method: string): HandlerFn {
+    // eslint-disable-next-line no-underscore-dangle
+    const handler = (server as { server: { _requestHandlers: Map<string, HandlerFn> } }).server._requestHandlers.get(
+        method,
+    );
+    if (!handler) throw new Error(`Handler "${method}" not registered`);
+    return handler;
+}
+
+/**
+ * Constructs a real `ActorsMcpServer` backed by an `InMemoryTaskStore`, runs `run` against it, and
+ * always closes it. Defaults match the existing `mcp.server.*` tests (telemetry off, placeholder
+ * token); pass `options` to override (e.g. telemetry on with no token for the shape tests).
+ */
+export async function withServer<T>(
+    run: (server: ActorsMcpServer) => Promise<T>,
+    options?: Partial<ActorsMcpServerOptions>,
+): Promise<T> {
+    const { ActorsMcpServer } = await import('../../../src/mcp/server.js');
+    const server = new ActorsMcpServer({
+        taskStore: new InMemoryTaskStore(),
+        setupSigintHandler: false,
+        telemetry: { enabled: false },
+        token: 'fake-token',
+        ...options,
+    });
+    try {
+        return await run(server);
+    } finally {
+        await server.close();
+    }
+}
+
+/**
+ * A synthetic internal tool whose `call` throws `error` (default: a plain `Error('boom')`), so
+ * dispatch falls through to the outer catch. An empty input schema validates against `{}`. Set
+ * `taskSupport` to make the tool eligible for the task path (it otherwise fails the pre-dispatch gate).
+ */
+export function makeThrowingTool(
+    options: { name?: string; error?: unknown; taskSupport?: (typeof ALLOWED_TASK_TOOL_EXECUTION_MODES)[number] } = {},
+): ToolEntry {
+    const { name = 'test-throwing-tool', error = new Error('boom'), taskSupport } = options;
+    return {
+        type: TOOL_TYPE.INTERNAL,
+        name,
+        description: 'throws',
+        inputSchema: { type: 'object', properties: {} } as ToolInputSchema,
+        ajvValidate: compileSchema({ type: 'object', properties: {} }),
+        ...(taskSupport ? { execution: { taskSupport } } : {}),
+        call: async (_toolArgs: InternalToolArgs) => {
+            throw error;
+        },
+    };
+}
+
+/**
+ * A synthetic internal tool that records what the server passed into `call` (whether it ran, and the
+ * `progressTracker` it received). Generalizes to any "did the server pass X to the tool?" assertion.
+ */
+export function makeRecorderTool(name: string): {
+    tool: ToolEntry;
+    received: { called: boolean; progressTracker: InternalToolArgs['progressTracker'] | undefined };
+} {
+    const received: { called: boolean; progressTracker: InternalToolArgs['progressTracker'] | undefined } = {
+        called: false,
+        progressTracker: undefined,
+    };
+    const tool: ToolEntry = {
+        type: TOOL_TYPE.INTERNAL,
+        name,
+        description: 'recorder tool for progress wiring tests',
+        inputSchema: { type: 'object', properties: {}, additionalProperties: true },
+        ajvValidate: Object.assign(() => true, { errors: null }) as unknown as ToolEntry['ajvValidate'],
+        paymentRequired: false,
+        annotations: {},
+        call: async (toolArgs: InternalToolArgs) => {
+            received.called = true;
+            received.progressTracker = toolArgs.progressTracker;
+            return respondRaw({ content: [{ type: 'text', text: 'ok' }] });
+        },
+    } as ToolEntry;
+    return { tool, received };
+}

--- a/tests/unit/mcp.server.capability_gating.test.ts
+++ b/tests/unit/mcp.server.capability_gating.test.ts
@@ -11,8 +11,7 @@ import { searchActors } from '../../src/tools/actors/search_actors.js';
 import { searchActorsWidget } from '../../src/tools/widgets/search_actors_widget.js';
 import type { ServerModeOption } from '../../src/types.js';
 import { SERVER_MODE } from '../../src/types.js';
-
-type InitHandler = (req: InitializeRequest, ctx: unknown) => Promise<unknown>;
+import { getRequestHandler } from './helpers/mcp_server.js';
 
 function makeInitializeRequest(supportsUi: boolean): InitializeRequest {
     const extensions = supportsUi ? { 'io.modelcontextprotocol/ui': { mimeTypes: [RESOURCE_MIME_TYPE] } } : {};
@@ -40,14 +39,7 @@ function makeServer(serverMode: ServerModeOption): ActorsMcpServer {
  * transport layer). Mirrors what the SDK does when a real client sends `initialize`.
  */
 async function dispatchInitialize(server: ActorsMcpServer, request: InitializeRequest): Promise<void> {
-    // eslint-disable-next-line no-underscore-dangle
-    const handler = (
-        server.server as unknown as {
-            _requestHandlers: Map<string, InitHandler>;
-        }
-    )._requestHandlers.get('initialize');
-    if (!handler) throw new Error('initialize handler not registered');
-    await handler(request, {});
+    await getRequestHandler(server, 'initialize')(request as unknown as Record<string, unknown>, {});
 }
 
 describe('ActorsMcpServer initialize handler', () => {

--- a/tests/unit/mcp.server.error_handling.test.ts
+++ b/tests/unit/mcp.server.error_handling.test.ts
@@ -1,14 +1,10 @@
-import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import log from '@apify/log';
 
 import { TOOL_STATUS } from '../../src/const.js';
-import { ActorsMcpServer } from '../../src/mcp/server.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../src/types.js';
-import { TOOL_TYPE } from '../../src/types.js';
-import { compileSchema } from '../../src/utils/ajv.js';
 import { getToolCallErrorUserText } from '../../src/utils/mcp.js';
+import { getRequestHandler, makeThrowingTool, withServer } from './helpers/mcp_server.js';
 
 /**
  * Covers the `server.onerror` wiring in `setupErrorHandling()`: client faults softFail with a
@@ -19,13 +15,7 @@ describe('ActorsMcpServer onerror', () => {
     afterEach(() => vi.restoreAllMocks());
 
     it('soft-fails client faults with a sanitized message and error-logs the rest', async () => {
-        const server = new ActorsMcpServer({
-            taskStore: new InMemoryTaskStore(),
-            setupSigintHandler: false,
-            telemetry: { enabled: false },
-            token: 'fake-token',
-        });
-        try {
+        await withServer(async (server) => {
             const softFail = vi.spyOn(log, 'softFail').mockImplementation(() => log);
             const errorLog = vi.spyOn(log, 'error').mockImplementation(() => log);
 
@@ -37,9 +27,7 @@ describe('ActorsMcpServer onerror', () => {
 
             server.server.onerror?.(new Error('Unexpected internal failure'));
             expect(errorLog).toHaveBeenCalledTimes(1);
-        } finally {
-            await server.close();
-        }
+        });
     });
 });
 
@@ -50,54 +38,20 @@ describe('ActorsMcpServer onerror', () => {
  * in `toolTelemetry` — no `failureCategory`/`failureHttpStatus` (which would leak onto the wire).
  */
 describe('CallToolRequestSchema handler outer catch', () => {
-    type HandlerFn = (req: Record<string, unknown>, extra: Record<string, unknown>) => Promise<Record<string, unknown>>;
-
-    // A synthetic internal tool whose call throws a plain (non-McpError) error, so dispatch falls
-    // through to the outer catch. An empty input schema validates against `{}`.
-    function makeThrowingTool(): ToolEntry {
-        return {
-            type: TOOL_TYPE.INTERNAL,
-            name: 'test-throwing-tool',
-            description: 'throws',
-            inputSchema: { type: 'object', properties: {} } as ToolInputSchema,
-            ajvValidate: compileSchema({ type: 'object', properties: {} }),
-            call: async (_toolArgs: InternalToolArgs) => {
-                throw new Error('boom');
-            },
-        };
-    }
-
-    function getToolCallHandler(server: ActorsMcpServer): HandlerFn {
-        // eslint-disable-next-line no-underscore-dangle
-        const handler = (
-            server as unknown as { server: { _requestHandlers: Map<string, HandlerFn> } }
-        ).server._requestHandlers.get('tools/call');
-        if (!handler) throw new Error('tools/call handler not registered');
-        return handler;
-    }
-
     async function dispatchThrow(aborted: boolean) {
-        const server = new ActorsMcpServer({
-            taskStore: new InMemoryTaskStore(),
-            setupSigintHandler: false,
-            telemetry: { enabled: false },
-            token: 'fake-token',
-        });
-        try {
+        return withServer(async (server) => {
             vi.spyOn(log, 'error').mockImplementation(() => log);
             vi.spyOn(log, 'exception').mockImplementation(() => log);
             server.upsertTools([makeThrowingTool()]);
-            const handler = getToolCallHandler(server);
-            return await handler(
+            const handler = getRequestHandler(server, 'tools/call');
+            return handler(
                 {
                     method: 'tools/call',
                     params: { name: 'test-throwing-tool', arguments: {}, _meta: { mcpSessionId: 's1' } },
                 },
                 { signal: { aborted }, sendNotification: vi.fn() },
             );
-        } finally {
-            await server.close();
-        }
+        });
     }
 
     it('preserves ABORTED toolStatus and emits only { toolStatus } when the request was aborted', async () => {

--- a/tests/unit/mcp.server.progress_wiring.test.ts
+++ b/tests/unit/mcp.server.progress_wiring.test.ts
@@ -1,80 +1,20 @@
-import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import { describe, expect, it, vi } from 'vitest';
 
 import { HELPER_TOOLS } from '../../src/const.js';
-import type { ActorsMcpServer } from '../../src/mcp/server.js';
-import type { InternalToolArgs, ToolEntry } from '../../src/types.js';
-import { TOOL_TYPE } from '../../src/types.js';
-import { respondRaw } from '../../src/utils/mcp.js';
 import { ProgressTracker } from '../../src/utils/progress.js';
+import { getRequestHandler, makeRecorderTool, withServer } from './helpers/mcp_server.js';
 
 /**
  * Covers the request-metadata → `createProgressTracker` wiring in `tools/call`. The unit tests
  * for `get-actor-run` itself inject a fake tracker directly into the tool, so they would not
  * catch a regression in the server-level opt-in.
- *
- * TODO(followup): lift `withServer`, `getCallToolHandler`, and `makeRecorderTool` to
- * `tests/unit/_helpers/` and reuse from `mcp.task_notifications.test.ts` and
- * `mcp.server.capability_gating.test.ts` (both already duplicate the same server bootstrap and
- * `_requestHandlers.get(...)` getter). The recorder pattern generalizes to any "did the server
- * pass X to the tool?" assertion (apifyClient, extra.signal, future opt-ins).
  */
-
-type HandlerFn = (req: Record<string, unknown>, extra: Record<string, unknown>) => Promise<Record<string, unknown>>;
-
-function getCallToolHandler(server: unknown): HandlerFn {
-    // eslint-disable-next-line no-underscore-dangle
-    const handler = (server as { server: { _requestHandlers: Map<string, HandlerFn> } }).server._requestHandlers.get(
-        'tools/call',
-    );
-    if (!handler) throw new Error('Handler "tools/call" not registered');
-    return handler;
-}
-
-function makeRecorderTool(name: string): {
-    tool: ToolEntry;
-    received: { progressTracker: InternalToolArgs['progressTracker'] | undefined };
-} {
-    const received: { progressTracker: InternalToolArgs['progressTracker'] | undefined } = {
-        progressTracker: undefined,
-    };
-    const tool: ToolEntry = {
-        type: TOOL_TYPE.INTERNAL,
-        name,
-        description: 'recorder tool for progress wiring tests',
-        inputSchema: { type: 'object', properties: {}, additionalProperties: true },
-        ajvValidate: Object.assign(() => true, { errors: null }) as unknown as ToolEntry['ajvValidate'],
-        paymentRequired: false,
-        annotations: {},
-        call: async (toolArgs: InternalToolArgs) => {
-            received.progressTracker = toolArgs.progressTracker;
-            return respondRaw({ content: [{ type: 'text', text: 'ok' }] });
-        },
-    } as ToolEntry;
-    return { tool, received };
-}
-
-async function withServer<T>(run: (server: ActorsMcpServer) => Promise<T>): Promise<T> {
-    const { ActorsMcpServer: ActorsMcpServerClass } = await import('../../src/mcp/server.js');
-    const taskStore = new InMemoryTaskStore();
-    const server = new ActorsMcpServerClass({
-        taskStore,
-        setupSigintHandler: false,
-        telemetry: { enabled: false },
-        token: 'fake-token',
-    });
-    try {
-        return await run(server);
-    } finally {
-        await server.close();
-    }
-}
 
 async function runRecorder(toolName: string, meta: Record<string, unknown>) {
     return withServer(async (server) => {
         const { tool, received } = makeRecorderTool(toolName);
         server.upsertTools([tool]);
-        const handler = getCallToolHandler(server as never);
+        const handler = getRequestHandler(server, 'tools/call');
         await handler(
             { method: 'tools/call', params: { name: toolName, arguments: {}, _meta: meta } },
             { sendNotification: vi.fn() },

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -14,10 +14,10 @@ import { compileSchema } from '../../src/utils/ajv.js';
 import { getRequestHandler, makeRecorderTool, makeThrowingTool, withServer } from './helpers/mcp_server.js';
 
 /**
- * Pins the handler-level behavior contracts that umbrella #658 will merge (the sync
- * `CallToolRequestSchema` catch and the `executeToolAndUpdateTask` catch). Failure classes are
- * fabricated by throwing from a fake tool's `call`; both the sync path (result shapes) and the task
- * path (terminal status mapping) assert the same source-of-truth per class.
+ * Pins the handler-level behavior contracts the sync `CallToolRequestSchema` catch and the
+ * `executeToolAndUpdateTask` catch must share. Failure classes are fabricated by throwing from a
+ * fake tool's `call`; both the sync path (result shapes) and the task path (terminal status
+ * mapping) assert the same source-of-truth per class.
  */
 
 const PERMISSION_HTTP_STATUS = 403;
@@ -356,9 +356,9 @@ describe('executeToolAndUpdateTask()', () => {
 
     describe('task-call telemetry properties per failure class', () => {
         // Same seam and per-class expectations as the sync block: the task catch builds its
-        // callDiagnostics via its own duplicated inline logic (the duplication #658 merges), so pin
-        // it separately. Telemetry fires once via finishTaskTracking; the emitted properties carry
-        // no task-specific key (taskId appears only in the log line, not in the Segment properties).
+        // callDiagnostics via its own duplicated inline logic, so pin it separately. Telemetry fires
+        // once via finishTaskTracking; the emitted properties carry no task-specific key (taskId
+        // appears only in the log line, not in the Segment properties).
         for (const fc of FAILURE_CLASSES) {
             it(`emits telemetry properties for a ${fc.label} failure in task mode`, async () => {
                 const trackSpy = vi.spyOn(telemetry, 'trackToolCall').mockImplementation(() => {});
@@ -390,10 +390,9 @@ describe('executeToolAndUpdateTask()', () => {
     });
 
     it('stores an empty {} completed result for an ACTOR_MCP tool in task mode', async () => {
-        // KNOWN GAP (#1063): executeToolAndUpdateTask has no ACTOR_MCP dispatch branch, so `result`
-        // stays the initial {} and is stored as `completed`. This pins today's buggy behavior. FLIP
-        // WHEN #1063 LANDS: the task path will then dispatch the ACTOR_MCP tool and store a real
-        // result, so update this test to assert that result instead of {}.
+        // KNOWN GAP: executeToolAndUpdateTask has no ACTOR_MCP dispatch branch, so `result` stays the
+        // initial {} and is stored as `completed`. This pins today's buggy behavior — if that branch
+        // is added, update this test to assert the real result instead of {}.
         await withServer(async (server) => {
             silenceLogs();
             const { task, result } = await runTaskAndReadBack(server, makeActorMcpTool());

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -116,18 +116,6 @@ async function runSync(server: ActorsMcpServer, tool: ToolEntry): Promise<Record
 
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
 
-/** Polls (real timers) until `predicate` returns truthy, then returns that value. Throws `message` if it never does. */
-async function pollUntil<T>(predicate: () => Promise<T> | T, message: string): Promise<NonNullable<T>> {
-    for (let i = 0; i < 2000; i++) {
-        const value = await predicate();
-        if (value) return value;
-        await new Promise((resolve) => {
-            setImmediate(resolve);
-        });
-    }
-    throw new Error(message);
-}
-
 /** Asserts the telemetry `properties` shape `trackToolCall` received for a failure class. */
 function expectFailureClassTelemetry(
     trackSpy: { mock: { calls: [unknown, unknown, Record<string, unknown>][] } },
@@ -155,10 +143,13 @@ async function runTaskAndReadBack(server: ActorsMcpServer, tool: ToolEntry) {
         },
         { signal: { aborted: false }, sendNotification: vi.fn() },
     )) as { task: { taskId: string } };
-    const task = await pollUntil(async () => {
+    const task = await vi.waitFor(async () => {
         const current = await server.taskStore.getTask(res.task.taskId);
-        return current && TERMINAL_STATUSES.has(current.status) ? current : null;
-    }, `Task ${res.task.taskId} did not reach a terminal status`);
+        if (!current || !TERMINAL_STATUSES.has(current.status)) {
+            throw new Error(`Task ${res.task.taskId} did not reach a terminal status`);
+        }
+        return current;
+    });
     const result = await server.taskStore.getTaskResult(res.task.taskId);
     return { task, result: result as Record<string, unknown> };
 }
@@ -276,7 +267,9 @@ describe('executeToolAndUpdateTask()', () => {
                         await runTaskAndReadBack(server, tool);
                         // The task path stores the terminal result *before* finishTaskTracking fires
                         // trackToolCall, so terminal status alone does not imply telemetry was emitted.
-                        await pollUntil(() => trackSpy.mock.calls.length > 0, 'trackToolCall spy was not called');
+                        await vi.waitFor(() => {
+                            if (trackSpy.mock.calls.length === 0) throw new Error('trackToolCall spy was not called');
+                        });
                     },
                     { token: undefined, telemetry: { enabled: true }, allowUnauthMode: true },
                 );

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -1,0 +1,301 @@
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ApifyApiError } from 'apify-client';
+import type { AxiosResponse } from 'axios';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import log from '@apify/log';
+
+import { APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED, FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
+import type { ActorsMcpServer } from '../../src/mcp/server.js';
+import * as telemetry from '../../src/telemetry.js';
+import type { ToolEntry, ToolInputSchema } from '../../src/types.js';
+import { TOOL_TYPE } from '../../src/types.js';
+import { compileSchema } from '../../src/utils/ajv.js';
+import { getRequestHandler, makeRecorderTool, makeThrowingTool, withServer } from './helpers/mcp_server.js';
+
+/**
+ * Pins the handler-level behavior contracts that umbrella #658 will merge (the sync
+ * `CallToolRequestSchema` catch and the `executeToolAndUpdateTask` catch). Failure classes are
+ * fabricated by throwing from a fake tool's `call`; both the sync path (result shapes) and the task
+ * path (terminal status mapping) assert the same source-of-truth per class. See DESIGN
+ * `.devforge/2-design.md`.
+ */
+
+const PERMISSION_HTTP_STATUS = 403;
+
+/** A 402 x402 payment-required condition. Any object with `statusCode: 402` satisfies the predicate. */
+function makePaymentRequiredError(): Error {
+    return Object.assign(new Error('Payment required'), { statusCode: 402 });
+}
+
+/** A real full-permission-not-approved `ApifyApiError`, built against the src/const.ts type constant. */
+function makePermissionApprovalError(): ApifyApiError {
+    return new ApifyApiError(
+        {
+            data: { error: { type: APIFY_ERROR_TYPE_FULL_PERMISSION_NOT_APPROVED, message: 'needs approval' } },
+            status: PERMISSION_HTTP_STATUS,
+        } as AxiosResponse,
+        1,
+    );
+}
+
+type FailureClass = {
+    label: string;
+    makeError: () => unknown;
+    taskStatus: 'completed' | 'failed';
+    /** Set only for the generic class — 402/approval store no internalToolStatus. */
+    internalToolStatus?: string;
+    telemetry: { tool_status: string; failure_category: string; failure_http_status?: number };
+};
+
+const FAILURE_CLASSES: FailureClass[] = [
+    {
+        label: '402 payment-required',
+        makeError: makePaymentRequiredError,
+        taskStatus: 'completed',
+        telemetry: {
+            tool_status: TOOL_STATUS.SOFT_FAIL,
+            failure_category: FAILURE_CATEGORY.INVALID_INPUT,
+            failure_http_status: 402,
+        },
+    },
+    {
+        label: 'permission-approval',
+        makeError: makePermissionApprovalError,
+        taskStatus: 'completed',
+        telemetry: {
+            tool_status: TOOL_STATUS.SOFT_FAIL,
+            failure_category: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
+            failure_http_status: PERMISSION_HTTP_STATUS,
+        },
+    },
+    {
+        label: 'generic execution error',
+        makeError: () => new Error('boom'),
+        taskStatus: 'failed',
+        internalToolStatus: TOOL_STATUS.FAILED,
+        telemetry: {
+            tool_status: TOOL_STATUS.FAILED,
+            failure_category: FAILURE_CATEGORY.INTERNAL_ERROR,
+        },
+    },
+];
+
+/** Silence the error-path logging the failure branches emit, keeping test output clean. */
+function silenceLogs(): void {
+    vi.spyOn(log, 'error').mockImplementation(() => log);
+    vi.spyOn(log, 'exception').mockImplementation(() => log);
+    vi.spyOn(log, 'softFail').mockImplementation(() => log);
+    vi.spyOn(log, 'warning').mockImplementation(() => log);
+}
+
+/** An ACTOR_MCP tool with `taskSupport` forced so it clears the pre-dispatch gate (see the gap test). */
+function makeActorMcpTool(): ToolEntry {
+    return {
+        type: TOOL_TYPE.ACTOR_MCP,
+        name: 'test-actor-mcp-tool',
+        description: 'actor-mcp',
+        inputSchema: { type: 'object', properties: {} } as ToolInputSchema,
+        ajvValidate: compileSchema({ type: 'object', properties: {} }),
+        originToolName: 'origin-tool',
+        actorId: 'test/actor',
+        serverId: 'server-id',
+        serverUrl: 'https://example.invalid/mcp',
+        execution: { taskSupport: 'optional' },
+    } as ToolEntry;
+}
+
+async function runSync(server: ActorsMcpServer, tool: ToolEntry): Promise<Record<string, unknown>> {
+    server.upsertTools([tool]);
+    const handler = getRequestHandler(server, 'tools/call');
+    return handler(
+        { method: 'tools/call', params: { name: tool.name, arguments: {}, _meta: { mcpSessionId: 's1' } } },
+        { signal: { aborted: false }, sendNotification: vi.fn() },
+    );
+}
+
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
+
+/** Polls (real timers) until `predicate` returns truthy, then returns that value. Throws `message` if it never does. */
+async function pollUntil<T>(predicate: () => Promise<T> | T, message: string): Promise<NonNullable<T>> {
+    for (let i = 0; i < 2000; i++) {
+        const value = await predicate();
+        if (value) return value;
+        await new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+    }
+    throw new Error(message);
+}
+
+/** Asserts the telemetry `properties` shape `trackToolCall` received for a failure class. */
+function expectFailureClassTelemetry(
+    trackSpy: { mock: { calls: [unknown, unknown, Record<string, unknown>][] } },
+    fc: FailureClass,
+): void {
+    expect(trackSpy.mock.calls).toHaveLength(1);
+    const properties = trackSpy.mock.calls[0][2];
+    expect(properties.tool_status).toBe(fc.telemetry.tool_status);
+    expect(properties.failure_category).toBe(fc.telemetry.failure_category);
+    if (fc.telemetry.failure_http_status === undefined) {
+        expect(properties).not.toHaveProperty('failure_http_status');
+    } else {
+        expect(properties.failure_http_status).toBe(fc.telemetry.failure_http_status);
+    }
+}
+
+/** Drives a task-mode call, waits for terminal status, and reads back the stored task + result. */
+async function runTaskAndReadBack(server: ActorsMcpServer, tool: ToolEntry) {
+    server.upsertTools([tool]);
+    const handler = getRequestHandler(server, 'tools/call');
+    const res = (await handler(
+        {
+            method: 'tools/call',
+            params: { name: tool.name, arguments: {}, _meta: { mcpSessionId: 's1' }, task: { ttl: 60_000 } },
+        },
+        { signal: { aborted: false }, sendNotification: vi.fn() },
+    )) as { task: { taskId: string } };
+    const task = await pollUntil(async () => {
+        const current = await server.taskStore.getTask(res.task.taskId);
+        return current && TERMINAL_STATUSES.has(current.status) ? current : null;
+    }, `Task ${res.task.taskId} did not reach a terminal status`);
+    const result = await server.taskStore.getTaskResult(res.task.taskId);
+    return { task, result: result as Record<string, unknown> };
+}
+
+describe('CallToolRequestSchema handler', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    describe('sync failure result shapes', () => {
+        it('returns the payment-required response shape for a 402 failure', async () => {
+            await withServer(async (server) => {
+                silenceLogs();
+                const result = await runSync(server, makeThrowingTool({ error: makePaymentRequiredError() }));
+                expect(result.isError).toBe(true);
+                expect(result.content).toEqual([{ type: 'text', text: 'Payment required' }]);
+                // Server-internal telemetry/status must not leak onto the wire.
+                expect(result.toolTelemetry).toBeUndefined();
+                expect('internalToolStatus' in result).toBe(false);
+            });
+        });
+
+        it('returns the permission-approval response shape for a permission-approval failure', async () => {
+            await withServer(async (server) => {
+                silenceLogs();
+                const result = await runSync(server, makeThrowingTool({ error: makePermissionApprovalError() }));
+                expect(result.isError).toBe(true);
+                expect(result.content).toEqual([{ type: 'text', text: 'needs approval' }]);
+                expect(result.toolTelemetry).toBeUndefined();
+                expect('internalToolStatus' in result).toBe(false);
+            });
+        });
+    });
+
+    it('rejects a task-augmented call to a tool without taskSupport before dispatch', async () => {
+        await withServer(async (server) => {
+            silenceLogs();
+            const { tool, received } = makeRecorderTool('no-task-support-tool');
+            server.upsertTools([tool]);
+            // failInvalidParams awaits sendLoggingMessage before throwing McpError; the harness has
+            // no transport (notification would throw "Not connected"), so stub it to observe the
+            // real InvalidParams rejection.
+            vi.spyOn(server.server, 'sendLoggingMessage').mockResolvedValue(undefined);
+            const handler = getRequestHandler(server, 'tools/call');
+            await expect(
+                handler(
+                    {
+                        method: 'tools/call',
+                        params: {
+                            name: 'no-task-support-tool',
+                            arguments: {},
+                            _meta: { mcpSessionId: 's1' },
+                            task: { ttl: 60_000 },
+                        },
+                    },
+                    { signal: { aborted: false }, sendNotification: vi.fn() },
+                ),
+            ).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+            expect(received.called).toBe(false);
+        });
+    });
+
+    describe('tool-call telemetry properties per failure class', () => {
+        // Telemetry on: no token + allowUnauthMode so prepareTelemetryData skips the userInfo network
+        // call (userId null) while trackToolCall still fires. Assert the properties shape per class.
+        for (const fc of FAILURE_CLASSES) {
+            it(`emits telemetry properties for a ${fc.label} failure`, async () => {
+                const trackSpy = vi.spyOn(telemetry, 'trackToolCall').mockImplementation(() => {});
+                await withServer(
+                    async (server) => {
+                        silenceLogs();
+                        await runSync(server, makeThrowingTool({ error: fc.makeError() }));
+                    },
+                    { token: undefined, telemetry: { enabled: true }, allowUnauthMode: true },
+                );
+                expectFailureClassTelemetry(trackSpy, fc);
+            });
+        }
+    });
+});
+
+describe('executeToolAndUpdateTask()', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    describe('task terminal status per failure class', () => {
+        for (const fc of FAILURE_CLASSES) {
+            it(`stores a ${fc.label} failure with terminal status ${fc.taskStatus}`, async () => {
+                await withServer(async (server) => {
+                    silenceLogs();
+                    const tool = makeThrowingTool({ error: fc.makeError(), taskSupport: 'optional' });
+                    const { task, result } = await runTaskAndReadBack(server, tool);
+
+                    expect(task.status).toBe(fc.taskStatus);
+                    if (fc.internalToolStatus === undefined) {
+                        expect('internalToolStatus' in result).toBe(false);
+                    } else {
+                        expect(result.isError).toBe(true);
+                        expect(result.internalToolStatus).toBe(fc.internalToolStatus);
+                    }
+                });
+            });
+        }
+    });
+
+    describe('task-call telemetry properties per failure class', () => {
+        // Same seam and per-class expectations as the sync block: the task catch builds its
+        // callDiagnostics via its own duplicated inline logic (the duplication #658 merges), so pin
+        // it separately. Telemetry fires once via finishTaskTracking; the emitted properties carry
+        // no task-specific key (taskId appears only in the log line, not in the Segment properties).
+        for (const fc of FAILURE_CLASSES) {
+            it(`emits telemetry properties for a ${fc.label} failure in task mode`, async () => {
+                const trackSpy = vi.spyOn(telemetry, 'trackToolCall').mockImplementation(() => {});
+                await withServer(
+                    async (server) => {
+                        silenceLogs();
+                        const tool = makeThrowingTool({ error: fc.makeError(), taskSupport: 'optional' });
+                        await runTaskAndReadBack(server, tool);
+                        // The task path stores the terminal result *before* finishTaskTracking fires
+                        // trackToolCall, so terminal status alone does not imply telemetry was emitted.
+                        await pollUntil(() => trackSpy.mock.calls.length > 0, 'trackToolCall spy was not called');
+                    },
+                    { token: undefined, telemetry: { enabled: true }, allowUnauthMode: true },
+                );
+                expectFailureClassTelemetry(trackSpy, fc);
+                expect(trackSpy.mock.calls[0][2]).not.toHaveProperty('taskId');
+            });
+        }
+    });
+
+    it('stores an empty {} completed result for an ACTOR_MCP tool in task mode', async () => {
+        // KNOWN GAP (#1063): executeToolAndUpdateTask has no ACTOR_MCP dispatch branch, so `result`
+        // stays the initial {} and is stored as `completed`. This pins today's buggy behavior. FLIP
+        // WHEN #1063 LANDS: the task path will then dispatch the ACTOR_MCP tool and store a real
+        // result, so update this test to assert that result instead of {}.
+        await withServer(async (server) => {
+            silenceLogs();
+            const { task, result } = await runTaskAndReadBack(server, makeActorMcpTool());
+            expect(task.status).toBe('completed');
+            expect(result).toEqual({});
+        });
+    });
+});

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -17,8 +17,7 @@ import { getRequestHandler, makeRecorderTool, makeThrowingTool, withServer } fro
  * Pins the handler-level behavior contracts that umbrella #658 will merge (the sync
  * `CallToolRequestSchema` catch and the `executeToolAndUpdateTask` catch). Failure classes are
  * fabricated by throwing from a fake tool's `call`; both the sync path (result shapes) and the task
- * path (terminal status mapping) assert the same source-of-truth per class. See DESIGN
- * `.devforge/2-design.md`.
+ * path (terminal status mapping) assert the same source-of-truth per class.
  */
 
 const PERMISSION_HTTP_STATUS = 403;

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -22,8 +22,32 @@ import { getRequestHandler, makeRecorderTool, makeThrowingTool, withServer } fro
 
 const PERMISSION_HTTP_STATUS = 403;
 
-/** A 402 x402 payment-required condition. Any object with `statusCode: 402` satisfies the predicate. */
+/** x402 payload as the axios interceptor decodes it from the `payment-required` header. */
+const X402_PAYMENT_DATA = {
+    x402Version: 1,
+    accepts: [{ scheme: 'exact', network: 'base-sepolia', maxAmountRequired: '10000' }],
+};
+
+/** The wire `content` `buildPaymentRequiredResponse` produces for X402_PAYMENT_DATA. */
+const X402_RESPONSE_CONTENT = [
+    { type: 'text', text: JSON.stringify(X402_PAYMENT_DATA) },
+    { type: 'text', text: 'Payment required to run this Actor or access this resource.' },
+];
+
+/**
+ * A 402 x402 payment-required condition. Any object with `statusCode: 402` satisfies the predicate;
+ * the payment payload rides the same `Symbol.for('paymentRequiredData')` property the production
+ * axios interceptor attaches, so the handler exercises the full x402 response build.
+ */
 function makePaymentRequiredError(): Error {
+    return Object.assign(new Error('Payment required'), {
+        statusCode: 402,
+        [Symbol.for('paymentRequiredData')]: X402_PAYMENT_DATA,
+    });
+}
+
+/** A 402 with no captured payment payload — exercises the message-only fallback branch. */
+function makeBarePaymentRequiredError(): Error {
     return Object.assign(new Error('Payment required'), { statusCode: 402 });
 }
 
@@ -42,9 +66,11 @@ type FailureClass = {
     label: string;
     makeError: () => unknown;
     taskStatus: 'completed' | 'failed';
-    /** Set only for the generic class — 402/approval store no internalToolStatus. */
-    internalToolStatus?: string;
+    /** Exact stored task-store payload — deep-equal pin, so any added/dropped key fails. */
+    storedResult: Record<string, unknown>;
     telemetry: { tool_status: string; failure_category: string; failure_http_status?: number };
+    /** Failure-class keys expected on top of BASE_TELEMETRY_KEYS (exact-key-set pin). */
+    telemetryExtraKeys: string[];
 };
 
 const FAILURE_CLASSES: FailureClass[] = [
@@ -52,32 +78,69 @@ const FAILURE_CLASSES: FailureClass[] = [
         label: '402 payment-required',
         makeError: makePaymentRequiredError,
         taskStatus: 'completed',
+        storedResult: { content: X402_RESPONSE_CONTENT, isError: true, structuredContent: X402_PAYMENT_DATA },
         telemetry: {
             tool_status: TOOL_STATUS.SOFT_FAIL,
             failure_category: FAILURE_CATEGORY.INVALID_INPUT,
             failure_http_status: 402,
         },
+        telemetryExtraKeys: ['failure_category', 'failure_http_status'],
     },
     {
         label: 'permission-approval',
         makeError: makePermissionApprovalError,
         taskStatus: 'completed',
+        storedResult: { content: [{ type: 'text', text: 'needs approval' }], isError: true },
         telemetry: {
             tool_status: TOOL_STATUS.SOFT_FAIL,
             failure_category: FAILURE_CATEGORY.PERMISSION_APPROVAL_REQUIRED,
             failure_http_status: PERMISSION_HTTP_STATUS,
         },
+        telemetryExtraKeys: ['failure_category', 'failure_http_status'],
     },
     {
         label: 'generic execution error',
         makeError: () => new Error('boom'),
         taskStatus: 'failed',
-        internalToolStatus: TOOL_STATUS.FAILED,
+        storedResult: {
+            content: [
+                {
+                    type: 'text',
+                    text: 'Error calling tool "test-throwing-tool": boom. Verify the tool name and input parameters.',
+                },
+            ],
+            isError: true,
+            internalToolStatus: TOOL_STATUS.FAILED,
+        },
         telemetry: {
             tool_status: TOOL_STATUS.FAILED,
             failure_category: FAILURE_CATEGORY.INTERNAL_ERROR,
         },
+        telemetryExtraKeys: ['failure_category', 'failure_detail'],
     },
+];
+
+/**
+ * Keys `prepareTelemetryData` + the handler `finally` finalization put on every tool-call Segment
+ * event, sync and task paths alike — pinned empirically. This suite is the only CI guard for these
+ * shapes (dashboards consume them; the internal repo does not), so the pin is an exact key set: a
+ * key appearing or disappearing must be a conscious edit here.
+ */
+const BASE_TELEMETRY_KEYS = [
+    'app',
+    'app_version',
+    'mcp_client_capabilities',
+    'mcp_client_name',
+    'mcp_client_version',
+    'mcp_protocol_version',
+    'mcp_session_id',
+    'tool_exec_time_ms',
+    'tool_name',
+    'tool_response_content_bytes',
+    'tool_response_file_bytes',
+    'tool_response_structured_content_bytes',
+    'tool_status',
+    'transport_type',
 ];
 
 /** Silence the error-path logging the failure branches emit, keeping test output clean. */
@@ -122,6 +185,7 @@ function expectFailureClassTelemetry(
 ): void {
     expect(trackSpy.mock.calls).toHaveLength(1);
     const properties = trackSpy.mock.calls[0][2];
+    expect(Object.keys(properties).sort()).toEqual([...BASE_TELEMETRY_KEYS, ...fc.telemetryExtraKeys].sort());
     expect(properties.tool_status).toBe(fc.telemetry.tool_status);
     expect(properties.failure_category).toBe(fc.telemetry.failure_category);
     if (fc.telemetry.failure_http_status === undefined) {
@@ -157,13 +221,28 @@ describe('CallToolRequestSchema handler', () => {
     afterEach(() => vi.restoreAllMocks());
 
     describe('sync failure result shapes', () => {
-        it('returns the payment-required response shape for a 402 failure', async () => {
+        it('returns the x402 payment-required response shape for a 402 failure', async () => {
             await withServer(async (server) => {
                 silenceLogs();
                 const result = await runSync(server, makeThrowingTool({ error: makePaymentRequiredError() }));
                 expect(result.isError).toBe(true);
-                expect(result.content).toEqual([{ type: 'text', text: 'Payment required' }]);
+                // Per the x402 MCP transport spec the payload rides both structuredContent and
+                // content[0].text as JSON — payment clients parse these; pin both exactly.
+                expect(result.content).toEqual(X402_RESPONSE_CONTENT);
+                expect(result.structuredContent).toEqual(X402_PAYMENT_DATA);
                 // Server-internal telemetry/status must not leak onto the wire.
+                expect(result.toolTelemetry).toBeUndefined();
+                expect('internalToolStatus' in result).toBe(false);
+            });
+        });
+
+        it('returns the message-only payment-required response for a 402 without payment data', async () => {
+            await withServer(async (server) => {
+                silenceLogs();
+                const result = await runSync(server, makeThrowingTool({ error: makeBarePaymentRequiredError() }));
+                expect(result.isError).toBe(true);
+                expect(result.content).toEqual([{ type: 'text', text: 'Payment required' }]);
+                expect(result.structuredContent).toBeUndefined();
                 expect(result.toolTelemetry).toBeUndefined();
                 expect('internalToolStatus' in result).toBe(false);
             });
@@ -209,6 +288,32 @@ describe('CallToolRequestSchema handler', () => {
         });
     });
 
+    it('rejects arguments failing the input schema as an InvalidParams protocol error', async () => {
+        // Pins the deliberate divergence from SDK 1.29 defaults: validation failures surface as
+        // McpError protocol errors, never as isError tool results. The taskSupport-gate test above
+        // covers the other failInvalidParams instance; this one covers AJV validation.
+        await withServer(async (server) => {
+            silenceLogs();
+            const { tool, received } = makeRecorderTool('strict-schema-tool');
+            const schema = { type: 'object', properties: { x: { type: 'string' } }, required: ['x'] };
+            tool.inputSchema = schema as ToolInputSchema;
+            tool.ajvValidate = compileSchema(schema);
+            server.upsertTools([tool]);
+            vi.spyOn(server.server, 'sendLoggingMessage').mockResolvedValue(undefined);
+            const handler = getRequestHandler(server, 'tools/call');
+            await expect(
+                handler(
+                    {
+                        method: 'tools/call',
+                        params: { name: 'strict-schema-tool', arguments: {}, _meta: { mcpSessionId: 's1' } },
+                    },
+                    { signal: { aborted: false }, sendNotification: vi.fn() },
+                ),
+            ).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+            expect(received.called).toBe(false);
+        });
+    });
+
     describe('tool-call telemetry properties per failure class', () => {
         // Telemetry on: no token + allowUnauthMode so prepareTelemetryData skips the userInfo network
         // call (userId null) while trackToolCall still fires. Assert the properties shape per class.
@@ -240,12 +345,10 @@ describe('executeToolAndUpdateTask()', () => {
                     const { task, result } = await runTaskAndReadBack(server, tool);
 
                     expect(task.status).toBe(fc.taskStatus);
-                    if (fc.internalToolStatus === undefined) {
-                        expect('internalToolStatus' in result).toBe(false);
-                    } else {
-                        expect(result.isError).toBe(true);
-                        expect(result.internalToolStatus).toBe(fc.internalToolStatus);
-                    }
+                    // Exact-object pin: a payment client fetches this via tasks/result, so the
+                    // payload must not drift, and no internal key (toolTelemetry,
+                    // internalToolStatus on completed classes) may appear.
+                    expect(result).toEqual(fc.storedResult);
                 });
             });
         }
@@ -269,11 +372,19 @@ describe('executeToolAndUpdateTask()', () => {
                         await vi.waitFor(() => {
                             if (trackSpy.mock.calls.length === 0) throw new Error('trackToolCall spy was not called');
                         });
+                        // Let any queued duplicate fire land before the single-call assertion below.
+                        await new Promise((resolve) => {
+                            setImmediate(resolve);
+                        });
+                        await new Promise((resolve) => {
+                            setImmediate(resolve);
+                        });
                     },
                     { token: undefined, telemetry: { enabled: true }, allowUnauthMode: true },
                 );
                 expectFailureClassTelemetry(trackSpy, fc);
                 expect(trackSpy.mock.calls[0][2]).not.toHaveProperty('taskId');
+                expect(trackSpy.mock.calls[0][2]).not.toHaveProperty('task_id');
             });
         }
     });

--- a/tests/unit/mcp.task_notifications.test.ts
+++ b/tests/unit/mcp.task_notifications.test.ts
@@ -1,10 +1,9 @@
-import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { RELATED_TASK_META_KEY } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
 
 import { emitTaskStatusNotification } from '../../src/mcp/server.js';
-import { getRequestHandler } from './helpers/mcp_server.js';
+import { getRequestHandler, withServer } from './helpers/mcp_server.js';
 
 // Helper to create a minimal TaskStore mock
 function makeTaskStore(task: Record<string, unknown> | undefined) {
@@ -114,58 +113,50 @@ describe('tasks/result _meta.related-task injection', () => {
     const fakeRequest = { method: 'tools/call', params: { name: 'test-tool', arguments: {} } };
 
     it('injects _meta.related-task into tasks/result response (MUST)', async () => {
-        const { ActorsMcpServer } = await import('../../src/mcp/server.js');
-        const taskStore = new InMemoryTaskStore();
-        const server = new ActorsMcpServer({ taskStore, setupSigintHandler: false, telemetry: { enabled: false } });
+        await withServer(async (server) => {
+            const task = await server.taskStore.createTask({ ttl: 60_000 }, 'req-1', fakeRequest as never);
+            await server.taskStore.storeTaskResult(
+                task.taskId,
+                'completed',
+                { content: [{ type: 'text', text: 'done' }] },
+                undefined,
+            );
 
-        const task = await taskStore.createTask({ ttl: 60_000 }, 'req-1', fakeRequest as never);
-        await taskStore.storeTaskResult(
-            task.taskId,
-            'completed',
-            { content: [{ type: 'text', text: 'done' }] },
-            undefined,
-        );
+            const handler = getRequestHandler(server, 'tasks/result');
+            const result = await handler(
+                { method: 'tasks/result', params: { taskId: task.taskId } },
+                { sendNotification: vi.fn() },
+            );
 
-        const handler = getRequestHandler(server, 'tasks/result');
-        const result = await handler(
-            { method: 'tasks/result', params: { taskId: task.taskId } },
-            { sendNotification: vi.fn() },
-        );
-
-        expect((result as Record<string, unknown>)._meta).toMatchObject({
-            [RELATED_TASK_META_KEY]: { taskId: task.taskId },
+            expect((result as Record<string, unknown>)._meta).toMatchObject({
+                [RELATED_TASK_META_KEY]: { taskId: task.taskId },
+            });
         });
-
-        await server.close();
     });
 
     it('merges _meta.related-task with existing _meta keys', async () => {
-        const { ActorsMcpServer } = await import('../../src/mcp/server.js');
-        const taskStore = new InMemoryTaskStore();
-        const server = new ActorsMcpServer({ taskStore, setupSigintHandler: false, telemetry: { enabled: false } });
+        await withServer(async (server) => {
+            const task = await server.taskStore.createTask({ ttl: 60_000 }, 'req-2', fakeRequest as never);
+            const existingMeta = { 'com.apify/ActorRun': { runId: 'run-abc' } };
+            await server.taskStore.storeTaskResult(
+                task.taskId,
+                'completed',
+                {
+                    content: [{ type: 'text', text: 'done' }],
+                    _meta: existingMeta,
+                },
+                undefined,
+            );
 
-        const task = await taskStore.createTask({ ttl: 60_000 }, 'req-2', fakeRequest as never);
-        const existingMeta = { 'com.apify/ActorRun': { runId: 'run-abc' } };
-        await taskStore.storeTaskResult(
-            task.taskId,
-            'completed',
-            {
-                content: [{ type: 'text', text: 'done' }],
-                _meta: existingMeta,
-            },
-            undefined,
-        );
+            const handler = getRequestHandler(server, 'tasks/result');
+            const result = (await handler(
+                { method: 'tasks/result', params: { taskId: task.taskId } },
+                { sendNotification: vi.fn() },
+            )) as Record<string, unknown>;
 
-        const handler = getRequestHandler(server, 'tasks/result');
-        const result = (await handler(
-            { method: 'tasks/result', params: { taskId: task.taskId } },
-            { sendNotification: vi.fn() },
-        )) as Record<string, unknown>;
-
-        const meta = result._meta as Record<string, unknown>;
-        expect(meta[RELATED_TASK_META_KEY]).toEqual({ taskId: task.taskId });
-        expect(meta['com.apify/ActorRun']).toEqual({ runId: 'run-abc' });
-
-        await server.close();
+            const meta = result._meta as Record<string, unknown>;
+            expect(meta[RELATED_TASK_META_KEY]).toEqual({ taskId: task.taskId });
+            expect(meta['com.apify/ActorRun']).toEqual({ runId: 'run-abc' });
+        });
     });
 });

--- a/tests/unit/mcp.task_notifications.test.ts
+++ b/tests/unit/mcp.task_notifications.test.ts
@@ -4,6 +4,7 @@ import { RELATED_TASK_META_KEY } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
 
 import { emitTaskStatusNotification } from '../../src/mcp/server.js';
+import { getRequestHandler } from './helpers/mcp_server.js';
 
 // Helper to create a minimal TaskStore mock
 function makeTaskStore(task: Record<string, unknown> | undefined) {
@@ -109,18 +110,6 @@ describe('emitTaskStatusNotification', () => {
 });
 
 describe('tasks/result _meta.related-task injection', () => {
-    type HandlerFn = (req: Record<string, unknown>, extra: Record<string, unknown>) => Promise<Record<string, unknown>>;
-
-    // Helper to dispatch a handler by method name via the SDK's internal handler map
-    function getHandler(server: unknown, method: string) {
-        // eslint-disable-next-line no-underscore-dangle
-        const handler = (
-            server as { server: { _requestHandlers: Map<string, HandlerFn> } }
-        ).server._requestHandlers.get(method);
-        if (!handler) throw new Error(`Handler "${method}" not registered`);
-        return handler;
-    }
-
     // Minimal fake CallToolRequest required by InMemoryTaskStore.createTask
     const fakeRequest = { method: 'tools/call', params: { name: 'test-tool', arguments: {} } };
 
@@ -137,7 +126,7 @@ describe('tasks/result _meta.related-task injection', () => {
             undefined,
         );
 
-        const handler = getHandler(server as never, 'tasks/result');
+        const handler = getRequestHandler(server, 'tasks/result');
         const result = await handler(
             { method: 'tasks/result', params: { taskId: task.taskId } },
             { sendNotification: vi.fn() },
@@ -167,7 +156,7 @@ describe('tasks/result _meta.related-task injection', () => {
             undefined,
         );
 
-        const handler = getHandler(server as never, 'tasks/result');
+        const handler = getRequestHandler(server, 'tasks/result');
         const result = (await handler(
             { method: 'tasks/result', params: { taskId: task.taskId } },
             { sendNotification: vi.fn() },


### PR DESCRIPTION
## What we're solving

Umbrella #658 will merge the two near-duplicate tool-call paths in `src/mcp/server.ts` (sync `CallToolRequestSchema` handler and `executeToolAndUpdateTask`). Five handler-level contracts had no tests, so the refactor could silently change them. The riskiest is telemetry property shapes: nothing in CI guards them — the internal repo consumes none of them in code, only analytics dashboards do. Closes #1061 (step 1 of #658).

## How

New `tests/unit/mcp.server.tool_call_contracts.test.ts`, table-driven per failure class (402 / permission-approval / generic execution error), driving the real handler with synthetic tools that throw the class fixture:

- Task terminal-status mapping: 402 and permission-approval stored `completed`; generic stored `failed` + `internalToolStatus`. Stored payloads are exact-object pins (deep-equal), so no key can appear or vanish unnoticed.
- Telemetry property shapes per class on **both** paths (`vi.spyOn` on `trackToolCall`; telemetry enabled with no token + `allowUnauthMode`, so no network). Assertions pin the **exact Segment key set** per class (14 base keys + per-class `failure_http_status` / `failure_detail`), not a subset — a key added, dropped, or renamed fails the suite by name.
- Sync 402 / permission-approval result shapes (no telemetry keys leak onto the wire). The 402 fixture carries a real x402 payload via the interceptor's `Symbol.for('paymentRequiredData')`, so the full `buildPaymentRequiredResponse` build (content JSON + `structuredContent`) is pinned; a message-only variant keeps the no-payment-data fallback covered.
- Validation → protocol-error contract: both `failInvalidParams` instances pinned — the taskSupport pre-dispatch gate (task-augmented call to a tool without `taskSupport` → `InvalidParams`, tool never invoked) and AJV schema failures (→ `InvalidParams`, never an `isError` result — the deliberate divergence from SDK 1.29 defaults).
- ACTOR_MCP-in-task-mode gap: the task path has no ACTOR_MCP branch and stores `{}` as `completed` — pinned as current behavior with a comment to flip when #1063 closes it.

Also lifts the harness the existing `mcp.server.*` suites copy-pasted into `tests/unit/helpers/mcp_server.ts` and migrates `mcp.server.error_handling`, `mcp.server.progress_wiring`, `mcp.task_notifications` onto it — assertion text unchanged, plumbing only. One deliberate deviation: the migrated `mcp.task_notifications` suite now constructs the server with the harness default `token: 'fake-token'` where it was previously tokenless — verified inert (the task handlers never read the token). `mcp.server.capability_gating` keeps its own harness (its lifecycle differs) but reuses the shared `getRequestHandler` reach.

Rebased onto master after #1056 (ToolResponse branding): the shared `makeRecorderTool` returns `respondRaw({...})`, absorbing the branding fix #1056 made to the old in-file copy this PR deletes.

## Alternatives considered

- Copy the harness locally instead of extracting — rejected in review; extraction stops the duplication spreading further.
- `vi.mock` of the telemetry module — the lighter namespace spy intercepts fine, so the full mock wasn't needed.
- Skipping the ACTOR_MCP gap until #1063 — pinning it now documents the gap and forces a conscious flip.

## Run evidence

- `type-check`, `lint`, `test:unit` (980 passed / 2 skipped on master 2b33c07), `format`, `check:agents` all green.
- Red-checks: flipped pinned expectations (task terminal status; task-path `failure_http_status`) → tests failed → restored. Second pass: dropped a base telemetry key → 6 tests failed; dropped `structuredContent` from the pinned stored 402 payload → test failed → restored.
- Review: staff-review PASS after one fix round; final reviewers code-review PASS and thermonuclear (all findings fixed). A second adversarial review pass hardened the pins: exact telemetry key sets, exact stored payloads, real x402 fixture data, the AJV `InvalidParams` pin, a `task_id` leak check, and a duplicate-fire flush before the single-call telemetry assertion.

## Notes for `apify-mcp-server-internal`

No internal change needed: internal consumes none of the tool-call telemetry shapes in code (verified) — this suite is the only guard for them. Result shapes / `_meta` are pinned, not changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUZNJQKNCn7ntZCbYsFer5