### PR TITLE
refactor: Dedup the tool-loading mode-resolution gate

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -443,6 +443,29 @@ export class ActorsMcpServer {
     }
 
     /**
+     * Buffer-or-compose gate shared by the actor-tools loaders: if the server mode isn't
+     * resolved yet, queue `actorTools` for `updateToolsAfterServerModeResolved` and
+     * (if non-empty) upsert them immediately with the given `shouldNotify`; otherwise
+     * compose the mode-specific set via `getToolsForServerMode` and upsert that with
+     * `shouldNotify`.
+     *
+     * Callers pass different `shouldNotify` values: `loadToolsByName` forwards
+     * `actorTools.length > 0` (notify only when actor tools were fetched), while
+     * `loadToolsFromUrl` and `loadToolsFromInput` pass `false` and defer to the
+     * post-initialize reconcile. See `updateToolsAfterServerModeResolved` for the full
+     * rationale.
+     */
+    private registerFetchedActorTools(input: Input, actorTools: ToolEntry[], shouldNotify: boolean): void {
+        if (!this.serverModeResolved) {
+            this.pendingToolsAfterModeResolved.push({ input, actorTools });
+            if (actorTools.length > 0) this.upsertTools(actorTools, shouldNotify);
+            return;
+        }
+        const tools = getToolsForServerMode(input, actorTools, this.serverMode);
+        if (tools.length > 0) this.upsertTools(tools, shouldNotify);
+    }
+
+    /**
      * Loads missing toolNames from a provided list of tool names.
      * Skips toolNames that are already loaded and loads only the missing ones.
      * @param toolNames - Array of tool names to ensure are loaded
@@ -459,16 +482,7 @@ export class ActorsMcpServer {
             paymentProvider: this.options.paymentProvider,
         });
 
-        if (!this.serverModeResolved) {
-            this.pendingToolsAfterModeResolved.push({ input: restoreInput, actorTools });
-            if (actorTools.length > 0) this.upsertTools(actorTools, true);
-            return;
-        }
-
-        const toolsToLoad = getToolsForServerMode(restoreInput, actorTools, this.serverMode);
-        if (toolsToLoad.length > 0) {
-            this.upsertTools(toolsToLoad, actorTools.length > 0);
-        }
+        this.registerFetchedActorTools(restoreInput, actorTools, actorTools.length > 0);
     }
 
     /**
@@ -496,20 +510,8 @@ export class ActorsMcpServer {
             paymentProvider: this.options.paymentProvider,
         });
 
-        if (!this.serverModeResolved) {
-            this.pendingToolsAfterModeResolved.push({ input, actorTools });
-            if (actorTools.length > 0) {
-                log.debug('Loading actor tools from query parameters before mode resolution');
-                this.upsertTools(actorTools, false);
-            }
-            return;
-        }
-
-        const tools = getToolsForServerMode(input, actorTools, this.serverMode);
-        if (tools.length > 0) {
-            log.debug('Loading tools from query parameters');
-            this.upsertTools(tools, false);
-        }
+        log.debug('Loading tools from query parameters');
+        this.registerFetchedActorTools(input, actorTools, false);
     }
 
     /**
@@ -526,13 +528,7 @@ export class ActorsMcpServer {
             actorStore: this.actorStore,
             paymentProvider: this.options.paymentProvider,
         });
-        if (!this.serverModeResolved) {
-            this.pendingToolsAfterModeResolved.push({ input, actorTools });
-            if (actorTools.length > 0) this.upsertTools(actorTools);
-            return;
-        }
-        const tools = getToolsForServerMode(input, actorTools, this.serverMode);
-        if (tools.length > 0) this.upsertTools(tools);
+        this.registerFetchedActorTools(input, actorTools, false);
     }
 
     /** Delete tools from the server and notify the handler.

--- a/tests/unit/mcp.server.capability_gating.test.ts
+++ b/tests/unit/mcp.server.capability_gating.test.ts
@@ -9,9 +9,27 @@ import { RESOURCE_MIME_TYPE } from '../../src/resources/widgets.js';
 import { callActorApps } from '../../src/tools/actors/call_actor.js';
 import { searchActors } from '../../src/tools/actors/search_actors.js';
 import { searchActorsWidget } from '../../src/tools/widgets/search_actors_widget.js';
-import type { ServerModeOption } from '../../src/types.js';
-import { SERVER_MODE } from '../../src/types.js';
+import type { ServerModeOption, ToolEntry } from '../../src/types.js';
+import { SERVER_MODE, TOOL_TYPE } from '../../src/types.js';
+import type * as ToolsLoaderModule from '../../src/utils/tools_loader.js';
+import { getActors } from '../../src/utils/tools_loader.js';
 import { getRequestHandler } from './helpers/mcp_server.js';
+
+// Stub getActors so tests can produce a non-empty actorTools array without a network
+// fetch to the Apify platform. getToolsForServerMode / toolNamesToInput stay real.
+vi.mock('../../src/utils/tools_loader.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof ToolsLoaderModule>();
+    return { ...actual, getActors: vi.fn() };
+});
+
+const getActorsMock = vi.mocked(getActors);
+
+const FAKE_ACTOR_FULL_NAME = 'apify/fake-actor';
+const FAKE_ACTOR_TOOL: ToolEntry = {
+    type: TOOL_TYPE.ACTOR,
+    name: 'apify--fake-actor',
+    actorFullName: FAKE_ACTOR_FULL_NAME,
+} as unknown as ToolEntry;
 
 function makeInitializeRequest(supportsUi: boolean): InitializeRequest {
     const extensions = supportsUi ? { 'io.modelcontextprotocol/ui': { mimeTypes: [RESOURCE_MIME_TYPE] } } : {};
@@ -45,12 +63,18 @@ async function dispatchInitialize(server: ActorsMcpServer, request: InitializeRe
 describe('ActorsMcpServer initialize handler', () => {
     const servers: ActorsMcpServer[] = [];
 
+    // Default: no actor tools resolved, matching the real getActors() behavior for
+    // inputs that only reference HELPER_TOOLS names (used by the pre-existing tests below).
+    getActorsMock.mockResolvedValue([]);
+
     afterEach(async () => {
         while (servers.length > 0) {
             const server = servers.pop();
             server?.tools.clear();
             await server?.close();
         }
+        getActorsMock.mockReset();
+        getActorsMock.mockResolvedValue([]);
     });
 
     const track = (server: ActorsMcpServer): ActorsMcpServer => {
@@ -171,4 +195,70 @@ describe('ActorsMcpServer initialize handler', () => {
             expect(server.tools.get(HELPER_TOOLS.STORE_SEARCH_WIDGET)).toBe(searchActorsWidget);
         },
     );
+
+    describe('registerFetchedActorTools notify behavior', () => {
+        it('loadToolsByName notifies eagerly pre-mode-resolution when actor tools are non-empty', async () => {
+            const server = track(makeServer('auto'));
+            const apifyClient = new ApifyClient({ token: 'test-token' });
+            const notifyHandler = vi.fn();
+            server.registerToolsChangedHandler(notifyHandler);
+            getActorsMock.mockResolvedValueOnce([FAKE_ACTOR_TOOL]);
+
+            await server.loadToolsByName(['apify/fake-actor'], apifyClient);
+
+            expect(notifyHandler).toHaveBeenCalledTimes(1);
+        });
+
+        it('loadToolsByName notifies with the composed set when server mode is already resolved', async () => {
+            const server = track(makeServer(SERVER_MODE.DEFAULT));
+            const apifyClient = new ApifyClient({ token: 'test-token' });
+            const notifyHandler = vi.fn();
+            server.registerToolsChangedHandler(notifyHandler);
+            getActorsMock.mockResolvedValueOnce([FAKE_ACTOR_TOOL]);
+
+            await server.loadToolsByName(['apify/fake-actor'], apifyClient);
+
+            expect(notifyHandler).toHaveBeenCalledTimes(1);
+        });
+
+        it('loadToolsFromInput does not notify pre-mode-resolution even when actor tools are non-empty', async () => {
+            const server = track(makeServer('auto'));
+            const apifyClient = new ApifyClient({ token: 'test-token' });
+            const notifyHandler = vi.fn();
+            server.registerToolsChangedHandler(notifyHandler);
+            getActorsMock.mockResolvedValueOnce([FAKE_ACTOR_TOOL]);
+
+            await server.loadToolsFromInput({ actors: ['apify/fake-actor'] }, apifyClient);
+
+            expect(notifyHandler).not.toHaveBeenCalled();
+        });
+
+        it('loadToolsFromUrl does not notify pre-mode-resolution even when actor tools are non-empty', async () => {
+            const server = track(makeServer('auto'));
+            const apifyClient = new ApifyClient({ token: 'test-token' });
+            const notifyHandler = vi.fn();
+            server.registerToolsChangedHandler(notifyHandler);
+            getActorsMock.mockResolvedValueOnce([FAKE_ACTOR_TOOL]);
+
+            await server.loadToolsFromUrl('http://localhost?actors=apify/fake-actor', apifyClient);
+
+            expect(notifyHandler).not.toHaveBeenCalled();
+        });
+
+        it('notifies with the full set once initialize runs the pending-tools reconcile', async () => {
+            const server = track(makeServer('auto'));
+            const apifyClient = new ApifyClient({ token: 'test-token' });
+            getActorsMock.mockResolvedValueOnce([FAKE_ACTOR_TOOL]);
+
+            await server.loadToolsFromInput({ actors: ['apify/fake-actor'] }, apifyClient);
+
+            const notifyHandler = vi.fn();
+            server.registerToolsChangedHandler(notifyHandler);
+
+            await dispatchInitialize(server, makeInitializeRequest(true));
+
+            expect(notifyHandler).toHaveBeenCalledTimes(1);
+            expect(notifyHandler.mock.calls[0][0]).toContain(FAKE_ACTOR_FULL_NAME);
+        });
+    });
 });


### PR DESCRIPTION
Part of #1066 (checkbox: dedup the mode-resolution gate).

`loadToolsByName`, `loadToolsFromUrl`, and `loadToolsFromInput` each repeated the same buffer-or-compose block after `getActors()` — buffer the fetched actor tools when the server mode isn't resolved yet, otherwise compose the mode-specific set and upsert. The three differed only in the `notify` value passed to `upsertTools` (and loadToolsFromUrl's debug logs), and the reason those notify values differ was documented only on `updateToolsAfterServerModeResolved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pXZvhEoE6Lz3DpBSL3n1Y

---
_Generated by [Claude Code](https://claude.ai/code/session_016pXZvhEoE6Lz3DpBSL3n1Y)_