### PR TITLE
chore: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!-- Keep it short. A reviewer should understand this PR without reverse-engineering the diff. -->
+
+## Issue
+<!-- "Closes #123". No issue? Write "Ad-hoc —" and one line on why this change is needed. -->
+
+## What changed
+
+
+## Why this approach
+<!-- The reasoning, not a restatement of the diff. -->
+
+## What I'm unsure about
+<!-- Where should the reviewer look hardest? If AI tools wrote parts you don't fully follow, say which. -->
+
+## Proof it works
+<!-- Passing CI, a test run, or a screenshot/link to an Apify platform run. Not "works on my machine". -->
+
+---
+- [ ] Single concern — unrelated changes split into other PRs
+- [ ] Clean diff — no debug logs, commented-out code, or formatting-only noise
+- [ ] I reviewed my own diff before requesting review

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,17 @@
-<!-- Keep it short. A reviewer should understand this PR without reverse-engineering the diff. -->
+<!-- A PR that is hard to review is not ready for review. One concern per PR, clean diff (no debug logs, formatting noise, commented-out code). -->
 
-## Issue
-<!-- "Closes #123". No issue? Write "Ad-hoc —" and one line on why this change is needed. -->
+<!-- AI agents: fill in Why, What changed, and Proof it works. Leave "Notes for reviewers" empty — it belongs to the human author. No file lists, no restating the diff, no praising the change. -->
+
+<!-- Human author: an AI draft is a draft, not a description. Before requesting review: (1) self-review your own diff in the GitHub UI, (2) check every claim below against the diff and cut what you wouldn't say yourself, (3) write "Notes for reviewers" in your own words. -->
+
+## Why
+<!-- "Closes #123". No issue? Ad-hoc is the exception, not the default — one line on the problem and why the change is needed. Evidence beats adjectives: a measurement, a failing run, a probe result. -->
 
 ## What changed
+<!-- For a small fix, "Before: … / Now: …" is enough. Don't list files — the diff shows that. Explain the approach only when it's non-obvious; otherwise it's noise. -->
 
-
-## Why this approach
-<!-- The reasoning, not a restatement of the diff. -->
-
-## What I'm unsure about
-<!-- Where should the reviewer look hardest? If AI tools wrote parts you don't fully follow, say which. -->
+## Notes for reviewers (human-written)
+<!-- Your own words — two sentences beat none. Where should review look hardest? What are you unsure about? If AI wrote parts you don't fully follow, say which — the reviewer must not be the first human to read them. Any impact on apify-mcp-server-internal (internals.js exports, _meta, structuredContent, clientInfo, ?ui=/?payment=)? -->
 
 ## Proof it works
-<!-- Passing CI, a test run, or a screenshot/link to an Apify platform run. Not "works on my machine". -->
-
----
-- [ ] Single concern — unrelated changes split into other PRs
-- [ ] Clean diff — no debug logs, commented-out code, or formatting-only noise
-- [ ] I reviewed my own diff before requesting review
+<!-- Not "unit tests pass" — CI shows that. An end-to-end MCP probe (mcpc transcript), a screenshot, or a link to an Actor run on the Apify platform. "Works on my machine" / "the AI said it works" is not proof. -->


### PR DESCRIPTION
## Why
Ad-hoc — PR descriptions here are mostly AI-written prose. The template encodes the team PR guidelines at the point where the description gets written: agents get a lane, and one section is reserved for the human author.

## What changed
Adds `.github/pull_request_template.md`. GitHub auto-loads it into the description box on every new PR; agents read the same file when drafting bodies. All prompts are HTML comments — visible in the edit box, invisible in the rendered PR.

Sections, modeled on the strongest real PR descriptions in this repo and apify-core (evidence-based why, Before/Now for small fixes, reviewer-effort calibration, screenshot/staging proof):

- **Why** — issue link, or ad-hoc as the exception with the problem stated; evidence beats adjectives.
- **What changed** — Before/Now is enough for a small fix; no file lists; approach rationale only when non-obvious.
- **Notes for reviewers (human-written)** — where to look hardest, what the author is unsure about, which parts AI wrote that they don't fully follow, impact on `apify-mcp-server-internal`. Agents are told to leave it empty; an empty or agent-prose section is visible at a glance.
- **Proof it works** — e2e mcpc probe, screenshot, or platform run link. Not "unit tests pass" (CI shows that); not "the AI said it works".


## Notes for reviewers (human-written)

Open for discussion :) 

## Proof it works
No proof yet

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkU9wM2H2N1dNYVRdoRhzp)_