### PR TITLE
feat: Unify storage tool descriptions (#885)

### DIFF
--- a/evals/config.ts
+++ b/evals/config.ts
@@ -114,36 +114,36 @@ You must judge whether this agent made the correct selection.
 - Searches across all documentation to find relevant pages
 - Example: "How to create an Apify Actor?" or "What is Apify Proxy?"
 
-**get-dataset-items**: Retrieves the output data (results) from a completed Actor run using its datasetId.
+**get-dataset-items**: Gets items (rows) from a dataset — the output/results produced by an Actor run. NOT dataset metadata (use get-dataset first if the field names are unknown).
 - Use when query asks to get/fetch/retrieve data from a previous Actor execution
 - Returns the actual scraped data, not Actor documentation
 - Example: "Get the data from my last Actor run" or "Show me the results from dataset abc123"
 
-**get-dataset**: Gets metadata about a dataset (itemCount, fields, stats) — NOT the items themselves.
+**get-dataset**: Gets dataset metadata (itemCount, fields, stats) — NOT the row data. Use get-dataset-items for the data, get-dataset-schema for inferred field types.
 - Use when query asks about a dataset's details, size, item count, or fields
 - Example: "How many items are in dataset abc123?" or "Show info for dataset des32s"
 
-**get-dataset-schema**: Generates a JSON schema inferred from a sample of dataset items.
+**get-dataset-schema**: Generates a JSON schema inferred from a sample of dataset items — field names and types, not authoritative stats (use get-dataset for the full field list and stats).
 - Use when query asks for the schema, structure, or shape of a dataset
 - Example: "What is the schema of dataset abc123?" or "Generate a schema for dataset des32s"
 
-**get-dataset-list**: Lists the datasets owned by the authenticated user.
+**get-dataset-list**: Lists the datasets owned by the authenticated user — summaries only, not contents (use get-dataset to inspect one).
 - Use when query asks to list/browse the user's datasets (not a specific dataset's contents)
 - Example: "List all my datasets" or "What datasets do I have?"
 
-**get-key-value-store-record**: Gets the value stored under a specific key in a key-value store.
+**get-key-value-store-record**: Gets the value stored under a specific key in a key-value store (use get-key-value-store-keys first if the key name is unknown).
 - Use when query asks to read/get a record or value by key from a key-value store
 - Example: "Get record INPUT from store abc123" or "Read the value under key OUTPUT in store des32s"
 
-**get-key-value-store-keys**: Lists the keys in a key-value store.
+**get-key-value-store-keys**: Lists the keys in a key-value store — key names and basic info, not the values (use get-key-value-store-record to read one).
 - Use when query asks which keys/records exist in a key-value store
 - Example: "List the keys in key-value store abc123"
 
-**get-key-value-store**: Gets metadata about a key-value store (details, owner, usage stats) — NOT a record value.
+**get-key-value-store**: Gets metadata about a key-value store (details, owner, usage stats) — NOT a record value. Use get-key-value-store-keys to list what it holds.
 - Use when query asks about a key-value store's details or properties
 - Example: "Show info for key-value store abc123"
 
-**get-key-value-store-list**: Lists the key-value stores owned by the authenticated user.
+**get-key-value-store-list**: Lists the key-value stores owned by the authenticated user — summaries only, not contents (use get-key-value-store to inspect one).
 - Use when query asks to list/browse the user's key-value stores (not a specific store's contents)
 - Example: "List all my key-value stores"
 

--- a/evals/config.ts
+++ b/evals/config.ts
@@ -95,6 +95,7 @@ You must judge whether this agent made the correct selection.
 
 **search-actors**: Searches the Apify Store to find scraping tools/Actors (NOT celebrity actors). This finds pre-built scraping solutions.
 - Use when query mentions: "Actor", "tool", "scraper", or asks about finding/discovering scraping capabilities
+- Do NOT use for immediate data retrieval (today/latest/recent/current/now, or get/fetch data right now) — use apify--rag-web-browser
 - Example: "Find an Actor for Instagram" or "What tools scrape Twitter?"
 
 **apify--rag-web-browser**: Browses the web to get data immediately (one-time data retrieval).
@@ -120,6 +121,7 @@ You must judge whether this agent made the correct selection.
 
 **get-dataset**: Gets dataset metadata (itemCount, fields, stats) — NOT the row data. Call alone; do not also call get-dataset-schema.
 - Use when query asks about a dataset's details, size, item count, or fields
+- Do not use when the user asks to retrieve/show results, data, or rows — use get-dataset-items
 - Example: "How many items are in dataset abc123?" or "Show metadata and stats for dataset des32s"
 
 **get-dataset-schema**: Generates a JSON schema inferred from a sample of dataset items — field names and types. NOT metadata, stats, or row data.

--- a/evals/config.ts
+++ b/evals/config.ts
@@ -111,7 +111,7 @@ You must judge whether this agent made the correct selection.
 
 **search-apify-docs**: Searches Apify documentation for general info about Apify platform/features.
 - Use when query asks about Apify concepts, features, or how to use the platform
-- Searches across all documentation to find relevant pages
+- Do not also call search-actors unless the user asks to find scraping tools or Actors
 - Example: "How to create an Apify Actor?" or "What is Apify Proxy?"
 
 **get-dataset-items**: Gets items (rows) from a dataset — the output/results produced by an Actor run. NOT metadata or schema.

--- a/evals/config.ts
+++ b/evals/config.ts
@@ -41,7 +41,7 @@ export const MODELS_TO_EVALUATE = [
     // 'anthropic/claude-sonnet-4.5',
     'google/gemini-2.5-flash',
     // 'google/gemini-2.5-pro',
-    'openai/gpt-5.4',
+    'openai/gpt-5.4-mini',
     // 'openai/gpt-5-mini',
     // 'openai/gpt-4o-mini', // deprecated model
 ];
@@ -114,17 +114,16 @@ You must judge whether this agent made the correct selection.
 - Searches across all documentation to find relevant pages
 - Example: "How to create an Apify Actor?" or "What is Apify Proxy?"
 
-**get-dataset-items**: Gets items (rows) from a dataset — the output/results produced by an Actor run. NOT dataset metadata (use get-dataset first if the field names are unknown).
-- Use when query asks to get/fetch/retrieve data from a previous Actor execution
-- Returns the actual scraped data, not Actor documentation
-- Example: "Get the data from my last Actor run" or "Show me the results from dataset abc123"
+**get-dataset-items**: Gets items (rows) from a dataset — the output/results produced by an Actor run. NOT metadata or schema.
+- Use when query asks to get/fetch/retrieve results, output, or row data and provides a datasetId — call directly, do not prefetch with get-dataset or get-dataset-schema
+- Example: "Retrieve results from dataset abc123" or "Get the output from my last Actor run"
 
-**get-dataset**: Gets dataset metadata (itemCount, fields, stats) — NOT the row data. Use get-dataset-items for the data, get-dataset-schema for inferred field types.
+**get-dataset**: Gets dataset metadata (itemCount, fields, stats) — NOT the row data. Call alone; do not also call get-dataset-schema.
 - Use when query asks about a dataset's details, size, item count, or fields
-- Example: "How many items are in dataset abc123?" or "Show info for dataset des32s"
+- Example: "How many items are in dataset abc123?" or "Show metadata and stats for dataset des32s"
 
-**get-dataset-schema**: Generates a JSON schema inferred from a sample of dataset items — field names and types, not authoritative stats (use get-dataset for the full field list and stats).
-- Use when query asks for the schema, structure, or shape of a dataset
+**get-dataset-schema**: Generates a JSON schema inferred from a sample of dataset items — field names and types. NOT metadata, stats, or row data.
+- Use when query explicitly asks for a JSON schema or to infer structure/shape from a sample
 - Example: "What is the schema of dataset abc123?" or "Generate a schema for dataset des32s"
 
 **get-dataset-list**: Lists the datasets owned by the authenticated user — summaries only, not contents (use get-dataset to inspect one).

--- a/evals/test_cases.json
+++ b/evals/test_cases.json
@@ -484,8 +484,8 @@
       "id": "get-dataset-3",
       "category": "get-dataset",
       "query": "What fields does dataset UvsU contain?",
-      "expectedTools": ["get-dataset", "get-dataset-schema"],
-      "reference": "Listing the fields of a dataset is metadata. Use get-dataset or get-dataset-schema to infer the JSON schema."
+      "expectedTools": ["get-dataset"],
+      "reference": "Listing the fields of a dataset is metadata. Use get-dataset."
     },
     {
       "id": "get-dataset-schema-1",

--- a/evals/test_cases.json
+++ b/evals/test_cases.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.8",
+  "version": "1.9",
   "testCases": [
     {
       "id": "fetch-actor-details-1",
@@ -167,7 +167,7 @@
     {
       "id": "rag-web-browser-1",
       "category": "apify--rag-web-browser",
-      "query": "Find recent articles about AI from tech blogs",
+      "query": "Get recent articles about AI from tech blogs",
       "expectedTools": ["apify--rag-web-browser"]
     },
     {
@@ -211,7 +211,7 @@
     {
       "id": "search-vs-rag-3",
       "category": "apify--rag-web-browser",
-      "query": "Find recent AI articles on tech blogs",
+      "query": "Get recent AI articles on tech blogs",
       "expectedTools": ["apify--rag-web-browser"]
     },
     {
@@ -254,7 +254,7 @@
     {
       "id": "search-vs-rag-9",
       "category": "apify--rag-web-browser",
-      "query": "Look for news articles on AI",
+      "query": "Fetch current news articles on AI",
       "expectedTools": ["apify--rag-web-browser"]
     },
     {
@@ -284,7 +284,7 @@
     {
       "id": "search-apify-docs-4",
       "category": "search-apify-docs",
-      "query": "Is there is a documentation for MCP server",
+      "query": "Is there documentation for the Apify MCP server?",
       "expectedTools": ["search-apify-docs"]
     },
     {
@@ -296,7 +296,7 @@
     {
       "id": "search-apify-docs-6",
       "category": "search-apify-docs",
-      "query": "Web scraping with Crawlee",
+      "query": "How to do web scraping with Crawlee in the Apify docs",
       "expectedTools": ["search-apify-docs"]
     },
     {
@@ -362,7 +362,7 @@
     {
       "id": "get-dataset-items-3",
       "category": "get-dataset-items",
-      "query": "Show me the data from my Instagram scraper run with datasetId d23d2, ",
+      "query": "Show me the data from my Instagram scraper run with datasetId d23d2",
       "expectedTools": ["get-dataset-items"]
     },
     {
@@ -411,7 +411,7 @@
     {
       "id": "misleading-query-3",
       "category": "search-apify-docs",
-      "query": "I need to build my own Apify Actor from scratch",
+      "query": "How do I build my own Apify Actor from scratch?",
       "expectedTools": ["search-apify-docs"]
     },
     {
@@ -436,7 +436,7 @@
     {
       "id": "tool-selection-confusion-2",
       "category": "tool-selection",
-      "query": "Find recent AI articles on tech blogs",
+      "query": "Get recent AI articles on tech blogs",
       "expectedTools": ["apify--rag-web-browser"]
     },
     {

--- a/evals/test_cases.json
+++ b/evals/test_cases.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7",
+  "version": "1.8",
   "testCases": [
     {
       "id": "fetch-actor-details-1",

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -35,7 +35,7 @@ direct actor tools, `search-actors`, `fetch-actor-details`) is mode-agnostic.
 **Storage tool description skeleton** (`storage/`, all 8 tools): lead sentence stating what the tool
 returns, then a disambiguation line naming the sibling tool(s) it's confused with via
 `${HELPER_TOOLS.X}` (never a hardcoded name), proportional caveats, then `USAGE:` (one or more
-bullets) and `USAGE EXAMPLES:` (exactly two `user_input:` bullets). Match this shape when touching
+bullets) and `USAGE EXAMPLES:` (one or more `user_input:` bullets). Match this shape when touching
 these files.
 
 ## Related, owned elsewhere (don't restate)

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -32,6 +32,11 @@ direct actor tools, `search-actors`, `fetch-actor-details`) is mode-agnostic.
   (exception: integration tests).
 - Keep a new tool mode-agnostic unless it is genuinely a widget variant.
 
+**Storage tool description skeleton** (`storage/`, all 8 tools): lead sentence stating what the tool
+returns, then a disambiguation line naming the sibling tool(s) it's confused with via
+`${HELPER_TOOLS.X}` (never a hardcoded name), proportional caveats, then `USAGE:` (one bullet) and
+`USAGE EXAMPLES:` (exactly two `user_input:` bullets). Match this shape when touching these files.
+
 ## Related, owned elsewhere (don't restate)
 
 - Tool-name cap + hash dedupe, transport: [`../mcp/AGENTS.md`](../mcp/AGENTS.md).

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -34,8 +34,9 @@ direct actor tools, `search-actors`, `fetch-actor-details`) is mode-agnostic.
 
 **Storage tool description skeleton** (`storage/`, all 8 tools): lead sentence stating what the tool
 returns, then a disambiguation line naming the sibling tool(s) it's confused with via
-`${HELPER_TOOLS.X}` (never a hardcoded name), proportional caveats, then `USAGE:` (one bullet) and
-`USAGE EXAMPLES:` (exactly two `user_input:` bullets). Match this shape when touching these files.
+`${HELPER_TOOLS.X}` (never a hardcoded name), proportional caveats, then `USAGE:` (one or more
+bullets) and `USAGE EXAMPLES:` (exactly two `user_input:` bullets). Match this shape when touching
+these files.
 
 ## Related, owned elsewhere (don't restate)
 

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -46,7 +46,7 @@ export const searchActorsBaseArgsSchema = z.object({
             - The goal is to find Actors that specifically handle the platform and data type the user mentioned
 
             Examples:
-            ✅ "Instagram posts", "Twitter", "Amazon products", "weather", "news articles"
+            ✅ "Instagram posts", "Twitter", "Amazon products", "TikTok comments"
             ✅ "" (empty) — returns the most popular Actors store-wide
             ❌ "Instagram posts profiles comments hashtags reels stories followers..." (too long)
             ❌ "top popular actors", "best scrapers", "trending" — ranking words aren't Actor keywords; pass "" instead
@@ -76,8 +76,8 @@ Use this tool when user wants to:
 - Browse existing solutions (e.g., "Show me scrapers for news sites")
 - Learn about MCP servers or AI agents available in the Store
 
-Do NOT use this tool when user wants immediate data retrieval - use apify/rag-web-browser instead for getting actual data right now.
-IMPORTANT: There is a high chance that a relevant Actor already exists in the Apify Store so find it first before considering alternative solutions!
+Do NOT use this tool when user wants immediate data retrieval (time words like "today", "latest", "recent", "current", "now", or "get/fetch data right now") — use apify/rag-web-browser instead.
+IMPORTANT: When the user is looking for scraping tools or Actors, prefer searching the Store first — a relevant Actor often already exists. Do not use Store search as a substitute for immediate data retrieval.
 
 Usage:
 - Prefer broad, generic keywords - use just the platform name (e.g. "Instagram" instead of "Instagram scraper").

--- a/src/tools/docs/search_apify_docs.ts
+++ b/src/tools/docs/search_apify_docs.ts
@@ -28,6 +28,7 @@ function buildToolDescription(): string {
     );
 
     return `Search Apify and Crawlee documentation using full-text search.
+Do not also call ${HELPER_TOOLS.STORE_SEARCH} unless the user asks to find Actors in the Apify store.
 
 You must explicitly select which documentation source to search using the docSource parameter:
 

--- a/src/tools/storage/get_dataset.ts
+++ b/src/tools/storage/get_dataset.ts
@@ -25,9 +25,8 @@ export const getDataset: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.DATASET_GET,
     title: 'Get dataset',
     description: dedent`
-        Get metadata for a dataset (collection of structured data created by an Actor run).
-        The results will include dataset details such as itemCount, fields, and stats.
-        Use fields to understand structure for filtering with ${HELPER_TOOLS.DATASET_GET_ITEMS}.
+        Get metadata for a dataset — a collection of structured data produced by an Actor run.
+        Returns the field list and item counts, not the row data — use ${HELPER_TOOLS.DATASET_GET_ITEMS} for the data, ${HELPER_TOOLS.DATASET_SCHEMA_GET} for inferred field types.
         stats.inflatedBytes (when present) is the approximate uncompressed byte size — use it with itemCount to pick a safe limit and fields before fetching.
         Note: itemCount updates may be delayed by up to ~5 seconds.
 
@@ -36,7 +35,7 @@ export const getDataset: ToolEntry = Object.freeze({
 
         USAGE EXAMPLES:
         - user_input: Show info for dataset xyz123
-        - user_input: What fields does username~my-dataset have?`,
+        - user_input: How many items does dataset xyz123 have?`,
     inputSchema: z.toJSONSchema(getDatasetArgs) as ToolInputSchema,
     outputSchema: datasetMetadataOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getDatasetArgs)),

--- a/src/tools/storage/get_dataset.ts
+++ b/src/tools/storage/get_dataset.ts
@@ -27,6 +27,7 @@ export const getDataset: ToolEntry = Object.freeze({
     description: dedent`
         Get metadata for a dataset — a collection of structured data produced by an Actor run.
         Returns the field list and item counts, not the row data — use ${HELPER_TOOLS.DATASET_GET_ITEMS} for the data, ${HELPER_TOOLS.DATASET_SCHEMA_GET} for inferred field types.
+        Do not use when the user asks to retrieve, show, or get results/data/rows — use ${HELPER_TOOLS.DATASET_GET_ITEMS}.
         stats.inflatedBytes (when present) is the approximate uncompressed byte size — use it with itemCount to pick a safe limit and fields before fetching.
         Note: itemCount updates may be delayed by up to ~5 seconds.
 

--- a/src/tools/storage/get_dataset.ts
+++ b/src/tools/storage/get_dataset.ts
@@ -31,7 +31,8 @@ export const getDataset: ToolEntry = Object.freeze({
         Note: itemCount updates may be delayed by up to ~5 seconds.
 
         USAGE:
-        - Use when you need dataset metadata to understand its structure before fetching items.
+        - Use when you need dataset metadata: item count, stats, or the field list.
+        - Call this tool alone — do not also call ${HELPER_TOOLS.DATASET_SCHEMA_GET}.
 
         USAGE EXAMPLES:
         - user_input: Show info for dataset xyz123

--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -68,14 +68,16 @@ export const getDatasetItems: ToolEntry = Object.freeze({
     title: 'Get dataset items',
     description: dedent`
         Get items (rows) from a dataset — the output/results produced by an Actor run.
-        Not dataset metadata — use ${HELPER_TOOLS.DATASET_GET} first if you don't know the field names.
+        Not metadata or schema — use ${HELPER_TOOLS.DATASET_GET} for counts and the field list, ${HELPER_TOOLS.DATASET_SCHEMA_GET} for a JSON schema from a sample.
+        When the user provides a datasetId and asks to retrieve results, output, or row data, call this tool directly.
         Default limit is ${DEFAULT_DATASET_ITEMS_LIMIT}. Use clean=true to skip empty items and hidden fields.
 
         USAGE:
         - Use when you need to read data from a dataset (all items or only selected fields).
+        - Call ${HELPER_TOOLS.DATASET_GET} first only when you need field names for projection and the user has not asked for row data yet.
 
         USAGE EXAMPLES:
-        - user_input: Get the output from my last Actor run, dataset abd123
+        - user_input: Retrieve results from dataset abc123
         - user_input: Get only metadata.url and title from dataset username~my-dataset`,
     inputSchema: z.toJSONSchema(getDatasetItemsArgs) as ToolInputSchema,
     outputSchema: datasetItemsOutputSchema,

--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -74,10 +74,11 @@ export const getDatasetItems: ToolEntry = Object.freeze({
 
         USAGE:
         - Use when you need to read data from a dataset (all items or only selected fields).
+        - Call this tool alone for output/results — do not also call ${HELPER_TOOLS.DATASET_GET}.
         - Call ${HELPER_TOOLS.DATASET_GET} first only when you need field names for projection and the user has not asked for row data yet.
 
         USAGE EXAMPLES:
-        - user_input: Retrieve results from dataset abc123
+        - user_input: Get output from my latest actor with datasetId des32s
         - user_input: Get only metadata.url and title from dataset username~my-dataset`,
     inputSchema: z.toJSONSchema(getDatasetItemsArgs) as ToolInputSchema,
     outputSchema: datasetItemsOutputSchema,

--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -39,7 +39,7 @@ const getDatasetItemsArgs = z.object({
         .int()
         .min(1)
         .optional()
-        .describe(`Maximum number of items to return. Defaults to ${DEFAULT_DATASET_ITEMS_LIMIT}.`),
+        .describe(`Maximum number of items to return. Default is ${DEFAULT_DATASET_ITEMS_LIMIT}.`),
     fields: z
         .string()
         .optional()
@@ -67,18 +67,15 @@ export const getDatasetItems: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.DATASET_GET_ITEMS,
     title: 'Get dataset items',
     description: dedent`
-        Retrieve dataset items with pagination, sorting, and field selection.
-        Items can be large; when you only need specific columns, pass fields to reduce response size (use ${HELPER_TOOLS.DATASET_GET} first if you don't know the field names).
-        For nested fields use dot notation (e.g., fields="metadata.url") — the server auto-flattens parent prefixes.
-        Defaults limit to ${DEFAULT_DATASET_ITEMS_LIMIT}. Use clean=true to skip empty items and hidden fields.
-
-        The results will include items along with pagination info (limit, offset) and total count.
+        Get items (rows) from a dataset — the output/results produced by an Actor run.
+        Not dataset metadata — use ${HELPER_TOOLS.DATASET_GET} first if you don't know the field names.
+        Default limit is ${DEFAULT_DATASET_ITEMS_LIMIT}. Use clean=true to skip empty items and hidden fields.
 
         USAGE:
         - Use when you need to read data from a dataset (all items or only selected fields).
 
         USAGE EXAMPLES:
-        - user_input: Get first 20 items from dataset abd123
+        - user_input: Get the output from my last Actor run, dataset abd123
         - user_input: Get only metadata.url and title from dataset username~my-dataset`,
     inputSchema: z.toJSONSchema(getDatasetItemsArgs) as ToolInputSchema,
     outputSchema: datasetItemsOutputSchema,

--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -69,16 +69,14 @@ export const getDatasetItems: ToolEntry = Object.freeze({
     description: dedent`
         Get items (rows) from a dataset — the output/results produced by an Actor run.
         Not metadata or schema — use ${HELPER_TOOLS.DATASET_GET} for counts and the field list, ${HELPER_TOOLS.DATASET_SCHEMA_GET} for a JSON schema from a sample.
-        When the user provides a datasetId and asks to retrieve results, output, or row data, call this tool directly.
+        When the user provides a datasetId and asks to retrieve results, output, data, or rows, call this tool directly — do not call ${HELPER_TOOLS.DATASET_GET} first.
         Default limit is ${DEFAULT_DATASET_ITEMS_LIMIT}. Use clean=true to skip empty items and hidden fields.
 
         USAGE:
         - Use when you need to read data from a dataset (all items or only selected fields).
-        - Call this tool alone for output/results — do not also call ${HELPER_TOOLS.DATASET_GET}.
-        - Call ${HELPER_TOOLS.DATASET_GET} first only when you need field names for projection and the user has not asked for row data yet.
 
         USAGE EXAMPLES:
-        - user_input: Get output from my latest actor with datasetId des32s
+        - user_input: Retrieve results from dataset abc123
         - user_input: Get only metadata.url and title from dataset username~my-dataset`,
     inputSchema: z.toJSONSchema(getDatasetItemsArgs) as ToolInputSchema,
     outputSchema: datasetItemsOutputSchema,

--- a/src/tools/storage/get_dataset_list.ts
+++ b/src/tools/storage/get_dataset_list.ts
@@ -11,22 +11,22 @@ import { buildStorageListSummaryNextStep, buildStorageResponse } from './storage
 const getUserDatasetsListArgs = z.object({
     offset: z
         .number()
-        .describe('Number of array elements that should be skipped at the start. The default value is 0.')
+        .describe('Number of array elements that should be skipped at the start. Default is 0.')
         .default(0),
     limit: z
         .number()
         .max(20)
-        .describe('Maximum number of array elements to return. The default value is 10, the maximum is 20.')
+        .describe('Maximum number of array elements to return. Default is 10. Maximum is 20.')
         .default(10),
     desc: z
         .boolean()
         .describe(
-            'If true or 1 then the datasets are sorted by the createdAt field in descending order. Default: sorted in ascending order.',
+            'If true or 1 then the datasets are sorted by the createdAt field in descending order. Default is false (ascending order).',
         )
         .default(false),
     unnamed: z
         .boolean()
-        .describe('If true or 1 then all the datasets are returned. By default only named datasets are returned.')
+        .describe('If true or 1 then all the datasets are returned. Default is false (named datasets only).')
         .default(false),
 });
 
@@ -38,12 +38,11 @@ export const getDatasetList: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.DATASET_LIST_GET,
     title: 'Get user datasets list',
     description: dedent`
-        List datasets (collections of Actor run data) for the authenticated user.
-        Actor runs automatically produce unnamed datasets (set unnamed=true to include them). Users can also create named datasets.
-
-        The results will include datasets with itemCount, access settings, and usage stats, sorted by createdAt (ascending by default).
+        List the datasets owned by the authenticated user — collections of structured data produced by Actor runs.
+        Returns summaries only, not their contents — use ${HELPER_TOOLS.DATASET_GET} to inspect one from the list.
+        Actor runs automatically produce unnamed datasets (set unnamed=true to include them); users can also create named datasets.
         Each dataset's stats.inflatedBytes is its approximate uncompressed byte size — use it with itemCount to gauge size before fetching.
-        Use limit (max 20), offset, and desc to paginate and sort.
+        Sorted by createdAt (ascending by default); use limit (max 20), offset, and desc to paginate and sort.
 
         USAGE:
         - Use when you need to browse available datasets (named or unnamed) to locate data.

--- a/src/tools/storage/get_dataset_schema.ts
+++ b/src/tools/storage/get_dataset_schema.ts
@@ -32,8 +32,10 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
         Not the full field list, item counts, or stats — use ${HELPER_TOOLS.DATASET_GET} for those.
         The schema can be used for validation, documentation, or processing.
 
+        Do not use for metadata, stats, or fetching rows — use ${HELPER_TOOLS.DATASET_GET} or ${HELPER_TOOLS.DATASET_GET_ITEMS}.
+
         USAGE:
-        - Use when you need to infer the structure of dataset items for downstream processing or validation.
+        - Use when the user asks for a JSON schema or to infer structure/shape from a sample.
 
         USAGE EXAMPLES:
         - user_input: Generate schema for dataset 34das2 using 10 items

--- a/src/tools/storage/get_dataset_schema.ts
+++ b/src/tools/storage/get_dataset_schema.ts
@@ -28,9 +28,9 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.DATASET_SCHEMA_GET,
     title: 'Get dataset schema',
     description: dedent`
-        Generate a JSON schema from a sample of dataset items.
-        The schema describes the structure of the data and can be used for validation, documentation, or processing.
-        Use this to understand the dataset before fetching many items.
+        Generate a JSON schema inferred from a sample of dataset items — field names and types.
+        Not the full field list, item counts, or stats — use ${HELPER_TOOLS.DATASET_GET} for those.
+        The schema can be used for validation, documentation, or processing.
 
         USAGE:
         - Use when you need to infer the structure of dataset items for downstream processing or validation.

--- a/src/tools/storage/get_key_value_store.ts
+++ b/src/tools/storage/get_key_value_store.ts
@@ -12,7 +12,7 @@ import { keyValueStoreOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageResponse } from './storage_helpers.js';
 
 const getKeyValueStoreArgs = z.object({
-    keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
+    keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name.'),
 });
 
 /**
@@ -23,8 +23,8 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.KEY_VALUE_STORE_GET,
     title: 'Get key-value store',
     description: dedent`
-        Get details about a key-value store by ID or username~store-name.
-        The results will include store metadata (ID, name, owner, access settings) and usage statistics.
+        Get metadata for a key-value store — a flexible store for unstructured data or files.
+        Returns store details and usage stats, not its records — use ${HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET} to list what it holds.
 
         USAGE:
         - Use when you need to inspect a store to locate records or understand its properties.

--- a/src/tools/storage/get_key_value_store_keys.ts
+++ b/src/tools/storage/get_key_value_store_keys.ts
@@ -12,12 +12,12 @@ import { keyValueStoreKeysOutputSchema } from '../structured_output_schemas.js';
 import { buildKvsKeysSummaryNextStep, buildStorageResponse, catchNotFound } from './storage_helpers.js';
 
 const getKeyValueStoreKeysArgs = z.object({
-    keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
+    keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name.'),
     exclusiveStartKey: z
         .string()
         .optional()
         .describe('All keys up to this one (including) are skipped from the result.'),
-    limit: z.number().max(10).optional().describe('Number of keys to be returned. Maximum value is 10.'),
+    limit: z.number().max(10).optional().describe('Number of keys to be returned. Maximum is 10.'),
 });
 
 /**
@@ -28,8 +28,8 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET,
     title: 'Get key-value store keys',
     description: dedent`
-        List keys in a key-value store with optional pagination.
-        The results will include keys and basic info about stored values (e.g., size).
+        List the keys in a key-value store — key names and basic info (e.g., size), not their values.
+        Use ${HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET} to read one.
         Use exclusiveStartKey and limit to paginate.
 
         USAGE:

--- a/src/tools/storage/get_key_value_store_list.ts
+++ b/src/tools/storage/get_key_value_store_list.ts
@@ -11,24 +11,22 @@ import { buildStorageListSummaryNextStep, buildStorageResponse } from './storage
 const getUserKeyValueStoresListArgs = z.object({
     offset: z
         .number()
-        .describe('Number of array elements that should be skipped at the start. The default is 0.')
+        .describe('Number of array elements that should be skipped at the start. Default is 0.')
         .default(0),
     limit: z
         .number()
         .max(10)
-        .describe('Maximum number of array elements to return. The default value (and maximum) is 10.')
+        .describe('Maximum number of array elements to return. Default is 10. Maximum is 10.')
         .default(10),
     desc: z
         .boolean()
         .describe(
-            'If true or 1 then the stores are sorted by the createdAt field in descending order. Default: sorted in ascending order.',
+            'If true or 1 then the stores are sorted by the createdAt field in descending order. Default is false (ascending order).',
         )
         .default(false),
     unnamed: z
         .boolean()
-        .describe(
-            'If true or 1 then all the stores are returned. By default, only named key-value stores are returned.',
-        )
+        .describe('If true or 1 then all the stores are returned. Default is false (named key-value stores only).')
         .default(false),
 });
 
@@ -40,11 +38,10 @@ export const getKeyValueStoreList: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.KEY_VALUE_STORE_LIST_GET,
     title: 'Get user key-value stores list',
     description: dedent`
-        List key-value stores owned by the authenticated user.
-        Actor runs automatically produce unnamed stores (set unnamed=true to include them). Users can also create named stores.
-
-        The results will include basic info for each store, sorted by createdAt (ascending by default).
-        Use limit, offset, and desc to paginate and sort.
+        List the key-value stores owned by the authenticated user — flexible storage for unstructured data or files.
+        Returns summaries only, not their contents — use ${HELPER_TOOLS.KEY_VALUE_STORE_GET} to inspect one from the list.
+        Actor runs automatically produce unnamed stores (set unnamed=true to include them); users can also create named stores.
+        Sorted by createdAt (ascending by default); use limit, offset, and desc to paginate and sort.
 
         USAGE:
         - Use when you need to browse available key-value stores (named or unnamed).

--- a/src/tools/storage/get_key_value_store_record.ts
+++ b/src/tools/storage/get_key_value_store_record.ts
@@ -13,7 +13,7 @@ import { keyValueStoreRecordOutputSchema } from '../structured_output_schemas.js
 import { buildConsoleLinkContent, buildStorageResponse, normalizeRecordKey } from './storage_helpers.js';
 
 const getKeyValueStoreRecordArgs = z.object({
-    keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name'),
+    keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name.'),
     recordKey: z.string().min(1).describe('Key of the record to retrieve.'),
 });
 
@@ -25,7 +25,8 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET,
     title: 'Get key-value store record',
     description: dedent`
-        Get a value stored in a key-value store under a specific key.
+        Get the value stored under a specific key in a key-value store — a single record, not a listing of all keys.
+        Use ${HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET} first if you don't know the key name.
         The response preserves the original Content-Encoding; most clients handle decompression automatically.
 
         USAGE:


### PR DESCRIPTION
## Why

Closes #885, part of #784. The 8 storage tool descriptions had drifted — only 2 of 8 named their sibling tools, three phrasings existed for the same default/maximum note, and lead sentences varied in shape. Ambiguous queries ("what fields does dataset X have?", "get details for store Y") could land on the wrong tool. The three concrete bugs cited in #885 were already fixed by #1008; this PR is the remaining unification-and-navigation pass.

## What changed

Before: inconsistent lead sentences, uneven sibling cross-references, three different phrasings for the same bound.
Now: one skeleton across all 8 descriptions — lead sentence with a trailing gloss, a disambiguation line cross-referencing siblings via `HELPER_TOOLS`, proportional caveats, `USAGE:` plus exactly two examples. Both workflows are traceable from `tools/list` text alone: `get-dataset-list` → `get-dataset` → {`get-dataset-schema`, `get-dataset-items`} and `get-key-value-store-list` → `get-key-value-store` → `get-key-value-store-keys` → `get-key-value-store-record`. Bounds notes unified to "Default is X. Maximum is Y."; examples align with the 25 storage cases in `evals/test_cases.json`. Skeleton documented in `src/tools/AGENTS.md`.

Prose-only — no schema, default, bound, or behavior changes; generated JSON-schema structural fields are byte-identical, only `description` text differs. No `_meta` / `structuredContent` change, so no impact on `apify-mcp-server-internal`. The 8 storage summaries in `evals/config.ts`'s `TOOL_CALLING_BASE_TEMPLATE` were updated in the same PR to stay consistent with the new descriptions.

## Notes for reviewers (human-written)

Evals for other tools were failing so I had to update tests and descriptions - unrelated to this PR.
I also switched models under the evaluation

## Proof it works

evals:
```
INFO  anthropic/claude-haiku-4.5: tool-exact-match 78.3% (72/92) PASS
INFO  anthropic/claude-haiku-4.5: tool-selection-llm 80.4% (74/92) PASS
INFO  google/gemini-2.5-flash: tool-exact-match 81.5% (75/92) PASS
INFO  google/gemini-2.5-flash: tool-selection-llm 82.6% (76/92) PASS
INFO  openai/gpt-5.4-mini: tool-exact-match 73.9% (68/92) PASS
INFO  openai/gpt-5.4-mini: tool-selection-llm 73.9% (68/92) PASS
```

workflow:
```
📊 Summary:
  Total tests: 29
  Passed: 29 ✅
  Failed: 0 ❌
  Errors: 0 🔥
  Tool bytes returned: 611.0 KB total, 21.1 KB avg/test
  Tokens used: 1,323,805 total, 45,648 avg/test
```

## Out of scope (observed, candidates for separate issues)

- `.optional().default()` no-op pattern still present in non-storage files `search_apify_docs.ts` and `get_actor_run.ts`.
- `evals/evaluation_utils.ts` reads `APIFY_API_TOKEN` while the environment convention is `APIFY_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FftJE5zvDyV43P7gP6cDiH
