### PR TITLE
feat: Advertise URI templates in resources/templates/list

### DIFF
--- a/src/resources/AGENTS.md
+++ b/src/resources/AGENTS.md
@@ -45,7 +45,9 @@ JSON-RPC error, never success-shaped content): 3xx/4xx except 429 → `InvalidPa
 status (network, mid-stream drop) → `InternalError`. 401/403 append a hint via `getHttpErrorHint()`
 (shared with `tools/call`); failures are logged via `logHttpError` (5xx → exception). Size
 link-outs are **successful** reads returning a download pointer, not failures. Discovery is the
-server-instructions prose; `resources/templates/list` returns nothing.
+server-instructions prose plus `resources/templates/list`, which advertises the common URL shapes
+(dataset items, KVS record/keys, run, log) as RFC 6570 templates with paging params — advertisement
+only, not a route table: the read path stays generic and accepts any Apify API GET URL.
 
 ## Gotcha
 

--- a/src/resources/resource_service.ts
+++ b/src/resources/resource_service.ts
@@ -13,6 +13,7 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import log from '@apify/log';
 
 import type { ApifyClient } from '../apify_client.js';
+import { getApifyAPIBaseUrl } from '../apify_client.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { SERVER_MODE } from '../types.js';
 import { readApiResource } from './api_resources.js';
@@ -166,11 +167,50 @@ export function createResourceService(options: ResourceServiceOptions): Resource
         throw new McpError(ErrorCode.InvalidParams, `Failed to read ${uri}: not a readable resource.`, { uri });
     };
 
-    // Read is a generic proxy over any Apify API GET URL, advertised in the server instructions;
-    // there are no fixed templates to enumerate.
-    const listResourceTemplates = async (): Promise<ListResourceTemplatesResult> => ({
-        resourceTemplates: [],
-    });
+    // Advertise the common URL shapes so clients that never surface the server instructions can
+    // still discover the read proxy and its paging parameters (RFC 6570 `{?var}` = query params).
+    // Advertisement only, NOT a route table: the read path stays a generic proxy, and any other
+    // Apify API GET URL is readable the same way.
+    const listResourceTemplates = async (): Promise<ListResourceTemplatesResult> => {
+        const api = getApifyAPIBaseUrl();
+        return {
+            resourceTemplates: [
+                {
+                    uriTemplate: `${api}/v2/datasets/{datasetId}/items{?limit,offset,clean,fields,format}`,
+                    name: 'dataset-items',
+                    description:
+                        'Items of a dataset, read via resources/read (the server injects the Apify token). ' +
+                        'Page with limit/offset — responses inline up to 256 KB, larger ones return a download URL.',
+                    mimeType: 'application/json',
+                },
+                {
+                    uriTemplate: `${api}/v2/key-value-stores/{storeId}/records/{recordKey}`,
+                    name: 'key-value-store-record',
+                    description:
+                        'A single record, returned whole in its stored Content-Type via resources/read. ' +
+                        'Not pageable — a record over 256 KB returns a download URL instead.',
+                },
+                {
+                    uriTemplate: `${api}/v2/key-value-stores/{storeId}/keys{?limit,exclusiveStartKey}`,
+                    name: 'key-value-store-keys',
+                    description: 'Keys of a key-value store. Page with limit/exclusiveStartKey (not offset).',
+                    mimeType: 'application/json',
+                },
+                {
+                    uriTemplate: `${api}/v2/actor-runs/{runId}`,
+                    name: 'actor-run',
+                    description: 'Metadata of an Actor run: status, storage IDs, usage.',
+                    mimeType: 'application/json',
+                },
+                {
+                    uriTemplate: `${api}/v2/logs/{runId}`,
+                    name: 'actor-run-log',
+                    description: 'Log of an Actor run. Inlines up to 256 KB, larger returns a download URL.',
+                    mimeType: 'text/plain',
+                },
+            ],
+        };
+    };
 
     return {
         listResources,

--- a/src/resources/resource_service.ts
+++ b/src/resources/resource_service.ts
@@ -178,10 +178,12 @@ export function createResourceService(options: ResourceServiceOptions): Resource
                 {
                     uriTemplate: `${api}/v2/datasets/{datasetId}/items{?limit,offset,clean,fields,format}`,
                     name: 'dataset-items',
+                    // No mimeType: `format` selects among 7 response types (json/jsonl/xml/html/csv/xlsx/rss),
+                    // and the spec allows a template mimeType only when all matching resources share one.
                     description:
                         'Items of a dataset, read via resources/read (the server injects the Apify token). ' +
-                        'Page with limit/offset — responses inline up to 256 KB, larger ones return a download URL.',
-                    mimeType: 'application/json',
+                        'Page with limit/offset; format defaults to JSON — responses inline up to 256 KB, ' +
+                        'larger ones return a download URL.',
                 },
                 {
                     uriTemplate: `${api}/v2/key-value-stores/{storeId}/records/{recordKey}`,

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -49,7 +49,7 @@ These tools are called **Actors**. They enable you to extract structured data fr
 - Any Apify API GET endpoint can be read as an MCP resource. Pass the full \`https://api.apify.com/v2/...\` URL to \`resources/read\`; the server injects the session's Apify token and returns the response body. Reads require an Apify token — a session without one (e.g. payment-only x402/Skyfire) fails with a JSON-RPC error.
 - Actor and tool results return storage IDs, not resource URLs — build the URL from the ID (e.g. a \`datasetId\` becomes \`https://api.apify.com/v2/datasets/{datasetId}/items\`) and read it via \`resources/read\`.
 - Reads inline up to ~256 KB; a larger response is not downloaded — it returns a short notice with a download URL instead of the body, so page large datasets/lists with \`limit\` and \`offset\` to stay under the cap.
-- Examples: \`https://api.apify.com/v2/datasets/{datasetId}/items?clean=true&format=json&limit=100\`, \`https://api.apify.com/v2/key-value-stores/{storeId}/records/{recordKey}\`.
+- Examples: \`https://api.apify.com/v2/datasets/{datasetId}/items?clean=true&format=json&limit=100\`, \`https://api.apify.com/v2/key-value-stores/{storeId}/records/{recordKey}\`. \`resources/templates/list\` enumerates the common shapes with their paging parameters.
 ${
     isApps
         ? `

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -2204,6 +2204,14 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                     );
                     await client.close();
                 });
+
+                it('advertises API URL templates via resources/templates/list', async () => {
+                    client = await createClientFn({ tools: ['storage'] });
+                    const { resourceTemplates } = await client.listResourceTemplates();
+                    const datasetItems = resourceTemplates.find((t) => t.name === 'dataset-items');
+                    expect(datasetItems?.uriTemplate).toContain('/v2/datasets/{datasetId}/items{?limit,offset,');
+                    await client.close();
+                });
             });
 
             it('rejects get-key-value-store-record when required keyValueStoreId is missing', async () => {

--- a/tests/unit/resources.service.test.ts
+++ b/tests/unit/resources.service.test.ts
@@ -188,6 +188,9 @@ describe('createResourceService()', () => {
                 expect(template.uriTemplate).toMatch(/^https:\/\/api\.apify\.com\/v2\//);
                 expect(template.description).toBeTruthy();
             }
+            // dataset-items advertises `format` (7 response types), so it must not pin a mimeType —
+            // the spec allows a template mimeType only when all matching resources share one type.
+            expect(resourceTemplates.find((t) => t.name === 'dataset-items')).not.toHaveProperty('mimeType');
         });
 
         it('exposes paging parameters as RFC 6570 query expansions', async () => {

--- a/tests/unit/resources.service.test.ts
+++ b/tests/unit/resources.service.test.ts
@@ -169,15 +169,41 @@ describe('createResourceService()', () => {
     });
 
     describe('listResourceTemplates()', () => {
-        it('returns no templates (the read proxy is advertised via server instructions)', async () => {
+        it('advertises the common API URL shapes with descriptions', async () => {
             const service = createResourceService({
                 getMode: () => 'default',
                 getAvailableWidgets: () => new Map(),
             });
 
-            const result = await service.listResourceTemplates();
+            const { resourceTemplates } = await service.listResourceTemplates();
 
-            expect(result.resourceTemplates).toEqual([]);
+            expect(resourceTemplates.map((t) => t.name)).toEqual([
+                'dataset-items',
+                'key-value-store-record',
+                'key-value-store-keys',
+                'actor-run',
+                'actor-run-log',
+            ]);
+            for (const template of resourceTemplates) {
+                expect(template.uriTemplate).toMatch(/^https:\/\/api\.apify\.com\/v2\//);
+                expect(template.description).toBeTruthy();
+            }
+        });
+
+        it('exposes paging parameters as RFC 6570 query expansions', async () => {
+            const service = createResourceService({
+                getMode: () => 'default',
+                getAvailableWidgets: () => new Map(),
+            });
+
+            const { resourceTemplates } = await service.listResourceTemplates();
+            const byName = new Map(resourceTemplates.map((t) => [t.name, t.uriTemplate]));
+
+            expect(byName.get('dataset-items')).toContain('{?limit,offset,');
+            // KV key listings page with exclusiveStartKey, not offset.
+            expect(byName.get('key-value-store-keys')).toContain('{?limit,exclusiveStartKey}');
+            // A single record has no paging parameters at all.
+            expect(byName.get('key-value-store-record')).not.toContain('{?');
         });
     });
 });


### PR DESCRIPTION
## Why

Closes #1095. Stacked on #1094. `resources/templates/list` returned `[]`, so a client that doesn't surface server instructions can't tell any API resources exist — or which URLs page.

## What changed

`listResourceTemplates` now advertises five RFC 6570 templates (dataset items, KV record, KV keys, run, run log). Descriptions carry the paging semantics (`{?limit,offset,…}` vs `exclusiveStartKey` vs not pageable), the 256 KB cap, and that reads go through `resources/read` with the server injecting the token. Advertisement only — the read path stays a generic proxy; any other Apify API GET URL remains readable. URLs derive from `getApifyAPIBaseUrl()`.

## Tools vs resources

The templates advertise data the storage tools already serve, on purpose: tools are the guided, model-driven surface — and the only one in payment mode or for clients without resources support. Resources are the raw data plane. No tool is removed. Follow-up: tools return resource links (#998, #587).

## Notes for reviewers (human-written)

None

## Proof it works

```
$ mcpc --json @stdio resources-templates-list
[ { "name": "dataset-items",
    "uriTemplate": "https://api.apify.com/v2/datasets/{datasetId}/items{?limit,offset,clean,fields,format}", … },
  … 5 templates ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wv2ptD8dSxeeVK9QnDK1k2