### PR TITLE
refactor: Split widget flag into base + widget response builders

### DIFF
--- a/src/resources/widgets.ts
+++ b/src/resources/widgets.ts
@@ -182,3 +182,14 @@ export async function resolveAvailableWidgets(baseDir: string): Promise<Map<stri
 export function getWidgetConfig(uri: string): WidgetConfig | undefined {
     return WIDGET_REGISTRY[uri];
 }
+
+/**
+ * Actor-run widget `_meta`, with a per-run `openai/widgetDescription` merged in.
+ * Shared by `buildStartRunWidgetResponse` and `buildGetActorRunWidgetResponse`.
+ */
+export function buildActorRunWidgetMeta(descriptionName: string): NonNullable<Resource['_meta']> {
+    return {
+        ...(getWidgetConfig(WIDGET_URIS.ACTOR_RUN)?.meta ?? {}),
+        'openai/widgetDescription': `Actor run progress for ${descriptionName}`,
+    };
+}

--- a/src/tools/actors/actor_executor.ts
+++ b/src/tools/actors/actor_executor.ts
@@ -88,7 +88,6 @@ export const actorExecutor: ActorExecutor = {
 
         return buildGetActorRunSuccessResponse({
             ...fetchResult.result,
-            widget: false,
             linkContext: await getConsoleLinkContext(apifyClient.token, apifyClient),
         }) as ActorExecutionResult;
     },

--- a/src/tools/actors/actor_executor.ts
+++ b/src/tools/actors/actor_executor.ts
@@ -3,7 +3,7 @@ import log from '@apify/log';
 import type { ActorExecutionParams, ActorExecutionResult, ActorExecutor } from '../../types.js';
 import { getConsoleLinkContext } from '../../utils/console_link.js';
 import { redactSkyfirePayId } from '../../utils/logging.js';
-import { buildGetActorRunSuccessResponse } from '../runs/get_actor_run.js';
+import { buildGetActorRunResponse } from '../runs/get_actor_run.js';
 import { abortRunOnSignal, CALL_ACTOR_WAIT_SECS_DEFAULT, fetchActorRunData } from './actor_run_response.js';
 
 /**
@@ -86,7 +86,7 @@ export const actorExecutor: ActorExecutor = {
             dataset.itemsSchema = { type: 'object', properties: params.datasetItemsSchema };
         }
 
-        return buildGetActorRunSuccessResponse({
+        return buildGetActorRunResponse({
             ...fetchResult.result,
             linkContext: await getConsoleLinkContext(apifyClient.token, apifyClient),
         }) as ActorExecutionResult;

--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -4,7 +4,7 @@ import log from '@apify/log';
 
 import type { ApifyClient } from '../../apify_client.js';
 import { DATASET_SIZE_HINT_BYTES, HELPER_TOOLS, NARROW_OUTPUT_HINT } from '../../const.js';
-import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
+import { buildActorRunWidgetMeta } from '../../resources/widgets.js';
 import type { ConsoleLinkContext } from '../../types.js';
 import {
     buildConsoleDatasetUrl,
@@ -703,13 +703,10 @@ async function waitForRunWithProgress(opts: {
 
 /**
  * Shared construction for the immediate start response, used by both the base and widget
- * builders below. Returns `base` (structuredContent minus `nextStep`), the computed `summary`,
- * and `computedNextStep` (the non-widget nextStep) — each builder picks its own `nextStep`/meta.
+ * builders below. Returns the full `RunResponse` with the computed (non-widget) `nextStep`;
+ * `buildStartRunWidgetResponse` overrides `nextStep` on its own copy.
  */
-function buildStartRunSharedContent(
-    actorName: string,
-    actorRun: ActorRun,
-): { base: Omit<RunResponse, 'nextStep'>; summary: string; computedNextStep: string } {
+function buildStartRunSharedContent(actorName: string, actorRun: ActorRun): RunResponse {
     // Start path returns before any metadata fetch, so every entry — default and aliases — is id-only.
     const datasetIds = buildStorageAliasIds(actorRun.storageIds?.datasets, actorRun.defaultDatasetId ?? undefined);
     const kvIds = buildStorageAliasIds(
@@ -723,13 +720,13 @@ function buildStartRunSharedContent(
         Object.fromEntries(Object.entries(kvIds).map(([alias, id]) => [alias, { id }])),
     );
 
-    const { summary, nextStep: computedNextStep } = buildStatusSummaryNextStep({
+    const { summary, nextStep } = buildStatusSummaryNextStep({
         run: actorRun,
         dataset: datasets?.default,
         keyValueStore: keyValueStores?.default,
     });
 
-    const base: Omit<RunResponse, 'nextStep'> = {
+    return {
         runId: actorRun.id,
         actorId: actorRun.actId,
         actorName,
@@ -740,9 +737,8 @@ function buildStartRunSharedContent(
             ...(keyValueStores && { keyValueStores }),
         },
         summary,
+        nextStep,
     };
-
-    return { base, summary, computedNextStep };
 }
 
 /**
@@ -757,16 +753,16 @@ export function buildStartRunResponse(params: {
 }): ToolResponse {
     const { actorName, actorRun, linkContext } = params;
 
-    const { base, summary, computedNextStep } = buildStartRunSharedContent(actorName, actorRun);
-    const nextStep = computedNextStep;
-
-    const structuredContent: RunResponse = { ...base, nextStep };
+    const structuredContent = buildStartRunSharedContent(actorName, actorRun);
     const consoleLinks = applyConsoleLinks(structuredContent, linkContext);
 
-    return respondOk([JSON.stringify(structuredContent), `${summary}\n${nextStep}${consoleLinks}`], {
-        structuredContent,
-        meta: undefined,
-    });
+    return respondOk(
+        [
+            JSON.stringify(structuredContent),
+            `${structuredContent.summary}\n${structuredContent.nextStep}${consoleLinks}`,
+        ],
+        { structuredContent },
+    );
 }
 
 /**
@@ -777,20 +773,16 @@ export function buildStartRunResponse(params: {
 export function buildStartRunWidgetResponse(params: { actorName: string; actorRun: ActorRun }): ToolResponse {
     const { actorName, actorRun } = params;
 
-    const { base, summary } = buildStartRunSharedContent(actorName, actorRun);
-    const nextStep = WIDGET_NO_POLL_NEXT_STEP;
+    const base = buildStartRunSharedContent(actorName, actorRun);
+    const structuredContent = { ...base, nextStep: WIDGET_NO_POLL_NEXT_STEP };
 
-    const structuredContent: RunResponse = { ...base, nextStep };
-
-    const widgetMeta = {
-        ...(getWidgetConfig(WIDGET_URIS.ACTOR_RUN)?.meta ?? {}),
-        'openai/widgetDescription': `Actor run progress for ${actorName}`,
-    };
-
-    return respondOk([JSON.stringify(structuredContent), `${summary}\n${nextStep}`], {
-        structuredContent,
-        meta: widgetMeta,
-    });
+    return respondOk(
+        [JSON.stringify(structuredContent), `${structuredContent.summary}\n${structuredContent.nextStep}`],
+        {
+            structuredContent,
+            meta: buildActorRunWidgetMeta(actorName),
+        },
+    );
 }
 
 // -----------------------------------------------------------------------------

--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -774,25 +774,20 @@ export function buildStartRunResponse(params: {
  * nextStep is replaced with a no-poll message and widget _meta is included so the UI renders
  * automatically. Used only by `*-widget` tools.
  */
-export function buildStartRunWidgetResponse(params: {
-    actorName: string;
-    actorRun: ActorRun;
-    linkContext?: ConsoleLinkContext;
-}): ToolResponse {
-    const { actorName, actorRun, linkContext } = params;
+export function buildStartRunWidgetResponse(params: { actorName: string; actorRun: ActorRun }): ToolResponse {
+    const { actorName, actorRun } = params;
 
     const { base, summary } = buildStartRunSharedContent(actorName, actorRun);
     const nextStep = WIDGET_NO_POLL_NEXT_STEP;
 
     const structuredContent: RunResponse = { ...base, nextStep };
-    const consoleLinks = applyConsoleLinks(structuredContent, linkContext);
 
     const widgetMeta = {
         ...(getWidgetConfig(WIDGET_URIS.ACTOR_RUN)?.meta ?? {}),
         'openai/widgetDescription': `Actor run progress for ${actorName}`,
     };
 
-    return respondOk([JSON.stringify(structuredContent), `${summary}\n${nextStep}${consoleLinks}`], {
+    return respondOk([JSON.stringify(structuredContent), `${summary}\n${nextStep}`], {
         structuredContent,
         meta: widgetMeta,
     });

--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -702,24 +702,14 @@ async function waitForRunWithProgress(opts: {
 // -----------------------------------------------------------------------------
 
 /**
- * Build a RunResponse from an already-started ActorRun without waiting.
- * Used when waitSecs=0 (default and apps modes) and by widget variants that return immediately.
- * Storage metadata contains IDs only; pollers/widgets fetch updates via get-actor-run.
- *
- * Pass `widget: true` for widget-rendered responses: nextStep is replaced with a no-poll
- * message and widget _meta is included so the UI renders automatically.
- *
- * Invariant: `widget: true` is only valid from `*-widget` tools. Non-widget tools (call-actor,
- * direct actor tools) must omit it or pass `false`.
+ * Shared construction for the immediate start response, used by both the base and widget
+ * builders below. Returns `base` (structuredContent minus `nextStep`), the computed `summary`,
+ * and `computedNextStep` (the non-widget nextStep) — each builder picks its own `nextStep`/meta.
  */
-export function buildStartRunResponse(params: {
-    actorName: string;
-    actorRun: ActorRun;
-    widget?: boolean;
-    linkContext?: ConsoleLinkContext;
-}): ToolResponse {
-    const { actorName, actorRun, widget, linkContext } = params;
-
+function buildStartRunSharedContent(
+    actorName: string,
+    actorRun: ActorRun,
+): { base: Omit<RunResponse, 'nextStep'>; summary: string; computedNextStep: string } {
     // Start path returns before any metadata fetch, so every entry — default and aliases — is id-only.
     const datasetIds = buildStorageAliasIds(actorRun.storageIds?.datasets, actorRun.defaultDatasetId ?? undefined);
     const kvIds = buildStorageAliasIds(
@@ -739,9 +729,7 @@ export function buildStartRunResponse(params: {
         keyValueStore: keyValueStores?.default,
     });
 
-    const nextStep = widget ? WIDGET_NO_POLL_NEXT_STEP : computedNextStep;
-
-    const structuredContent: RunResponse = {
+    const base: Omit<RunResponse, 'nextStep'> = {
         runId: actorRun.id,
         actorId: actorRun.actId,
         actorName,
@@ -752,16 +740,57 @@ export function buildStartRunResponse(params: {
             ...(keyValueStores && { keyValueStores }),
         },
         summary,
-        nextStep,
     };
+
+    return { base, summary, computedNextStep };
+}
+
+/**
+ * Build a RunResponse from an already-started ActorRun without waiting.
+ * Used when waitSecs=0 (default and apps modes).
+ * Storage metadata contains IDs only; pollers fetch updates via get-actor-run.
+ */
+export function buildStartRunResponse(params: {
+    actorName: string;
+    actorRun: ActorRun;
+    linkContext?: ConsoleLinkContext;
+}): ToolResponse {
+    const { actorName, actorRun, linkContext } = params;
+
+    const { base, summary, computedNextStep } = buildStartRunSharedContent(actorName, actorRun);
+    const nextStep = computedNextStep;
+
+    const structuredContent: RunResponse = { ...base, nextStep };
     const consoleLinks = applyConsoleLinks(structuredContent, linkContext);
 
-    const widgetMeta = widget
-        ? {
-              ...(getWidgetConfig(WIDGET_URIS.ACTOR_RUN)?.meta ?? {}),
-              'openai/widgetDescription': `Actor run progress for ${actorName}`,
-          }
-        : undefined;
+    return respondOk([JSON.stringify(structuredContent), `${summary}\n${nextStep}${consoleLinks}`], {
+        structuredContent,
+        meta: undefined,
+    });
+}
+
+/**
+ * Build a RunResponse from an already-started ActorRun for widget-rendered responses:
+ * nextStep is replaced with a no-poll message and widget _meta is included so the UI renders
+ * automatically. Used only by `*-widget` tools.
+ */
+export function buildStartRunWidgetResponse(params: {
+    actorName: string;
+    actorRun: ActorRun;
+    linkContext?: ConsoleLinkContext;
+}): ToolResponse {
+    const { actorName, actorRun, linkContext } = params;
+
+    const { base, summary } = buildStartRunSharedContent(actorName, actorRun);
+    const nextStep = WIDGET_NO_POLL_NEXT_STEP;
+
+    const structuredContent: RunResponse = { ...base, nextStep };
+    const consoleLinks = applyConsoleLinks(structuredContent, linkContext);
+
+    const widgetMeta = {
+        ...(getWidgetConfig(WIDGET_URIS.ACTOR_RUN)?.meta ?? {}),
+        'openai/widgetDescription': `Actor run progress for ${actorName}`,
+    };
 
     return respondOk([JSON.stringify(structuredContent), `${summary}\n${nextStep}${consoleLinks}`], {
         structuredContent,

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -34,7 +34,7 @@ import { respondErrorNoTelemetry, respondServerError, respondUserError, type Too
 import { classifyFailureCategory, extractAjvErrorDetails } from '../../utils/tool_status.js';
 import { extractActorId } from '../../utils/tools.js';
 import { actorNameToToolName, isActorBlockedUnderPaymentProvider } from '../actor_tool_naming.js';
-import { buildGetActorRunSuccessResponse } from '../runs/get_actor_run.js';
+import { buildGetActorRunResponse } from '../runs/get_actor_run.js';
 import { actorRunOutputSchema } from '../structured_output_schemas.js';
 import {
     abortRunOnSignal,
@@ -612,7 +612,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<obje
         if ('error' in fetchResult) return fetchResult.error;
 
         return {
-            ...buildGetActorRunSuccessResponse({ ...fetchResult.result, linkContext }),
+            ...buildGetActorRunResponse({ ...fetchResult.result, linkContext }),
             toolTelemetry: { actorId: resolvedActorId },
         };
     } catch (error) {

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -612,7 +612,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<obje
         if ('error' in fetchResult) return fetchResult.error;
 
         return {
-            ...buildGetActorRunSuccessResponse({ ...fetchResult.result, widget: false, linkContext }),
+            ...buildGetActorRunSuccessResponse({ ...fetchResult.result, linkContext }),
             toolTelemetry: { actorId: resolvedActorId },
         };
     } catch (error) {

--- a/src/tools/runs/get_actor_run.ts
+++ b/src/tools/runs/get_actor_run.ts
@@ -2,7 +2,7 @@ import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
-import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
+import { buildActorRunWidgetMeta } from '../../resources/widgets.js';
 import type { ConsoleLinkContext, HelperTool, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema, fixZodSchemaRequired } from '../../utils/ajv.js';
@@ -88,7 +88,7 @@ export function buildGetActorRunError(runId: string, error: unknown): ToolRespon
  * Build the success response. `content[0]` is the JSON-stringified `structuredContent`
  * mirror (per MCP spec); `content[1]` carries an LLM-readable narrative of `summary` + `nextStep`.
  */
-export function buildGetActorRunSuccessResponse(
+export function buildGetActorRunResponse(
     params: FetchActorRunResult & { linkContext?: ConsoleLinkContext },
 ): ToolResponse {
     const { run, structuredContent, linkContext } = params;
@@ -121,9 +121,8 @@ export function buildGetActorRunWidgetResponse(params: FetchActorRunResult): Too
         {
             structuredContent: widgetContent,
             meta: {
-                ...(getWidgetConfig(WIDGET_URIS.ACTOR_RUN)?.meta ?? {}),
+                ...buildActorRunWidgetMeta(structuredContent.actorName ?? structuredContent.runId),
                 ...(buildUsageMeta(run) ?? {}),
-                'openai/widgetDescription': `Actor run progress for ${structuredContent.actorName ?? structuredContent.runId}`,
             },
         },
     );
@@ -153,7 +152,7 @@ export const getActorRun: ToolEntry = Object.freeze({
             if ('aborted' in fetchResult) return {};
             if ('error' in fetchResult) return fetchResult.error;
 
-            return buildGetActorRunSuccessResponse({
+            return buildGetActorRunResponse({
                 ...fetchResult.result,
                 linkContext: await getConsoleLinkContext(apifyToken, client),
             });

--- a/src/tools/runs/get_actor_run.ts
+++ b/src/tools/runs/get_actor_run.ts
@@ -86,25 +86,30 @@ export function buildGetActorRunError(runId: string, error: unknown): ToolRespon
 
 /**
  * Build the success response. `content[0]` is the JSON-stringified `structuredContent`
- * mirror (per MCP spec); `content[1]` carries an LLM-readable narrative — `summary` +
- * `nextStep` in default mode, a short pointer in widget mode.
+ * mirror (per MCP spec); `content[1]` carries an LLM-readable narrative of `summary` + `nextStep`.
  */
 export function buildGetActorRunSuccessResponse(
-    params: FetchActorRunResult & { widget: boolean; linkContext?: ConsoleLinkContext },
+    params: FetchActorRunResult & { linkContext?: ConsoleLinkContext },
 ): ToolResponse {
-    const { run, structuredContent, widget, linkContext } = params;
+    const { run, structuredContent, linkContext } = params;
 
-    if (!widget) {
-        // Mints the `apifyConsoleUrl` fields onto structuredContent and returns the narrative suffix in one pass.
-        const consoleLinks = applyConsoleLinks(structuredContent, linkContext);
-        return respondOk(
-            [
-                JSON.stringify(structuredContent),
-                `${structuredContent.summary}\n${structuredContent.nextStep}${consoleLinks}`,
-            ],
-            { structuredContent, meta: buildUsageMeta(run) },
-        );
-    }
+    // Mints the `apifyConsoleUrl` fields onto structuredContent and returns the narrative suffix in one pass.
+    const consoleLinks = applyConsoleLinks(structuredContent, linkContext);
+    return respondOk(
+        [
+            JSON.stringify(structuredContent),
+            `${structuredContent.summary}\n${structuredContent.nextStep}${consoleLinks}`,
+        ],
+        { structuredContent, meta: buildUsageMeta(run) },
+    );
+}
+
+/**
+ * Build the widget success response. `content[1]` carries a short pointer instead of the
+ * summary/nextStep narrative. Used only by `*-widget` tools; does not apply console links.
+ */
+export function buildGetActorRunWidgetResponse(params: FetchActorRunResult): ToolResponse {
+    const { run, structuredContent } = params;
 
     // Override nextStep so the model reading structuredContent (content[0]) also sees no-poll guidance.
     const widgetContent = { ...structuredContent, nextStep: WIDGET_NO_POLL_NEXT_STEP };
@@ -150,7 +155,6 @@ export const getActorRun: ToolEntry = Object.freeze({
 
             return buildGetActorRunSuccessResponse({
                 ...fetchResult.result,
-                widget: false,
                 linkContext: await getConsoleLinkContext(apifyToken, client),
             });
         } catch (error) {

--- a/src/tools/widgets/call_actor_widget.ts
+++ b/src/tools/widgets/call_actor_widget.ts
@@ -10,7 +10,7 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { respondServerError } from '../../utils/mcp.js';
 import { extractActorId } from '../../utils/tools.js';
-import { buildStartRunResponse } from '../actors/actor_run_response.js';
+import { buildStartRunWidgetResponse } from '../actors/actor_run_response.js';
 import {
     buildCallActorErrorResponse,
     callActorPreExecute,
@@ -120,7 +120,7 @@ export const callActorWidget: ToolEntry = Object.freeze({
                 runId: actorRun.id,
                 mcpSessionId: toolArgs.mcpSessionId,
             });
-            const response = buildStartRunResponse({ actorName: baseActorName, actorRun, widget: true });
+            const response = buildStartRunWidgetResponse({ actorName: baseActorName, actorRun });
             return {
                 ...response,
                 toolTelemetry: { actorId: resolvedActorId },

--- a/src/tools/widgets/get_actor_run_widget.ts
+++ b/src/tools/widgets/get_actor_run_widget.ts
@@ -8,7 +8,7 @@ import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { fetchActorRunData } from '../actors/actor_run_response.js';
-import { buildGetActorRunError, buildGetActorRunSuccessResponse } from '../runs/get_actor_run.js';
+import { buildGetActorRunError, buildGetActorRunWidgetResponse } from '../runs/get_actor_run.js';
 import { actorRunOutputSchema } from '../structured_output_schemas.js';
 
 /**
@@ -71,7 +71,7 @@ export const getActorRunWidget: ToolEntry = Object.freeze({
             if ('aborted' in fetchResult) return {};
             if ('error' in fetchResult) return fetchResult.error;
 
-            return buildGetActorRunSuccessResponse({ ...fetchResult.result, widget: true });
+            return buildGetActorRunWidgetResponse({ ...fetchResult.result });
         } catch (error) {
             logHttpError(error, 'Failed to get Actor run (widget)', { runId: parsed.runId });
             return buildGetActorRunError(parsed.runId, error);

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
     buildStartRunResponse,
+    buildStartRunWidgetResponse,
     buildStatusSummaryNextStep,
     collapseArrayIndices,
     type RunDataset,
@@ -731,11 +732,10 @@ describe('buildStartRunResponse()', () => {
         expect(content[1].text).toContain(VERBATIM_LINKS_NUDGE);
     });
 
-    it('includes widget metadata and no-poll nextStep when widget=true', () => {
-        const result = buildStartRunResponse({
+    it('buildStartRunWidgetResponse includes widget metadata and a no-poll nextStep', () => {
+        const result = buildStartRunWidgetResponse({
             actorName: 'apify/rag-web-browser',
             actorRun,
-            widget: true,
         });
 
         const { structuredContent, _meta } = result as {

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -648,16 +648,18 @@ describe('get-actor-run default response', () => {
 // buildStartRunResponse — the "fire and forget" (waitSecs=0) response builder
 // -----------------------------------------------------------------------------
 
-describe('buildStartRunResponse()', () => {
-    const actorRun = {
-        id: 'run-abc',
-        actId: 'actor-xyz',
-        status: 'RUNNING',
-        startedAt: new Date('2026-01-02T03:04:05.000Z'),
-        defaultDatasetId: 'dataset-abc',
-        defaultKeyValueStoreId: 'kv-abc',
-    } as unknown as ActorRun;
+// Shared by buildStartRunResponse() and buildStartRunWidgetResponse() below — both builders
+// consume the same ActorRun shape.
+const actorRun = {
+    id: 'run-abc',
+    actId: 'actor-xyz',
+    status: 'RUNNING',
+    startedAt: new Date('2026-01-02T03:04:05.000Z'),
+    defaultDatasetId: 'dataset-abc',
+    defaultKeyValueStoreId: 'kv-abc',
+} as unknown as ActorRun;
 
+describe('buildStartRunResponse()', () => {
     it('builds correct RunResponse shape without widget metadata', () => {
         const result = buildStartRunResponse({ actorName: 'apify/rag-web-browser', actorRun });
 
@@ -731,8 +733,10 @@ describe('buildStartRunResponse()', () => {
         expect(content[1].text).toContain('Apify Console: run https://console.apify.com/actors/runs/run-abc');
         expect(content[1].text).toContain(VERBATIM_LINKS_NUDGE);
     });
+});
 
-    it('buildStartRunWidgetResponse includes widget metadata and a no-poll nextStep', () => {
+describe('buildStartRunWidgetResponse()', () => {
+    it('includes widget metadata and a no-poll nextStep', () => {
         const result = buildStartRunWidgetResponse({
             actorName: 'apify/rag-web-browser',
             actorRun,

--- a/tests/unit/tools.get_actor_run.widget.response.test.ts
+++ b/tests/unit/tools.get_actor_run.widget.response.test.ts
@@ -18,6 +18,8 @@ const MOCK_RUN_RUNNING = {
     status: 'RUNNING',
     startedAt: new Date('2026-04-20T12:00:00.000Z'),
     stats: { runTimeSecs: 5, computeUnits: 0.01, memMaxBytes: 1024 },
+    usageTotalUsd: 0.0002,
+    usageUsd: { ACTOR_COMPUTE_UNITS: 0.0002 },
 };
 
 const MOCK_ACTOR = {
@@ -48,6 +50,7 @@ describe('get-actor-run-widget response', () => {
             _meta?: {
                 ui?: { resourceUri?: string; visibility?: readonly string[]; csp?: unknown };
                 'openai/widgetDescription'?: string;
+                'com.apify/ActorRun'?: { usageTotalUsd?: number; usageUsd?: unknown };
             };
         };
 
@@ -71,6 +74,11 @@ describe('get-actor-run-widget response', () => {
         expect(_meta?.ui?.visibility).toEqual(['model', 'app']);
         expect(_meta?.ui?.csp).toBeDefined();
         expect(_meta?.['openai/widgetDescription']).toContain('apify/rag-web-browser');
+        // Widget _meta also carries run usage metadata (buildUsageMeta), alongside widget-specific meta.
+        expect(_meta?.['com.apify/ActorRun']).toEqual({
+            usageTotalUsd: 0.0002,
+            usageUsd: { ACTOR_COMPUTE_UNITS: 0.0002 },
+        });
     });
 
     it('carries widget _meta on the tool definition', () => {


### PR DESCRIPTION
Part of #1066 (checkbox: split the `widget` boolean param).

`buildStartRunResponse` and `buildGetActorRunSuccessResponse` each took a `widget` boolean and branched internally. Every caller passed a literal — widget tools `true`, everything else `false`/omitted — so the "widget only from `*-widget` tools" rule was enforced by a comment, not the type system.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pXZvhEoE6Lz3DpBSL3n1Y

---
_Generated by [Claude Code](https://claude.ai/code/session_016pXZvhEoE6Lz3DpBSL3n1Y)_