### PR TITLE
refactor: Stream resources/read under one inline cap, align with spec

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -11,13 +11,10 @@ export const ACTOR_MAX_MEMORY_MBYTES = 4_096; // If the Actor requires 8GB of me
 /**
  * Content larger than this is linked out instead of inlined, since inlining it would blow up the context
  * window (base64 inflates a binary payload ~33%, and a large text/JSON body overflows it just as easily).
- * The key-value-store-record tool and the API-resource proxy both cap binaries here (link to a fetchable
- * URL); the proxy additionally links oversized text/JSON to a download URL.
+ * The key-value-store-record tool caps binaries here (link to a fetchable URL); the API-resource proxy
+ * caps every body here — its download is also aborted mid-flight at this limit via axios `maxContentLength`.
  */
 export const MAX_INLINE_BYTES = 256 * 1024;
-
-/** Hard cap on bytes the API-resource proxy downloads; enforced mid-flight by axios `maxContentLength`. */
-export const MAX_DOWNLOAD_BYTES = 5 * 1024 * 1024;
 
 /**
  * Advisory threshold (uncompressed bytes) above which dataset tools append a size hint steering the

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -642,21 +642,22 @@ export class ActorsMcpServer {
         return meta?.apifyToken || this.options.token;
     }
 
+    /**
+     * Token-scoped client for resources/read (the API proxy needs auth). Deliberately token-only:
+     * unlike the CallTool path it does NOT forward provider/payment headers, so a payment-only
+     * session (x402/Skyfire, no Apify token) has no client and every read fails by design.
+     */
+    private resolveApifyClient(params: ApifyRequestParams): ApifyClient | undefined {
+        const token = this.resolveApifyToken(params._meta);
+        return token ? new ApifyClient({ token }) : undefined;
+    }
+
     private setupResourceHandlers(): void {
         const resourceService = createResourceService({
             paymentProvider: this.options.paymentProvider,
             getMode: () => this.serverMode,
             getAvailableWidgets: () => this.availableWidgets,
         });
-
-        // Build a token-scoped client for resources/read (the API proxy needs auth). This is deliberately
-        // token-only: unlike the CallTool path it does NOT forward provider/payment headers, so a
-        // payment-only session (x402/Skyfire, no Apify token) has no client and every read soft-fails by
-        // design. Resources are scoped to token sessions; the server-instructions state a read needs a token.
-        const resolveApifyClient = (params: ApifyRequestParams): ApifyClient | undefined => {
-            const token = this.resolveApifyToken(params._meta);
-            return token ? new ApifyClient({ token }) : undefined;
-        };
 
         this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
             return await resourceService.listResources();
@@ -665,7 +666,7 @@ export class ActorsMcpServer {
         this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
             return await resourceService.readResource(
                 request.params.uri,
-                resolveApifyClient(request.params as ApifyRequestParams),
+                this.resolveApifyClient(request.params as ApifyRequestParams),
             );
         });
 

--- a/src/resources/AGENTS.md
+++ b/src/resources/AGENTS.md
@@ -46,7 +46,9 @@ JSON-RPC error, never success-shaped content): 3xx/4xx except 429 → `InvalidPa
 status (network, mid-stream drop) → `InternalError`. 401/403 append a hint via `getHttpErrorHint()`
 (shared with `tools/call`); failures are logged via `logHttpError` (5xx → exception). Size
 link-outs are **successful** reads returning a download pointer, not failures. Discovery is the
-server-instructions prose; `resources/templates/list` returns nothing.
+server-instructions prose plus `resources/templates/list`, which advertises the common URL shapes
+(dataset items, KVS record/keys, run, log) as RFC 6570 templates with paging params — advertisement
+only, not a route table: the read path stays generic and accepts any Apify API GET URL.
 
 ## Gotcha
 

--- a/src/resources/AGENTS.md
+++ b/src/resources/AGENTS.md
@@ -29,9 +29,10 @@ header for those, silently degrading to unauthenticated).
 `readApiResource()` streams the body verbatim —
 `httpClient.axios.request({ method: 'GET', responseType: 'stream', maxContentLength: MAX_INLINE_BYTES })`
 — and branches on the declared Content-Type: textual base types (text/*, JSON, XML) as `text` with
-the full header, everything else (including no Content-Type) as a base64 `blob` with the base MIME
-type, empty body as empty text preserving the Content-Type. The body is never parsed, so bytes
-round-trip exactly. axios enforces `MAX_INLINE_BYTES` (256 KB) mid-consumption on streamed
+the full header, decoded with the declared charset (default utf-8; a charset Node cannot decode
+falls through to blob — lossless beats mangled text, same rule as apify-client's body_parser);
+everything else (including no Content-Type) as a base64 `blob` with the base MIME type; empty body
+as empty text preserving the Content-Type. The body is never parsed, so bytes round-trip exactly. axios enforces `MAX_INLINE_BYTES` (256 KB) mid-consumption on streamed
 responses (axios ≥1.16: byte-counting wrapper throws `ERR_BAD_RESPONSE`, counting decoded bytes) —
 after the request resolves, outside any retry wrapper. On trip, the proxy links out: a `text/plain`
 block carrying the store's signed `recordPublicUrl` for a KVS record, else the token-gated API URL,

--- a/src/resources/AGENTS.md
+++ b/src/resources/AGENTS.md
@@ -10,7 +10,8 @@ Three files serving the MCP `resources/*` surface:
   builds it from the per-request token (`_meta.apifyToken || options.token`). This is
   token-only by design — it does not forward payment headers like the CallTool path, so a
   payment-only session (x402/Skyfire, no token) gets no client and every read fails with an
-  `InvalidParams` JSON-RPC error.
+  `InvalidParams` JSON-RPC error. It routes every http(s) URI to `readApiResource()`, which
+  owns the single origin gate; only non-http schemes fall through to widgets/usage-guide/fallback.
 - `api_resources.ts` — a thin MCP-resource proxy over the Apify API: any Apify API GET
   endpoint is readable as a resource, identified by its real API URL.
 - `widgets.ts` — the registry of UI widgets (the metadata that maps a widget name to
@@ -19,51 +20,39 @@ Three files serving the MCP `resources/*` surface:
 ## API resources (`api_resources.ts`)
 
 Resource URIs are real Apify API GET URLs (`https://api.apify.com/v2/...`), built from the storage
-IDs that Actors and tools return (e.g. a `datasetId` → `.../datasets/{id}/items`) — no custom scheme
-to translate. `isApifyApiUri()` gates reads to the configured API origin
-(`getApifyAPIBaseUrl()`): the apify-client attaches the session token as an `Authorization`
-header to **every** outbound request, so we must never hand it a non-Apify host.
+IDs that Actors and tools return (e.g. a `datasetId` → `.../datasets/{id}/items`) — no custom scheme.
+`isApifyApiUri()` gates reads to the configured API origin (`getApifyAPIBaseUrl()`): the apify-client
+attaches the session token as an `Authorization` header to **every** outbound request, so we must
+never hand it a non-Apify host.
 
-`readApiResource()` is a generic proxy: `apifyClient.httpClient.axios.request({ method: 'GET', responseType: 'arraybuffer', maxContentLength: MAX_DOWNLOAD_BYTES })`
-(do **not** set `forceBuffer` — that skips the client's Content-Type parsing). It calls the
-apify-client's own axios instance directly instead of `httpClient.call()`, deliberately skipping
-apify-client's retry wrapper: that wrapper would misclassify the `maxContentLength` abort below as a
-retryable network error and retry it 8 times (~127s of backoff) instead of failing fast — so this is
-one attempt, no retries. `MAX_DOWNLOAD_BYTES` (5 MB) is enforced mid-flight by axios as bytes arrive, so
-an oversized dataset/log is aborted during download instead of being buffered whole first; on trip, the
-proxy links out the same way as an oversized inline body (below), skipping straight past the parse step.
-The parsed body is JSON → object, text/xml → string, anything else → `Buffer`, empty → `undefined`.
-Binary and empty bodies are keyed off the JS type; a JSON body is re-serialized with `JSON.stringify`
-(keyed off the declared Content-Type) so `null` and bare-string primitives round-trip, and text/xml
-strings are emitted verbatim. Buffers over `MAX_INLINE_BYTES`
-(256 KB, unchanged) link out — an explanatory `text/plain` block naming the URL + size + type
-(`resources/read` has no `resource_link` content type) — instead of inlining base64. For a KVS
-record the URL is the store's `recordPublicUrl` (auth-free only when the store has a URL-signing key);
-an unsigned record URL and every other endpoint fall back to the token-gated API URL, so the block says
-the link may require the token. A text/JSON body over the same `MAX_INLINE_BYTES` cap links out the same
-way — the signed `recordPublicUrl` for a KVS record, else the token-gated API URL — with a hint to page a
-dataset/list via `limit`/`offset` (measured on the serialized bytes we would emit, not a `Content-Length`
-header; a single record or log can't be paged, so the link is the real remedy).
+`readApiResource()` streams the body verbatim —
+`apifyClient.httpClient.axios.request({ method: 'GET', responseType: 'stream', maxContentLength: MAX_INLINE_BYTES })`
+— and branches on the declared Content-Type: textual base types (text/*, JSON, XML) return as `text`
+with the full header (charset included), everything else (including no Content-Type) as a base64
+`blob` with the base MIME type, an empty body as empty text preserving the Content-Type. The body is
+never parsed, so JSON primitives and bytes round-trip exactly. axios enforces `MAX_INLINE_BYTES`
+(256 KB) mid-consumption on streamed responses (axios ≥1.16: byte-counting wrapper throws
+`ERR_BAD_RESPONSE`, counting decoded bytes), so an oversized body aborts at the limit instead of
+buffering — the abort happens after the request resolves, outside any retry wrapper. On trip, the
+proxy links out: an explanatory `text/plain` block (`resources/read` has no `resource_link` type)
+carrying the store's `recordPublicUrl` for a KVS record (auth-free only with a URL-signing key) or
+the token-gated API URL otherwise, plus a `limit`/`offset` paging hint for datasets/lists. It calls
+the client's axios instance directly instead of `httpClient.call()`: with a stream body, `call()`
+would hand non-2xx responses to `ApifyApiError` unconsumed (junk message, stranded socket per retry)
+— so this is one attempt, no retries, and the error body is read here to surface the API's message.
 
-Genuine failures **throw** an `McpError` so the SDK returns a JSON-RPC error, not success-shaped content
-for an unreadable resource (the direction SEP-2164 makes a MUST; success-content for a nonexistent
-resource is the anti-pattern). `statusToErrorCode()` maps the code: 3xx/4xx except 429 → `InvalidParams`
-(-32602: bad URI, missing/invalid token, private or nonexistent resource — SEP-2164 remaps "nonexistent"
-here too); 429, 5xx, or no status (network failure) → `InternalError` (-32603: transient/upstream). The
-no-token and bad-origin pre-flight guards throw `InvalidParams` directly. This axios instance resolves
-non-2xx responses (`validateStatus: null`) instead of throwing, so a non-2xx is caught on the resolved
-`status` and re-thrown; only network-level failures (and the `maxContentLength` abort) reach the `catch`.
-The size link-outs are the exception — they are **successful** reads returning a download pointer, not
-failures, so they still return a `text` block. A 401/403 failure appends an actionable hint via
-`getHttpErrorHint()` (shared with the `tools/call` error path in `utils/mcp.ts`): 401 points at
-`APIFY_TOKEN`, 403 flags a private resource or insufficient access. The sibling `resource_service.ts`
-throws the same `InvalidParams` error from its generic "not found" fallback (a non-Apify URL never
-reaches `readApiResource`, so bad-origin is handled there in practice); its widget-not-found branches
-stay as content.
+Genuine failures **throw** an `McpError` so the SDK returns a JSON-RPC error, not success-shaped
+content for an unreadable resource (the direction SEP-2164 makes a MUST). `statusToErrorCode()`:
+3xx/4xx except 429 → `InvalidParams` (bad URI, missing/invalid token, private or nonexistent
+resource); 429, 5xx, or no status (network, mid-stream drop) → `InternalError`. The no-token and
+bad-origin guards throw `InvalidParams` directly; 401/403 append a hint via `getHttpErrorHint()`
+(shared with `tools/call` in `utils/mcp.ts`); non-2xx and network failures are logged via
+`logHttpError` (5xx → exception). Size link-outs are the exception — **successful** reads returning
+a download pointer. The sibling `resource_service.ts` throws the same `InvalidParams` from its
+generic non-http fallback; widget-not-found branches stay as content.
 
 Discovery is the server-instructions prose, not a fixed list: `resources/templates/list` returns
-nothing and `resources/list` serves only widgets + the usage guide. The read path is a generic
-proxy, so any Apify API GET URL works whether or not it was ever listed.
+nothing and `resources/list` serves only widgets + the usage guide.
 
 ## Gotcha
 

--- a/src/resources/AGENTS.md
+++ b/src/resources/AGENTS.md
@@ -5,59 +5,51 @@
 
 Three files serving the MCP `resources/*` surface:
 
-- `resource_service.ts` — handles `ListResources` / `ListResourceTemplates` /
-  read-resource requests. Takes an optional `apifyClient` on list/read; the server
-  builds it from the per-request token (`_meta.apifyToken || options.token`). This is
-  token-only by design — it does not forward payment headers like the CallTool path, so a
-  payment-only session (x402/Skyfire, no token) gets no client and every read fails with an
-  `InvalidParams` JSON-RPC error. It routes every http(s) URI to `readApiResource()`, which
-  owns the single origin gate; only non-http schemes fall through to widgets/usage-guide/fallback.
-- `api_resources.ts` — a thin MCP-resource proxy over the Apify API: any Apify API GET
-  endpoint is readable as a resource, identified by its real API URL.
-- `widgets.ts` — the registry of UI widgets (the metadata that maps a widget name to
-  its resource); the widgets themselves are built in [`../web`](../web/AGENTS.md).
+- `resource_service.ts` — handles `ListResources` / `ListResourceTemplates` / read-resource
+  requests. Takes an optional `apifyClient` on read, built by the server from the per-request
+  token (`_meta.apifyToken || options.token`). Token-only by design — no payment headers, so a
+  payment-only session (x402/Skyfire) gets no client and every read fails with `InvalidParams`.
+  Routes every http(s) URI to `readApiResource()`, which owns the single origin gate; non-http
+  schemes fall through to widgets/usage-guide/fallback.
+- `api_resources.ts` — a thin streaming MCP-resource proxy: any Apify API GET endpoint is
+  readable as a resource, identified by its real API URL.
+- `widgets.ts` — the registry of UI widgets; the widgets themselves are built in
+  [`../web`](../web/AGENTS.md).
 
 ## API resources (`api_resources.ts`)
 
 Resource URIs are real Apify API GET URLs (`https://api.apify.com/v2/...`), built from the storage
-IDs that Actors and tools return (e.g. a `datasetId` → `.../datasets/{id}/items`) — no custom scheme.
-`isApifyApiUri()` gates reads to the configured API origin (`getApifyAPIBaseUrl()`): the apify-client
-attaches the session token as an `Authorization` header to **every** outbound request, so we must
-never hand it a non-Apify host.
+IDs that Actors and tools return. This is a deliberate deviation from the MCP spec's `https://`
+scheme guidance (SHOULD only be used for client-fetchable URLs — ours are token-gated): the
+identity with the platform's own URLs is the feature. Revisit when tools start emitting
+`resource_link`s, where clients may fetch `https://` URIs directly. `isApifyApiUri()` gates reads
+to the configured API origin and rejects userinfo-bearing URLs (axios drops the `Authorization`
+header for those, silently degrading to unauthenticated).
 
 `readApiResource()` streams the body verbatim —
-`apifyClient.httpClient.axios.request({ method: 'GET', responseType: 'stream', maxContentLength: MAX_INLINE_BYTES })`
-— and branches on the declared Content-Type: textual base types (text/*, JSON, XML) return as `text`
-with the full header (charset included), everything else (including no Content-Type) as a base64
-`blob` with the base MIME type, an empty body as empty text preserving the Content-Type. The body is
-never parsed, so JSON primitives and bytes round-trip exactly. axios enforces `MAX_INLINE_BYTES`
-(256 KB) mid-consumption on streamed responses (axios ≥1.16: byte-counting wrapper throws
-`ERR_BAD_RESPONSE`, counting decoded bytes), so an oversized body aborts at the limit instead of
-buffering — the abort happens after the request resolves, outside any retry wrapper. On trip, the
-proxy links out: an explanatory `text/plain` block (`resources/read` has no `resource_link` type)
-carrying the store's `recordPublicUrl` for a KVS record (auth-free only with a URL-signing key) or
-the token-gated API URL otherwise, plus a `limit`/`offset` paging hint for datasets/lists. It calls
-the client's axios instance directly instead of `httpClient.call()`: with a stream body, `call()`
-would hand non-2xx responses to `ApifyApiError` unconsumed (junk message, stranded socket per retry)
-— so this is one attempt, no retries, and the error body is read here to surface the API's message.
+`httpClient.axios.request({ method: 'GET', responseType: 'stream', maxContentLength: MAX_INLINE_BYTES })`
+— and branches on the declared Content-Type: textual base types (text/*, JSON, XML) as `text` with
+the full header, everything else (including no Content-Type) as a base64 `blob` with the base MIME
+type, empty body as empty text preserving the Content-Type. The body is never parsed, so bytes
+round-trip exactly. axios enforces `MAX_INLINE_BYTES` (256 KB) mid-consumption on streamed
+responses (axios ≥1.16: byte-counting wrapper throws `ERR_BAD_RESPONSE`, counting decoded bytes) —
+after the request resolves, outside any retry wrapper. On trip, the proxy links out: a `text/plain`
+block carrying the store's signed `recordPublicUrl` for a KVS record, else the token-gated API URL,
+plus a `limit`/`offset` paging hint. It calls the client's axios instance directly, not
+`httpClient.call()`: with a stream body, `call()` hands non-2xx responses to `ApifyApiError`
+unconsumed (junk message, stranded socket per retry) — one attempt, no retries; the error body is
+read here to surface the API's message.
 
-Genuine failures **throw** an `McpError` so the SDK returns a JSON-RPC error, not success-shaped
-content for an unreadable resource (the direction SEP-2164 makes a MUST). `statusToErrorCode()`:
-3xx/4xx except 429 → `InvalidParams` (bad URI, missing/invalid token, private or nonexistent
-resource); 429, 5xx, or no status (network, mid-stream drop) → `InternalError`. The no-token and
-bad-origin guards throw `InvalidParams` directly; 401/403 append a hint via `getHttpErrorHint()`
-(shared with `tools/call` in `utils/mcp.ts`); non-2xx and network failures are logged via
-`logHttpError` (5xx → exception). Size link-outs are the exception — **successful** reads returning
-a download pointer. The sibling `resource_service.ts` throws the same `InvalidParams` from its
-generic non-http fallback; widget-not-found branches stay as content.
-
-Discovery is the server-instructions prose, not a fixed list: `resources/templates/list` returns
-nothing and `resources/list` serves only widgets + the usage guide.
+Genuine failures **throw** an `McpError` carrying `data: { uri }` (SEP-2164 / draft spec: a
+JSON-RPC error, never success-shaped content): 3xx/4xx except 429 → `InvalidParams`; 429, 5xx, no
+status (network, mid-stream drop) → `InternalError`. 401/403 append a hint via `getHttpErrorHint()`
+(shared with `tools/call`); failures are logged via `logHttpError` (5xx → exception). Size
+link-outs are **successful** reads returning a download pointer, not failures. Discovery is the
+server-instructions prose; `resources/templates/list` returns nothing.
 
 ## Gotcha
 
-`widgets.ts` is **metadata only** — it registers and locates widgets. The actual
-React widget code and design rules live in [`../web/AGENTS.md`](../web/AGENTS.md);
-keep the two in sync (a widget registered here must exist there, and vice versa).
+`widgets.ts` is **metadata only** — it registers and locates widgets. The actual React widget code
+and design rules live in [`../web/AGENTS.md`](../web/AGENTS.md); keep the two in sync.
 
 After any change here run the root [Verification](../../AGENTS.md) steps.

--- a/src/resources/api_resources.ts
+++ b/src/resources/api_resources.ts
@@ -130,6 +130,12 @@ function isMaxContentLengthAbort(err: unknown): boolean {
     return isAxiosError(err) && err.code === 'ERR_BAD_RESPONSE' && err.message.includes('maxContentLength');
 }
 
+/** `charset` parameter of a Content-Type header, lowercased; `undefined` when absent. */
+function parseCharset(contentType: string | undefined): string | undefined {
+    const match = /;\s*charset\s*=\s*"?([^";]+)"?/i.exec(contentType ?? '');
+    return match?.[1].trim().toLowerCase();
+}
+
 /** Drain a response stream into one Buffer. Chunks are Buffers (`objectMode: false`). */
 async function collectStream(data: unknown): Promise<Buffer> {
     const chunks: Buffer[] = [];
@@ -254,11 +260,15 @@ export async function readApiResource(uri: string, apifyClient?: ApifyClient): P
     }
 
     const baseMimeType = parseBaseMimeType(contentType);
-    if (isTextualMimeType(baseMimeType)) {
-        // Verbatim, with the FULL declared Content-Type — charset included, a client needs it to decode.
-        return buildTextResult(uri, body.toString('utf-8'), contentType);
+    const charset = parseCharset(contentType) ?? 'utf-8';
+    // Decode with the DECLARED charset, not hardcoded UTF-8 — latin1 bytes decoded as UTF-8 mangle
+    // irreversibly to U+FFFD. A charset Node cannot decode falls through to the blob branch (lossless
+    // base64 beats text in a wrong encoding), the same rule as apify-client's body_parser. The full
+    // Content-Type — charset included — rides along on the text result.
+    if (isTextualMimeType(baseMimeType) && Buffer.isEncoding(charset)) {
+        return buildTextResult(uri, body.toString(charset), contentType);
     }
-    // Binary: base MIME type only (parameters are meaningless for a blob).
+    // Binary or undecodable text: base MIME type only (parameters are meaningless for a blob).
     return {
         contents: [
             {

--- a/src/resources/api_resources.ts
+++ b/src/resources/api_resources.ts
@@ -8,17 +8,28 @@ import { isAxiosError } from 'axios';
 
 import type { ApifyClient } from '../apify_client.js';
 import { getApifyAPIBaseUrl } from '../apify_client.js';
-import { MAX_DOWNLOAD_BYTES, MAX_INLINE_BYTES } from '../const.js';
-import { classifyBinaryRecordSize } from '../tools/storage/storage_helpers.js';
+import { MAX_INLINE_BYTES } from '../const.js';
+import { parseBaseMimeType } from '../tools/storage/storage_helpers.js';
 import { getHttpStatusCode, logHttpError } from '../utils/logging.js';
 import { getHttpErrorHint } from '../utils/mcp.js';
 
-const JSON_MIME_TYPE = 'application/json';
 const TEXT_MIME_TYPE = 'text/plain';
 
-/** True when the declared Content-Type is JSON, so the body must be re-serialized to round-trip primitives. */
-function isJsonContentType(contentType: string | undefined): boolean {
-    return contentType?.split(';')[0].trim().toLowerCase() === JSON_MIME_TYPE;
+/**
+ * Base MIME types emitted as `text` contents; everything else (including a missing
+ * Content-Type) is emitted as a base64 `blob`. JSON and XML are text so the raw body
+ * stays readable and byte-exact — the proxy never parses or re-serializes it.
+ */
+function isTextualMimeType(baseMimeType: string | undefined): boolean {
+    if (!baseMimeType) return false;
+    return (
+        baseMimeType.startsWith('text/') ||
+        baseMimeType === 'application/json' ||
+        baseMimeType.endsWith('+json') ||
+        baseMimeType === 'application/xml' ||
+        baseMimeType.endsWith('+xml') ||
+        baseMimeType === 'application/javascript'
+    );
 }
 
 /**
@@ -63,7 +74,7 @@ function safeDecodeURIComponent(segment: string): string {
 }
 
 /**
- * Download URL for a binary too large to inline. For a key-value-store record URI, returns the
+ * Download URL for a body too large to inline. For a key-value-store record URI, returns the
  * store's signed `recordPublicUrl` — fetchable without an API token when the client can read the
  * store's URL signing key. Falls back to the original API URL for any other endpoint, or if minting
  * the signed URL fails (fetching that link then needs a token).
@@ -87,63 +98,97 @@ async function fetchRecordDownloadUrl(uri: string, apifyClient: ApifyClient): Pr
 }
 
 /**
- * Single text-contents result. Defaults to text/plain (errors, refusals, link-outs); pass
- * `mimeType` to preserve a body's declared Content-Type (e.g. an empty record).
+ * Single text-contents result. Defaults to text/plain (link-outs); pass `mimeType`
+ * to preserve a body's declared Content-Type (e.g. an empty record).
  */
 function buildTextResult(uri: string, text: string, mimeType: string = TEXT_MIME_TYPE): ReadResourceResult {
     return { contents: [{ uri, mimeType, text } satisfies TextResourceContents] };
 }
 
 /**
+ * Successful read of a body too large to inline: a download pointer instead of the content.
+ * NOT a failure (no McpError) — the resource is readable, just not inline. The link is only
+ * auth-free for a key-value-store record whose store has a URL-signing key; an unsigned record
+ * URL and every other (token-gated) API URL still need the Apify token.
+ */
+async function buildLinkOutResult(uri: string, apifyClient: ApifyClient): Promise<ReadResourceResult> {
+    const downloadUrl = await fetchRecordDownloadUrl(uri, apifyClient);
+    return buildTextResult(
+        uri,
+        `Response body exceeds the ${MAX_INLINE_BYTES}-byte inline limit. Download it from ${downloadUrl} ` +
+            `(may require your Apify API token). For a dataset/list, re-read with a smaller limit/offset range.`,
+    );
+}
+
+/** The mid-consumption abort axios raises when a streamed body crosses `maxContentLength`. */
+function isMaxContentLengthAbort(err: unknown): boolean {
+    return isAxiosError(err) && err.code === 'ERR_BAD_RESPONSE' && err.message.includes('maxContentLength');
+}
+
+/** Drain a response stream into one Buffer. Chunks are Buffers (`objectMode: false`). */
+async function collectStream(data: unknown): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of data as AsyncIterable<Buffer | string>) {
+        chunks.push(Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+}
+
+/** `error.message` from an Apify API error body, or `undefined` when the body isn't that shape. */
+function parseApiErrorMessage(body: Buffer | undefined): string | undefined {
+    if (!body || body.length === 0) return undefined;
+    try {
+        const parsed = JSON.parse(body.toString('utf-8')) as { error?: { message?: unknown } };
+        return typeof parsed?.error?.message === 'string' ? parsed.error.message : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
  * Read any Apify API GET endpoint as an MCP resource.
  *
- * A thin proxy: the apify-client injects the session token (and the MCP-origin header),
- * performs the GET, and parses the body by Content-Type — JSON to an object, text/xml to a
- * string, anything else to a Buffer, an empty body to `undefined`. We branch on that resulting
- * JS type, not the MIME type. Genuine failures (no token, bad origin, a missing resource, a bad
- * token, a 5xx, a network error) throw an `McpError` so the SDK returns a JSON-RPC error rather
- * than success-shaped content for an unreadable resource (see SEP-2164). Size link-outs are NOT
- * failures — they are successful reads returning a download pointer — so they still return content.
+ * A thin streaming proxy: the apify-client injects the session token (and the MCP-origin header),
+ * the body streams in verbatim and is returned by its declared Content-Type — textual types
+ * (text/*, JSON, XML) as `text`, anything else as a base64 `blob`. The body is never parsed, so
+ * JSON primitives, formatting, and bytes round-trip exactly.
  *
- * The download itself goes straight through `apifyClient.httpClient.axios` (the same axios
- * instance apify-client builds internally, so token/origin headers and Content-Type parsing
- * still apply) instead of `httpClient.call()`. This is one attempt, no retries: `call()` would
- * retry the size-cap abort below as if it were a flaky network error, adding 8 retries and
- * ~127s of backoff for what is a deliberate, permanent rejection. The download is capped at
- * `MAX_DOWNLOAD_BYTES` (5 MB) via axios's `maxContentLength`, checked incrementally as bytes
- * arrive — so an oversized dataset/log is aborted mid-flight instead of being buffered whole
- * before the (separate, smaller) `MAX_INLINE_BYTES` inline check ever runs.
+ * Genuine failures (no token, bad origin, a missing resource, a bad token, a 5xx, a network error)
+ * throw an `McpError` so the SDK returns a JSON-RPC error rather than success-shaped content for an
+ * unreadable resource (see SEP-2164). A body over `MAX_INLINE_BYTES` is NOT a failure — it is a
+ * successful read returning a download pointer.
+ *
+ * The request goes straight through `apifyClient.httpClient.axios` (the same axios instance
+ * apify-client builds internally, so token/origin headers still apply) instead of
+ * `httpClient.call()`: with `responseType: 'stream'`, a non-2xx reaches `call()` as an unconsumed
+ * stream — its `ApifyApiError` message degrades to junk and each retry attempt strands an unread
+ * socket. One attempt, no retries. `maxContentLength` is enforced by axios itself mid-consumption
+ * (verified in axios@1.16.1: the adapter wraps streamed responses in a byte-counting generator
+ * that throws `ERR_BAD_RESPONSE` when the decoded size crosses the limit), so an oversized body
+ * is aborted at ~`MAX_INLINE_BYTES`, never buffered whole.
  */
 export async function readApiResource(uri: string, apifyClient?: ApifyClient): Promise<ReadResourceResult> {
-    if (!apifyClient) {
-        throw new McpError(ErrorCode.InvalidParams, `Failed to read ${uri}: no Apify token in this session.`);
-    }
+    // Origin first: a non-Apify URL is never readable, with or without a token.
     if (!isApifyApiUri(uri)) {
         throw new McpError(
             ErrorCode.InvalidParams,
             `Failed to read ${uri}: only Apify API URLs (${getApifyAPIBaseUrl()}) are readable as resources.`,
         );
     }
+    if (!apifyClient) {
+        throw new McpError(ErrorCode.InvalidParams, `Failed to read ${uri}: no Apify token in this session.`);
+    }
 
     let response: { data: unknown; headers: Record<string, unknown>; status: number; statusText: string };
     try {
-        // Default responseType is `arraybuffer`, which lets the client's parse interceptor decode
-        // the body by Content-Type. Do NOT set `forceBuffer` — that would keep everything as raw bytes.
         response = await apifyClient.httpClient.axios.request<unknown>({
             url: uri,
             method: 'GET',
-            responseType: 'arraybuffer',
-            maxContentLength: MAX_DOWNLOAD_BYTES,
+            responseType: 'stream',
+            maxContentLength: MAX_INLINE_BYTES,
         });
     } catch (err) {
-        if (isAxiosError(err) && err.code === 'ERR_BAD_RESPONSE' && err.message.includes('maxContentLength')) {
-            const downloadUrl = await fetchRecordDownloadUrl(uri, apifyClient);
-            return buildTextResult(
-                uri,
-                `Response body exceeds the ${MAX_DOWNLOAD_BYTES}-byte download limit. Download it from ${downloadUrl} ` +
-                    `(may require your Apify API token). For a dataset/list, re-read with a smaller limit/offset range.`,
-            );
-        }
+        logHttpError(err, `resources/read request failed`, { uri });
         const status = getHttpStatusCode(err);
         const message = err instanceof Error ? err.message : String(err);
         const hint = getHttpErrorHint(status);
@@ -153,89 +198,62 @@ export async function readApiResource(uri: string, apifyClient?: ApifyClient): P
         );
     }
 
+    let body: Buffer | undefined;
+    let overLimit = false;
+    try {
+        body = await collectStream(response.data);
+    } catch (err) {
+        if (isMaxContentLengthAbort(err)) {
+            overLimit = true;
+        } else {
+            // A drop mid-body (reset, truncation, bad gzip). Never return partial content.
+            logHttpError(err, `resources/read response interrupted`, { uri });
+            const message = err instanceof Error ? err.message : String(err);
+            throw new McpError(ErrorCode.InternalError, `Failed to read ${uri}: response interrupted: ${message}`);
+        }
+    }
+
     // `validateStatus: null` on this axios instance resolves non-2xx responses instead of throwing,
-    // so a failed request must be checked here rather than in the catch block above.
+    // so a failed request is checked here. The error body was just collected above (Apify API error
+    // bodies are small JSON; if one somehow crossed the limit, fall back to the status text).
     if (response.status >= 300) {
-        const body = response.data as { error?: { message?: unknown } } | undefined;
-        const message = typeof body?.error?.message === 'string' ? body.error.message : response.statusText;
+        const message = parseApiErrorMessage(body) ?? response.statusText;
         const hint = getHttpErrorHint(response.status);
+        logHttpError(Object.assign(new Error(message), { statusCode: response.status }), `resources/read failed`, {
+            uri,
+        });
         throw new McpError(
             statusToErrorCode(response.status),
             `Failed to read ${uri}: HTTP ${response.status}: ${message}${hint ? `. ${hint}` : ''}`,
         );
     }
 
+    if (overLimit || body === undefined) {
+        return buildLinkOutResult(uri, apifyClient);
+    }
+
     const contentTypeHeader = response.headers['content-type'];
     const contentType = typeof contentTypeHeader === 'string' ? contentTypeHeader : undefined;
-    const { data } = response;
 
-    // An empty response body (e.g. an Actor that wrote an empty OUTPUT) maps to `undefined`; emit empty
-    // text, preserving the record's declared Content-Type. JSON `null` maps to JS `null` — a distinct,
-    // meaningful value — so it is NOT treated as empty here and round-trips through the JSON branch below.
-    if (data === undefined) {
+    // An empty body (e.g. an Actor that wrote an empty OUTPUT) is empty text preserving the
+    // declared Content-Type, matching the empty-record behavior of get-key-value-store-record.
+    if (body.length === 0) {
         return buildTextResult(uri, '', contentType);
     }
 
-    if (Buffer.isBuffer(data)) {
-        const disposition = classifyBinaryRecordSize(contentType, data);
-        // Above the inline limit, link out with an explanatory text block (resources/read has no
-        // resource_link content type), matching the soft-fail contract. The link is only auth-free for a
-        // key-value-store record whose store has a URL-signing key; an unsigned record URL and every other
-        // (token-gated) API URL still need the Apify token — so the message says it may require it.
-        if (disposition.kind === 'linkOut') {
-            const downloadUrl = await fetchRecordDownloadUrl(uri, apifyClient);
-            return buildTextResult(
+    const baseMimeType = parseBaseMimeType(contentType);
+    if (isTextualMimeType(baseMimeType)) {
+        // Verbatim, with the FULL declared Content-Type — charset included, a client needs it to decode.
+        return buildTextResult(uri, body.toString('utf-8'), contentType);
+    }
+    // Binary: base MIME type only (parameters are meaningless for a blob).
+    return {
+        contents: [
+            {
                 uri,
-                `Response body (${disposition.mimeType ?? 'binary'}, ${disposition.bytes} bytes) is too large to inline. ` +
-                    `Download it from ${downloadUrl} (may require your Apify API token).`,
-            );
-        }
-        return {
-            contents: [
-                {
-                    uri,
-                    ...(disposition.mimeType && { mimeType: disposition.mimeType }),
-                    blob: disposition.base64,
-                } satisfies BlobResourceContents,
-            ],
-        };
-    }
-
-    // Serialize the body to the exact text we would inline, then size-guard it below.
-    let text: string;
-    let mimeType: string;
-    if (isJsonContentType(contentType)) {
-        // A JSON body must be re-serialized so primitives round-trip as valid JSON: a bare JSON string
-        // `"hi"` parses to the JS string `hi`, and emitting it verbatim would drop the quotes; JSON `null`
-        // must stay `null`, not collapse to empty text. Branch on the declared Content-Type, not the parsed
-        // JS type, so the type alone can't misclassify a string body.
-        text = JSON.stringify(data);
-        mimeType = contentType ?? JSON_MIME_TYPE;
-    } else {
-        // text/xml bodies are JS strings, emitted verbatim with their FULL declared Content-Type — charset
-        // included, since a client needs it to decode the text. This is deliberately unlike the binary path,
-        // where `classifyBinaryRecordSize` strips the Content-Type to its base MIME type (only the base type is
-        // meaningful for a blob, and the image/audio routing keys off it). Any other parsed object (no/unknown
-        // Content-Type) is lossless-serialized as JSON.
-        text = typeof data === 'string' ? data : JSON.stringify(data);
-        mimeType = contentType ?? (typeof data === 'string' ? TEXT_MIME_TYPE : JSON_MIME_TYPE);
-    }
-
-    // Symmetric with the binary link-out above: a body over the inline limit would blow up the caller's
-    // context, so link out instead of inlining. We measure the serialized bytes we would actually emit —
-    // not a Content-Length header, which reports the original wire body (a different size after
-    // re-serialization) and is often absent on chunked/gzip list responses. The link is the store's signed
-    // `recordPublicUrl` for a KVS record (fetchable without a token) and the token-gated API URL otherwise;
-    // limit/offset paging only works for a dataset/list, so it's offered as a secondary hint, not the sole
-    // remedy — a single record or log cannot be paged and would otherwise dead-end.
-    const bytes = Buffer.byteLength(text);
-    if (bytes > MAX_INLINE_BYTES) {
-        const downloadUrl = await fetchRecordDownloadUrl(uri, apifyClient);
-        return buildTextResult(
-            uri,
-            `Response body (~${bytes} bytes) is too large to inline. Download it from ${downloadUrl} ` +
-                `(may require your Apify API token). For a dataset/list, re-read with a smaller limit/offset range.`,
-        );
-    }
-    return buildTextResult(uri, text, mimeType);
+                ...(baseMimeType && { mimeType: baseMimeType }),
+                blob: body.toString('base64'),
+            } satisfies BlobResourceContents,
+        ],
+    };
 }

--- a/src/resources/api_resources.ts
+++ b/src/resources/api_resources.ts
@@ -48,11 +48,16 @@ function statusToErrorCode(status: number | undefined): ErrorCode {
  *
  * This is the security gate for the generic read proxy: the apify-client attaches the
  * session token as an `Authorization` header to every outbound request, so we must only
- * hand it Apify API URLs — never an arbitrary host.
+ * hand it Apify API URLs — never an arbitrary host. Userinfo-bearing URLs
+ * (`user@api.apify.com`) are rejected even when the host is genuinely ours: axios drops
+ * the default `Authorization` header for credentials-bearing URLs, so the read would
+ * silently run unauthenticated.
  */
 export function isApifyApiUri(uri: string): boolean {
     try {
-        return new URL(uri).origin === new URL(getApifyAPIBaseUrl()).origin;
+        const url = new URL(uri);
+        if (url.username || url.password) return false;
+        return url.origin === new URL(getApifyAPIBaseUrl()).origin;
     } catch {
         return false;
     }
@@ -173,10 +178,13 @@ export async function readApiResource(uri: string, apifyClient?: ApifyClient): P
         throw new McpError(
             ErrorCode.InvalidParams,
             `Failed to read ${uri}: only Apify API URLs (${getApifyAPIBaseUrl()}) are readable as resources.`,
+            { uri },
         );
     }
     if (!apifyClient) {
-        throw new McpError(ErrorCode.InvalidParams, `Failed to read ${uri}: no Apify token in this session.`);
+        throw new McpError(ErrorCode.InvalidParams, `Failed to read ${uri}: no Apify token in this session.`, {
+            uri,
+        });
     }
 
     let response: { data: unknown; headers: Record<string, unknown>; status: number; statusText: string };
@@ -195,6 +203,7 @@ export async function readApiResource(uri: string, apifyClient?: ApifyClient): P
         throw new McpError(
             statusToErrorCode(status),
             `Failed to read ${uri}: ${status ? `HTTP ${status}: ` : ''}${message}${hint ? `. ${hint}` : ''}`,
+            { uri },
         );
     }
 
@@ -209,7 +218,9 @@ export async function readApiResource(uri: string, apifyClient?: ApifyClient): P
             // A drop mid-body (reset, truncation, bad gzip). Never return partial content.
             logHttpError(err, `resources/read response interrupted`, { uri });
             const message = err instanceof Error ? err.message : String(err);
-            throw new McpError(ErrorCode.InternalError, `Failed to read ${uri}: response interrupted: ${message}`);
+            throw new McpError(ErrorCode.InternalError, `Failed to read ${uri}: response interrupted: ${message}`, {
+                uri,
+            });
         }
     }
 
@@ -225,6 +236,7 @@ export async function readApiResource(uri: string, apifyClient?: ApifyClient): P
         throw new McpError(
             statusToErrorCode(response.status),
             `Failed to read ${uri}: HTTP ${response.status}: ${message}${hint ? `. ${hint}` : ''}`,
+            { uri },
         );
     }
 

--- a/src/resources/resource_service.ts
+++ b/src/resources/resource_service.ts
@@ -15,7 +15,7 @@ import log from '@apify/log';
 import type { ApifyClient } from '../apify_client.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { SERVER_MODE } from '../types.js';
-import { isApifyApiUri, readApiResource } from './api_resources.js';
+import { readApiResource } from './api_resources.js';
 import type { AvailableWidget } from './widgets.js';
 import { RESOURCE_MIME_TYPE } from './widgets.js';
 
@@ -84,7 +84,9 @@ export function createResourceService(options: ResourceServiceOptions): Resource
     };
 
     const readResource = async (uri: string, apifyClient?: ApifyClient): Promise<ExtendedReadResourceResult> => {
-        if (isApifyApiUri(uri)) {
+        // Route every http(s) URI to the API proxy — it owns the single origin gate, so a
+        // non-Apify URL gets the explanatory origin refusal instead of the generic fallback.
+        if (/^https?:\/\//i.test(uri)) {
             // API contents carry no widget `_meta`/`html`; the extended shape only adds optional fields.
             return (await readApiResource(uri, apifyClient)) as ExtendedReadResourceResult;
         }
@@ -158,7 +160,7 @@ export function createResourceService(options: ResourceServiceOptions): Resource
             }
         }
 
-        // A URI that is neither an Apify API URL, the usage guide, nor a served widget is not a
+        // A URI that is neither an http(s) URL, the usage guide, nor a served widget is not a
         // readable resource — throw so the SDK returns a JSON-RPC error instead of success-shaped
         // "not found" content (see SEP-2164 and src/resources/AGENTS.md).
         throw new McpError(ErrorCode.InvalidParams, `Failed to read ${uri}: not a readable resource.`);

--- a/src/resources/resource_service.ts
+++ b/src/resources/resource_service.ts
@@ -13,6 +13,7 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import log from '@apify/log';
 
 import type { ApifyClient } from '../apify_client.js';
+import { getApifyAPIBaseUrl } from '../apify_client.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { SERVER_MODE } from '../types.js';
 import { readApiResource } from './api_resources.js';
@@ -166,11 +167,52 @@ export function createResourceService(options: ResourceServiceOptions): Resource
         throw new McpError(ErrorCode.InvalidParams, `Failed to read ${uri}: not a readable resource.`, { uri });
     };
 
-    // Read is a generic proxy over any Apify API GET URL, advertised in the server instructions;
-    // there are no fixed templates to enumerate.
-    const listResourceTemplates = async (): Promise<ListResourceTemplatesResult> => ({
-        resourceTemplates: [],
-    });
+    // Advertise the common URL shapes so clients that never surface the server instructions can
+    // still discover the read proxy and its paging parameters (RFC 6570 `{?var}` = query params).
+    // Advertisement only, NOT a route table: the read path stays a generic proxy, and any other
+    // Apify API GET URL is readable the same way.
+    const listResourceTemplates = async (): Promise<ListResourceTemplatesResult> => {
+        const api = getApifyAPIBaseUrl();
+        return {
+            resourceTemplates: [
+                {
+                    uriTemplate: `${api}/v2/datasets/{datasetId}/items{?limit,offset,clean,fields,format}`,
+                    name: 'dataset-items',
+                    // No mimeType: `format` selects among 7 response types (json/jsonl/xml/html/csv/xlsx/rss),
+                    // and the spec allows a template mimeType only when all matching resources share one.
+                    description:
+                        'Items of a dataset, read via resources/read (the server injects the Apify token). ' +
+                        'Page with limit/offset; format defaults to JSON — responses inline up to 256 KB, ' +
+                        'larger ones return a download URL.',
+                },
+                {
+                    uriTemplate: `${api}/v2/key-value-stores/{storeId}/records/{recordKey}`,
+                    name: 'key-value-store-record',
+                    description:
+                        'A single record, returned whole in its stored Content-Type via resources/read. ' +
+                        'Not pageable — a record over 256 KB returns a download URL instead.',
+                },
+                {
+                    uriTemplate: `${api}/v2/key-value-stores/{storeId}/keys{?limit,exclusiveStartKey}`,
+                    name: 'key-value-store-keys',
+                    description: 'Keys of a key-value store. Page with limit/exclusiveStartKey (not offset).',
+                    mimeType: 'application/json',
+                },
+                {
+                    uriTemplate: `${api}/v2/actor-runs/{runId}`,
+                    name: 'actor-run',
+                    description: 'Metadata of an Actor run: status, storage IDs, usage.',
+                    mimeType: 'application/json',
+                },
+                {
+                    uriTemplate: `${api}/v2/logs/{runId}`,
+                    name: 'actor-run-log',
+                    description: 'Log of an Actor run. Inlines up to 256 KB, larger returns a download URL.',
+                    mimeType: 'text/plain',
+                },
+            ],
+        };
+    };
 
     return {
         listResources,

--- a/src/resources/resource_service.ts
+++ b/src/resources/resource_service.ts
@@ -163,7 +163,7 @@ export function createResourceService(options: ResourceServiceOptions): Resource
         // A URI that is neither an http(s) URL, the usage guide, nor a served widget is not a
         // readable resource — throw so the SDK returns a JSON-RPC error instead of success-shaped
         // "not found" content (see SEP-2164 and src/resources/AGENTS.md).
-        throw new McpError(ErrorCode.InvalidParams, `Failed to read ${uri}: not a readable resource.`);
+        throw new McpError(ErrorCode.InvalidParams, `Failed to read ${uri}: not a readable resource.`, { uri });
     };
 
     // Read is a generic proxy over any Apify API GET URL, advertised in the server instructions;

--- a/src/tools/storage/get_key_value_store_record.ts
+++ b/src/tools/storage/get_key_value_store_record.ts
@@ -11,9 +11,9 @@ import { computeValueBytes, stripQuoteWrappers } from '../../utils/generic.js';
 import { respondRaw, respondUserError } from '../../utils/mcp.js';
 import { keyValueStoreRecordOutputSchema } from '../structured_output_schemas.js';
 import {
+    buildBinaryRecordDisposition,
     buildConsoleLinkContent,
     buildStorageResponse,
-    classifyBinaryRecordSize,
     normalizeRecordKey,
 } from './storage_helpers.js';
 
@@ -85,9 +85,9 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
         // structuredContent — so emit a minimal schema-conforming descriptor alongside the block.
         // The Console link (Console UI token sessions) rides as a trailing text block.
         if (Buffer.isBuffer(value)) {
-            // Shared with the API-resource proxy: normalizes the MIME type (so the image/audio checks below
-            // don't miss `Image/PNG`) and decides inline-vs-link-out at the same byte threshold.
-            const disposition = classifyBinaryRecordSize(contentType, value);
+            // Normalizes the MIME type (so the image/audio checks below don't miss `Image/PNG`) and
+            // decides inline-vs-link-out at the same MAX_INLINE_BYTES threshold the API-resource proxy uses.
+            const disposition = buildBinaryRecordDisposition(contentType, value);
             const { mimeType } = disposition;
             const structuredContent = {
                 keyValueStoreId,

--- a/src/tools/storage/storage_helpers.ts
+++ b/src/tools/storage/storage_helpers.ts
@@ -177,13 +177,20 @@ export type BinaryRecordDisposition =
     | { kind: 'linkOut'; mimeType?: string; bytes: number };
 
 /**
- * Classify a binary record value for transport. Shared by the get-key-value-store-record tool and the
- * API-resource proxy so the MIME normalization, inline threshold, and base64 encoding stay in one place.
- * It does NOT mint the link-out URL — the two callers build different URLs (a signed record URL vs the
- * API URL) via async calls — so the caller handles `linkOut` by minting its own URL.
+ * Base MIME type of a Content-Type header: parameters stripped, lowercased
+ * (`Image/PNG; charset=…` → `image/png`), `undefined` when no header was declared.
+ * Shared by the get-key-value-store-record tool and the API-resource proxy.
+ */
+export function parseBaseMimeType(contentType: string | undefined): string | undefined {
+    return contentType?.split(';')[0].trim().toLowerCase();
+}
+
+/**
+ * Classify a binary record value for transport. It does NOT mint the link-out URL — the caller
+ * handles `linkOut` by minting its own URL (a signed record URL vs the API URL) via async calls.
  */
 export function classifyBinaryRecordSize(contentType: string | undefined, value: Buffer): BinaryRecordDisposition {
-    const mimeType = contentType?.split(';')[0].trim().toLowerCase();
+    const mimeType = parseBaseMimeType(contentType);
     if (value.length > MAX_INLINE_BYTES) {
         return { kind: 'linkOut', ...(mimeType !== undefined && { mimeType }), bytes: value.length };
     }

--- a/src/tools/storage/storage_helpers.ts
+++ b/src/tools/storage/storage_helpers.ts
@@ -186,10 +186,11 @@ export function parseBaseMimeType(contentType: string | undefined): string | und
 }
 
 /**
- * Classify a binary record value for transport. It does NOT mint the link-out URL — the caller
- * handles `linkOut` by minting its own URL (a signed record URL vs the API URL) via async calls.
+ * Build the transport disposition for a binary record value: normalize the MIME type, decide
+ * inline-vs-link-out at the byte threshold, base64-encode when inlining. It does NOT mint the
+ * link-out URL — the caller handles `linkOut` by minting its own URL via async calls.
  */
-export function classifyBinaryRecordSize(contentType: string | undefined, value: Buffer): BinaryRecordDisposition {
+export function buildBinaryRecordDisposition(contentType: string | undefined, value: Buffer): BinaryRecordDisposition {
     const mimeType = parseBaseMimeType(contentType);
     if (value.length > MAX_INLINE_BYTES) {
         return { kind: 'linkOut', ...(mimeType !== undefined && { mimeType }), bytes: value.length };

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -46,9 +46,9 @@ These tools are called **Actors**. They enable you to extract structured data fr
 - **Key-value store:** Flexible storage for unstructured data or auxiliary files.
 
 ## Apify API resources
-- Any Apify API GET endpoint can be read as an MCP resource. Pass the full \`https://api.apify.com/v2/...\` URL to \`resources/read\`; the server injects the session's Apify token and returns the response body. Reads require an Apify token — a session without one (e.g. payment-only x402/Skyfire) soft-fails with an explanatory message.
+- Any Apify API GET endpoint can be read as an MCP resource. Pass the full \`https://api.apify.com/v2/...\` URL to \`resources/read\`; the server injects the session's Apify token and returns the response body. Reads require an Apify token — a session without one (e.g. payment-only x402/Skyfire) fails with a JSON-RPC error.
 - Actor and tool results return storage IDs, not resource URLs — build the URL from the ID (e.g. a \`datasetId\` becomes \`https://api.apify.com/v2/datasets/{datasetId}/items\`) and read it via \`resources/read\`.
-- Reads inline up to ~256 KB; a larger response returns a short notice instead of the body, so page large datasets/lists with \`limit\` and \`offset\` to stay under the cap, and responses over 5 MB are not downloaded at all — the notice carries a download URL instead.
+- Reads inline up to ~256 KB; a larger response is not downloaded — it returns a short notice with a download URL instead of the body, so page large datasets/lists with \`limit\` and \`offset\` to stay under the cap.
 - Examples: \`https://api.apify.com/v2/datasets/{datasetId}/items?clean=true&format=json&limit=100\`, \`https://api.apify.com/v2/key-value-stores/{storeId}/records/{recordKey}\`.
 ${
     isApps

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -49,7 +49,7 @@ These tools are called **Actors**. They enable you to extract structured data fr
 - Any Apify API GET endpoint can be read as an MCP resource. Pass the full \`https://api.apify.com/v2/...\` URL to \`resources/read\`; the server injects the session's Apify token and returns the response body. Reads require an Apify token — a session without one (e.g. payment-only x402/Skyfire) fails with a JSON-RPC error.
 - Actor and tool results return storage IDs, not resource URLs — build the URL from the ID (e.g. a \`datasetId\` becomes \`https://api.apify.com/v2/datasets/{datasetId}/items\`) and read it via \`resources/read\`.
 - Reads inline up to ~256 KB; a larger response is not downloaded — it returns a short notice with a download URL instead of the body, so page large datasets/lists with \`limit\` and \`offset\` to stay under the cap.
-- Examples: \`https://api.apify.com/v2/datasets/{datasetId}/items?clean=true&format=json&limit=100\`, \`https://api.apify.com/v2/key-value-stores/{storeId}/records/{recordKey}\`.
+- Examples: \`https://api.apify.com/v2/datasets/{datasetId}/items?clean=true&format=json&limit=100\`, \`https://api.apify.com/v2/key-value-stores/{storeId}/records/{recordKey}\`. \`resources/templates/list\` enumerates the common shapes with their paging parameters.
 ${
     isApps
         ? `

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2204,6 +2204,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     );
                     await client.close();
                 });
+
+                it('advertises API URL templates via resources/templates/list', async () => {
+                    client = await createClientFn({ tools: ['storage'] });
+                    const { resourceTemplates } = await client.listResourceTemplates();
+                    const datasetItems = resourceTemplates.find((t) => t.name === 'dataset-items');
+                    expect(datasetItems?.uriTemplate).toContain('/v2/datasets/{datasetId}/items{?limit,offset,');
+                    await client.close();
+                });
             });
 
             it('rejects get-key-value-store-record when required keyValueStoreId is missing', async () => {

--- a/tests/unit/resources.api.test.ts
+++ b/tests/unit/resources.api.test.ts
@@ -1,10 +1,12 @@
+import { Readable } from 'node:stream';
+
 import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { AxiosError } from 'axios';
 import { describe, expect, it } from 'vitest';
 
 import type { ApifyClient } from '../../src/apify_client.js';
-import { MAX_DOWNLOAD_BYTES, MAX_INLINE_BYTES } from '../../src/const.js';
+import { MAX_INLINE_BYTES } from '../../src/const.js';
 import { isApifyApiUri, readApiResource } from '../../src/resources/api_resources.js';
 
 const API = 'https://api.apify.com';
@@ -21,7 +23,25 @@ async function expectReadError(promise: Promise<unknown>): Promise<McpError> {
     return error as McpError;
 }
 
-type RequestConfig = { url: string; maxContentLength?: number };
+/** Body stream the stubbed request returns; chunked to prove multi-chunk reassembly. */
+function streamOf(...chunks: (string | Buffer)[]): Readable {
+    return Readable.from(chunks.map((c) => Buffer.from(c)));
+}
+
+/**
+ * Models the axios stream `maxContentLength` enforcement (axios ≥1.16 wraps streamed responses in a
+ * byte-counting generator): yields a prefix, then throws the same abort axios raises over the limit.
+ */
+function abortingStream(prefix: string | Buffer = 'partial'): Readable {
+    return Readable.from(
+        (async function* generate() {
+            yield Buffer.from(prefix);
+            throw new AxiosError(`maxContentLength size of ${MAX_INLINE_BYTES} exceeded`, 'ERR_BAD_RESPONSE');
+        })(),
+    );
+}
+
+type RequestConfig = { url: string; responseType?: string; maxContentLength?: number };
 type RequestResult = { data: unknown; headers: Record<string, unknown>; status: number; statusText: string };
 
 type StubOptions = {
@@ -46,20 +66,30 @@ function stubApifyClient(opts: StubOptions = {}): ApifyClient {
         httpClient: {
             axios: {
                 request:
-                    opts.request ?? (async () => ({ data: undefined, headers: {}, status: 200, statusText: 'OK' })),
+                    opts.request ?? (async () => ({ data: streamOf(), headers: {}, status: 200, statusText: 'OK' })),
             },
         },
     } as unknown as ApifyClient;
 }
 
-/** Build a request stub returning a fixed 200 response, capturing the requested config. */
-function requestReturning(data: unknown, contentType?: string) {
+/** Build a request stub returning a fixed 200 response body, capturing the requested config. */
+function requestReturning(data: Readable, contentType?: string) {
     const captured: RequestConfig = { url: '' };
     const request = async (config: RequestConfig): Promise<RequestResult> => {
         Object.assign(captured, config);
         return { data, headers: contentType ? { 'content-type': contentType } : {}, status: 200, statusText: 'OK' };
     };
     return { request, captured };
+}
+
+/** Request stub resolving a non-2xx response (`validateStatus: null` semantics) with a body stream. */
+function requestFailing(status: number, statusText: string, body?: object) {
+    return async (): Promise<RequestResult> => ({
+        data: body ? streamOf(JSON.stringify(body)) : streamOf(),
+        headers: { 'content-type': 'application/json; charset=utf-8' },
+        status,
+        statusText,
+    });
 }
 
 describe('isApifyApiUri()', () => {
@@ -92,49 +122,35 @@ describe('readApiResource()', () => {
         expect(error.message).toContain('only Apify API URLs');
     });
 
-    it('passes the full URL through to httpClient.axios.request', async () => {
-        const { request, captured } = requestReturning([{ a: 1 }], 'application/json');
+    it('requests the full URL as a stream capped at MAX_INLINE_BYTES', async () => {
+        // The size cap is enforced by axios itself mid-consumption (streamed responses are wrapped in a
+        // byte-counting generator since axios 1.16), so the contract under test is the request config.
+        const { request, captured } = requestReturning(streamOf('[]'), 'application/json');
         const uri = `${API}/v2/datasets/ds-1/items?limit=5`;
 
         await readApiResource(uri, stubApifyClient({ request }));
 
         expect(captured.url).toBe(uri);
+        expect(captured.responseType).toBe('stream');
+        expect(captured.maxContentLength).toBe(MAX_INLINE_BYTES);
     });
 
-    it('caps the download at MAX_DOWNLOAD_BYTES via axios maxContentLength', async () => {
-        // Enforced mid-flight by axios itself, not after buffering the full body — see const.ts.
-        const { request, captured } = requestReturning(undefined);
-
-        await readApiResource(`${API}/v2/datasets/ds-1/items`, stubApifyClient({ request }));
-
-        expect(captured.maxContentLength).toBe(MAX_DOWNLOAD_BYTES);
-    });
-
-    it('serializes a parsed JSON body as text with its content-type', async () => {
-        const { request } = requestReturning({ query: 'hi' }, 'application/json');
+    it('returns a JSON body verbatim, reassembling chunks, with its full content-type', async () => {
+        const { request } = requestReturning(streamOf('{"query"', ':"hi"}'), 'application/json; charset=utf-8');
 
         const result = await readApiResource(
             `${API}/v2/key-value-stores/kv-1/records/INPUT`,
             stubApifyClient({ request }),
         );
 
-        expect(firstContent(result).mimeType).toBe('application/json');
-        expect(JSON.parse(firstContent(result).text as string)).toEqual({ query: 'hi' });
+        expect(firstContent(result).mimeType).toBe('application/json; charset=utf-8');
+        expect(firstContent(result).text).toBe('{"query":"hi"}');
     });
 
-    it('serializes a dataset items array as JSON', async () => {
-        const { request } = requestReturning([{ a: 1 }, { a: 2 }], 'application/json');
-
-        const result = await readApiResource(`${API}/v2/datasets/ds-1/items`, stubApifyClient({ request }));
-
-        expect(firstContent(result).mimeType).toBe('application/json');
-        expect(JSON.parse(firstContent(result).text as string)).toEqual([{ a: 1 }, { a: 2 }]);
-    });
-
-    it('round-trips a JSON null body instead of dropping it as empty text', async () => {
-        // apify-client parses a literal JSON `null` body to JS null; it must serialize back to "null",
-        // not collapse to empty text (which would look like an absent record).
-        const { request } = requestReturning(null, 'application/json');
+    it('returns a JSON null body as the literal "null", not empty text', async () => {
+        // The body is never parsed, so a literal JSON `null` passes through byte-exact instead of
+        // collapsing to empty text (which would look like an absent record).
+        const { request } = requestReturning(streamOf('null'), 'application/json');
 
         const result = await readApiResource(
             `${API}/v2/key-value-stores/kv-1/records/OUTPUT`,
@@ -145,23 +161,20 @@ describe('readApiResource()', () => {
         expect(firstContent(result).text).toBe('null');
     });
 
-    it('re-serializes a bare JSON string body so the quotes survive', async () => {
-        // A bare JSON string body parses to a JS string; emitting it verbatim would yield invalid JSON
-        // (`hello`, not `"hello"`). Re-serialize when the declared Content-Type is JSON.
-        const { request } = requestReturning('hello', 'application/json');
+    it('returns a bare JSON string body with its quotes intact', async () => {
+        const { request } = requestReturning(streamOf('"hello"'), 'application/json');
 
         const result = await readApiResource(
             `${API}/v2/key-value-stores/kv-1/records/GREETING`,
             stubApifyClient({ request }),
         );
 
-        expect(firstContent(result).mimeType).toBe('application/json');
         expect(firstContent(result).text).toBe('"hello"');
         expect(JSON.parse(firstContent(result).text as string)).toBe('hello');
     });
 
     it('returns a text body verbatim with its content-type', async () => {
-        const { request } = requestReturning('hello world', 'text/plain; charset=utf-8');
+        const { request } = requestReturning(streamOf('hello world'), 'text/plain; charset=utf-8');
 
         const result = await readApiResource(
             `${API}/v2/key-value-stores/kv-1/records/NOTE`,
@@ -172,8 +185,21 @@ describe('readApiResource()', () => {
         expect(firstContent(result).text).toBe('hello world');
     });
 
-    it('returns binary values as a base64 blob with mimeType', async () => {
-        const { request } = requestReturning(Buffer.from('binary-data'), 'image/png');
+    it('returns an XML body as text', async () => {
+        const { request } = requestReturning(streamOf('<a>1</a>'), 'application/xml');
+
+        const result = await readApiResource(
+            `${API}/v2/key-value-stores/kv-1/records/FEED`,
+            stubApifyClient({ request }),
+        );
+
+        expect(firstContent(result).mimeType).toBe('application/xml');
+        expect(firstContent(result).text).toBe('<a>1</a>');
+    });
+
+    it('returns binary values as a base64 blob with the base mimeType', async () => {
+        // Content-Type parameters are stripped for blobs — only the base type is meaningful.
+        const { request } = requestReturning(streamOf(Buffer.from('binary-data')), 'Image/PNG; name=a.png');
 
         const result = await readApiResource(
             `${API}/v2/key-value-stores/kv-1/records/IMG`,
@@ -186,93 +212,23 @@ describe('readApiResource()', () => {
         expect(contents).not.toHaveProperty('text');
     });
 
-    it('links to the signed record URL instead of inlining a binary above the size limit', async () => {
-        // Inlining a multi-MB blob as base64 would blow up the client's context; link out instead.
-        // The link is the store's signed recordPublicUrl, so a client can fetch it without a token.
-        const oversized = Buffer.alloc(MAX_INLINE_BYTES + 1);
-        const uri = `${API}/v2/key-value-stores/kv-1/records/BIG`;
-        const { request } = requestReturning(oversized, 'application/octet-stream');
+    it('returns a body with no content-type as a blob without a mimeType', async () => {
+        // No declared Content-Type → base64 blob, the lossless choice (the real API always declares one).
+        const { request } = requestReturning(streamOf('mystery'));
 
-        const result = await readApiResource(uri, stubApifyClient({ request }));
-
-        const contents = firstContent(result);
-        expect(contents.mimeType).toBe('text/plain');
-        expect(contents).not.toHaveProperty('blob');
-        expect(contents.text).toContain('too large to inline');
-        expect(contents.text).toContain(signedUrl('kv-1', 'BIG'));
-        expect(contents.text).toContain(String(MAX_INLINE_BYTES + 1));
-        expect(contents.text).toContain('application/octet-stream');
-    });
-
-    it('still mints a signed link for a record key with malformed percent-encoding', async () => {
-        // A stray `%` in the key path used to throw in decodeURIComponent and drop the link to the
-        // token-gated API URL; safeDecodeURIComponent keeps the raw segment so the signed link survives.
-        const oversized = Buffer.alloc(MAX_INLINE_BYTES + 1);
-        const uri = `${API}/v2/key-value-stores/kv-1/records/BIG%`;
-        const { request } = requestReturning(oversized, 'application/octet-stream');
-
-        const result = await readApiResource(uri, stubApifyClient({ request }));
-
-        expect(firstContent(result).text).toContain(signedUrl('kv-1', 'BIG%'));
-    });
-
-    it('falls back to the API URL when minting the signed link fails', async () => {
-        const oversized = Buffer.alloc(MAX_INLINE_BYTES + 1);
-        const uri = `${API}/v2/key-value-stores/kv-1/records/BIG`;
-        const { request } = requestReturning(oversized, 'application/octet-stream');
-
-        const result = await readApiResource(uri, stubApifyClient({ request, recordPublicUrlThrows: true }));
-
-        expect(firstContent(result).text).toContain(uri);
-    });
-
-    it('links an oversized JSON dataset body to a download URL with a paging hint', async () => {
-        // A large dataset read with no limit parses to a JS array; serializing and inlining it would
-        // blow up the caller's context, exactly like an oversized binary. Link out instead: a non-record
-        // endpoint has no signed URL, so the link is the same (token-gated) API URL, with a paging hint.
-        const huge = [{ v: 'x'.repeat(MAX_INLINE_BYTES) }];
-        const uri = `${API}/v2/datasets/ds-1/items`;
-        const { request } = requestReturning(huge, 'application/json');
-
-        const result = await readApiResource(uri, stubApifyClient({ request }));
+        const result = await readApiResource(
+            `${API}/v2/key-value-stores/kv-1/records/RAW`,
+            stubApifyClient({ request }),
+        );
 
         const contents = firstContent(result);
-        expect(contents.mimeType).toBe('text/plain');
-        expect(contents.text).toContain('too large to inline');
-        expect(contents.text).toContain(uri);
-        expect(contents.text).toContain('limit');
-        expect(contents.text).toContain('offset');
-        // The body itself is not inlined.
-        expect(contents.text).not.toContain('xxxxxxxxxx');
+        expect(contents.blob).toBe(Buffer.from('mystery').toString('base64'));
+        expect(contents).not.toHaveProperty('mimeType');
     });
 
-    it('links an oversized text KVS record to its signed download URL', async () => {
-        // A KVS record has no limit/offset paging, so an oversized text/JSON record must link out like a
-        // binary. Prefer the store's signed recordPublicUrl so the user can fetch it without a token.
-        const uri = `${API}/v2/key-value-stores/kv-1/records/BIG_TEXT`;
-        const { request } = requestReturning('x'.repeat(MAX_INLINE_BYTES + 1), 'text/plain; charset=utf-8');
-
-        const result = await readApiResource(uri, stubApifyClient({ request }));
-
-        const contents = firstContent(result);
-        expect(contents.mimeType).toBe('text/plain');
-        expect(contents.text).toContain('too large to inline');
-        expect(contents.text).toContain(signedUrl('kv-1', 'BIG_TEXT'));
-        expect(contents.text).toContain(String(MAX_INLINE_BYTES + 1));
-    });
-
-    it('falls back to the API URL when an oversized text record link cannot be signed', async () => {
-        const uri = `${API}/v2/key-value-stores/kv-1/records/BIG_TEXT`;
-        const { request } = requestReturning('x'.repeat(MAX_INLINE_BYTES + 1), 'text/plain; charset=utf-8');
-
-        const result = await readApiResource(uri, stubApifyClient({ request, recordPublicUrlThrows: true }));
-
-        expect(firstContent(result).text).toContain(uri);
-    });
-
-    it('returns empty text for an empty body', async () => {
-        // The client maps an empty record body to `undefined` (e.g. an Actor that writes an empty OUTPUT).
-        const { request } = requestReturning(undefined, 'application/json');
+    it('returns empty text preserving the content-type for an empty body', async () => {
+        // e.g. an Actor that writes an empty OUTPUT record.
+        const { request } = requestReturning(streamOf(), 'application/json');
 
         const result = await readApiResource(
             `${API}/v2/key-value-stores/kv-1/records/OUTPUT`,
@@ -281,8 +237,61 @@ describe('readApiResource()', () => {
 
         expect(firstContent(result).text).toBe('');
         expect(firstContent(result)).not.toHaveProperty('blob');
-        // Empty body still preserves the record's declared Content-Type rather than defaulting to text/plain.
         expect(firstContent(result).mimeType).toBe('application/json');
+    });
+
+    it('links to the signed record URL when a KVS record body crosses the inline limit', async () => {
+        // Inlining a multi-MB body would blow up the client's context; link out instead. The link is
+        // the store's signed recordPublicUrl, so a client can fetch it without a token.
+        const uri = `${API}/v2/key-value-stores/kv-1/records/BIG`;
+        const { request } = requestReturning(abortingStream(), 'application/octet-stream');
+
+        const result = await readApiResource(uri, stubApifyClient({ request }));
+
+        const contents = firstContent(result);
+        expect(contents.mimeType).toBe('text/plain');
+        expect(contents).not.toHaveProperty('blob');
+        expect(contents.text).toContain('exceeds');
+        expect(contents.text).toContain(String(MAX_INLINE_BYTES));
+        expect(contents.text).toContain(signedUrl('kv-1', 'BIG'));
+        // The partial body is never returned.
+        expect(contents.text).not.toContain('partial');
+    });
+
+    it('still mints a signed link for a record key with malformed percent-encoding', async () => {
+        // A stray `%` in the key path used to throw in decodeURIComponent and drop the link to the
+        // token-gated API URL; safeDecodeURIComponent keeps the raw segment so the signed link survives.
+        const uri = `${API}/v2/key-value-stores/kv-1/records/BIG%`;
+        const { request } = requestReturning(abortingStream(), 'application/octet-stream');
+
+        const result = await readApiResource(uri, stubApifyClient({ request }));
+
+        expect(firstContent(result).text).toContain(signedUrl('kv-1', 'BIG%'));
+    });
+
+    it('falls back to the API URL when minting the signed link fails', async () => {
+        const uri = `${API}/v2/key-value-stores/kv-1/records/BIG`;
+        const { request } = requestReturning(abortingStream(), 'application/octet-stream');
+
+        const result = await readApiResource(uri, stubApifyClient({ request, recordPublicUrlThrows: true }));
+
+        expect(firstContent(result).text).toContain(uri);
+    });
+
+    it('links an oversized dataset body to its API URL with a paging hint', async () => {
+        // A non-record endpoint has no signed URL, so the link is the same (token-gated) API URL;
+        // a dataset/list can shrink below the cap via limit/offset, so the hint names both.
+        const uri = `${API}/v2/datasets/ds-1/items`;
+        const { request } = requestReturning(abortingStream(), 'application/json');
+
+        const result = await readApiResource(uri, stubApifyClient({ request }));
+
+        const contents = firstContent(result);
+        expect(contents.mimeType).toBe('text/plain');
+        expect(contents.text).toContain('exceeds');
+        expect(contents.text).toContain(uri);
+        expect(contents.text).toContain('limit');
+        expect(contents.text).toContain('offset');
     });
 
     it('throws when the request fails, mapping the error status to a code', async () => {
@@ -299,53 +308,29 @@ describe('readApiResource()', () => {
         expect(error.message).toContain('404');
     });
 
-    it('links to the signed record URL when axios aborts a KVS record download over the limit', async () => {
-        // A single attempt, no apify-client retries: apify-client would otherwise misclassify this abort
-        // as a retryable network error and retry it 8 times.
-        const abort = new AxiosError(`maxContentLength size of ${MAX_DOWNLOAD_BYTES} exceeded`, 'ERR_BAD_RESPONSE');
-        const uri = `${API}/v2/key-value-stores/kv-1/records/BIG`;
-        const client = stubApifyClient({
-            request: async () => {
-                throw abort;
-            },
-        });
+    it('throws InternalError when the body is interrupted mid-stream (never partial content)', async () => {
+        const dropped = Readable.from(
+            (async function* generate() {
+                yield Buffer.from('{"items":[');
+                throw new Error('socket hang up');
+            })(),
+        );
+        const { request } = requestReturning(dropped, 'application/json');
 
-        const result = await readApiResource(uri, client);
+        const error = await expectReadError(
+            readApiResource(`${API}/v2/datasets/ds-1/items`, stubApifyClient({ request })),
+        );
 
-        const contents = firstContent(result);
-        expect(contents.text).toContain('download limit');
-        expect(contents.text).toContain(String(MAX_DOWNLOAD_BYTES));
-        expect(contents.text).toContain(signedUrl('kv-1', 'BIG'));
-        expect(contents.text).toContain('limit');
-        expect(contents.text).toContain('offset');
-    });
-
-    it('links to the plain API URL when axios aborts a dataset-items download over the limit', async () => {
-        const abort = new AxiosError(`maxContentLength size of ${MAX_DOWNLOAD_BYTES} exceeded`, 'ERR_BAD_RESPONSE');
-        const uri = `${API}/v2/datasets/ds-1/items`;
-        const client = stubApifyClient({
-            request: async () => {
-                throw abort;
-            },
-        });
-
-        const result = await readApiResource(uri, client);
-
-        const contents = firstContent(result);
-        expect(contents.text).toContain('download limit');
-        expect(contents.text).toContain(uri);
-        expect(contents.text).toContain('limit');
-        expect(contents.text).toContain('offset');
+        expect(error.code).toBe(ErrorCode.InternalError);
+        expect(error.message).toContain('response interrupted');
+        expect(error.message).toContain('socket hang up');
     });
 
     it('throws InvalidParams with the parsed error message for a resolved non-2xx 4xx response', async () => {
         const uri = `${API}/v2/datasets/missing/items`;
         const client = stubApifyClient({
-            request: async () => ({
-                data: { error: { message: 'Dataset was not found', type: 'record-not-found' } },
-                headers: {},
-                status: 404,
-                statusText: 'Not Found',
+            request: requestFailing(404, 'Not Found', {
+                error: { message: 'Dataset was not found', type: 'record-not-found' },
             }),
         });
 
@@ -357,9 +342,7 @@ describe('readApiResource()', () => {
 
     it('throws InternalError falling back to statusText for a resolved 5xx with no parsable error body', async () => {
         const uri = `${API}/v2/datasets/missing/items`;
-        const client = stubApifyClient({
-            request: async () => ({ data: undefined, headers: {}, status: 500, statusText: 'Internal Server Error' }),
-        });
+        const client = stubApifyClient({ request: requestFailing(500, 'Internal Server Error') });
 
         const error = await expectReadError(readApiResource(uri, client));
 
@@ -367,15 +350,27 @@ describe('readApiResource()', () => {
         expect(error.message).toContain(`Failed to read ${uri}: HTTP 500: Internal Server Error`);
     });
 
+    it('falls back to statusText when a non-2xx error body itself crosses the limit', async () => {
+        const uri = `${API}/v2/datasets/missing/items`;
+        const client = stubApifyClient({
+            request: async () => ({
+                data: abortingStream(),
+                headers: {},
+                status: 502,
+                statusText: 'Bad Gateway',
+            }),
+        });
+
+        const error = await expectReadError(readApiResource(uri, client));
+
+        expect(error.code).toBe(ErrorCode.InternalError);
+        expect(error.message).toContain('HTTP 502: Bad Gateway');
+    });
+
     it('appends the auth hint for a 401 response', async () => {
         const uri = `${API}/v2/datasets/ds-1/items`;
         const client = stubApifyClient({
-            request: async () => ({
-                data: { error: { message: 'Token invalid' } },
-                headers: {},
-                status: 401,
-                statusText: 'Unauthorized',
-            }),
+            request: requestFailing(401, 'Unauthorized', { error: { message: 'Token invalid' } }),
         });
 
         const error = await expectReadError(readApiResource(uri, client));
@@ -388,12 +383,7 @@ describe('readApiResource()', () => {
     it('appends the private-resource hint for a 403 response', async () => {
         const uri = `${API}/v2/datasets/ds-1/items`;
         const client = stubApifyClient({
-            request: async () => ({
-                data: { error: { message: 'Forbidden' } },
-                headers: {},
-                status: 403,
-                statusText: 'Forbidden',
-            }),
+            request: requestFailing(403, 'Forbidden', { error: { message: 'Forbidden' } }),
         });
 
         const error = await expectReadError(readApiResource(uri, client));

--- a/tests/unit/resources.api.test.ts
+++ b/tests/unit/resources.api.test.ts
@@ -105,6 +105,13 @@ describe('isApifyApiUri()', () => {
         expect(isApifyApiUri('ui://widget/search.html')).toBe(false);
         expect(isApifyApiUri('not a url')).toBe(false);
     });
+
+    it('rejects userinfo-bearing URLs even on the API host', () => {
+        // axios drops the default Authorization header for credentials-bearing URLs, so such a
+        // read would silently run unauthenticated; refuse it at the gate instead.
+        expect(isApifyApiUri('https://evil.com@api.apify.com/v2/datasets/ds-1/items')).toBe(false);
+        expect(isApifyApiUri('https://user:pass@api.apify.com/v2/datasets/ds-1/items')).toBe(false);
+    });
 });
 
 describe('readApiResource()', () => {
@@ -120,6 +127,8 @@ describe('readApiResource()', () => {
 
         expect(error.code).toBe(ErrorCode.InvalidParams);
         expect(error.message).toContain('only Apify API URLs');
+        // Spec error shape: the failing URI rides in error.data, not only in the message text.
+        expect(error.data).toEqual({ uri: 'https://example.com/steal-my-token' });
     });
 
     it('requests the full URL as a stream capped at MAX_INLINE_BYTES', async () => {
@@ -338,6 +347,7 @@ describe('readApiResource()', () => {
 
         expect(error.code).toBe(ErrorCode.InvalidParams);
         expect(error.message).toContain(`Failed to read ${uri}: HTTP 404: Dataset was not found`);
+        expect(error.data).toEqual({ uri });
     });
 
     it('throws InternalError falling back to statusText for a resolved 5xx with no parsable error body', async () => {

--- a/tests/unit/resources.api.test.ts
+++ b/tests/unit/resources.api.test.ts
@@ -194,6 +194,37 @@ describe('readApiResource()', () => {
         expect(firstContent(result).text).toBe('hello world');
     });
 
+    it('decodes a text body with its declared non-UTF-8 charset', async () => {
+        // latin1 bytes are not valid UTF-8; a hardcoded UTF-8 decode would mangle them to U+FFFD.
+        const body = Buffer.from('Café à côté', 'latin1');
+        const { request } = requestReturning(streamOf(body), 'text/plain; charset=latin1');
+
+        const result = await readApiResource(
+            `${API}/v2/key-value-stores/kv-1/records/NOTE`,
+            stubApifyClient({ request }),
+        );
+
+        expect(firstContent(result).text).toBe('Café à côté');
+        expect(firstContent(result).mimeType).toBe('text/plain; charset=latin1');
+    });
+
+    it('returns a lossless blob instead of text for a charset Node cannot decode', async () => {
+        // `iso-8859-1` is not a Buffer encoding label. Decoding with the wrong charset would corrupt
+        // the bytes irreversibly, so the body ships as base64 — same rule as apify-client's body_parser.
+        const body = Buffer.from('Café à côté', 'latin1');
+        const { request } = requestReturning(streamOf(body), 'text/plain; charset=iso-8859-1');
+
+        const result = await readApiResource(
+            `${API}/v2/key-value-stores/kv-1/records/NOTE`,
+            stubApifyClient({ request }),
+        );
+
+        const contents = firstContent(result);
+        expect(contents.blob).toBe(body.toString('base64'));
+        expect(contents).not.toHaveProperty('text');
+        expect(contents.mimeType).toBe('text/plain');
+    });
+
     it('returns an XML body as text', async () => {
         const { request } = requestReturning(streamOf('<a>1</a>'), 'application/xml');
 

--- a/tests/unit/resources.service.test.ts
+++ b/tests/unit/resources.service.test.ts
@@ -169,15 +169,44 @@ describe('createResourceService()', () => {
     });
 
     describe('listResourceTemplates()', () => {
-        it('returns no templates (the read proxy is advertised via server instructions)', async () => {
+        it('advertises the common API URL shapes with descriptions', async () => {
             const service = createResourceService({
                 getMode: () => 'default',
                 getAvailableWidgets: () => new Map(),
             });
 
-            const result = await service.listResourceTemplates();
+            const { resourceTemplates } = await service.listResourceTemplates();
 
-            expect(result.resourceTemplates).toEqual([]);
+            expect(resourceTemplates.map((t) => t.name)).toEqual([
+                'dataset-items',
+                'key-value-store-record',
+                'key-value-store-keys',
+                'actor-run',
+                'actor-run-log',
+            ]);
+            for (const template of resourceTemplates) {
+                expect(template.uriTemplate).toMatch(/^https:\/\/api\.apify\.com\/v2\//);
+                expect(template.description).toBeTruthy();
+            }
+            // dataset-items advertises `format` (7 response types), so it must not pin a mimeType —
+            // the spec allows a template mimeType only when all matching resources share one type.
+            expect(resourceTemplates.find((t) => t.name === 'dataset-items')).not.toHaveProperty('mimeType');
+        });
+
+        it('exposes paging parameters as RFC 6570 query expansions', async () => {
+            const service = createResourceService({
+                getMode: () => 'default',
+                getAvailableWidgets: () => new Map(),
+            });
+
+            const { resourceTemplates } = await service.listResourceTemplates();
+            const byName = new Map(resourceTemplates.map((t) => [t.name, t.uriTemplate]));
+
+            expect(byName.get('dataset-items')).toContain('{?limit,offset,');
+            // KV key listings page with exclusiveStartKey, not offset.
+            expect(byName.get('key-value-store-keys')).toContain('{?limit,exclusiveStartKey}');
+            // A single record has no paging parameters at all.
+            expect(byName.get('key-value-store-record')).not.toContain('{?');
         });
     });
 });

--- a/tests/unit/resources.service.test.ts
+++ b/tests/unit/resources.service.test.ts
@@ -101,6 +101,7 @@ describe('createResourceService()', () => {
             expect(error).toBeInstanceOf(McpError);
             expect((error as McpError).code).toBe(ErrorCode.InvalidParams);
             expect((error as McpError).message).toContain('file://missing.md');
+            expect((error as McpError).data).toEqual({ uri: 'file://missing.md' });
         });
 
         it('throws the origin refusal for a non-Apify https URL', async () => {

--- a/tests/unit/resources.service.test.ts
+++ b/tests/unit/resources.service.test.ts
@@ -103,6 +103,21 @@ describe('createResourceService()', () => {
             expect((error as McpError).message).toContain('file://missing.md');
         });
 
+        it('throws the origin refusal for a non-Apify https URL', async () => {
+            // http(s) URIs route to readApiResource, whose origin gate owns the refusal — the user
+            // sees why the read was rejected, not the generic not-a-readable-resource fallback.
+            const service = createResourceService({
+                getMode: () => 'default',
+                getAvailableWidgets: () => new Map(),
+            });
+
+            const error = await service.readResource('https://example.com/steal-my-token').catch((e: unknown) => e);
+
+            expect(error).toBeInstanceOf(McpError);
+            expect((error as McpError).code).toBe(ErrorCode.InvalidParams);
+            expect((error as McpError).message).toContain('only Apify API URLs');
+        });
+
         it('returns widget HTML when the widget exists', async () => {
             const fs = await import('node:fs');
             const readFileSync = vi.mocked(fs.readFileSync);

--- a/tests/unit/tools.storage_helpers.test.ts
+++ b/tests/unit/tools.storage_helpers.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { HELPER_TOOLS, MAX_INLINE_BYTES } from '../../src/const.js';
 import {
     buildDatasetItemsSummaryNextStep,
-    classifyBinaryRecordSize,
+    buildBinaryRecordDisposition,
     normalizeRecordKey,
 } from '../../src/tools/storage/storage_helpers.js';
 
@@ -74,11 +74,11 @@ describe('normalizeRecordKey()', () => {
     });
 });
 
-describe('classifyBinaryRecordSize()', () => {
+describe('buildBinaryRecordDisposition()', () => {
     it('inlines a value at or below the size limit as base64', () => {
         const value = Buffer.from('binary-data');
 
-        const result = classifyBinaryRecordSize('image/png', value);
+        const result = buildBinaryRecordDisposition('image/png', value);
 
         expect(result).toEqual({ kind: 'inline', mimeType: 'image/png', base64: value.toString('base64') });
     });
@@ -86,7 +86,7 @@ describe('classifyBinaryRecordSize()', () => {
     it('links out a value above the size limit, reporting its byte length', () => {
         const value = Buffer.alloc(MAX_INLINE_BYTES + 1);
 
-        const result = classifyBinaryRecordSize('application/octet-stream', value);
+        const result = buildBinaryRecordDisposition('application/octet-stream', value);
 
         expect(result).toEqual({
             kind: 'linkOut',
@@ -95,14 +95,20 @@ describe('classifyBinaryRecordSize()', () => {
         });
     });
 
+    it('inlines a value of exactly MAX_INLINE_BYTES (strict > threshold)', () => {
+        const result = buildBinaryRecordDisposition('application/octet-stream', Buffer.alloc(MAX_INLINE_BYTES));
+
+        expect(result.kind).toBe('inline');
+    });
+
     it('strips Content-Type parameters and lowercases the MIME type', () => {
-        const result = classifyBinaryRecordSize('Image/PNG; charset=utf-8', Buffer.from('x'));
+        const result = buildBinaryRecordDisposition('Image/PNG; charset=utf-8', Buffer.from('x'));
 
         expect(result.mimeType).toBe('image/png');
     });
 
     it('omits mimeType when no Content-Type is declared', () => {
-        const result = classifyBinaryRecordSize(undefined, Buffer.from('x'));
+        const result = buildBinaryRecordDisposition(undefined, Buffer.from('x'));
 
         expect(result).not.toHaveProperty('mimeType');
     });


### PR DESCRIPTION
## Why

Review follow-up to #1003: the buffered proxy held up to 5 MB in RAM per read, the wrong-origin refusal was dead code, errors lacked the spec's `data: { uri }`, and `user@api.apify.com` URLs silently read unauthenticated.

## What changed

The read is now a stream capped at 256 KB — axios aborts the download mid-flight. One limit, one link-out site, body returned verbatim by Content-Type (the JSON re-serialization logic is deleted). `readApiResource` owns the single origin gate and rejects userinfo URLs. Errors throw `McpError` with `data: { uri }` and are logged.

Raw axios instead of `httpClient.call()` on purpose: with a stream body, `call()` turns non-2xx into junk messages and strands a socket per retry. One attempt, as before.

Also: `buildBinaryRecordDisposition` rename, `resolveApifyClient` as a private method, exactly-at-limit boundary test, AGENTS.md trimmed with the `https://`-scheme deviation documented. Templates follow-up: #1095 (stacked as #1096).

## Tools vs resources

Same data as the storage tools, on purpose: tools are the guided, model-driven surface — and the only one in payment mode or for clients without resources support. Resources are the raw data plane. Shared size/MIME helpers prevent drift; no tool is removed. Follow-up: tools return resource links (#998, #587).

## Notes for reviewers (human-written)

I've refactored the code with couple of cosmetic changes, private method vs const, shortened AGENTS.md significanlty.

The biggest change is the removal of 5MB. We need only single threshold. 
I'm not sure about the actually value, no strong preference.

The important things is templates follow up in #1095 , please read rationale there

## Proof it works

Live mcpc against the real API:

```
$ mcpc --json @stdio resources-read ".../v2/store?limit=1000"   # ~1 MB body
→ "Response body exceeds the 262144-byte inline limit. Download it from … re-read with a smaller limit/offset range."
```

Also probed live: 404 keeps the API's message (`HTTP 404: Dataset was not found`, `-32602`); non-Apify and `evil.com@api.apify.com` URLs get the origin refusal; pretty-printed JSON comes back byte-exact; `?limit=1&offset=0` vs `offset=1` return successive items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wv2ptD8dSxeeVK9QnDK1k2