### PR TITLE
fix(mcp): strip server-internal toolTelemetry at the wire boundary

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -100,6 +100,7 @@ import {
     extractAjvErrorDetails,
     extractToolTelemetry,
     getToolStatusFromError,
+    stripToolTelemetry,
 } from '../utils/tool_status.js';
 import {
     buildActorFields,
@@ -836,9 +837,15 @@ export class ActorsMcpServer {
             let resolvedToolName = name;
             // Captured by `captureResult` so the `finally` block can measure response size for telemetry.
             let toolResult: unknown = null;
+            // Single wire boundary: every tool-call response leaves the handler through here, so this
+            // is where the server-internal `toolTelemetry` field is guaranteed to be stripped. The
+            // tool-dispatch paths read it via `extractToolTelemetry()` (which also strips it), but the
+            // framework paths that bypass that helper — notably the outer `catch` — would otherwise
+            // pass it straight to the client, since `CallToolResultSchema` is a passthrough schema.
             const captureResult = <T>(r: T): T => {
-                toolResult = r;
-                return r;
+                const result = stripToolTelemetry(r);
+                toolResult = result;
+                return result;
             };
             const failInvalidParams = async (
                 message: string,
@@ -1311,14 +1318,13 @@ export class ActorsMcpServer {
                     validationMissingProperty: callDiagnostics.validation_missing_property,
                     validationAdditionalProperty: callDiagnostics.validation_additional_property,
                 });
-                // This framework outer-catch path bypasses extractToolTelemetry (returned via
-                // captureResult), so preserve the pre-existing wire shape { toolStatus } exactly:
-                // reuse the local ABORTED-aware toolStatus, do NOT re-derive from the error (which
-                // would drop ABORTED and leak failureCategory/failureHttpStatus onto the wire).
+                // The ABORTED-aware `toolStatus` computed above is already what the `finally` block
+                // reports to telemetry, so it does not need to ride along on the response. Attaching
+                // it here as `toolTelemetry` is what leaked it to the client (#1052): this path
+                // bypasses `extractToolTelemetry()`, the only other place the field is stripped.
                 return captureResult({
                     ...respondOk(getToolCallErrorUserText(name, error)),
                     isError: true,
-                    toolTelemetry: { toolStatus },
                 });
             } finally {
                 if (shouldTrackTelemetry) {

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -148,6 +148,23 @@ export function extractAjvErrorDetails(errors: ErrorObject[] | null | undefined)
 }
 
 /**
+ * Removes the server-internal `toolTelemetry` field from a tool response, in place.
+ *
+ * The MCP SDK's `CallToolResultSchema` is a `z.looseObject`, so every key left on the response is
+ * passed through to the client. `toolTelemetry` carries server-internal outcome data (toolStatus,
+ * failureCategory, …) that must never reach the wire, so it has to be stripped on *every* return
+ * path — not just the ones that read it via `extractToolTelemetry()`.
+ *
+ * @see https://github.com/apify/apify-mcp-server/issues/1052
+ */
+export function stripToolTelemetry<T>(res: T): T {
+    if (res !== null && typeof res === 'object') {
+        delete (res as { toolTelemetry?: unknown }).toolTelemetry;
+    }
+    return res;
+}
+
+/**
  * Reads `toolTelemetry` from a tool response, strips it, and returns toolStatus + callDiagnostics.
  *
  * toolStatus resolution:
@@ -164,7 +181,7 @@ export function extractToolTelemetry(
     actorId: string | undefined,
 ): { toolStatus: ToolStatus; callDiagnostics: CallDiagnostics } {
     const telemetry = res.toolTelemetry as ToolTelemetryContext | undefined;
-    delete res.toolTelemetry;
+    stripToolTelemetry(res);
 
     // Tool-reported actorId (e.g. from call-actor) takes precedence over server-side actorId
     const actorFields = buildActorFields(actorName, telemetry?.actorId ?? actorId);

--- a/tests/unit/mcp.server.error_handling.test.ts
+++ b/tests/unit/mcp.server.error_handling.test.ts
@@ -1,4 +1,6 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import log from '@apify/log';
@@ -45,12 +47,15 @@ describe('ActorsMcpServer onerror', () => {
 
 /**
  * Covers the tool-dispatch outer `catch` in the `CallToolRequestSchema` handler (server.ts).
- * That response is returned via `captureResult` and never passes through `extractToolTelemetry`,
- * so it must preserve the pre-computed, ABORTED-aware `toolStatus` and emit only `{ toolStatus }`
- * in `toolTelemetry` — no `failureCategory`/`failureHttpStatus` (which would leak onto the wire).
+ * That response never passes through `extractToolTelemetry`, so `captureResult` is what strips the
+ * server-internal `toolTelemetry` field from it (#1052) — nothing of it may reach the client.
+ *
+ * The pre-computed, ABORTED-aware `toolStatus` is still reported to telemetry from the handler's
+ * local state, so stripping the field costs no classification accuracy.
  */
 describe('CallToolRequestSchema handler outer catch', () => {
     type HandlerFn = (req: Record<string, unknown>, extra: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    type TelemetryArgs = { toolStatus: string; callDiagnostics: Record<string, unknown> };
 
     // A synthetic internal tool whose call throws a plain (non-McpError) error, so dispatch falls
     // through to the outer catch. An empty input schema validates against `{}`.
@@ -83,38 +88,98 @@ describe('CallToolRequestSchema handler outer catch', () => {
             telemetry: { enabled: false },
             token: 'fake-token',
         });
+        // The handler reports the outcome to telemetry from its own local state, not from the
+        // response — spy on it so we can assert the classification survives the strip.
+        const telemetrySpy = vi.spyOn(
+            server as unknown as { logToolCallAndTelemetry: (args: TelemetryArgs) => void },
+            'logToolCallAndTelemetry',
+        );
         try {
             vi.spyOn(log, 'error').mockImplementation(() => log);
             vi.spyOn(log, 'exception').mockImplementation(() => log);
             server.upsertTools([makeThrowingTool()]);
             const handler = getToolCallHandler(server);
-            return await handler(
+            const result = await handler(
                 {
                     method: 'tools/call',
                     params: { name: 'test-throwing-tool', arguments: {}, _meta: { mcpSessionId: 's1' } },
                 },
                 { signal: { aborted }, sendNotification: vi.fn() },
             );
+            return { result, reportedToolStatus: telemetrySpy.mock.calls[0]?.[0]?.toolStatus };
         } finally {
             await server.close();
         }
     }
 
-    it('preserves ABORTED toolStatus and emits only { toolStatus } when the request was aborted', async () => {
-        const result = await dispatchThrow(true);
+    it('strips toolTelemetry from the response and still reports ABORTED when the request was aborted', async () => {
+        const { result, reportedToolStatus } = await dispatchThrow(true);
 
         expect(result.isError).toBe(true);
         expect(result.content).toEqual([
             { type: 'text', text: getToolCallErrorUserText('test-throwing-tool', new Error('boom')) },
         ]);
-        // Only toolStatus — no failureCategory/failureHttpStatus leaking onto the wire.
-        expect(result.toolTelemetry).toEqual({ toolStatus: TOOL_STATUS.ABORTED });
+        // Server-internal field — must not survive onto the wire.
+        expect(result).not.toHaveProperty('toolTelemetry');
+        // ...but the ABORTED-aware classification still reaches telemetry.
+        expect(reportedToolStatus).toBe(TOOL_STATUS.ABORTED);
     });
 
-    it('emits only { toolStatus } (derived FAILED) when the request was not aborted', async () => {
-        const result = await dispatchThrow(false);
+    it('strips toolTelemetry from the response and still reports FAILED when the request was not aborted', async () => {
+        const { result, reportedToolStatus } = await dispatchThrow(false);
 
         expect(result.isError).toBe(true);
-        expect(result.toolTelemetry).toEqual({ toolStatus: TOOL_STATUS.FAILED });
+        expect(result).not.toHaveProperty('toolTelemetry');
+        expect(reportedToolStatus).toBe(TOOL_STATUS.FAILED);
+    });
+});
+
+/**
+ * Wire-level guard for the outer catch: `CallToolResultSchema` is a `z.looseObject`, so any key left
+ * on the response object is forwarded verbatim to the client. `toolTelemetry` is server-internal and
+ * must never reach the wire on any path — including the paths that bypass `extractToolTelemetry()`.
+ */
+describe('CallToolRequestSchema handler wire shape', () => {
+    function makeThrowingTool(): ToolEntry {
+        return {
+            type: TOOL_TYPE.INTERNAL,
+            name: 'test-throwing-tool',
+            description: 'throws',
+            inputSchema: { type: 'object', properties: {} } as ToolInputSchema,
+            ajvValidate: compileSchema({ type: 'object', properties: {} }),
+            call: async (_toolArgs: InternalToolArgs) => {
+                throw new Error('boom');
+            },
+        };
+    }
+
+    it('does not leak toolTelemetry to the client when an internal tool throws', async () => {
+        const server = new ActorsMcpServer({
+            taskStore: new InMemoryTaskStore(),
+            setupSigintHandler: false,
+            telemetry: { enabled: false },
+            token: 'fake-token',
+        });
+        const client = new Client({ name: 'wire-client', version: '0.0.0' });
+        try {
+            vi.spyOn(log, 'error').mockImplementation(() => log);
+            vi.spyOn(log, 'exception').mockImplementation(() => log);
+            server.upsertTools([makeThrowingTool()]);
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), server.server.connect(serverTransport)]);
+
+            const result = await client.callTool({
+                name: 'test-throwing-tool',
+                arguments: {},
+                _meta: { mcpSessionId: 'wire-1' },
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result).not.toHaveProperty('toolTelemetry');
+        } finally {
+            await client.close();
+            await server.close();
+        }
     });
 });

--- a/tests/unit/utils.tool_status.test.ts
+++ b/tests/unit/utils.tool_status.test.ts
@@ -10,6 +10,7 @@ import {
     extractAjvErrorDetails,
     extractToolTelemetry,
     getToolStatusFromError,
+    stripToolTelemetry,
 } from '../../src/utils/tool_status.js';
 
 describe('getToolStatusFromError', () => {
@@ -209,6 +210,32 @@ describe('extractToolTelemetry', () => {
         const { toolStatus, callDiagnostics } = extractToolTelemetry({ content: 'ok' }, undefined, undefined);
         expect(toolStatus).toBe(TOOL_STATUS.SUCCEEDED);
         expect(callDiagnostics).toEqual({});
+    });
+});
+
+describe('stripToolTelemetry', () => {
+    it('removes the server-internal toolTelemetry field, preserving the rest of the response', () => {
+        const res = {
+            content: [{ type: 'text', text: 'boom' }],
+            isError: true,
+            toolTelemetry: { toolStatus: TOOL_STATUS.FAILED },
+        };
+
+        const stripped = stripToolTelemetry(res);
+
+        expect(stripped).not.toHaveProperty('toolTelemetry');
+        expect(stripped).toEqual({ content: [{ type: 'text', text: 'boom' }], isError: true });
+        // Strips in place, so the captured response and the returned one are the same object.
+        expect(stripped).toBe(res);
+    });
+
+    it('leaves a response without toolTelemetry untouched', () => {
+        expect(stripToolTelemetry({ content: 'ok', isError: false })).toEqual({ content: 'ok', isError: false });
+    });
+
+    it('passes through non-object responses', () => {
+        expect(stripToolTelemetry(undefined)).toBeUndefined();
+        expect(stripToolTelemetry(null)).toBeNull();
     });
 });
 


### PR DESCRIPTION
Closes #1052

## Problem

INTERNAL tools with no `try/catch` of their own let a thrown error propagate to the framework's outer `catch` in the `CallToolRequestSchema` handler. That path returns via `captureResult` and never goes through `extractToolTelemetry()` — the only place `toolTelemetry` is stripped. Because the MCP SDK's `CallToolResultSchema` is a `z.looseObject` (passthrough), the server-internal `toolTelemetry: { toolStatus }` key is forwarded verbatim **to the client**.

Confirmed end-to-end, not just by reading the code: driving a real MCP `Client` over an in-memory transport against a throwing INTERNAL tool, the client-visible result carries `toolTelemetry` on `master`.

## Fix — option 1 from the issue (single framework boundary)

`captureResult` is the one point every tool-call response leaves the handler through, so the strip goes there. That closes the leak on **every** return path — including future ones — rather than only the paths that happen to read the field.

- **`src/utils/tool_status.ts`** — new `stripToolTelemetry()`; `extractToolTelemetry()` now delegates its `delete` to it, so there is a single definition of "remove the internal field".
- **`src/mcp/server.ts`** — `captureResult()` strips `toolTelemetry` before the response is captured and returned.
- **`src/mcp/server.ts`** — the outer catch no longer attaches `toolTelemetry` at all. The ABORTED-aware `toolStatus` it carried is already reported to telemetry from the handler's local state, so **no classification accuracy is lost**. (The comment there previously explained the field was kept for byte-identity during #937; that rationale is what this PR retires.)

~10 lines of production code.

I scoped this to the **leak** only — the issue's second effect (generic `getToolCallErrorUserText` instead of tool-specific messages, i.e. option 2's per-tool `try/catch`) is a separate, larger change across several tools and is better as its own PR. Happy to follow up if you want it.

## Wire-shape change (please read)

This **changes client-facing wire output**: the leaked `toolTelemetry` key is gone from error responses. As you flagged in the issue, `apify-mcp-server-internal` consumes the stripped wire shape — it should need no change (it now simply always sees the shape it already expected), but it's worth a matching assertion in its contract suite. I can't touch that repo, so flagging it here.

## Tests

- **New wire-level test** (`tests/unit/mcp.server.error_handling.test.ts`): real `Client` + `InMemoryTransport` linked pair against a throwing INTERNAL tool, asserting the client-visible result has no `toolTelemetry`. **Fails on `master`, passes here** — this is the before/after wire snapshot the issue asked for.
- The two existing outer-catch tests pinned the *leaked* shape (`expect(result.toolTelemetry).toEqual({ toolStatus })`). They now assert the field is **absent** from the response while the ABORTED / FAILED status still reaches telemetry (spying on `logToolCallAndTelemetry`) — so the strip is proven not to cost classification.
- **New unit tests** for `stripToolTelemetry()` (`tests/unit/utils.tool_status.test.ts`): strips in place, leaves clean responses untouched, passes through non-objects.

Local gates, all green:

```
pnpm run format:check   All matched files use the correct format. (223 files)
pnpm run lint           Found 0 warnings and 0 errors. (190 files)
pnpm run type-check     tsc -p tsconfig.json --noEmit — clean
pnpm run build:core     tsc -b src — clean
pnpm run test:unit      Test Files 70 passed (70)
                        Tests 963 passed | 2 skipped (965)
```

CHANGELOG is git-cliff-generated from the conventional commit, so it is not hand-edited.

---

Prepared with AI assistance (Claude Code); every line reviewed and the behaviour verified locally against the repo's own harness. Opened as a **draft** — happy to adjust the approach (e.g. option 2 instead) before you spend review time on it.