### PR TITLE
docs: Fix mcpc connect syntax in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Zero tolerance for errors — fix before proceeding, don't defer.
 
 When the user says "test with mcpc", **use mcpc** — do not invent a substitute (no curl, no ad-hoc Node/Python scripts, no unit tests in place of an e2e probe). Use the **apify CLI** (`apify datasets`, `apify key-value-stores`, `apify actors`, …) for ground-truth data — never curl the Apify API.
 
-After `pnpm run build`, run `mcpc` (no args) to check sessions: if `@stdio` (default) / `@stdio-full` (non-default tools) is listed, `mcpc @stdio restart`; otherwise `mcpc --config .mcp.json stdio connect @stdio`. Use the `mcpc-tester` subagent for systematic spec/edge-case coverage; call mcpc directly for quick checks.
+After `pnpm run build`, run `mcpc` (no args) to check sessions: if `@stdio` (default) / `@stdio-full` (non-default tools) is listed, `mcpc @stdio restart`; otherwise `mcpc connect .mcp.json:stdio @stdio` (non-default tools: `mcpc connect .mcp.json:stdio-full @stdio-full`). Use the `mcpc-tester` subagent for systematic spec/edge-case coverage; call mcpc directly for quick checks.
 
 ## Testing
 


### PR DESCRIPTION
The e2e-testing section of AGENTS.md documents a fallback command that doesn't work: `mcpc --config .mcp.json stdio connect @stdio`. mcpc has no `--config` flag, so every agent following the doc hits an error and has to rediscover the real syntax (this happened during the #885 description work).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FftJE5zvDyV43P7gP6cDiH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FftJE5zvDyV43P7gP6cDiH)_