### PR TITLE
fix: Align MCP Apps widget pricing with Store page

### DIFF
--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -45,6 +45,10 @@ const pricingEventsSchema = {
             description: { type: 'string', description: 'Event description' },
             priceUsd: { type: 'number', description: 'Price in USD' },
             tieredPricing: eventTieredPricingSchema,
+            isPrimaryEvent: {
+                type: 'boolean',
+                description: 'Whether this is the primary event shown on the public Store pricing badge',
+            },
         },
     },
     description: 'Event-based pricing information',

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -42,6 +42,10 @@ const pricingEventsSchema = {
             description: { type: 'string', description: 'Event description' },
             priceUsd: { type: 'number', description: 'Price in USD' },
             tieredPricing: eventTieredPricingSchema,
+            isPrimaryEvent: {
+                type: 'boolean',
+                description: 'Whether this is the primary event shown on the public Store pricing badge',
+            },
         },
     },
     description: 'Event-based pricing information',

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -44,10 +44,18 @@ const pricingEventsSchema = {
             title: { type: 'string', description: 'Event title' },
             description: { type: 'string', description: 'Event description' },
             priceUsd: { type: 'number', description: 'Price in USD' },
+            paidPlanPriceUsd: {
+                type: 'number',
+                description: 'Price in USD on the cheapest public paid plan, present only when below priceUsd',
+            },
             tieredPricing: eventTieredPricingSchema,
             isPrimaryEvent: {
                 type: 'boolean',
                 description: 'Whether this is the primary event shown on the public Store pricing badge',
+            },
+            isOneTimeEvent: {
+                type: 'boolean',
+                description: 'Whether the event is charged once per run rather than per result',
             },
         },
     },
@@ -86,6 +94,10 @@ export const pricingSchema = {
                 "The user's plan tier used to resolve pricing (always the user's tier, even if a different tier was used as fallback)",
         },
         pricePerUnit: { type: 'number', description: 'Price per unit (for non-free models)' },
+        paidPlanPricePerUnit: {
+            type: 'number',
+            description: 'Price per unit on the cheapest public paid plan, present only when below pricePerUnit',
+        },
         unitName: { type: 'string', description: 'Unit name for pricing' },
         trialMinutes: { type: 'number', description: 'Trial period in minutes' },
         tieredPricing: tieredPricingSchema,

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -330,9 +330,8 @@ export type WidgetActor = {
  * Formats Actor for widget UI components.
  * Used only in OpenAI (widget) mode — search results and Actor details widgets.
  *
- * Always uses simplified tier-aware pricing so the widget's top-level
- * `pricePerUnit` / `events[0].priceUsd` (which is what the widget UI renders)
- * matches the tier-filtered prices shown in the LLM text and structured output.
+ * Uses complete pricing so the widget badge can pick the primary event and GOLD tier
+ * the same way the public Store page does.
  */
 export function formatActorForWidget(actor: Actor | ActorStoreList, userTier: PricingTier): WidgetActor {
     const fullName = `${actor.username}/${actor.name}`;
@@ -352,6 +351,6 @@ export function formatActorForWidget(actor: Actor | ActorStoreList, userTier: Pr
             totalUsers: actor.stats?.totalUsers || 0,
         },
         url: `${APIFY_STORE_URL}/${fullName}`,
-        currentPricingInfo: pricingInfoToSimplifiedStructured(getActorPricingInfo(actor), userTier),
+        currentPricingInfo: pricingInfoToStructured(getActorPricingInfo(actor), userTier),
     };
 }

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -330,8 +330,7 @@ export type WidgetActor = {
  * Formats Actor for widget UI components.
  * Used only in OpenAI (widget) mode — search results and Actor details widgets.
  *
- * Uses complete pricing so the widget badge can pick the primary event and GOLD tier
- * the same way the public Store page does.
+ * Uses complete pricing so the widget badge can pick the primary event and match the public Store pricing badge logic.
  */
 export function formatActorForWidget(actor: Actor | ActorStoreList, userTier: PricingTier): WidgetActor {
     const fullName = `${actor.username}/${actor.name}`;

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -314,7 +314,13 @@ export type WidgetActor = {
  * Formats Actor for widget UI components.
  * Used only in OpenAI (widget) mode — search results and Actor details widgets.
  *
- * Uses complete pricing so the widget badge can pick the primary event and match the public Store pricing badge logic.
+ * Uses complete pricing so the widget badge can match the public Store page: the primary event
+ * (`isPrimaryEvent`) priced at the GOLD tier. GOLD is the best tier listed on apify.com/pricing
+ * (Business plan); PLATINUM/DIAMOND are enterprise-only and the Store does not show them.
+ * Rendering lives in `formatPricing` (src/web/src/utils/formatting.ts).
+ *
+ * Complete mode carries every event's description and full tier matrix (no simplified-mode
+ * 5-event trim). Accepted: bounded by the 10-Actor search cap, and the widget renders only the badge.
  */
 export function formatActorForWidget(actor: Actor | ActorStoreList, userTier: PricingTier): WidgetActor {
     const fullName = `${actor.username}/${actor.name}`;

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -314,9 +314,9 @@ export type WidgetActor = {
  * Formats Actor for widget UI components.
  * Used only in OpenAI (widget) mode — search results and Actor details widgets.
  *
- * Uses complete pricing so the widget badge can match the public Store page: the primary event
- * (`isPrimaryEvent`) priced at the GOLD tier. GOLD is the best tier listed on apify.com/pricing
- * (Business plan); PLATINUM/DIAMOND are enterprise-only and the Store does not show them.
+ * Uses complete pricing (full tier matrix + `userTier`) so the widget badge can show the primary
+ * event (`isPrimaryEvent`) at the user's own tier, plus the Store page's "from" price (GOLD, the
+ * best tier listed on apify.com/pricing) as a hint when a paid plan is cheaper.
  * Rendering lives in `formatPricing` (src/web/src/utils/formatting.ts).
  *
  * Complete mode carries every event's description and full tier matrix (no simplified-mode

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -314,9 +314,8 @@ export type WidgetActor = {
  * Formats Actor for widget UI components.
  * Used only in OpenAI (widget) mode — search results and Actor details widgets.
  *
- * Always uses simplified tier-aware pricing so the widget's top-level
- * `pricePerUnit` / `events[0].priceUsd` (which is what the widget UI renders)
- * matches the tier-filtered prices shown in the LLM text and structured output.
+ * Uses complete pricing so the widget badge can pick the primary event and GOLD tier
+ * the same way the public Store page does.
  */
 export function formatActorForWidget(actor: Actor | ActorStoreList, userTier: PricingTier): WidgetActor {
     const fullName = `${actor.username}/${actor.name}`;
@@ -336,6 +335,6 @@ export function formatActorForWidget(actor: Actor | ActorStoreList, userTier: Pr
             totalUsers: actor.stats?.totalUsers || 0,
         },
         url: `${APIFY_STORE_URL}/${fullName}`,
-        currentPricingInfo: pricingInfoToSimplifiedStructured(getActorPricingInfo(actor), userTier),
+        currentPricingInfo: pricingInfoToStructured(getActorPricingInfo(actor), userTier),
     };
 }

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -314,13 +314,10 @@ export type WidgetActor = {
  * Formats Actor for widget UI components.
  * Used only in OpenAI (widget) mode — search results and Actor details widgets.
  *
- * Uses complete pricing (full tier matrix + `userTier`) so the widget badge can show the primary
- * event (`isPrimaryEvent`) at the user's own tier, plus the Store page's "from" price (GOLD, the
- * best tier listed on apify.com/pricing) as a hint when a paid plan is cheaper.
- * Rendering lives in `formatPricing` (src/web/src/utils/formatting.ts).
- *
- * Complete mode carries every event's description and full tier matrix (no simplified-mode
- * 5-event trim). Accepted: bounded by the 10-Actor search cap, and the widget renders only the badge.
+ * Uses simplified pricing: the server resolves the user's tier and adds the Store page's "from"
+ * price (`paidPlanPriceUsd` / `paidPlanPricePerUnit`) when a paid plan is cheaper, so the widget
+ * badge only renders — the pricing rule lives in one place (src/utils/pricing_info.ts).
+ * See apify/apify-mcp-server#905.
  */
 export function formatActorForWidget(actor: Actor | ActorStoreList, userTier: PricingTier): WidgetActor {
     const fullName = `${actor.username}/${actor.name}`;
@@ -340,6 +337,6 @@ export function formatActorForWidget(actor: Actor | ActorStoreList, userTier: Pr
             totalUsers: actor.stats?.totalUsers || 0,
         },
         url: `${APIFY_STORE_URL}/${fullName}`,
-        currentPricingInfo: pricingInfoToStructured(getActorPricingInfo(actor), userTier),
+        currentPricingInfo: pricingInfoToSimplifiedStructured(getActorPricingInfo(actor), userTier),
     };
 }

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -314,8 +314,7 @@ export type WidgetActor = {
  * Formats Actor for widget UI components.
  * Used only in OpenAI (widget) mode — search results and Actor details widgets.
  *
- * Uses complete pricing so the widget badge can pick the primary event and GOLD tier
- * the same way the public Store page does.
+ * Uses complete pricing so the widget badge can pick the primary event and match the public Store pricing badge logic.
  */
 export function formatActorForWidget(actor: Actor | ActorStoreList, userTier: PricingTier): WidgetActor {
     const fullName = `${actor.username}/${actor.name}`;

--- a/src/utils/pricing_info.ts
+++ b/src/utils/pricing_info.ts
@@ -22,6 +22,7 @@
  *     description?: string,
  *     priceUsd?: number,
  *     tieredPricing?: [{ tier: string, priceUsd: number }],
+ *     isPrimaryEvent?: boolean,
  *   }],
  *   pricingNote?: string,
  *   eventDescriptionsOmitted?: boolean,

--- a/src/utils/pricing_info.ts
+++ b/src/utils/pricing_info.ts
@@ -70,6 +70,7 @@ export type ActorChargeEvent = {
     eventDescription?: string;
     eventPriceUsd?: number;
     eventTieredPricingUsd?: Partial<Record<PricingTier, TieredEventPrice>>;
+    isPrimaryEvent?: boolean;
 };
 
 export type TieredPricing = {
@@ -116,6 +117,7 @@ export type StructuredPricingInfo = {
             tier: string;
             priceUsd: number;
         }[];
+        isPrimaryEvent?: boolean;
     }[];
     pricingNote?: string;
     eventDescriptionsOmitted?: boolean;
@@ -339,6 +341,7 @@ function structurePayPerEventComplete(
                       priceUsd: (price as TieredEventPrice).tieredEventPriceUsd,
                   }))
                 : undefined,
+            ...(event.isPrimaryEvent ? { isPrimaryEvent: true } : {}),
         })),
     };
 }
@@ -482,6 +485,7 @@ function structurePayPerEventSimplified(
         const baseEvent = {
             title: event.eventTitle,
             ...(omitDescriptions ? {} : { description: event.eventDescription || '' }),
+            ...(event.isPrimaryEvent ? { isPrimaryEvent: true as const } : {}),
         };
 
         if (typeof event.eventPriceUsd === 'number') {
@@ -493,9 +497,8 @@ function structurePayPerEventSimplified(
 
         const { tier, value } = resolveTier(tieredMap, userTier);
         resolvedTiers.add(tier);
-        // Simplified mode resolves to one tier; `priceUsd` carries the resolved price
-        // (the widget reads it — src/web/src/utils/formatting.ts), so the 1-element
-        // `tieredPricing` array just duplicates it. Drop it.
+        // Simplified mode resolves to one tier; `priceUsd` carries the resolved price,
+        // so the 1-element `tieredPricing` array just duplicates it. Drop it.
         return {
             ...baseEvent,
             priceUsd: value.tieredEventPriceUsd,

--- a/src/utils/pricing_info.ts
+++ b/src/utils/pricing_info.ts
@@ -205,17 +205,20 @@ function resolveTier<T>(map: Record<string, T>, userTier: PricingTier): { tier: 
     return { tier: firstTier, value: firstValue };
 }
 
+/** Paid tiers below GOLD that a visitor can buy on apify.com/pricing (Starter, Scale). */
+const PUBLIC_FALLBACK_TIERS: PricingTier[] = ['BRONZE', 'SILVER'];
+
 /**
- * Price the public Store page advertises as "from": GOLD, else the cheapest paid tier. GOLD
- * (Business plan) is the best tier on apify.com/pricing; PLATINUM/DIAMOND are enterprise-only
- * and never shown there. Same rule as the widget badge (src/web/src/utils/formatting.ts).
+ * Price the public Store page advertises as "from": GOLD (Business, the best plan on
+ * apify.com/pricing), else the cheapest priced Starter/Scale tier. PLATINUM/DIAMOND are
+ * enterprise-only and never advertised; with no public paid tier there is no "from" price.
+ * The widget only renders what this produces (src/web/src/utils/formatting.ts).
  * See apify/apify-mcp-server#905.
  */
 function resolveAdvertisedPrice(priceByTier: Record<string, number>): number | undefined {
-    const paidTiers = Object.entries(priceByTier).filter(([tier, price]) => tier !== 'FREE' && price > 0);
-    if (paidTiers.length === 0) return undefined;
-    const goldPrice = paidTiers.find(([tier]) => tier === 'GOLD')?.[1];
-    return goldPrice ?? Math.min(...paidTiers.map(([, price]) => price));
+    if (priceByTier.GOLD > 0) return priceByTier.GOLD;
+    const publicPrices = PUBLIC_FALLBACK_TIERS.map((tier) => priceByTier[tier]).filter((price) => price > 0);
+    return publicPrices.length > 0 ? Math.min(...publicPrices) : undefined;
 }
 
 /** Currency text with 2 to 6 decimals: "$5.00", "$0.0945", "$0.00005" — sub-cent prices are never rounded to "$0.00". */

--- a/src/utils/pricing_info.ts
+++ b/src/utils/pricing_info.ts
@@ -37,10 +37,12 @@
  * `pricePerUnit` / event `priceUsd`. It drops the `tieredPricing` arrays (a single
  * resolved tier makes them redundant) and omits `userTier` (a session constant
  * returned once at the search-response top level). It emits `pricingNote` only when
- * the Actor actually has multiple tiers *and* they resolve consistently. The
- * note is omitted for single-tier Actors (the note's "higher tiers may offer
- * lower prices" promise is vacuous) and when PAY_PER_EVENT events resolve
- * to different tiers (no truthful single label).
+ * the Actor actually has multiple tiers *and* they resolve consistently. The note names
+ * the user's plan and, when a paid plan is cheaper, the price the Store page advertises
+ * ("Paid plans from $X") — GOLD, else the cheapest paid tier, the same rule as the widget
+ * badge. It is omitted for single-tier Actors and when PAY_PER_EVENT events resolve to
+ * different tiers (no truthful single label). Text uses plan names (Free, Starter, Scale,
+ * Business); structured `userTier` keeps the tier codes.
  *
  * Simplified `PAY_PER_EVENT` also trims long event lists:
  * - `events.length <= 5`: keep event descriptions
@@ -65,6 +67,24 @@ type TieredEventPrice = {
 
 export const PRICING_TIERS = ['FREE', 'BRONZE', 'SILVER', 'GOLD', 'PLATINUM', 'DIAMOND'] as const;
 export type PricingTier = (typeof PRICING_TIERS)[number];
+
+/**
+ * Plan names as users see them on apify.com/pricing. PLATINUM and DIAMOND are enterprise tiers
+ * with no public plan, so they keep a title-cased tier label. Text output uses these; structured
+ * output keeps the tier codes (a contract consumed by apify-mcp-server-internal).
+ */
+const PLAN_NAME_BY_TIER: Record<PricingTier, string> = {
+    FREE: 'Free',
+    BRONZE: 'Starter',
+    SILVER: 'Scale',
+    GOLD: 'Business',
+    PLATINUM: 'Platinum',
+    DIAMOND: 'Diamond',
+};
+
+function getPlanName(tier: string): string {
+    return PLAN_NAME_BY_TIER[tier as PricingTier] ?? tier;
+}
 
 export type ActorChargeEvent = {
     eventTitle: string;
@@ -137,9 +157,16 @@ type RentalLike = {
     tieredPricing?: TieredPricing;
 };
 
+/** The price the Store page advertises ("from $X"), with the unit it is quoted per. */
+type PaidPlanHint = {
+    price: number;
+    unit: string;
+};
+
 type SimplifiedResult = {
     patch: Partial<StructuredPricingInfo>;
     noteTier: string | null;
+    noteHint: PaidPlanHint | null;
 };
 
 const FREE_ACTOR_TEXT = 'This Actor is free to use. You are only charged for Apify platform usage.';
@@ -162,16 +189,67 @@ function resolveTier<T>(map: Record<string, T>, userTier: PricingTier): { tier: 
 }
 
 /**
- * Builds the simplified-mode pricing note, or returns null when no note should be shown.
- * DIAMOND is the top tier — "higher tiers may offer lower prices" is vacuous, so we skip
- * the note for DIAMOND users.
+ * Price the public Store page advertises as "from": GOLD, else the cheapest paid tier. GOLD
+ * (Business plan) is the best tier on apify.com/pricing; PLATINUM/DIAMOND are enterprise-only
+ * and never shown there. Same rule as the widget badge (src/web/src/utils/formatting.ts).
+ * See apify/apify-mcp-server#905.
  */
-function buildPricingNote(resolvedTier: string): string | null {
-    if (resolvedTier === 'DIAMOND') return null;
-    return (
-        `Prices shown are for ${resolvedTier} tier. ` +
-        `Higher tiers may offer lower prices — use fetch-actor-details to see the full pricing table.`
+function resolveAdvertisedPrice(priceByTier: Record<string, number>): number | undefined {
+    const paidTiers = Object.entries(priceByTier).filter(([tier, price]) => tier !== 'FREE' && price > 0);
+    if (paidTiers.length === 0) return undefined;
+    const goldPrice = paidTiers.find(([tier]) => tier === 'GOLD')?.[1];
+    return goldPrice ?? Math.min(...paidTiers.map(([, price]) => price));
+}
+
+/** Hint for the note: the advertised price, only when it undercuts what this user pays. */
+function buildPaidPlanHint(priceByTier: Record<string, number>, ownPrice: number, unit: string): PaidPlanHint | null {
+    const advertised = resolveAdvertisedPrice(priceByTier);
+    return advertised !== undefined && advertised < ownPrice ? { price: advertised, unit } : null;
+}
+
+/** How a unit price is quoted in text: "per 1000 results" scales the raw per-unit price by 1000. */
+type PriceQuote = {
+    unit: string;
+    scale: number;
+};
+
+function buildUnitPaidPlanHint(tieredPricing: TieredPricing, ownPrice: number, quote: PriceQuote): PaidPlanHint | null {
+    const priceByTier = Object.fromEntries(
+        Object.entries(tieredPricing).map(([tier, entry]) => [tier, entry.tieredPricePerUnitUsd * quote.scale]),
     );
+    return buildPaidPlanHint(priceByTier, ownPrice * quote.scale, quote.unit);
+}
+
+/**
+ * Event whose price the Store badge advertises: the flagged primary event, else the only
+ * multi-tier event. With several tiered events and no flag there is no truthful single number.
+ */
+function findAdvertisedEvent(events: ActorChargeEvent[]): ActorChargeEvent | undefined {
+    const primaryEvent = events.find((event) => event.isPrimaryEvent);
+    if (primaryEvent) return primaryEvent;
+    const tieredEvents = events.filter((event) => hasMultipleTiers(event.eventTieredPricingUsd));
+    return tieredEvents.length === 1 ? tieredEvents[0] : undefined;
+}
+
+function buildEventPaidPlanHint(events: ActorChargeEvent[], userTier: PricingTier): PaidPlanHint | null {
+    const tieredMap = findAdvertisedEvent(events)?.eventTieredPricingUsd as
+        | Record<string, TieredEventPrice>
+        | undefined;
+    if (!hasTiers(tieredMap)) return null;
+    const priceByTier = Object.fromEntries(
+        Object.entries(tieredMap).map(([tier, entry]) => [tier, entry.tieredEventPriceUsd]),
+    );
+    return buildPaidPlanHint(priceByTier, resolveTier(tieredMap, userTier).value.tieredEventPriceUsd, 'per event');
+}
+
+/**
+ * Builds the simplified-mode pricing note, or returns null when no note should be shown.
+ * DIAMOND is the top tier — nothing is cheaper, so the note is skipped for DIAMOND users.
+ */
+function buildPricingNote(resolvedTier: string, hint: PaidPlanHint | null): string | null {
+    if (resolvedTier === 'DIAMOND') return null;
+    const paidPlans = hint ? ` Paid plans from $${hint.price} ${hint.unit}.` : '';
+    return `Prices shown are for the ${getPlanName(resolvedTier)} plan.${paidPlans} Use fetch-actor-details for the full pricing table.`;
 }
 
 function getSingleResolvedTier(resolvedTiers: Set<string>): string | null {
@@ -239,7 +317,9 @@ function formatDatasetItemComplete(info: DatasetItemLike): string {
     const tierEntries = info.tieredPricing ? Object.entries(info.tieredPricing) : [];
 
     if (tierEntries.length > 1) {
-        const tierList = tierEntries.map(([tier, obj]) => `${tier}: $${obj.tieredPricePerUnitUsd * 1000}`).join(', ');
+        const tierList = tierEntries
+            .map(([tier, obj]) => `${getPlanName(tier)}: $${obj.tieredPricePerUnitUsd * 1000}`)
+            .join(', ');
         return `This Actor has tiered pricing per 1000 ${unitLabel}: ${tierList}.`;
     }
 
@@ -252,7 +332,9 @@ function formatRentalComplete(info: RentalLike): string {
     const tierEntries = info.tieredPricing ? Object.entries(info.tieredPricing) : [];
 
     if (tierEntries.length > 1) {
-        const tierList = tierEntries.map(([tier, obj]) => `${tier}: $${obj.tieredPricePerUnitUsd}`).join(', ');
+        const tierList = tierEntries
+            .map(([tier, obj]) => `${getPlanName(tier)}: $${obj.tieredPricePerUnitUsd}`)
+            .join(', ');
         return (
             `This Actor is rental and has tiered pricing per month: ${tierList}, ` +
             `with a trial period of ${value} ${unit}.`
@@ -282,7 +364,7 @@ function formatCompleteEventDetail(event: ActorChargeEvent): string {
     if (!hasTiers(tiered)) return 'No price info';
     if (hasMultipleTiers(tiered)) {
         return `${Object.entries(tiered)
-            .map(([tier, price]) => `${tier}: $${price.tieredEventPriceUsd}`)
+            .map(([tier, price]) => `${getPlanName(tier)}: $${price.tieredEventPriceUsd}`)
             .join(', ')} per event`;
     }
     const [price] = Object.values(tiered);
@@ -368,7 +450,11 @@ function formatDatasetItemSimplified(info: DatasetItemLike, userTier: PricingTie
     if (hasTiers(info.tieredPricing)) {
         const { tier, value } = resolveTier(info.tieredPricing, userTier);
         const base = `This Actor costs $${value.tieredPricePerUnitUsd * 1000} per 1000 ${unitLabel}.`;
-        const note = hasMultipleTiers(info.tieredPricing) ? buildPricingNote(tier) : null;
+        const hint = buildUnitPaidPlanHint(info.tieredPricing, value.tieredPricePerUnitUsd, {
+            unit: `per 1000 ${unitLabel}`,
+            scale: 1000,
+        });
+        const note = hasMultipleTiers(info.tieredPricing) ? buildPricingNote(tier, hint) : null;
         return note ? `${base} ${note}` : base;
     }
     return `This Actor costs $${(info.pricePerUnitUsd ?? 0) * 1000} per 1000 ${unitLabel}.`;
@@ -381,7 +467,11 @@ function formatRentalSimplified(info: RentalLike, userTier: PricingTier): string
         const base =
             `This Actor is rental and costs $${entry.tieredPricePerUnitUsd} per month, ` +
             `with a trial period of ${value} ${unit}.`;
-        const note = hasMultipleTiers(info.tieredPricing) ? buildPricingNote(tier) : null;
+        const hint = buildUnitPaidPlanHint(info.tieredPricing, entry.tieredPricePerUnitUsd, {
+            unit: 'per month',
+            scale: 1,
+        });
+        const note = hasMultipleTiers(info.tieredPricing) ? buildPricingNote(tier, hint) : null;
         return note ? `${base} ${note}` : base;
     }
     return `This Actor is rental and costs $${info.pricePerUnitUsd ?? 0} per month, with a trial period of ${value} ${unit}.`;
@@ -418,7 +508,7 @@ function formatPayPerEventSimplified(
     const body = `This Actor is paid per event:\n${eventLines.join('\n')}`;
     const anyMultiTier = events.some((event) => hasMultipleTiers(event.eventTieredPricingUsd));
     const noteTier = anyMultiTier ? getSingleResolvedTier(resolvedTiers) : null;
-    const pricingNote = noteTier ? buildPricingNote(noteTier) : null;
+    const pricingNote = noteTier ? buildPricingNote(noteTier, buildEventPaidPlanHint(events, userTier)) : null;
     const tail = [pricingNote, omitDescriptions ? EVENT_DESCRIPTIONS_OMITTED_NOTE : null]
         .filter((n): n is string => !!n)
         .join('\n');
@@ -435,8 +525,8 @@ export function pricingInfoToSimplifiedStructured(
     const base: StructuredPricingInfo = { model: pricingInfo?.pricingModel || ACTOR_PRICING_MODEL.FREE };
     if (isFreeActor(pricingInfo)) return base;
 
-    const { patch, noteTier } = resolveSimplifiedPatch(pricingInfo, userTier);
-    const pricingNote = noteTier ? buildPricingNote(noteTier) : null;
+    const { patch, noteTier, noteHint } = resolveSimplifiedPatch(pricingInfo, userTier);
+    const pricingNote = noteTier ? buildPricingNote(noteTier, noteHint) : null;
     return {
         ...base,
         ...patch,
@@ -447,37 +537,49 @@ export function pricingInfoToSimplifiedStructured(
 function resolveSimplifiedPatch(pricingInfo: PricingInfo, userTier: PricingTier): SimplifiedResult {
     switch (pricingInfo.pricingModel) {
         case ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM: {
-            const r = structureTieredUnitSimplified(pricingInfo, userTier);
-            return { patch: { unitName: pricingInfo.unitName || 'result', ...r.patch }, noteTier: r.noteTier };
+            const unitLabel = pricingInfo.unitName ? `${pricingInfo.unitName}s` : 'results';
+            const r = structureTieredUnitSimplified(pricingInfo, userTier, {
+                unit: `per 1000 ${unitLabel}`,
+                scale: 1000,
+            });
+            return { ...r, patch: { unitName: pricingInfo.unitName || 'result', ...r.patch } };
         }
         case ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH: {
-            const r = structureTieredUnitSimplified(pricingInfo, userTier);
-            return { patch: { trialMinutes: pricingInfo.trialMinutes, ...r.patch }, noteTier: r.noteTier };
+            const r = structureTieredUnitSimplified(pricingInfo, userTier, { unit: 'per month', scale: 1 });
+            return { ...r, patch: { trialMinutes: pricingInfo.trialMinutes, ...r.patch } };
         }
         case ACTOR_PRICING_MODEL.PAY_PER_EVENT:
             return structurePayPerEventSimplified(pricingInfo.pricingPerEvent, userTier);
         default:
-            return { patch: {}, noteTier: null };
+            return { patch: {}, noteTier: null, noteHint: null };
     }
 }
 
-function structureTieredUnitSimplified(info: DatasetItemLike | RentalLike, userTier: PricingTier): SimplifiedResult {
+function structureTieredUnitSimplified(
+    info: DatasetItemLike | RentalLike,
+    userTier: PricingTier,
+    quote: PriceQuote,
+): SimplifiedResult {
     const patch: Partial<StructuredPricingInfo> = { pricePerUnit: info.pricePerUnitUsd ?? 0 };
     if (hasTiers(info.tieredPricing)) {
         const { tier, value } = resolveTier(info.tieredPricing, userTier);
         // Simplified mode resolves to one tier; the resolved price lives in `pricePerUnit`,
         // so the 1-element `tieredPricing` array just duplicates it. Drop it.
         patch.pricePerUnit = value.tieredPricePerUnitUsd;
-        return { patch, noteTier: hasMultipleTiers(info.tieredPricing) ? tier : null };
+        return {
+            patch,
+            noteTier: hasMultipleTiers(info.tieredPricing) ? tier : null,
+            noteHint: buildUnitPaidPlanHint(info.tieredPricing, value.tieredPricePerUnitUsd, quote),
+        };
     }
-    return { patch, noteTier: null };
+    return { patch, noteTier: null, noteHint: null };
 }
 
 function structurePayPerEventSimplified(
     pricingPerEvent: { actorChargeEvents: Record<string, ActorChargeEvent> } | undefined,
     userTier: PricingTier,
 ): SimplifiedResult {
-    if (!pricingPerEvent?.actorChargeEvents) return { patch: {}, noteTier: null };
+    if (!pricingPerEvent?.actorChargeEvents) return { patch: {}, noteTier: null, noteHint: null };
 
     const rawEvents = Object.values(pricingPerEvent.actorChargeEvents);
     const omitDescriptions = shouldOmitEventDescriptions(rawEvents.length);
@@ -519,5 +621,6 @@ function structurePayPerEventSimplified(
                 : {}),
         },
         noteTier,
+        noteHint: buildEventPaidPlanHint(rawEvents, userTier),
     };
 }

--- a/src/utils/pricing_info.ts
+++ b/src/utils/pricing_info.ts
@@ -14,6 +14,7 @@
  *   model: string,
  *   userTier?: PricingTier,
  *   pricePerUnit?: number,
+ *   paidPlanPricePerUnit?: number,   // simplified only: the Store's "from" price when cheaper
  *   unitName?: string,
  *   trialMinutes?: number,
  *   tieredPricing?: [{ tier: string, pricePerUnit: number }],
@@ -21,8 +22,10 @@
  *     title: string,
  *     description?: string,
  *     priceUsd?: number,
+ *     paidPlanPriceUsd?: number,     // simplified only, on the advertised event
  *     tieredPricing?: [{ tier: string, priceUsd: number }],
  *     isPrimaryEvent?: boolean,
+ *     isOneTimeEvent?: boolean,
  *   }],
  *   pricingNote?: string,
  *   eventDescriptionsOmitted?: boolean,
@@ -92,6 +95,8 @@ export type ActorChargeEvent = {
     eventPriceUsd?: number;
     eventTieredPricingUsd?: Partial<Record<PricingTier, TieredEventPrice>>;
     isPrimaryEvent?: boolean;
+    /** Charged once per run (e.g. "Actor start"); quoted per run instead of per 1,000. */
+    isOneTimeEvent?: boolean;
 };
 
 export type TieredPricing = {
@@ -124,6 +129,8 @@ export type StructuredPricingInfo = {
     model: string;
     userTier?: PricingTier;
     pricePerUnit?: number;
+    /** Simplified mode: the Store page's "from" price (GOLD, else cheapest paid tier) when it is below `pricePerUnit`. */
+    paidPlanPricePerUnit?: number;
     unitName?: string;
     trialMinutes?: number;
     tieredPricing?: {
@@ -134,11 +141,14 @@ export type StructuredPricingInfo = {
         title: string;
         description?: string;
         priceUsd?: number;
+        /** Simplified mode, advertised event only: the Store's "from" price when it is below `priceUsd`. */
+        paidPlanPriceUsd?: number;
         tieredPricing?: {
             tier: string;
             priceUsd: number;
         }[];
         isPrimaryEvent?: boolean;
+        isOneTimeEvent?: boolean;
     }[];
     pricingNote?: string;
     eventDescriptionsOmitted?: boolean;
@@ -157,10 +167,17 @@ type RentalLike = {
     tieredPricing?: TieredPricing;
 };
 
-/** The price the Store page advertises ("from $X"), with the unit it is quoted per. */
+/** How a unit price is quoted in text: "per 1000 results" scales the raw per-unit price by 1000. */
+type PriceQuote = {
+    unit: string;
+    scale: number;
+};
+
+/** The raw per-unit price the Store page advertises ("from $X"), how text quotes it, and which event it is about. */
 type PaidPlanHint = {
     price: number;
-    unit: string;
+    quote: PriceQuote;
+    title?: string;
 };
 
 type SimplifiedResult = {
@@ -201,23 +218,84 @@ function resolveAdvertisedPrice(priceByTier: Record<string, number>): number | u
     return goldPrice ?? Math.min(...paidTiers.map(([, price]) => price));
 }
 
-/** Hint for the note: the advertised price, only when it undercuts what this user pays. */
-function buildPaidPlanHint(priceByTier: Record<string, number>, ownPrice: number, unit: string): PaidPlanHint | null {
-    const advertised = resolveAdvertisedPrice(priceByTier);
-    return advertised !== undefined && advertised < ownPrice ? { price: advertised, unit } : null;
+/** Currency text with 2 to 6 decimals: "$5.00", "$0.0945", "$0.00005" — sub-cent prices are never rounded to "$0.00". */
+const USD_FORMAT = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6,
+});
+
+const PER_THOUSAND = 1000;
+/** Top tier: nothing is cheaper by plan, so no upsell hint in the note or the widget. */
+const TOP_TIER: PricingTier = 'DIAMOND';
+const PER_RUN_QUOTE: PriceQuote = { unit: 'per run', scale: 1 };
+const PER_MONTH_QUOTE: PriceQuote = { unit: 'per month', scale: 1 };
+
+/** Results and repeatable events are quoted per 1,000, as on the Store page. */
+function buildPerThousandQuote(unitLabel: string): PriceQuote {
+    return { unit: `/ 1,000 ${unitLabel}`, scale: PER_THOUSAND };
 }
 
-/** How a unit price is quoted in text: "per 1000 results" scales the raw per-unit price by 1000. */
-type PriceQuote = {
-    unit: string;
-    scale: number;
+/** One-time events ("Actor start") are charged once per run, so "per 1,000" would mislead. */
+function resolveEventQuote(event: ActorChargeEvent): PriceQuote {
+    return event.isOneTimeEvent ? PER_RUN_QUOTE : buildPerThousandQuote('events');
+}
+
+function formatQuotedPrice(price: number, quote: PriceQuote): string {
+    return `${USD_FORMAT.format(price * quote.scale)} ${quote.unit}`;
+}
+
+/** "Free: $5.00, Business: $2.00 / 1,000 results" — plan names, the unit once at the end. */
+function formatPlanPrices(priceByTier: Record<string, number>, quote: PriceQuote): string {
+    const list = Object.entries(priceByTier)
+        .map(([tier, price]) => `${getPlanName(tier)}: ${USD_FORMAT.format(price * quote.scale)}`)
+        .join(', ');
+    return `${list} ${quote.unit}`;
+}
+
+function getPriceByTier(tieredPricing: TieredPricing): Record<string, number> {
+    return Object.fromEntries(
+        Object.entries(tieredPricing).map(([tier, entry]) => [tier, entry.tieredPricePerUnitUsd]),
+    );
+}
+
+function getEventPriceByTier(tieredMap: Record<string, TieredEventPrice>): Record<string, number> {
+    return Object.fromEntries(Object.entries(tieredMap).map(([tier, entry]) => [tier, entry.tieredEventPriceUsd]));
+}
+
+/** What this user pays, with the tier it resolved to. */
+type ResolvedPrice = {
+    tier: string;
+    price: number;
 };
 
-function buildUnitPaidPlanHint(tieredPricing: TieredPricing, ownPrice: number, quote: PriceQuote): PaidPlanHint | null {
-    const priceByTier = Object.fromEntries(
-        Object.entries(tieredPricing).map(([tier, entry]) => [tier, entry.tieredPricePerUnitUsd * quote.scale]),
-    );
-    return buildPaidPlanHint(priceByTier, ownPrice * quote.scale, quote.unit);
+/**
+ * The advertised price as a hint for the note and the widget, only when it undercuts what this
+ * user pays. Top-tier users never get one, even if a developer priced a lower tier below theirs.
+ */
+function buildPaidPlanHint({
+    priceByTier,
+    own,
+    quote,
+    title,
+}: {
+    priceByTier: Record<string, number>;
+    own: ResolvedPrice;
+    quote: PriceQuote;
+    title?: string;
+}): PaidPlanHint | null {
+    if (own.tier === TOP_TIER) return null;
+    const advertised = resolveAdvertisedPrice(priceByTier);
+    return advertised !== undefined && advertised < own.price ? { price: advertised, quote, title } : null;
+}
+
+function buildUnitPaidPlanHint(
+    tieredPricing: TieredPricing,
+    own: ResolvedPrice,
+    quote: PriceQuote,
+): PaidPlanHint | null {
+    return buildPaidPlanHint({ priceByTier: getPriceByTier(tieredPricing), own, quote });
 }
 
 /**
@@ -232,14 +310,17 @@ function findAdvertisedEvent(events: ActorChargeEvent[]): ActorChargeEvent | und
 }
 
 function buildEventPaidPlanHint(events: ActorChargeEvent[], userTier: PricingTier): PaidPlanHint | null {
-    const tieredMap = findAdvertisedEvent(events)?.eventTieredPricingUsd as
-        | Record<string, TieredEventPrice>
-        | undefined;
-    if (!hasTiers(tieredMap)) return null;
-    const priceByTier = Object.fromEntries(
-        Object.entries(tieredMap).map(([tier, entry]) => [tier, entry.tieredEventPriceUsd]),
-    );
-    return buildPaidPlanHint(priceByTier, resolveTier(tieredMap, userTier).value.tieredEventPriceUsd, 'per event');
+    const event = findAdvertisedEvent(events);
+    const tieredMap = event?.eventTieredPricingUsd as Record<string, TieredEventPrice> | undefined;
+    if (!event || !hasTiers(tieredMap)) return null;
+    const resolved = resolveTier(tieredMap, userTier);
+    return buildPaidPlanHint({
+        priceByTier: getEventPriceByTier(tieredMap),
+        own: { tier: resolved.tier, price: resolved.value.tieredEventPriceUsd },
+        quote: resolveEventQuote(event),
+        // With several events, say which one the number is about.
+        title: events.length > 1 ? event.eventTitle : undefined,
+    });
 }
 
 /**
@@ -247,8 +328,9 @@ function buildEventPaidPlanHint(events: ActorChargeEvent[], userTier: PricingTie
  * DIAMOND is the top tier — nothing is cheaper, so the note is skipped for DIAMOND users.
  */
 function buildPricingNote(resolvedTier: string, hint: PaidPlanHint | null): string | null {
-    if (resolvedTier === 'DIAMOND') return null;
-    const paidPlans = hint ? ` Paid plans from $${hint.price} ${hint.unit}.` : '';
+    if (resolvedTier === TOP_TIER) return null;
+    const about = hint?.title ? ` (${hint.title})` : '';
+    const paidPlans = hint ? ` Paid plans from ${formatQuotedPrice(hint.price, hint.quote)}${about}.` : '';
     return `Prices shown are for the ${getPlanName(resolvedTier)} plan.${paidPlans} Use fetch-actor-details for the full pricing table.`;
 }
 
@@ -312,37 +394,28 @@ export function pricingInfoToString(pricingInfo: PricingInfo | null): string {
     }
 }
 
+/** Resolves the single price of a unit model: its only tier, else the flat price. */
+function getSingleUnitPrice(info: DatasetItemLike | RentalLike): number {
+    const [onlyTier] = info.tieredPricing ? Object.values(info.tieredPricing) : [];
+    return onlyTier?.tieredPricePerUnitUsd ?? info.pricePerUnitUsd ?? 0;
+}
+
 function formatDatasetItemComplete(info: DatasetItemLike): string {
-    const unitLabel = info.unitName ? `${info.unitName}s` : 'results';
-    const tierEntries = info.tieredPricing ? Object.entries(info.tieredPricing) : [];
-
-    if (tierEntries.length > 1) {
-        const tierList = tierEntries
-            .map(([tier, obj]) => `${getPlanName(tier)}: $${obj.tieredPricePerUnitUsd * 1000}`)
-            .join(', ');
-        return `This Actor has tiered pricing per 1000 ${unitLabel}: ${tierList}.`;
+    const quote = buildPerThousandQuote(info.unitName ? `${info.unitName}s` : 'results');
+    if (hasTiers(info.tieredPricing) && hasMultipleTiers(info.tieredPricing)) {
+        return `This Actor has tiered pricing: ${formatPlanPrices(getPriceByTier(info.tieredPricing), quote)}.`;
     }
-
-    const price = tierEntries.length === 1 ? tierEntries[0][1].tieredPricePerUnitUsd : (info.pricePerUnitUsd ?? 0);
-    return `This Actor costs $${price * 1000} per 1000 ${unitLabel}.`;
+    return `This Actor costs ${formatQuotedPrice(getSingleUnitPrice(info), quote)}.`;
 }
 
 function formatRentalComplete(info: RentalLike): string {
     const { value, unit } = convertMinutesToGreatestUnit(info.trialMinutes || 0);
-    const tierEntries = info.tieredPricing ? Object.entries(info.tieredPricing) : [];
-
-    if (tierEntries.length > 1) {
-        const tierList = tierEntries
-            .map(([tier, obj]) => `${getPlanName(tier)}: $${obj.tieredPricePerUnitUsd}`)
-            .join(', ');
-        return (
-            `This Actor is rental and has tiered pricing per month: ${tierList}, ` +
-            `with a trial period of ${value} ${unit}.`
-        );
+    const trial = `with a trial period of ${value} ${unit}.`;
+    if (hasTiers(info.tieredPricing) && hasMultipleTiers(info.tieredPricing)) {
+        const plans = formatPlanPrices(getPriceByTier(info.tieredPricing), PER_MONTH_QUOTE);
+        return `This Actor is rental and has tiered pricing: ${plans}, ${trial}`;
     }
-
-    const price = tierEntries.length === 1 ? tierEntries[0][1].tieredPricePerUnitUsd : (info.pricePerUnitUsd ?? 0);
-    return `This Actor is rental and costs $${price} per month, with a trial period of ${value} ${unit}.`;
+    return `This Actor is rental and costs ${formatQuotedPrice(getSingleUnitPrice(info), PER_MONTH_QUOTE)}, ${trial}`;
 }
 
 function formatPayPerEventComplete(
@@ -359,16 +432,13 @@ function formatPayPerEventComplete(
 }
 
 function formatCompleteEventDetail(event: ActorChargeEvent): string {
-    if (typeof event.eventPriceUsd === 'number') return `$${event.eventPriceUsd} per event`;
+    const quote = resolveEventQuote(event);
+    if (typeof event.eventPriceUsd === 'number') return formatQuotedPrice(event.eventPriceUsd, quote);
     const tiered = event.eventTieredPricingUsd as Record<string, TieredEventPrice> | undefined;
     if (!hasTiers(tiered)) return 'No price info';
-    if (hasMultipleTiers(tiered)) {
-        return `${Object.entries(tiered)
-            .map(([tier, price]) => `${getPlanName(tier)}: $${price.tieredEventPriceUsd}`)
-            .join(', ')} per event`;
-    }
+    if (hasMultipleTiers(tiered)) return formatPlanPrices(getEventPriceByTier(tiered), quote);
     const [price] = Object.values(tiered);
-    return `$${price.tieredEventPriceUsd} per event`;
+    return formatQuotedPrice(price.tieredEventPriceUsd, quote);
 }
 
 /** Complete structured contract used by `fetch-actor-details`. */
@@ -425,6 +495,7 @@ function structurePayPerEventComplete(
                   }))
                 : undefined,
             ...(event.isPrimaryEvent ? { isPrimaryEvent: true } : {}),
+            ...(event.isOneTimeEvent ? { isOneTimeEvent: true } : {}),
         })),
     };
 }
@@ -446,35 +517,32 @@ export function pricingInfoToSimplifiedString(pricingInfo: PricingInfo | null, u
 }
 
 function formatDatasetItemSimplified(info: DatasetItemLike, userTier: PricingTier): string {
-    const unitLabel = info.unitName ? `${info.unitName}s` : 'results';
+    const quote = buildPerThousandQuote(info.unitName ? `${info.unitName}s` : 'results');
     if (hasTiers(info.tieredPricing)) {
         const { tier, value } = resolveTier(info.tieredPricing, userTier);
-        const base = `This Actor costs $${value.tieredPricePerUnitUsd * 1000} per 1000 ${unitLabel}.`;
-        const hint = buildUnitPaidPlanHint(info.tieredPricing, value.tieredPricePerUnitUsd, {
-            unit: `per 1000 ${unitLabel}`,
-            scale: 1000,
-        });
+        const base = `This Actor costs ${formatQuotedPrice(value.tieredPricePerUnitUsd, quote)}.`;
+        const hint = buildUnitPaidPlanHint(info.tieredPricing, { tier, price: value.tieredPricePerUnitUsd }, quote);
         const note = hasMultipleTiers(info.tieredPricing) ? buildPricingNote(tier, hint) : null;
         return note ? `${base} ${note}` : base;
     }
-    return `This Actor costs $${(info.pricePerUnitUsd ?? 0) * 1000} per 1000 ${unitLabel}.`;
+    return `This Actor costs ${formatQuotedPrice(info.pricePerUnitUsd ?? 0, quote)}.`;
 }
 
 function formatRentalSimplified(info: RentalLike, userTier: PricingTier): string {
     const { value, unit } = convertMinutesToGreatestUnit(info.trialMinutes || 0);
+    const trial = `with a trial period of ${value} ${unit}.`;
     if (hasTiers(info.tieredPricing)) {
         const { tier, value: entry } = resolveTier(info.tieredPricing, userTier);
-        const base =
-            `This Actor is rental and costs $${entry.tieredPricePerUnitUsd} per month, ` +
-            `with a trial period of ${value} ${unit}.`;
-        const hint = buildUnitPaidPlanHint(info.tieredPricing, entry.tieredPricePerUnitUsd, {
-            unit: 'per month',
-            scale: 1,
-        });
+        const base = `This Actor is rental and costs ${formatQuotedPrice(entry.tieredPricePerUnitUsd, PER_MONTH_QUOTE)}, ${trial}`;
+        const hint = buildUnitPaidPlanHint(
+            info.tieredPricing,
+            { tier, price: entry.tieredPricePerUnitUsd },
+            PER_MONTH_QUOTE,
+        );
         const note = hasMultipleTiers(info.tieredPricing) ? buildPricingNote(tier, hint) : null;
         return note ? `${base} ${note}` : base;
     }
-    return `This Actor is rental and costs $${info.pricePerUnitUsd ?? 0} per month, with a trial period of ${value} ${unit}.`;
+    return `This Actor is rental and costs ${formatQuotedPrice(info.pricePerUnitUsd ?? 0, PER_MONTH_QUOTE)}, ${trial}`;
 }
 
 function formatPayPerEventSimplified(
@@ -500,7 +568,7 @@ function formatPayPerEventSimplified(
             }
         }
 
-        const detail = typeof price === 'number' ? `$${price} per event` : 'No price info';
+        const detail = typeof price === 'number' ? formatQuotedPrice(price, resolveEventQuote(event)) : 'No price info';
         if (omitDescriptions) return `  - **${event.eventTitle}**: ${detail}`;
         return `  - **${event.eventTitle}**: ${event.eventDescription ?? ''} (${detail})`;
     });
@@ -538,14 +606,11 @@ function resolveSimplifiedPatch(pricingInfo: PricingInfo, userTier: PricingTier)
     switch (pricingInfo.pricingModel) {
         case ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM: {
             const unitLabel = pricingInfo.unitName ? `${pricingInfo.unitName}s` : 'results';
-            const r = structureTieredUnitSimplified(pricingInfo, userTier, {
-                unit: `per 1000 ${unitLabel}`,
-                scale: 1000,
-            });
+            const r = structureTieredUnitSimplified(pricingInfo, userTier, buildPerThousandQuote(unitLabel));
             return { ...r, patch: { unitName: pricingInfo.unitName || 'result', ...r.patch } };
         }
         case ACTOR_PRICING_MODEL.FLAT_PRICE_PER_MONTH: {
-            const r = structureTieredUnitSimplified(pricingInfo, userTier, { unit: 'per month', scale: 1 });
+            const r = structureTieredUnitSimplified(pricingInfo, userTier, PER_MONTH_QUOTE);
             return { ...r, patch: { trialMinutes: pricingInfo.trialMinutes, ...r.patch } };
         }
         case ACTOR_PRICING_MODEL.PAY_PER_EVENT:
@@ -566,11 +631,9 @@ function structureTieredUnitSimplified(
         // Simplified mode resolves to one tier; the resolved price lives in `pricePerUnit`,
         // so the 1-element `tieredPricing` array just duplicates it. Drop it.
         patch.pricePerUnit = value.tieredPricePerUnitUsd;
-        return {
-            patch,
-            noteTier: hasMultipleTiers(info.tieredPricing) ? tier : null,
-            noteHint: buildUnitPaidPlanHint(info.tieredPricing, value.tieredPricePerUnitUsd, quote),
-        };
+        const noteHint = buildUnitPaidPlanHint(info.tieredPricing, { tier, price: value.tieredPricePerUnitUsd }, quote);
+        if (noteHint) patch.paidPlanPricePerUnit = noteHint.price;
+        return { patch, noteTier: hasMultipleTiers(info.tieredPricing) ? tier : null, noteHint };
     }
     return { patch, noteTier: null, noteHint: null };
 }
@@ -583,12 +646,15 @@ function structurePayPerEventSimplified(
 
     const rawEvents = Object.values(pricingPerEvent.actorChargeEvents);
     const omitDescriptions = shouldOmitEventDescriptions(rawEvents.length);
+    const advertisedEvent = findAdvertisedEvent(rawEvents);
+    const noteHint = buildEventPaidPlanHint(rawEvents, userTier);
     const resolvedTiers = new Set<string>();
     const events = rawEvents.map((event) => {
         const baseEvent = {
             title: event.eventTitle,
             ...(omitDescriptions ? {} : { description: event.eventDescription || '' }),
             ...(event.isPrimaryEvent ? { isPrimaryEvent: true as const } : {}),
+            ...(event.isOneTimeEvent ? { isOneTimeEvent: true as const } : {}),
         };
 
         if (typeof event.eventPriceUsd === 'number') {
@@ -605,6 +671,7 @@ function structurePayPerEventSimplified(
         return {
             ...baseEvent,
             priceUsd: value.tieredEventPriceUsd,
+            ...(event === advertisedEvent && noteHint ? { paidPlanPriceUsd: noteHint.price } : {}),
         };
     });
 
@@ -621,6 +688,6 @@ function structurePayPerEventSimplified(
                 : {}),
         },
         noteTier,
-        noteHint: buildEventPaidPlanHint(rawEvents, userTier),
+        noteHint,
     };
 }

--- a/src/web/src/types.ts
+++ b/src/web/src/types.ts
@@ -26,6 +26,7 @@ export type StructuredPricingInfo = {
             tier: string;
             priceUsd: number;
         }[];
+        isPrimaryEvent?: boolean;
     }[];
     pricingNote?: string;
     eventDescriptionsOmitted?: boolean;

--- a/src/web/src/types.ts
+++ b/src/web/src/types.ts
@@ -12,6 +12,7 @@ export type StructuredPricingInfo = {
     model: string;
     userTier?: string;
     pricePerUnit?: number;
+    paidPlanPricePerUnit?: number;
     unitName?: string;
     trialMinutes?: number;
     tieredPricing?: {
@@ -22,11 +23,13 @@ export type StructuredPricingInfo = {
         title: string;
         description?: string;
         priceUsd?: number;
+        paidPlanPriceUsd?: number;
         tieredPricing?: {
             tier: string;
             priceUsd: number;
         }[];
         isPrimaryEvent?: boolean;
+        isOneTimeEvent?: boolean;
     }[];
     pricingNote?: string;
     eventDescriptionsOmitted?: boolean;

--- a/src/web/src/utils/formatting.ts
+++ b/src/web/src/utils/formatting.ts
@@ -56,17 +56,23 @@ function formatFlatPricePerMonth(pricePerUnit: number | undefined): string {
     return `${formatPriceUsd(monthlyPrice)}/month + usage`;
 }
 
-function formatPayPerEventPricing(event: NonNullable<StructuredPricingInfo['events']>[0]): string {
+function formatPayPerEventPricing(
+    event: NonNullable<StructuredPricingInfo['events']>[0],
+    { showFromPrefix = false }: { showFromPrefix?: boolean } = {},
+): string {
     const title = event.title.toLowerCase() || 'result';
+    const prefix = showFromPrefix ? 'from ' : '';
 
     if (event.tieredPricing && event.tieredPricing.length > 0) {
+        // Match public Store: prefer GOLD, else cheapest paid tier.
+        const goldPrice = event.tieredPricing.find((tier) => tier.tier === 'GOLD' && tier.priceUsd > 0)?.priceUsd;
         const tieredPrices = event.tieredPricing
             .filter((tier) => tier.tier !== 'FREE' && tier.priceUsd > 0)
             .map((tier) => tier.priceUsd);
+        const displayPrice = goldPrice ?? (tieredPrices.length > 0 ? Math.min(...tieredPrices) : undefined);
 
-        if (tieredPrices.length > 0) {
-            const minPrice = Math.min(...tieredPrices);
-            const pricePerThousand = minPrice * PRICE_DISPLAY_UNIT_SIZE;
+        if (typeof displayPrice === 'number') {
+            const pricePerThousand = displayPrice * PRICE_DISPLAY_UNIT_SIZE;
             return `from ${formatPriceUsd(pricePerThousand)} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
         }
     }
@@ -76,9 +82,9 @@ function formatPayPerEventPricing(event: NonNullable<StructuredPricingInfo['even
 
         if (isPricedPerThousandResults) {
             const pricePerThousand = event.priceUsd * PRICE_DISPLAY_UNIT_SIZE;
-            return `${formatPriceUsd(pricePerThousand)} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
+            return `${prefix}${formatPriceUsd(pricePerThousand)} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
         }
-        return `${formatPriceUsd(event.priceUsd)} / ${title}`;
+        return `${prefix}${formatPriceUsd(event.priceUsd)} / ${title}`;
     }
 
     return 'Pay per event';
@@ -120,11 +126,12 @@ export const formatPricing = (pricing: StructuredPricingInfo): string => {
             return 'Pay per event';
         }
 
-        if (pricing.events.length === 1) {
-            return formatPayPerEventPricing(pricing.events[0]);
-        }
+        const primaryEvent =
+            pricing.events.length === 1 ? pricing.events[0] : pricing.events.find((event) => event.isPrimaryEvent);
 
-        return 'Pay per event';
+        return primaryEvent
+            ? formatPayPerEventPricing(primaryEvent, { showFromPrefix: pricing.events.length > 1 })
+            : 'Pay per event';
     }
 
     if (pricing.model === 'PRICE_PER_DATASET_ITEM') {

--- a/src/web/src/utils/formatting.ts
+++ b/src/web/src/utils/formatting.ts
@@ -64,15 +64,13 @@ function formatPayPerEventPricing(
     const prefix = showFromPrefix ? 'from ' : '';
 
     if (event.tieredPricing && event.tieredPricing.length > 0) {
-        // Match public Store: prefer GOLD, else cheapest paid tier.
-        const goldPrice = event.tieredPricing.find((tier) => tier.tier === 'GOLD' && tier.priceUsd > 0)?.priceUsd;
         const tieredPrices = event.tieredPricing
             .filter((tier) => tier.tier !== 'FREE' && tier.priceUsd > 0)
             .map((tier) => tier.priceUsd);
-        const displayPrice = goldPrice ?? (tieredPrices.length > 0 ? Math.min(...tieredPrices) : undefined);
 
-        if (typeof displayPrice === 'number') {
-            const pricePerThousand = displayPrice * PRICE_DISPLAY_UNIT_SIZE;
+        if (tieredPrices.length > 0) {
+            const minPrice = Math.min(...tieredPrices);
+            const pricePerThousand = minPrice * PRICE_DISPLAY_UNIT_SIZE;
             return `from ${formatPriceUsd(pricePerThousand)} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
         }
     }

--- a/src/web/src/utils/formatting.ts
+++ b/src/web/src/utils/formatting.ts
@@ -51,79 +51,105 @@ export function formatPriceUsd(price: number, options: FormatPriceUsdOptions = {
     return formatNumberWithOptions(price, { style: 'currency', ...intlOptions }); // Intl will return the format we want: i.e. -$123,323.21;
 }
 
+type TierPrice = { tier: string; price: number };
+
 /**
- * Tier the public Store badge prices at: GOLD, else the cheapest paid tier.
- * GOLD (Business plan) is the best tier listed on apify.com/pricing; PLATINUM/DIAMOND are
- * enterprise-only and the Store never shows them, so "cheapest tier" would undercut the badge.
- * See apify/apify-mcp-server#905.
+ * What this user pays: their tier, else FREE, else the first entry — the same fallback order as
+ * the server's `resolveTier` in src/utils/pricing_info.ts. Anonymous users resolve as FREE.
  */
-function resolveStoreBadgeTierPrice(tiers: { tier: string; price: number }[]): number | undefined {
+function resolveUserTierPrice(tiers: TierPrice[], userTier = 'FREE'): number | undefined {
+    const priceByTier = new Map(tiers.map(({ tier, price }) => [tier, price]));
+    return priceByTier.get(userTier) ?? priceByTier.get('FREE') ?? tiers[0]?.price;
+}
+
+/**
+ * What the public Store badge advertises: GOLD, else the cheapest paid tier.
+ * GOLD (Business plan) is the best tier listed on apify.com/pricing; PLATINUM/DIAMOND are
+ * enterprise-only and the Store never shows them. See apify/apify-mcp-server#905.
+ */
+function resolveStoreBadgeTierPrice(tiers: TierPrice[]): number | undefined {
     const paidTiers = tiers.filter(({ tier, price }) => tier !== 'FREE' && price > 0);
     if (paidTiers.length === 0) return undefined;
     const goldPrice = paidTiers.find(({ tier }) => tier === 'GOLD')?.price;
     return goldPrice ?? Math.min(...paidTiers.map(({ price }) => price));
 }
 
+/**
+ * Badge for a tiered price: what this user pays, plus the Store's "from" price as an upgrade hint
+ * when a paid plan is cheaper. The Store page shows "from GOLD" because it does not know the
+ * visitor; the widget does, so it shows both. Returns undefined when the user's price resolves to
+ * nothing (or zero) so callers fall back to their flat-price path. See apify/apify-mcp-server#905.
+ */
+function formatTieredPrice(
+    tiers: TierPrice[],
+    userTier: string | undefined,
+    scale: number,
+    toBadge: (amount: string) => string,
+): string | undefined {
+    const ownPrice = resolveUserTierPrice(tiers, userTier);
+    if (!ownPrice) return undefined;
+    const storePrice = resolveStoreBadgeTierPrice(tiers);
+    const hint =
+        storePrice !== undefined && storePrice < ownPrice
+            ? ` · from ${formatPriceUsd(storePrice * scale)} on paid plans`
+            : '';
+    return `${toBadge(formatPriceUsd(ownPrice * scale))}${hint}`;
+}
+
 function formatFlatPricePerMonth(pricing: StructuredPricingInfo): string {
-    // Complete-mode `pricePerUnit` is the un-resolved base price; tiered rentals need the same badge tier.
-    const badgePrice = pricing.tieredPricing?.length
-        ? resolveStoreBadgeTierPrice(
+    // Complete-mode `pricePerUnit` is the un-resolved base price; tiered rentals must resolve the tier.
+    const tieredBadge = pricing.tieredPricing?.length
+        ? formatTieredPrice(
               pricing.tieredPricing.map(({ tier, pricePerUnit }) => ({ tier, price: pricePerUnit })),
+              pricing.userTier,
+              1,
+              (amount) => `${amount}/month + usage`,
           )
         : undefined;
-    const monthlyPrice = badgePrice ?? pricing.pricePerUnit ?? 0;
-    return `${formatPriceUsd(monthlyPrice)}/month + usage`;
+    return tieredBadge ?? `${formatPriceUsd(pricing.pricePerUnit || 0)}/month + usage`;
 }
 
 function formatPayPerEventPricing(
     event: NonNullable<StructuredPricingInfo['events']>[0],
-    { shouldShowFromPrefix = false }: { shouldShowFromPrefix?: boolean } = {},
+    userTier: string | undefined,
 ): string {
     const title = event.title.toLowerCase() || 'result';
-    const prefix = shouldShowFromPrefix ? 'from ' : '';
+    const perThousand = (amount: string) => `${amount} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
 
     if (event.tieredPricing && event.tieredPricing.length > 0) {
-        const badgePrice = resolveStoreBadgeTierPrice(
+        const tieredBadge = formatTieredPrice(
             event.tieredPricing.map(({ tier, priceUsd }) => ({ tier, price: priceUsd })),
+            userTier,
+            PRICE_DISPLAY_UNIT_SIZE,
+            perThousand,
         );
-
-        if (typeof badgePrice === 'number') {
-            const pricePerThousand = badgePrice * PRICE_DISPLAY_UNIT_SIZE;
-            return `from ${formatPriceUsd(pricePerThousand)} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
-        }
+        if (tieredBadge) return tieredBadge;
     }
 
     if (typeof event.priceUsd === 'number') {
         const isPricedPerThousandResults = event.priceUsd < PER_THOUSAND_PRICING_THRESHOLD;
-
-        if (isPricedPerThousandResults) {
-            const pricePerThousand = event.priceUsd * PRICE_DISPLAY_UNIT_SIZE;
-            return `${prefix}${formatPriceUsd(pricePerThousand)} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
-        }
-        return `${prefix}${formatPriceUsd(event.priceUsd)} / ${title}`;
+        if (isPricedPerThousandResults) return perThousand(formatPriceUsd(event.priceUsd * PRICE_DISPLAY_UNIT_SIZE));
+        return `${formatPriceUsd(event.priceUsd)} / ${title}`;
     }
 
     return 'Pay per event';
 }
 
 function formatPricePerDatasetItem(pricing: StructuredPricingInfo): string {
-    const unitName = pricing.unitName || 'result';
-    const pluralUnitName = pluralize(unitName);
+    const pluralUnitName = pluralize(pricing.unitName || 'result');
+    const perThousand = (amount: string) => `${amount} / 1,000 ${pluralUnitName}`;
 
     if (pricing.tieredPricing && pricing.tieredPricing.length > 0) {
-        const badgePrice = resolveStoreBadgeTierPrice(
+        const tieredBadge = formatTieredPrice(
             pricing.tieredPricing.map(({ tier, pricePerUnit }) => ({ tier, price: pricePerUnit })),
+            pricing.userTier,
+            PRICE_DISPLAY_UNIT_SIZE,
+            perThousand,
         );
-
-        if (typeof badgePrice === 'number') {
-            const pricePerThousand = badgePrice * PRICE_DISPLAY_UNIT_SIZE;
-            return `from ${formatPriceUsd(pricePerThousand)} / 1,000 ${pluralUnitName}`;
-        }
+        if (tieredBadge) return tieredBadge;
     }
 
-    const pricePerUnit = pricing.pricePerUnit || 0;
-    const pricePerThousand = pricePerUnit * PRICE_DISPLAY_UNIT_SIZE;
-    return `from ${formatPriceUsd(pricePerThousand)} / 1,000 ${pluralUnitName}`;
+    return perThousand(formatPriceUsd((pricing.pricePerUnit || 0) * PRICE_DISPLAY_UNIT_SIZE));
 }
 
 export const formatPricing = (pricing: StructuredPricingInfo): string => {
@@ -144,9 +170,7 @@ export const formatPricing = (pricing: StructuredPricingInfo): string => {
         const primaryEvent =
             pricing.events.length === 1 ? pricing.events[0] : pricing.events.find((event) => event.isPrimaryEvent);
 
-        return primaryEvent
-            ? formatPayPerEventPricing(primaryEvent, { shouldShowFromPrefix: pricing.events.length > 1 })
-            : 'Pay per event';
+        return primaryEvent ? formatPayPerEventPricing(primaryEvent, pricing.userTier) : 'Pay per event';
     }
 
     if (pricing.model === 'PRICE_PER_DATASET_ITEM') {

--- a/src/web/src/utils/formatting.ts
+++ b/src/web/src/utils/formatting.ts
@@ -77,17 +77,23 @@ function resolveStoreBadgeTierPrice(tiers: TierPrice[]): number | undefined {
 /**
  * Badge for a tiered price: what this user pays, plus the Store's "from" price as an upgrade hint
  * when a paid plan is cheaper. The Store page shows "from GOLD" because it does not know the
- * visitor; the widget does, so it shows both. Returns undefined when the user's price resolves to
- * nothing (or zero) so callers fall back to their flat-price path. See apify/apify-mcp-server#905.
+ * visitor; the widget does, so it shows both. A $0 tier is a real price ("free for you") and is
+ * rendered; only an empty matrix returns undefined so callers fall back to their flat-price path.
+ * See apify/apify-mcp-server#905.
  */
-function formatTieredPrice(
-    tiers: TierPrice[],
-    userTier: string | undefined,
-    scale: number,
-    toBadge: (amount: string) => string,
-): string | undefined {
+function formatTieredPrice({
+    tiers,
+    userTier,
+    scale,
+    toBadge,
+}: {
+    tiers: TierPrice[];
+    userTier: string | undefined;
+    scale: number;
+    toBadge: (amount: string) => string;
+}): string | undefined {
     const ownPrice = resolveUserTierPrice(tiers, userTier);
-    if (!ownPrice) return undefined;
+    if (ownPrice === undefined) return undefined;
     const storePrice = resolveStoreBadgeTierPrice(tiers);
     const hint =
         storePrice !== undefined && storePrice < ownPrice
@@ -98,13 +104,13 @@ function formatTieredPrice(
 
 function formatFlatPricePerMonth(pricing: StructuredPricingInfo): string {
     // Complete-mode `pricePerUnit` is the un-resolved base price; tiered rentals must resolve the tier.
-    const tieredBadge = pricing.tieredPricing?.length
-        ? formatTieredPrice(
-              pricing.tieredPricing.map(({ tier, pricePerUnit }) => ({ tier, price: pricePerUnit })),
-              pricing.userTier,
-              1,
-              (amount) => `${amount}/month + usage`,
-          )
+    const tieredBadge = pricing.tieredPricing
+        ? formatTieredPrice({
+              tiers: pricing.tieredPricing.map(({ tier, pricePerUnit }) => ({ tier, price: pricePerUnit })),
+              userTier: pricing.userTier,
+              scale: 1,
+              toBadge: (amount) => `${amount}/month + usage`,
+          })
         : undefined;
     return tieredBadge ?? `${formatPriceUsd(pricing.pricePerUnit || 0)}/month + usage`;
 }
@@ -116,13 +122,13 @@ function formatPayPerEventPricing(
     const title = event.title.toLowerCase() || 'result';
     const perThousand = (amount: string) => `${amount} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
 
-    if (event.tieredPricing && event.tieredPricing.length > 0) {
-        const tieredBadge = formatTieredPrice(
-            event.tieredPricing.map(({ tier, priceUsd }) => ({ tier, price: priceUsd })),
+    if (event.tieredPricing) {
+        const tieredBadge = formatTieredPrice({
+            tiers: event.tieredPricing.map(({ tier, priceUsd }) => ({ tier, price: priceUsd })),
             userTier,
-            PRICE_DISPLAY_UNIT_SIZE,
-            perThousand,
-        );
+            scale: PRICE_DISPLAY_UNIT_SIZE,
+            toBadge: perThousand,
+        });
         if (tieredBadge) return tieredBadge;
     }
 
@@ -139,13 +145,13 @@ function formatPricePerDatasetItem(pricing: StructuredPricingInfo): string {
     const pluralUnitName = pluralize(pricing.unitName || 'result');
     const perThousand = (amount: string) => `${amount} / 1,000 ${pluralUnitName}`;
 
-    if (pricing.tieredPricing && pricing.tieredPricing.length > 0) {
-        const tieredBadge = formatTieredPrice(
-            pricing.tieredPricing.map(({ tier, pricePerUnit }) => ({ tier, price: pricePerUnit })),
-            pricing.userTier,
-            PRICE_DISPLAY_UNIT_SIZE,
-            perThousand,
-        );
+    if (pricing.tieredPricing) {
+        const tieredBadge = formatTieredPrice({
+            tiers: pricing.tieredPricing.map(({ tier, pricePerUnit }) => ({ tier, price: pricePerUnit })),
+            userTier: pricing.userTier,
+            scale: PRICE_DISPLAY_UNIT_SIZE,
+            toBadge: perThousand,
+        });
         if (tieredBadge) return tieredBadge;
     }
 

--- a/src/web/src/utils/formatting.ts
+++ b/src/web/src/utils/formatting.ts
@@ -2,8 +2,8 @@ import pluralize from 'pluralize';
 
 import type { StructuredPricingInfo } from '../types';
 
-const PER_THOUSAND_PRICING_THRESHOLD = 0.01;
 const PRICE_DISPLAY_UNIT_SIZE = 1000;
+const PAID_PLAN_HINT_SUFFIX = 'on paid plans';
 
 type FormatPriceUsdOptions = {
     decimals?: number;
@@ -51,111 +51,41 @@ export function formatPriceUsd(price: number, options: FormatPriceUsdOptions = {
     return formatNumberWithOptions(price, { style: 'currency', ...intlOptions }); // Intl will return the format we want: i.e. -$123,323.21;
 }
 
-type TierPrice = { tier: string; price: number };
-
-/**
- * What this user pays: their tier, else FREE, else the first entry — the same fallback order as
- * the server's `resolveTier` in src/utils/pricing_info.ts. Anonymous users resolve as FREE.
- */
-function resolveUserTierPrice(tiers: TierPrice[], userTier = 'FREE'): number | undefined {
-    const priceByTier = new Map(tiers.map(({ tier, price }) => [tier, price]));
-    return priceByTier.get(userTier) ?? priceByTier.get('FREE') ?? tiers[0]?.price;
+/** Badge prices show 2 to 6 decimals so sub-cent per-1,000 prices ("$0.0945") are not rounded away. */
+function formatBadgePrice(price: number): string {
+    return formatPriceUsd(price, { maximumFractionDigits: 6 });
 }
 
 /**
- * What the public Store badge advertises: GOLD, else the cheapest paid tier.
- * GOLD (Business plan) is the best tier listed on apify.com/pricing; PLATINUM/DIAMOND are
- * enterprise-only and the Store never shows them. See apify/apify-mcp-server#905.
- */
-function resolveStoreBadgeTierPrice(tiers: TierPrice[]): number | undefined {
-    const paidTiers = tiers.filter(({ tier, price }) => tier !== 'FREE' && price > 0);
-    if (paidTiers.length === 0) return undefined;
-    const goldPrice = paidTiers.find(({ tier }) => tier === 'GOLD')?.price;
-    return goldPrice ?? Math.min(...paidTiers.map(({ price }) => price));
-}
-
-/**
- * Badge for a tiered price: what this user pays, plus the Store's "from" price as an upgrade hint
- * when a paid plan is cheaper. The Store page shows "from GOLD" because it does not know the
- * visitor; the widget does, so it shows both. A $0 tier is a real price ("free for you") and is
- * rendered; only an empty matrix returns undefined so callers fall back to their flat-price path.
+ * Appends the Store page's "from" price as an upgrade hint. The server sets the paid-plan price
+ * only when a paid plan is cheaper than what this user pays, so presence alone decides.
  * See apify/apify-mcp-server#905.
  */
-function formatTieredPrice({
-    tiers,
-    userTier,
-    scale,
-    toBadge,
-}: {
-    tiers: TierPrice[];
-    userTier: string | undefined;
-    scale: number;
-    toBadge: (amount: string) => string;
-}): string | undefined {
-    const ownPrice = resolveUserTierPrice(tiers, userTier);
-    if (ownPrice === undefined) return undefined;
-    const storePrice = resolveStoreBadgeTierPrice(tiers);
-    const hint =
-        storePrice !== undefined && storePrice < ownPrice
-            ? ` · from ${formatPriceUsd(storePrice * scale)} on paid plans`
-            : '';
-    return `${toBadge(formatPriceUsd(ownPrice * scale))}${hint}`;
+function formatWithPaidPlanHint(badge: string, paidPlanPrice: number | undefined, scale: number): string {
+    if (paidPlanPrice === undefined) return badge;
+    return `${badge} · from ${formatBadgePrice(paidPlanPrice * scale)} ${PAID_PLAN_HINT_SUFFIX}`;
 }
 
 function formatFlatPricePerMonth(pricing: StructuredPricingInfo): string {
-    // Complete-mode `pricePerUnit` is the un-resolved base price; tiered rentals must resolve the tier.
-    const tieredBadge = pricing.tieredPricing
-        ? formatTieredPrice({
-              tiers: pricing.tieredPricing.map(({ tier, pricePerUnit }) => ({ tier, price: pricePerUnit })),
-              userTier: pricing.userTier,
-              scale: 1,
-              toBadge: (amount) => `${amount}/month + usage`,
-          })
-        : undefined;
-    return tieredBadge ?? `${formatPriceUsd(pricing.pricePerUnit || 0)}/month + usage`;
+    const badge = `${formatBadgePrice(pricing.pricePerUnit || 0)}/month + usage`;
+    return formatWithPaidPlanHint(badge, pricing.paidPlanPricePerUnit, 1);
 }
 
-function formatPayPerEventPricing(
-    event: NonNullable<StructuredPricingInfo['events']>[0],
-    userTier: string | undefined,
-): string {
+/** Repeatable events are quoted per 1,000 like the Store page; one-time events ("Actor start") per run. */
+function formatPayPerEventPricing(event: NonNullable<StructuredPricingInfo['events']>[0]): string {
+    if (typeof event.priceUsd !== 'number') return 'Pay per event';
+    if (event.isOneTimeEvent) {
+        return formatWithPaidPlanHint(`${formatBadgePrice(event.priceUsd)} per run`, event.paidPlanPriceUsd, 1);
+    }
     const title = event.title.toLowerCase() || 'result';
-    const perThousand = (amount: string) => `${amount} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
-
-    if (event.tieredPricing) {
-        const tieredBadge = formatTieredPrice({
-            tiers: event.tieredPricing.map(({ tier, priceUsd }) => ({ tier, price: priceUsd })),
-            userTier,
-            scale: PRICE_DISPLAY_UNIT_SIZE,
-            toBadge: perThousand,
-        });
-        if (tieredBadge) return tieredBadge;
-    }
-
-    if (typeof event.priceUsd === 'number') {
-        const isPricedPerThousandResults = event.priceUsd < PER_THOUSAND_PRICING_THRESHOLD;
-        if (isPricedPerThousandResults) return perThousand(formatPriceUsd(event.priceUsd * PRICE_DISPLAY_UNIT_SIZE));
-        return `${formatPriceUsd(event.priceUsd)} / ${title}`;
-    }
-
-    return 'Pay per event';
+    const badge = `${formatBadgePrice(event.priceUsd * PRICE_DISPLAY_UNIT_SIZE)} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
+    return formatWithPaidPlanHint(badge, event.paidPlanPriceUsd, PRICE_DISPLAY_UNIT_SIZE);
 }
 
 function formatPricePerDatasetItem(pricing: StructuredPricingInfo): string {
     const pluralUnitName = pluralize(pricing.unitName || 'result');
-    const perThousand = (amount: string) => `${amount} / 1,000 ${pluralUnitName}`;
-
-    if (pricing.tieredPricing) {
-        const tieredBadge = formatTieredPrice({
-            tiers: pricing.tieredPricing.map(({ tier, pricePerUnit }) => ({ tier, price: pricePerUnit })),
-            userTier: pricing.userTier,
-            scale: PRICE_DISPLAY_UNIT_SIZE,
-            toBadge: perThousand,
-        });
-        if (tieredBadge) return tieredBadge;
-    }
-
-    return perThousand(formatPriceUsd((pricing.pricePerUnit || 0) * PRICE_DISPLAY_UNIT_SIZE));
+    const badge = `${formatBadgePrice((pricing.pricePerUnit || 0) * PRICE_DISPLAY_UNIT_SIZE)} / 1,000 ${pluralUnitName}`;
+    return formatWithPaidPlanHint(badge, pricing.paidPlanPricePerUnit, PRICE_DISPLAY_UNIT_SIZE);
 }
 
 export const formatPricing = (pricing: StructuredPricingInfo): string => {
@@ -176,7 +106,7 @@ export const formatPricing = (pricing: StructuredPricingInfo): string => {
         const primaryEvent =
             pricing.events.length === 1 ? pricing.events[0] : pricing.events.find((event) => event.isPrimaryEvent);
 
-        return primaryEvent ? formatPayPerEventPricing(primaryEvent, pricing.userTier) : 'Pay per event';
+        return primaryEvent ? formatPayPerEventPricing(primaryEvent) : 'Pay per event';
     }
 
     if (pricing.model === 'PRICE_PER_DATASET_ITEM') {

--- a/src/web/src/utils/formatting.ts
+++ b/src/web/src/utils/formatting.ts
@@ -103,10 +103,14 @@ export const formatPricing = (pricing: StructuredPricingInfo): string => {
         }
 
         // The Store badge shows the API's primary event, not a generic label; see apify/apify-mcp-server#905.
-        const primaryEvent =
-            pricing.events.length === 1 ? pricing.events[0] : pricing.events.find((event) => event.isPrimaryEvent);
+        // Without the flag, the server marks the event it advertises in the pricing note with paidPlanPriceUsd.
+        const advertisedEvent =
+            pricing.events.length === 1
+                ? pricing.events[0]
+                : (pricing.events.find((event) => event.isPrimaryEvent) ??
+                  pricing.events.find((event) => event.paidPlanPriceUsd !== undefined));
 
-        return primaryEvent ? formatPayPerEventPricing(primaryEvent) : 'Pay per event';
+        return advertisedEvent ? formatPayPerEventPricing(advertisedEvent) : 'Pay per event';
     }
 
     if (pricing.model === 'PRICE_PER_DATASET_ITEM') {

--- a/src/web/src/utils/formatting.ts
+++ b/src/web/src/utils/formatting.ts
@@ -51,26 +51,44 @@ export function formatPriceUsd(price: number, options: FormatPriceUsdOptions = {
     return formatNumberWithOptions(price, { style: 'currency', ...intlOptions }); // Intl will return the format we want: i.e. -$123,323.21;
 }
 
-function formatFlatPricePerMonth(pricePerUnit: number | undefined): string {
-    const monthlyPrice = pricePerUnit || 0;
+/**
+ * Tier the public Store badge prices at: GOLD, else the cheapest paid tier.
+ * GOLD (Business plan) is the best tier listed on apify.com/pricing; PLATINUM/DIAMOND are
+ * enterprise-only and the Store never shows them, so "cheapest tier" would undercut the badge.
+ * See apify/apify-mcp-server#905.
+ */
+function resolveStoreBadgeTierPrice(tiers: { tier: string; price: number }[]): number | undefined {
+    const paidTiers = tiers.filter(({ tier, price }) => tier !== 'FREE' && price > 0);
+    if (paidTiers.length === 0) return undefined;
+    const goldPrice = paidTiers.find(({ tier }) => tier === 'GOLD')?.price;
+    return goldPrice ?? Math.min(...paidTiers.map(({ price }) => price));
+}
+
+function formatFlatPricePerMonth(pricing: StructuredPricingInfo): string {
+    // Complete-mode `pricePerUnit` is the un-resolved base price; tiered rentals need the same badge tier.
+    const badgePrice = pricing.tieredPricing?.length
+        ? resolveStoreBadgeTierPrice(
+              pricing.tieredPricing.map(({ tier, pricePerUnit }) => ({ tier, price: pricePerUnit })),
+          )
+        : undefined;
+    const monthlyPrice = badgePrice ?? pricing.pricePerUnit ?? 0;
     return `${formatPriceUsd(monthlyPrice)}/month + usage`;
 }
 
 function formatPayPerEventPricing(
     event: NonNullable<StructuredPricingInfo['events']>[0],
-    { showFromPrefix = false }: { showFromPrefix?: boolean } = {},
+    { shouldShowFromPrefix = false }: { shouldShowFromPrefix?: boolean } = {},
 ): string {
     const title = event.title.toLowerCase() || 'result';
-    const prefix = showFromPrefix ? 'from ' : '';
+    const prefix = shouldShowFromPrefix ? 'from ' : '';
 
     if (event.tieredPricing && event.tieredPricing.length > 0) {
-        const tieredPrices = event.tieredPricing
-            .filter((tier) => tier.tier !== 'FREE' && tier.priceUsd > 0)
-            .map((tier) => tier.priceUsd);
+        const badgePrice = resolveStoreBadgeTierPrice(
+            event.tieredPricing.map(({ tier, priceUsd }) => ({ tier, price: priceUsd })),
+        );
 
-        if (tieredPrices.length > 0) {
-            const minPrice = Math.min(...tieredPrices);
-            const pricePerThousand = minPrice * PRICE_DISPLAY_UNIT_SIZE;
+        if (typeof badgePrice === 'number') {
+            const pricePerThousand = badgePrice * PRICE_DISPLAY_UNIT_SIZE;
             return `from ${formatPriceUsd(pricePerThousand)} / 1,000 ${pluralize(title, PRICE_DISPLAY_UNIT_SIZE)}`;
         }
     }
@@ -93,14 +111,12 @@ function formatPricePerDatasetItem(pricing: StructuredPricingInfo): string {
     const pluralUnitName = pluralize(unitName);
 
     if (pricing.tieredPricing && pricing.tieredPricing.length > 0) {
-        const tieredPrices = pricing.tieredPricing
-            .filter((tier) => tier.tier !== 'FREE')
-            .map((tier) => tier.pricePerUnit)
-            .filter((price) => price > 0);
+        const badgePrice = resolveStoreBadgeTierPrice(
+            pricing.tieredPricing.map(({ tier, pricePerUnit }) => ({ tier, price: pricePerUnit })),
+        );
 
-        if (tieredPrices.length > 0) {
-            const minPrice = Math.min(...tieredPrices);
-            const pricePerThousand = minPrice * PRICE_DISPLAY_UNIT_SIZE;
+        if (typeof badgePrice === 'number') {
+            const pricePerThousand = badgePrice * PRICE_DISPLAY_UNIT_SIZE;
             return `from ${formatPriceUsd(pricePerThousand)} / 1,000 ${pluralUnitName}`;
         }
     }
@@ -116,7 +132,7 @@ export const formatPricing = (pricing: StructuredPricingInfo): string => {
     }
 
     if (pricing.model === 'FLAT_PRICE_PER_MONTH') {
-        return formatFlatPricePerMonth(pricing.pricePerUnit);
+        return formatFlatPricePerMonth(pricing);
     }
 
     if (pricing.model === 'PAY_PER_EVENT') {
@@ -124,11 +140,12 @@ export const formatPricing = (pricing: StructuredPricingInfo): string => {
             return 'Pay per event';
         }
 
+        // The Store badge shows the API's primary event, not a generic label; see apify/apify-mcp-server#905.
         const primaryEvent =
             pricing.events.length === 1 ? pricing.events[0] : pricing.events.find((event) => event.isPrimaryEvent);
 
         return primaryEvent
-            ? formatPayPerEventPricing(primaryEvent, { showFromPrefix: pricing.events.length > 1 })
+            ? formatPayPerEventPricing(primaryEvent, { shouldShowFromPrefix: pricing.events.length > 1 })
             : 'Pay per event';
     }
 

--- a/tests/unit/utils.pricing_info.test.ts
+++ b/tests/unit/utils.pricing_info.test.ts
@@ -101,6 +101,26 @@ const longPayPerEvent = {
     },
 } as unknown as PricingInfo;
 
+// E9: twitter-x-scraper-shaped — Actor start (one-time) + per-tweet result event flagged isPrimaryEvent.
+const primaryFlaggedPayPerEvent = {
+    pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
+    pricingPerEvent: {
+        actorChargeEvents: {
+            start: {
+                eventTitle: 'Actor start',
+                eventDescription: 'Actor start event',
+                eventPriceUsd: 0.0004,
+            },
+            'result-item': {
+                eventTitle: 'Each tweet',
+                eventDescription: 'Each tweet',
+                eventPriceUsd: 0.00025,
+                isPrimaryEvent: true,
+            },
+        },
+    },
+} as unknown as PricingInfo;
+
 // E4: single-tier actor — raw data has only one bucket.
 const singleTierPayPerEvent = {
     pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
@@ -193,6 +213,28 @@ describe('pricingInfoToStructured (complete mode)', () => {
                     description: 'A Google Maps place scraped',
                     priceUsd: undefined,
                     tieredPricing: [{ tier: 'FREE', priceUsd: 0.004 }],
+                },
+            ],
+        });
+    });
+
+    it('E9: PAY_PER_EVENT passes isPrimaryEvent through per event', () => {
+        expect(pricingInfoToStructured(primaryFlaggedPayPerEvent, 'GOLD')).toEqual({
+            model: 'PAY_PER_EVENT',
+            userTier: 'GOLD',
+            events: [
+                {
+                    title: 'Actor start',
+                    description: 'Actor start event',
+                    priceUsd: 0.0004,
+                    tieredPricing: undefined,
+                },
+                {
+                    title: 'Each tweet',
+                    description: 'Each tweet',
+                    priceUsd: 0.00025,
+                    tieredPricing: undefined,
+                    isPrimaryEvent: true,
                 },
             ],
         });
@@ -323,6 +365,25 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
                     title: 'Scraped place',
                     description: 'A Google Maps place scraped',
                     priceUsd: 0.004,
+                },
+            ],
+        });
+    });
+
+    it('E9: PAY_PER_EVENT simplified passes isPrimaryEvent through per event', () => {
+        expect(pricingInfoToSimplifiedStructured(primaryFlaggedPayPerEvent, 'GOLD')).toEqual({
+            model: 'PAY_PER_EVENT',
+            events: [
+                {
+                    title: 'Actor start',
+                    description: 'Actor start event',
+                    priceUsd: 0.0004,
+                },
+                {
+                    title: 'Each tweet',
+                    description: 'Each tweet',
+                    priceUsd: 0.00025,
+                    isPrimaryEvent: true,
                 },
             ],
         });

--- a/tests/unit/utils.pricing_info.test.ts
+++ b/tests/unit/utils.pricing_info.test.ts
@@ -163,12 +163,12 @@ const multiTierRental = {
 
 const freeActor = { pricingModel: ACTOR_PRICING_MODEL.FREE } as PricingInfo;
 
-const NOTE_GOLD =
-    'Prices shown are for GOLD tier. Higher tiers may offer lower prices — ' +
-    'use fetch-actor-details to see the full pricing table.';
+// A Business (GOLD) user already pays the Store's advertised price, so the note carries no "from" clause.
+const NOTE_GOLD = 'Prices shown are for the Business plan. Use fetch-actor-details for the full pricing table.';
+// A Free user sees the Store's advertised price (GOLD, else the cheapest paid tier) as the "from" clause.
 const NOTE_FREE =
-    'Prices shown are for FREE tier. Higher tiers may offer lower prices — ' +
-    'use fetch-actor-details to see the full pricing table.';
+    'Prices shown are for the Free plan. Paid plans from $4 per 1000 results. ' +
+    'Use fetch-actor-details for the full pricing table.';
 const EVENT_DESCRIPTIONS_OMITTED_NOTE =
     'Event descriptions were omitted because this actor has many pricing events. ' +
     'Use fetch-actor-details for full pricing details.';
@@ -273,8 +273,8 @@ describe('pricingInfoToString (complete mode)', () => {
         expect(out).toBe(
             'This Actor is paid per event:\n' +
                 '  - **Scraped place**: A Google Maps place scraped ' +
-                '(FREE: $0.004, BRONZE: $0.004, SILVER: $0.003, ' +
-                'GOLD: $0.0021, PLATINUM: $0.00126, DIAMOND: $0.00076 per event)\n' +
+                '(Free: $0.004, Starter: $0.004, Scale: $0.003, ' +
+                'Business: $0.0021, Platinum: $0.00126, Diamond: $0.00076 per event)\n' +
                 '  - **Actor start**: Initial fee for starting the Actor ($0.00005 per event)',
         );
     });
@@ -287,7 +287,7 @@ describe('pricingInfoToString (complete mode)', () => {
 
     it('E5: PRICE_PER_DATASET_ITEM lists all tiers per 1000 results', () => {
         expect(pricingInfoToString(multiTierDatasetItem)).toBe(
-            'This Actor has tiered pricing per 1000 results: FREE: $5, BRONZE: $4, GOLD: $2.',
+            'This Actor has tiered pricing per 1000 results: Free: $5, Starter: $4, Business: $2.',
         );
     });
 
@@ -323,6 +323,46 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
         });
     });
 
+    it('names the Free plan and the advertised paid-plan price for a FREE user (multi-event, single tiered event)', () => {
+        const out = pricingInfoToSimplifiedStructured(multiTierPayPerEvent, 'FREE');
+        expect(out.events?.[0].priceUsd).toBe(0.004);
+        expect(out.pricingNote).toBe(
+            'Prices shown are for the Free plan. Paid plans from $0.0021 per event. ' +
+                'Use fetch-actor-details for the full pricing table.',
+        );
+    });
+
+    it('takes the advertised price from the primary event when several events are tiered', () => {
+        const info = {
+            pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
+            pricingPerEvent: {
+                actorChargeEvents: {
+                    start: {
+                        eventTitle: 'Actor start',
+                        eventDescription: '',
+                        eventTieredPricingUsd: {
+                            FREE: { tieredEventPriceUsd: 0.0005 },
+                            GOLD: { tieredEventPriceUsd: 0.0004 },
+                        },
+                    },
+                    tweet: {
+                        eventTitle: 'Each tweet',
+                        eventDescription: '',
+                        isPrimaryEvent: true,
+                        eventTieredPricingUsd: {
+                            FREE: { tieredEventPriceUsd: 0.005 },
+                            GOLD: { tieredEventPriceUsd: 0.00025 },
+                        },
+                    },
+                },
+            },
+        } as unknown as PricingInfo;
+        expect(pricingInfoToSimplifiedStructured(info, 'FREE').pricingNote).toBe(
+            'Prices shown are for the Free plan. Paid plans from $0.00025 per event. ' +
+                'Use fetch-actor-details for the full pricing table.',
+        );
+    });
+
     it('E3: user on DIAMOND, actor offers only FREE — resolves to FREE price, note names FREE', () => {
         const info = {
             pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
@@ -353,7 +393,10 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
         } as unknown as PricingInfo;
         const out = pricingInfoToSimplifiedStructured(info, 'DIAMOND');
         expect(out.pricePerUnit).toBe(0.004);
-        expect(out.pricingNote).toContain('BRONZE');
+        expect(out.pricingNote).toBe(
+            'Prices shown are for the Starter plan. Paid plans from $3 per 1000 results. ' +
+                'Use fetch-actor-details for the full pricing table.',
+        );
         expect(out.tieredPricing).toBeUndefined();
         expect(out.userTier).toBeUndefined();
     });
@@ -466,6 +509,69 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
     });
 });
 
+describe('pricingNote edge cases', () => {
+    it('excludes a $0 paid tier from the advertised price, like the widget badge', () => {
+        const info = {
+            pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
+            pricePerUnitUsd: 0.005,
+            unitName: 'result',
+            tieredPricing: {
+                FREE: { tieredPricePerUnitUsd: 0.005 },
+                BRONZE: { tieredPricePerUnitUsd: 0.004 },
+                GOLD: { tieredPricePerUnitUsd: 0 },
+            },
+        } as unknown as PricingInfo;
+        expect(pricingInfoToSimplifiedString(info, 'FREE')).toBe(
+            'This Actor costs $5 per 1000 results. Prices shown are for the Free plan. ' +
+                'Paid plans from $4 per 1000 results. Use fetch-actor-details for the full pricing table.',
+        );
+    });
+
+    it('omits the "from" clause when several events are tiered and none is flagged primary', () => {
+        const info = {
+            pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
+            pricingPerEvent: {
+                actorChargeEvents: {
+                    a: {
+                        eventTitle: 'A',
+                        eventDescription: '',
+                        eventTieredPricingUsd: {
+                            FREE: { tieredEventPriceUsd: 0.01 },
+                            GOLD: { tieredEventPriceUsd: 0.005 },
+                        },
+                    },
+                    b: {
+                        eventTitle: 'B',
+                        eventDescription: '',
+                        eventTieredPricingUsd: {
+                            FREE: { tieredEventPriceUsd: 0.02 },
+                            GOLD: { tieredEventPriceUsd: 0.01 },
+                        },
+                    },
+                },
+            },
+        } as unknown as PricingInfo;
+        expect(pricingInfoToSimplifiedStructured(info, 'FREE').pricingNote).toBe(
+            'Prices shown are for the Free plan. Use fetch-actor-details for the full pricing table.',
+        );
+    });
+
+    it('prints an unknown tier code as is', () => {
+        const info = {
+            pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
+            pricePerUnitUsd: 0.005,
+            unitName: 'result',
+            tieredPricing: {
+                FREE: { tieredPricePerUnitUsd: 0.005 },
+                TITANIUM: { tieredPricePerUnitUsd: 0.003 },
+            },
+        } as unknown as PricingInfo;
+        expect(pricingInfoToString(info)).toBe(
+            'This Actor has tiered pricing per 1000 results: Free: $5, TITANIUM: $3.',
+        );
+    });
+});
+
 describe('pricingInfoToSimplifiedString (simplified mode)', () => {
     it('E2: user on GOLD — one price per event, pricingNote appended', () => {
         expect(pricingInfoToSimplifiedString(multiTierPayPerEvent, 'GOLD')).toBe(
@@ -490,6 +596,25 @@ describe('pricingInfoToSimplifiedString (simplified mode)', () => {
     it('E7: FLAT_PRICE_PER_MONTH simplified — rental price + trial + note', () => {
         expect(pricingInfoToSimplifiedString(multiTierRental, 'GOLD')).toBe(
             `This Actor is rental and costs $20 per month, with a trial period of 7 days. ${NOTE_GOLD}`,
+        );
+    });
+
+    it('FREE user — note names the Free plan and the advertised paid-plan price per model', () => {
+        expect(pricingInfoToSimplifiedString(multiTierDatasetItem, 'FREE')).toBe(
+            'This Actor costs $5 per 1000 results. Prices shown are for the Free plan. ' +
+                'Paid plans from $2 per 1000 results. Use fetch-actor-details for the full pricing table.',
+        );
+        expect(pricingInfoToSimplifiedString(multiTierRental, 'FREE')).toBe(
+            'This Actor is rental and costs $30 per month, with a trial period of 7 days. ' +
+                'Prices shown are for the Free plan. Paid plans from $20 per month. ' +
+                'Use fetch-actor-details for the full pricing table.',
+        );
+        expect(pricingInfoToSimplifiedString(multiTierPayPerEvent, 'FREE')).toBe(
+            'This Actor is paid per event:\n' +
+                '  - **Scraped place**: A Google Maps place scraped ($0.004 per event)\n' +
+                '  - **Actor start**: Initial fee for starting the Actor ($0.00005 per event)\n' +
+                'Prices shown are for the Free plan. Paid plans from $0.0021 per event. ' +
+                'Use fetch-actor-details for the full pricing table.',
         );
     });
 

--- a/tests/unit/utils.pricing_info.test.ts
+++ b/tests/unit/utils.pricing_info.test.ts
@@ -168,7 +168,7 @@ const freeActor = { pricingModel: ACTOR_PRICING_MODEL.FREE } as PricingInfo;
 
 // A Business (GOLD) user already pays the Store's advertised price, so the note carries no "from" clause.
 const NOTE_GOLD = 'Prices shown are for the Business plan. Use fetch-actor-details for the full pricing table.';
-// A Free user sees the Store's advertised price (GOLD, else the cheapest paid tier) as the "from" clause.
+// A Free user sees the Store's advertised price (GOLD, else the cheapest Starter/Scale tier) as the "from" clause.
 const NOTE_FREE =
     'Prices shown are for the Free plan. Paid plans from $4.00 / 1,000 results. ' +
     'Use fetch-actor-details for the full pricing table.';
@@ -642,6 +642,42 @@ describe('pricingNote edge cases', () => {
         expect(pricingInfoToSimplifiedString(info, 'FREE')).toBe(
             'This Actor costs $5.00 / 1,000 results. Prices shown are for the Free plan. ' +
                 'Paid plans from $4.00 / 1,000 results. Use fetch-actor-details for the full pricing table.',
+        );
+    });
+
+    it('advertises the cheapest Starter/Scale price when GOLD is missing, never an enterprise tier', () => {
+        const info = {
+            pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
+            pricePerUnitUsd: 0.004,
+            unitName: 'result',
+            tieredPricing: {
+                FREE: { tieredPricePerUnitUsd: 0.004 },
+                BRONZE: { tieredPricePerUnitUsd: 0.003 },
+                DIAMOND: { tieredPricePerUnitUsd: 0.0005 },
+            },
+        } as unknown as PricingInfo;
+        const out = pricingInfoToSimplifiedStructured(info, 'FREE');
+        expect(out.paidPlanPricePerUnit).toBe(0.003);
+        expect(out.pricingNote).toBe(
+            'Prices shown are for the Free plan. Paid plans from $3.00 / 1,000 results. ' +
+                'Use fetch-actor-details for the full pricing table.',
+        );
+    });
+
+    it('omits the "from" clause when the only paid tiers are enterprise (PLATINUM/DIAMOND)', () => {
+        const info = {
+            pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
+            pricePerUnitUsd: 0.004,
+            unitName: 'result',
+            tieredPricing: {
+                FREE: { tieredPricePerUnitUsd: 0.004 },
+                DIAMOND: { tieredPricePerUnitUsd: 0.0005 },
+            },
+        } as unknown as PricingInfo;
+        const out = pricingInfoToSimplifiedStructured(info, 'FREE');
+        expect(out.paidPlanPricePerUnit).toBeUndefined();
+        expect(out.pricingNote).toBe(
+            'Prices shown are for the Free plan. Use fetch-actor-details for the full pricing table.',
         );
     });
 

--- a/tests/unit/utils.pricing_info.test.ts
+++ b/tests/unit/utils.pricing_info.test.ts
@@ -14,7 +14,7 @@ import {
 // (fetch-actor-details) and simplified (search-actors).
 
 // E1/E2/E3: compass/crawler-google-places — PAY_PER_EVENT, multi-tier "Scraped place" event,
-// flat "Actor start" event.
+// flat one-time "Actor start" event.
 const multiTierPayPerEvent = {
     pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
     pricingPerEvent: {
@@ -35,6 +35,7 @@ const multiTierPayPerEvent = {
                 eventTitle: 'Actor start',
                 eventDescription: 'Initial fee for starting the Actor',
                 eventPriceUsd: 0.00005,
+                isOneTimeEvent: true,
             },
         },
     },
@@ -96,13 +97,14 @@ const longPayPerEvent = {
             f: {
                 eventTitle: 'Actor start',
                 eventDescription: 'Flat fee for starting an Actor run.',
+                isOneTimeEvent: true,
                 eventTieredPricingUsd: { FREE: { tieredEventPriceUsd: 0.001 } },
             },
         },
     },
 } as unknown as PricingInfo;
 
-// E9: twitter-x-scraper-shaped — Actor start (one-time) + per-tweet result event flagged isPrimaryEvent.
+// E9: twitter-x-scraper-shaped — one-time Actor start + per-tweet result event flagged isPrimaryEvent.
 const primaryFlaggedPayPerEvent = {
     pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
     pricingPerEvent: {
@@ -111,6 +113,7 @@ const primaryFlaggedPayPerEvent = {
                 eventTitle: 'Actor start',
                 eventDescription: 'Actor start event',
                 eventPriceUsd: 0.0004,
+                isOneTimeEvent: true,
             },
             'result-item': {
                 eventTitle: 'Each tweet',
@@ -167,7 +170,7 @@ const freeActor = { pricingModel: ACTOR_PRICING_MODEL.FREE } as PricingInfo;
 const NOTE_GOLD = 'Prices shown are for the Business plan. Use fetch-actor-details for the full pricing table.';
 // A Free user sees the Store's advertised price (GOLD, else the cheapest paid tier) as the "from" clause.
 const NOTE_FREE =
-    'Prices shown are for the Free plan. Paid plans from $4 per 1000 results. ' +
+    'Prices shown are for the Free plan. Paid plans from $4.00 / 1,000 results. ' +
     'Use fetch-actor-details for the full pricing table.';
 const EVENT_DESCRIPTIONS_OMITTED_NOTE =
     'Event descriptions were omitted because this actor has many pricing events. ' +
@@ -199,6 +202,7 @@ describe('pricingInfoToStructured (complete mode)', () => {
                     description: 'Initial fee for starting the Actor',
                     priceUsd: 0.00005,
                     tieredPricing: undefined,
+                    isOneTimeEvent: true,
                 },
             ],
         });
@@ -219,7 +223,7 @@ describe('pricingInfoToStructured (complete mode)', () => {
         });
     });
 
-    it('E9: PAY_PER_EVENT passes isPrimaryEvent through per event', () => {
+    it('E9: PAY_PER_EVENT passes isPrimaryEvent and isOneTimeEvent through per event', () => {
         expect(pricingInfoToStructured(primaryFlaggedPayPerEvent, 'GOLD')).toEqual({
             model: 'PAY_PER_EVENT',
             userTier: 'GOLD',
@@ -229,6 +233,7 @@ describe('pricingInfoToStructured (complete mode)', () => {
                     description: 'Actor start event',
                     priceUsd: 0.0004,
                     tieredPricing: undefined,
+                    isOneTimeEvent: true,
                 },
                 {
                     title: 'Each tweet',
@@ -268,26 +273,47 @@ describe('pricingInfoToStructured (complete mode)', () => {
 });
 
 describe('pricingInfoToString (complete mode)', () => {
-    it('E1: PAY_PER_EVENT lists all tiers inline for tiered events, flat for non-tiered', () => {
-        const out = pricingInfoToString(multiTierPayPerEvent);
-        expect(out).toBe(
+    it('E1: PAY_PER_EVENT lists all plans per 1,000 events for tiered events, per run for one-time events', () => {
+        expect(pricingInfoToString(multiTierPayPerEvent)).toBe(
             'This Actor is paid per event:\n' +
                 '  - **Scraped place**: A Google Maps place scraped ' +
-                '(Free: $0.004, Starter: $0.004, Scale: $0.003, ' +
-                'Business: $0.0021, Platinum: $0.00126, Diamond: $0.00076 per event)\n' +
-                '  - **Actor start**: Initial fee for starting the Actor ($0.00005 per event)',
+                '(Free: $4.00, Starter: $4.00, Scale: $3.00, ' +
+                'Business: $2.10, Platinum: $1.26, Diamond: $0.76 / 1,000 events)\n' +
+                '  - **Actor start**: Initial fee for starting the Actor ($0.00005 per run)',
         );
     });
 
-    it('E4: single-tier event renders as flat (no tier label)', () => {
+    it('E4: single-tier event renders as a flat price (no plan label)', () => {
         expect(pricingInfoToString(singleTierPayPerEvent)).toBe(
-            'This Actor is paid per event:\n' + '  - **Scraped place**: A Google Maps place scraped ($0.004 per event)',
+            'This Actor is paid per event:\n  - **Scraped place**: A Google Maps place scraped ($4.00 / 1,000 events)',
         );
     });
 
-    it('E5: PRICE_PER_DATASET_ITEM lists all tiers per 1000 results', () => {
+    it('E5: PRICE_PER_DATASET_ITEM lists all plans per 1,000 results', () => {
         expect(pricingInfoToString(multiTierDatasetItem)).toBe(
-            'This Actor has tiered pricing per 1000 results: Free: $5, Starter: $4, Business: $2.',
+            'This Actor has tiered pricing: Free: $5.00, Starter: $4.00, Business: $2.00 / 1,000 results.',
+        );
+    });
+
+    it('E7: FLAT_PRICE_PER_MONTH lists all plans per month', () => {
+        expect(pricingInfoToString(multiTierRental)).toBe(
+            'This Actor is rental and has tiered pricing: Free: $30.00, Business: $20.00 per month, ' +
+                'with a trial period of 7 days.',
+        );
+    });
+
+    it('prints an unknown tier code as is', () => {
+        const info = {
+            pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
+            pricePerUnitUsd: 0.005,
+            unitName: 'result',
+            tieredPricing: {
+                FREE: { tieredPricePerUnitUsd: 0.005 },
+                TITANIUM: { tieredPricePerUnitUsd: 0.003 },
+            },
+        } as unknown as PricingInfo;
+        expect(pricingInfoToString(info)).toBe(
+            'This Actor has tiered pricing: Free: $5.00, TITANIUM: $3.00 / 1,000 results.',
         );
     });
 
@@ -304,7 +330,7 @@ describe('pricingInfoToString (complete mode)', () => {
 // ─── Simplified mode: search-actors ───────────────────────────────────────────
 
 describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
-    it('E2: user on GOLD — resolved price reflects GOLD, pricingNote names GOLD', () => {
+    it('E2: user on GOLD — resolved price reflects GOLD, pricingNote names the Business plan', () => {
         expect(pricingInfoToSimplifiedStructured(multiTierPayPerEvent, 'GOLD')).toEqual({
             model: 'PAY_PER_EVENT',
             events: [
@@ -317,17 +343,20 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
                     title: 'Actor start',
                     description: 'Initial fee for starting the Actor',
                     priceUsd: 0.00005,
+                    isOneTimeEvent: true,
                 },
             ],
             pricingNote: NOTE_GOLD,
         });
     });
 
-    it('names the Free plan and the advertised paid-plan price for a FREE user (multi-event, single tiered event)', () => {
+    it('FREE user — note names the Free plan and the advertised price; the advertised event carries paidPlanPriceUsd', () => {
         const out = pricingInfoToSimplifiedStructured(multiTierPayPerEvent, 'FREE');
         expect(out.events?.[0].priceUsd).toBe(0.004);
+        expect(out.events?.[0].paidPlanPriceUsd).toBe(0.0021);
+        expect(out.events?.[1].paidPlanPriceUsd).toBeUndefined();
         expect(out.pricingNote).toBe(
-            'Prices shown are for the Free plan. Paid plans from $0.0021 per event. ' +
+            'Prices shown are for the Free plan. Paid plans from $2.10 / 1,000 events (Scraped place). ' +
                 'Use fetch-actor-details for the full pricing table.',
         );
     });
@@ -340,6 +369,7 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
                     start: {
                         eventTitle: 'Actor start',
                         eventDescription: '',
+                        isOneTimeEvent: true,
                         eventTieredPricingUsd: {
                             FREE: { tieredEventPriceUsd: 0.0005 },
                             GOLD: { tieredEventPriceUsd: 0.0004 },
@@ -357,13 +387,15 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
                 },
             },
         } as unknown as PricingInfo;
-        expect(pricingInfoToSimplifiedStructured(info, 'FREE').pricingNote).toBe(
-            'Prices shown are for the Free plan. Paid plans from $0.00025 per event. ' +
+        const out = pricingInfoToSimplifiedStructured(info, 'FREE');
+        expect(out.pricingNote).toBe(
+            'Prices shown are for the Free plan. Paid plans from $0.25 / 1,000 events (Each tweet). ' +
                 'Use fetch-actor-details for the full pricing table.',
         );
+        expect(out.events?.map((event) => event.paidPlanPriceUsd)).toEqual([undefined, 0.00025]);
     });
 
-    it('E3: user on DIAMOND, actor offers only FREE — resolves to FREE price, note names FREE', () => {
+    it('E3: user on DIAMOND, actor offers only FREE and BRONZE — resolves to the FREE price, hints BRONZE', () => {
         const info = {
             pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
             pricePerUnitUsd: 0.005,
@@ -377,6 +409,7 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
             model: 'PRICE_PER_DATASET_ITEM',
             pricePerUnit: 0.005,
             unitName: 'result',
+            paidPlanPricePerUnit: 0.004,
             pricingNote: NOTE_FREE,
         });
     });
@@ -393,15 +426,16 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
         } as unknown as PricingInfo;
         const out = pricingInfoToSimplifiedStructured(info, 'DIAMOND');
         expect(out.pricePerUnit).toBe(0.004);
+        expect(out.paidPlanPricePerUnit).toBe(0.003);
         expect(out.pricingNote).toBe(
-            'Prices shown are for the Starter plan. Paid plans from $3 per 1000 results. ' +
+            'Prices shown are for the Starter plan. Paid plans from $3.00 / 1,000 results. ' +
                 'Use fetch-actor-details for the full pricing table.',
         );
         expect(out.tieredPricing).toBeUndefined();
         expect(out.userTier).toBeUndefined();
     });
 
-    it('E4: single-tier actor — no pricingNote (the "higher tiers" promise is vacuous)', () => {
+    it('E4: single-tier actor — no pricingNote (nothing to compare against)', () => {
         expect(pricingInfoToSimplifiedStructured(singleTierPayPerEvent, 'GOLD')).toEqual({
             model: 'PAY_PER_EVENT',
             events: [
@@ -414,7 +448,7 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
         });
     });
 
-    it('E9: PAY_PER_EVENT simplified passes isPrimaryEvent through per event', () => {
+    it('E9: PAY_PER_EVENT simplified passes isPrimaryEvent and isOneTimeEvent through per event', () => {
         expect(pricingInfoToSimplifiedStructured(primaryFlaggedPayPerEvent, 'GOLD')).toEqual({
             model: 'PAY_PER_EVENT',
             events: [
@@ -422,6 +456,7 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
                     title: 'Actor start',
                     description: 'Actor start event',
                     priceUsd: 0.0004,
+                    isOneTimeEvent: true,
                 },
                 {
                     title: 'Each tweet',
@@ -442,7 +477,7 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
         });
     });
 
-    it('user on DIAMOND — resolved price is DIAMOND, pricingNote is suppressed (top tier)', () => {
+    it('user on DIAMOND — resolved price is DIAMOND, no hint, pricingNote is suppressed (top tier)', () => {
         const info = {
             pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
             pricePerUnitUsd: 0.005,
@@ -455,6 +490,7 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
         } as unknown as PricingInfo;
         const out = pricingInfoToSimplifiedStructured(info, 'DIAMOND');
         expect(out.pricePerUnit).toBe(0.001);
+        expect(out.paidPlanPricePerUnit).toBeUndefined();
         expect(out.pricingNote).toBeUndefined();
         expect(out.tieredPricing).toBeUndefined();
     });
@@ -501,7 +537,7 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
                 { title: 'Add-on: Popularity filter', priceUsd: 0.0013 },
                 { title: 'Add-on: Follower / Following', priceUsd: 0.004 },
                 { title: 'Add-on: Search video sorting', priceUsd: 0.0013 },
-                { title: 'Actor start', priceUsd: 0.001 },
+                { title: 'Actor start', priceUsd: 0.001, isOneTimeEvent: true },
             ],
             eventDescriptionsOmitted: true,
             eventDescriptionsNote: EVENT_DESCRIPTIONS_OMITTED_NOTE,
@@ -510,6 +546,88 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
 });
 
 describe('pricingNote edge cases', () => {
+    it('never hints a top-tier user, even when a developer priced a lower tier below DIAMOND', () => {
+        const info = {
+            pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
+            pricePerUnitUsd: 0.005,
+            unitName: 'result',
+            tieredPricing: {
+                FREE: { tieredPricePerUnitUsd: 0.005 },
+                GOLD: { tieredPricePerUnitUsd: 0.001 },
+                DIAMOND: { tieredPricePerUnitUsd: 0.002 },
+            },
+        } as unknown as PricingInfo;
+        const out = pricingInfoToSimplifiedStructured(info, 'DIAMOND');
+        expect(out.pricePerUnit).toBe(0.002);
+        expect(out.paidPlanPricePerUnit).toBeUndefined();
+        expect(out.pricingNote).toBeUndefined();
+    });
+
+    it('omits the event title from the note when the Actor has a single event', () => {
+        const info = {
+            pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
+            pricingPerEvent: {
+                actorChargeEvents: {
+                    result: {
+                        eventTitle: 'Result',
+                        eventDescription: '',
+                        eventTieredPricingUsd: {
+                            FREE: { tieredEventPriceUsd: 0.0027 },
+                            GOLD: { tieredEventPriceUsd: 0.0015 },
+                        },
+                    },
+                },
+            },
+        } as unknown as PricingInfo;
+        const out = pricingInfoToSimplifiedStructured(info, 'FREE');
+        expect(out.events?.[0].paidPlanPriceUsd).toBe(0.0015);
+        expect(out.pricingNote).toBe(
+            'Prices shown are for the Free plan. Paid plans from $1.50 / 1,000 events. ' +
+                'Use fetch-actor-details for the full pricing table.',
+        );
+    });
+
+    it('keeps the paid-plan price on the primary event when descriptions are trimmed (more than 5 events)', () => {
+        const addOn = (title: string) => ({
+            eventTitle: title,
+            eventDescription: 'Extra cost.',
+            eventTieredPricingUsd: { FREE: { tieredEventPriceUsd: 0.001 } },
+        });
+        const info = {
+            pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
+            pricingPerEvent: {
+                actorChargeEvents: {
+                    result: {
+                        eventTitle: 'Result',
+                        eventDescription: 'Cost per result.',
+                        isPrimaryEvent: true,
+                        eventTieredPricingUsd: {
+                            FREE: { tieredEventPriceUsd: 0.004 },
+                            GOLD: { tieredEventPriceUsd: 0.0015 },
+                        },
+                    },
+                    a: addOn('Add-on A'),
+                    b: addOn('Add-on B'),
+                    c: addOn('Add-on C'),
+                    d: addOn('Add-on D'),
+                    e: addOn('Add-on E'),
+                },
+            },
+        } as unknown as PricingInfo;
+        const out = pricingInfoToSimplifiedStructured(info, 'FREE');
+        expect(out.eventDescriptionsOmitted).toBe(true);
+        expect(out.events?.[0]).toEqual({
+            title: 'Result',
+            isPrimaryEvent: true,
+            priceUsd: 0.004,
+            paidPlanPriceUsd: 0.0015,
+        });
+        expect(out.pricingNote).toBe(
+            'Prices shown are for the Free plan. Paid plans from $1.50 / 1,000 events (Result). ' +
+                'Use fetch-actor-details for the full pricing table.',
+        );
+    });
+
     it('excludes a $0 paid tier from the advertised price, like the widget badge', () => {
         const info = {
             pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
@@ -522,8 +640,8 @@ describe('pricingNote edge cases', () => {
             },
         } as unknown as PricingInfo;
         expect(pricingInfoToSimplifiedString(info, 'FREE')).toBe(
-            'This Actor costs $5 per 1000 results. Prices shown are for the Free plan. ' +
-                'Paid plans from $4 per 1000 results. Use fetch-actor-details for the full pricing table.',
+            'This Actor costs $5.00 / 1,000 results. Prices shown are for the Free plan. ' +
+                'Paid plans from $4.00 / 1,000 results. Use fetch-actor-details for the full pricing table.',
         );
     });
 
@@ -551,24 +669,11 @@ describe('pricingNote edge cases', () => {
                 },
             },
         } as unknown as PricingInfo;
-        expect(pricingInfoToSimplifiedStructured(info, 'FREE').pricingNote).toBe(
+        const out = pricingInfoToSimplifiedStructured(info, 'FREE');
+        expect(out.pricingNote).toBe(
             'Prices shown are for the Free plan. Use fetch-actor-details for the full pricing table.',
         );
-    });
-
-    it('prints an unknown tier code as is', () => {
-        const info = {
-            pricingModel: ACTOR_PRICING_MODEL.PRICE_PER_DATASET_ITEM,
-            pricePerUnitUsd: 0.005,
-            unitName: 'result',
-            tieredPricing: {
-                FREE: { tieredPricePerUnitUsd: 0.005 },
-                TITANIUM: { tieredPricePerUnitUsd: 0.003 },
-            },
-        } as unknown as PricingInfo;
-        expect(pricingInfoToString(info)).toBe(
-            'This Actor has tiered pricing per 1000 results: Free: $5, TITANIUM: $3.',
-        );
+        expect(out.events?.map((event) => event.paidPlanPriceUsd)).toEqual([undefined, undefined]);
     });
 });
 
@@ -576,44 +681,44 @@ describe('pricingInfoToSimplifiedString (simplified mode)', () => {
     it('E2: user on GOLD — one price per event, pricingNote appended', () => {
         expect(pricingInfoToSimplifiedString(multiTierPayPerEvent, 'GOLD')).toBe(
             `This Actor is paid per event:\n` +
-                `  - **Scraped place**: A Google Maps place scraped ($0.0021 per event)\n` +
-                `  - **Actor start**: Initial fee for starting the Actor ($0.00005 per event)\n${NOTE_GOLD}`,
+                `  - **Scraped place**: A Google Maps place scraped ($2.10 / 1,000 events)\n` +
+                `  - **Actor start**: Initial fee for starting the Actor ($0.00005 per run)\n${NOTE_GOLD}`,
         );
     });
 
     it('E4: single-tier actor — flat price, no pricingNote', () => {
         expect(pricingInfoToSimplifiedString(singleTierPayPerEvent, 'GOLD')).toBe(
-            'This Actor is paid per event:\n' + '  - **Scraped place**: A Google Maps place scraped ($0.004 per event)',
+            'This Actor is paid per event:\n  - **Scraped place**: A Google Maps place scraped ($4.00 / 1,000 events)',
         );
     });
 
     it('E6: PRICE_PER_DATASET_ITEM simplified — single price + note', () => {
         expect(pricingInfoToSimplifiedString(multiTierDatasetItem, 'GOLD')).toBe(
-            `This Actor costs $2 per 1000 results. ${NOTE_GOLD}`,
+            `This Actor costs $2.00 / 1,000 results. ${NOTE_GOLD}`,
         );
     });
 
     it('E7: FLAT_PRICE_PER_MONTH simplified — rental price + trial + note', () => {
         expect(pricingInfoToSimplifiedString(multiTierRental, 'GOLD')).toBe(
-            `This Actor is rental and costs $20 per month, with a trial period of 7 days. ${NOTE_GOLD}`,
+            `This Actor is rental and costs $20.00 per month, with a trial period of 7 days. ${NOTE_GOLD}`,
         );
     });
 
     it('FREE user — note names the Free plan and the advertised paid-plan price per model', () => {
         expect(pricingInfoToSimplifiedString(multiTierDatasetItem, 'FREE')).toBe(
-            'This Actor costs $5 per 1000 results. Prices shown are for the Free plan. ' +
-                'Paid plans from $2 per 1000 results. Use fetch-actor-details for the full pricing table.',
+            'This Actor costs $5.00 / 1,000 results. Prices shown are for the Free plan. ' +
+                'Paid plans from $2.00 / 1,000 results. Use fetch-actor-details for the full pricing table.',
         );
         expect(pricingInfoToSimplifiedString(multiTierRental, 'FREE')).toBe(
-            'This Actor is rental and costs $30 per month, with a trial period of 7 days. ' +
-                'Prices shown are for the Free plan. Paid plans from $20 per month. ' +
+            'This Actor is rental and costs $30.00 per month, with a trial period of 7 days. ' +
+                'Prices shown are for the Free plan. Paid plans from $20.00 per month. ' +
                 'Use fetch-actor-details for the full pricing table.',
         );
         expect(pricingInfoToSimplifiedString(multiTierPayPerEvent, 'FREE')).toBe(
             'This Actor is paid per event:\n' +
-                '  - **Scraped place**: A Google Maps place scraped ($0.004 per event)\n' +
-                '  - **Actor start**: Initial fee for starting the Actor ($0.00005 per event)\n' +
-                'Prices shown are for the Free plan. Paid plans from $0.0021 per event. ' +
+                '  - **Scraped place**: A Google Maps place scraped ($4.00 / 1,000 events)\n' +
+                '  - **Actor start**: Initial fee for starting the Actor ($0.00005 per run)\n' +
+                'Prices shown are for the Free plan. Paid plans from $2.10 / 1,000 events (Scraped place). ' +
                 'Use fetch-actor-details for the full pricing table.',
         );
     });
@@ -629,7 +734,7 @@ describe('pricingInfoToSimplifiedString (simplified mode)', () => {
                 DIAMOND: { tieredPricePerUnitUsd: 0.001 },
             },
         } as unknown as PricingInfo;
-        expect(pricingInfoToSimplifiedString(info, 'DIAMOND')).toBe('This Actor costs $1 per 1000 results.');
+        expect(pricingInfoToSimplifiedString(info, 'DIAMOND')).toBe('This Actor costs $1.00 / 1,000 results.');
     });
 
     it('E8: FREE actor', () => {
@@ -637,21 +742,22 @@ describe('pricingInfoToSimplifiedString (simplified mode)', () => {
             'This Actor is free to use. You are only charged for Apify platform usage.',
         );
     });
+
     it('omits pricingNote text when PAY_PER_EVENT events resolve to different tiers', () => {
         expect(pricingInfoToSimplifiedString(mixedTierPayPerEvent, 'GOLD')).toBe(
-            'This Actor is paid per event:\n' + '  - **A**:  ($0.005 per event)\n' + '  - **B**:  ($0.02 per event)',
+            'This Actor is paid per event:\n  - **A**:  ($5.00 / 1,000 events)\n  - **B**:  ($20.00 / 1,000 events)',
         );
     });
 
     it('omits event descriptions in text when PAY_PER_EVENT has more than 5 events', () => {
         expect(pricingInfoToSimplifiedString(longPayPerEvent, 'FREE')).toBe(
             'This Actor is paid per event:\n' +
-                '  - **Result**: $0.0037 per event\n' +
-                '  - **Add-on: Date filter**: $0.0013 per event\n' +
-                '  - **Add-on: Popularity filter**: $0.0013 per event\n' +
-                '  - **Add-on: Follower / Following**: $0.004 per event\n' +
-                '  - **Add-on: Search video sorting**: $0.0013 per event\n' +
-                `  - **Actor start**: $0.001 per event\n${EVENT_DESCRIPTIONS_OMITTED_NOTE}`,
+                '  - **Result**: $3.70 / 1,000 events\n' +
+                '  - **Add-on: Date filter**: $1.30 / 1,000 events\n' +
+                '  - **Add-on: Popularity filter**: $1.30 / 1,000 events\n' +
+                '  - **Add-on: Follower / Following**: $4.00 / 1,000 events\n' +
+                '  - **Add-on: Search video sorting**: $1.30 / 1,000 events\n' +
+                `  - **Actor start**: $0.001 per run\n${EVENT_DESCRIPTIONS_OMITTED_NOTE}`,
         );
     });
 });

--- a/tests/unit/utils.pricing_info.test.ts
+++ b/tests/unit/utils.pricing_info.test.ts
@@ -102,6 +102,26 @@ const longPayPerEvent = {
     },
 } as unknown as PricingInfo;
 
+// E9: twitter-x-scraper-shaped — Actor start (one-time) + per-tweet result event flagged isPrimaryEvent.
+const primaryFlaggedPayPerEvent = {
+    pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
+    pricingPerEvent: {
+        actorChargeEvents: {
+            start: {
+                eventTitle: 'Actor start',
+                eventDescription: 'Actor start event',
+                eventPriceUsd: 0.0004,
+            },
+            'result-item': {
+                eventTitle: 'Each tweet',
+                eventDescription: 'Each tweet',
+                eventPriceUsd: 0.00025,
+                isPrimaryEvent: true,
+            },
+        },
+    },
+} as unknown as PricingInfo;
+
 // E4: single-tier actor — raw data has only one bucket.
 const singleTierPayPerEvent = {
     pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
@@ -194,6 +214,28 @@ describe('pricingInfoToStructured (complete mode)', () => {
                     description: 'A Google Maps place scraped',
                     priceUsd: undefined,
                     tieredPricing: [{ tier: 'FREE', priceUsd: 0.004 }],
+                },
+            ],
+        });
+    });
+
+    it('E9: PAY_PER_EVENT passes isPrimaryEvent through per event', () => {
+        expect(pricingInfoToStructured(primaryFlaggedPayPerEvent, 'GOLD')).toEqual({
+            model: 'PAY_PER_EVENT',
+            userTier: 'GOLD',
+            events: [
+                {
+                    title: 'Actor start',
+                    description: 'Actor start event',
+                    priceUsd: 0.0004,
+                    tieredPricing: undefined,
+                },
+                {
+                    title: 'Each tweet',
+                    description: 'Each tweet',
+                    priceUsd: 0.00025,
+                    tieredPricing: undefined,
+                    isPrimaryEvent: true,
                 },
             ],
         });
@@ -324,6 +366,25 @@ describe('pricingInfoToSimplifiedStructured (simplified mode)', () => {
                     title: 'Scraped place',
                     description: 'A Google Maps place scraped',
                     priceUsd: 0.004,
+                },
+            ],
+        });
+    });
+
+    it('E9: PAY_PER_EVENT simplified passes isPrimaryEvent through per event', () => {
+        expect(pricingInfoToSimplifiedStructured(primaryFlaggedPayPerEvent, 'GOLD')).toEqual({
+            model: 'PAY_PER_EVENT',
+            events: [
+                {
+                    title: 'Actor start',
+                    description: 'Actor start event',
+                    priceUsd: 0.0004,
+                },
+                {
+                    title: 'Each tweet',
+                    description: 'Each tweet',
+                    priceUsd: 0.00025,
+                    isPrimaryEvent: true,
                 },
             ],
         });

--- a/tests/unit/web.formatting.pricing.test.ts
+++ b/tests/unit/web.formatting.pricing.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { ACTOR_PRICING_MODEL } from '../../src/const.js';
+import type { ActorStoreList } from '../../src/types.js';
+import { formatActorForWidget } from '../../src/utils/actor_card.js';
+import type { PricingInfo } from '../../src/utils/pricing_info.js';
+import { formatPricing } from '../../src/web/src/utils/formatting.js';
+
+/**
+ * Mirrors xtdata/twitter-x-scraper current PAY_PER_EVENT pricing
+ * (see https://github.com/apify/apify-mcp-server/issues/905).
+ * Public Store page shows: "from $0.25 / 1,000 each tweet. cheaper for higher plans"
+ */
+const twitterXScraperPricing = {
+    pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
+    pricingPerEvent: {
+        actorChargeEvents: {
+            start: {
+                eventTitle: 'Actor Start',
+                eventDescription: 'Actor start event',
+                isOneTimeEvent: true,
+                eventTieredPricingUsd: {
+                    FREE: { tieredEventPriceUsd: 0.0005 },
+                    BRONZE: { tieredEventPriceUsd: 0.00047 },
+                    SILVER: { tieredEventPriceUsd: 0.00043 },
+                    GOLD: { tieredEventPriceUsd: 0.0004 },
+                    PLATINUM: { tieredEventPriceUsd: 0.0004 },
+                    DIAMOND: { tieredEventPriceUsd: 0.0004 },
+                },
+            },
+            'result-item': {
+                eventTitle: 'Each tweet. Cheaper for higher plans',
+                eventDescription: 'Each tweet. Cheaper for higher plans to avoid abusers.',
+                isPrimaryEvent: true,
+                isOneTimeEvent: false,
+                eventTieredPricingUsd: {
+                    FREE: { tieredEventPriceUsd: 0.005 },
+                    BRONZE: { tieredEventPriceUsd: 0.0008 },
+                    SILVER: { tieredEventPriceUsd: 0.0006 },
+                    GOLD: { tieredEventPriceUsd: 0.00025 },
+                    PLATINUM: { tieredEventPriceUsd: 0.00025 },
+                    DIAMOND: { tieredEventPriceUsd: 0.00025 },
+                },
+            },
+        },
+    },
+} as unknown as PricingInfo;
+
+const twitterXScraperStoreActor = {
+    id: 'twitter-x-scraper',
+    name: 'twitter-x-scraper',
+    username: 'xtdata',
+    title: 'X.com Twitter API Scraper',
+    description: 'Scrape Twitter (X) data efficiently.',
+    isDeprecated: false,
+    modifiedAt: new Date('2026-05-03T11:04:10.172Z'),
+    categories: ['SOCIAL_MEDIA'],
+    actorReviewRating: 3.4,
+    actorReviewCount: 5,
+    currentPricingInfo: twitterXScraperPricing,
+    stats: {
+        totalBuilds: 1,
+        totalRuns: 1,
+        totalUsers: 2400,
+        totalUsers30Days: 177,
+        actorReviewCount: 5,
+        actorReviewRating: 3.4,
+    },
+} as unknown as ActorStoreList;
+
+describe('formatPricing()', () => {
+    it('formats PAY_PER_EVENT with a single event', () => {
+        expect(
+            formatPricing({
+                model: 'PAY_PER_EVENT',
+                events: [{ title: 'Each tweet', priceUsd: 0.00025 }],
+            }),
+        ).toBe('$0.25 / 1,000 each tweets');
+    });
+
+    it('uses the event flagged isPrimaryEvent when an actor has multiple charge events', () => {
+        expect(
+            formatPricing({
+                model: 'PAY_PER_EVENT',
+                events: [
+                    { title: 'Actor start', priceUsd: 0.0004 },
+                    { title: 'Each tweet', priceUsd: 0.00025, isPrimaryEvent: true },
+                ],
+            }),
+        ).toBe('from $0.25 / 1,000 each tweets');
+    });
+
+    it('falls back to Pay per event when multi-event PPE has no primary event', () => {
+        expect(
+            formatPricing({
+                model: 'PAY_PER_EVENT',
+                events: [
+                    { title: 'Actor Start', priceUsd: 0.0005 },
+                    { title: 'Each tweet', priceUsd: 0.005 },
+                ],
+            }),
+        ).toBe('Pay per event');
+    });
+
+    it('falls back to Pay per event when there are no events', () => {
+        expect(formatPricing({ model: 'PAY_PER_EVENT', events: [] })).toBe('Pay per event');
+        expect(formatPricing({ model: 'PAY_PER_EVENT' })).toBe('Pay per event');
+    });
+
+    it('matches public Store page for multi-event PPE with a primary event (#905)', () => {
+        const widgetActor = formatActorForWidget(twitterXScraperStoreActor, 'FREE');
+
+        expect(formatPricing(widgetActor.currentPricingInfo)).toBe(
+            'from $0.25 / 1,000 each tweet. cheaper for higher plans',
+        );
+    });
+});

--- a/tests/unit/widget.formatting.test.ts
+++ b/tests/unit/widget.formatting.test.ts
@@ -114,4 +114,27 @@ describe('formatPricing()', () => {
             'from $0.25 / 1,000 each tweet. cheaper for higher plans',
         );
     });
+
+    it('uses the true cheapest tier, not GOLD, when a higher tier is cheaper', () => {
+        // compass/crawler-google-places-shaped: price decreases monotonically per tier,
+        // DIAMOND ($0.76/1,000) is cheaper than GOLD ($2.10/1,000).
+        const price = formatPricing({
+            model: 'PAY_PER_EVENT',
+            events: [
+                {
+                    title: 'Scraped place',
+                    tieredPricing: [
+                        { tier: 'FREE', priceUsd: 0.004 },
+                        { tier: 'BRONZE', priceUsd: 0.004 },
+                        { tier: 'SILVER', priceUsd: 0.003 },
+                        { tier: 'GOLD', priceUsd: 0.0021 },
+                        { tier: 'PLATINUM', priceUsd: 0.00126 },
+                        { tier: 'DIAMOND', priceUsd: 0.00076 },
+                    ],
+                },
+            ],
+        });
+
+        expect(price).toBe('from $0.76 / 1,000 scraped places');
+    });
 });

--- a/tests/unit/widget.formatting.test.ts
+++ b/tests/unit/widget.formatting.test.ts
@@ -75,7 +75,7 @@ describe('formatPricing()', () => {
                 model: 'PAY_PER_EVENT',
                 events: [{ title: 'Each tweet', priceUsd: 0.00025 }],
             }),
-        ).toBe('$0.25 / 1,000 each tweets');
+        ).toBe('$0.25 / 1,000 each tweet');
     });
 
     it('uses the event flagged isPrimaryEvent when an actor has multiple charge events', () => {
@@ -87,7 +87,7 @@ describe('formatPricing()', () => {
                     { title: 'Each tweet', priceUsd: 0.00025, isPrimaryEvent: true },
                 ],
             }),
-        ).toBe('from $0.25 / 1,000 each tweets');
+        ).toBe('from $0.25 / 1,000 each tweet');
     });
 
     it('falls back to Pay per event when multi-event PPE has no primary event', () => {

--- a/tests/unit/widget.formatting.test.ts
+++ b/tests/unit/widget.formatting.test.ts
@@ -108,6 +108,38 @@ describe('formatPricing()', () => {
         ).toBe('$5.00 / 1,000 each tweet. cheaper for higher plans · from $0.25 on paid plans');
     });
 
+    it('renders the event the server chose when no event is flagged primary (the only tiered one)', () => {
+        // compass/crawler-google-places-like: only "Scraped place" has tiers, "Actor start" is a flat one-time fee.
+        const actor = {
+            ...twitterXScraperStoreActor,
+            currentPricingInfo: {
+                pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
+                pricingPerEvent: {
+                    actorChargeEvents: {
+                        place: {
+                            eventTitle: 'Scraped place',
+                            eventDescription: 'A Google Maps place scraped',
+                            eventTieredPricingUsd: {
+                                FREE: { tieredEventPriceUsd: 0.004 },
+                                GOLD: { tieredEventPriceUsd: 0.0021 },
+                            },
+                        },
+                        start: {
+                            eventTitle: 'Actor start',
+                            eventDescription: 'Initial fee',
+                            eventPriceUsd: 0.00005,
+                            isOneTimeEvent: true,
+                        },
+                    },
+                },
+            },
+        } as unknown as ActorStoreList;
+        // The note says "Paid plans from $2.10 / 1,000 events (Scraped place)"; the badge must agree.
+        expect(formatPricing(formatActorForWidget(actor, 'FREE').currentPricingInfo)).toBe(
+            '$4.00 / 1,000 scraped places · from $2.10 on paid plans',
+        );
+    });
+
     it('falls back to Pay per event without a primary event, events, or a price', () => {
         expect(
             formatPricing({

--- a/tests/unit/widget.formatting.test.ts
+++ b/tests/unit/widget.formatting.test.ts
@@ -88,7 +88,7 @@ describe('formatPricing()', () => {
                     { title: 'Each tweet. Cheaper for higher plans', priceUsd: 0.00025, isPrimaryEvent: true },
                 ],
             }),
-        ).toBe('from $0.25 / 1,000 each tweet. cheaper for higher plans');
+        ).toBe('$0.25 / 1,000 each tweet. cheaper for higher plans');
     });
 
     it('falls back to Pay per event when multi-event PPE has no primary event', () => {
@@ -108,15 +108,18 @@ describe('formatPricing()', () => {
         expect(formatPricing({ model: 'PAY_PER_EVENT' })).toBe('Pay per event');
     });
 
-    it('matches public Store page for multi-event PPE with a primary event (#905)', () => {
-        const widgetActor = formatActorForWidget(twitterXScraperStoreActor, 'FREE');
-
-        expect(formatPricing(widgetActor.currentPricingInfo)).toBe(
-            'from $0.25 / 1,000 each tweet. cheaper for higher plans',
+    it("shows the user's own price plus the Store's paid-plan price for a multi-event Actor (#905)", () => {
+        // FREE user pays $0.005 per tweet; the Store page advertises "from $0.25" (GOLD).
+        expect(formatPricing(formatActorForWidget(twitterXScraperStoreActor, 'FREE').currentPricingInfo)).toBe(
+            '$5.00 / 1,000 each tweet. cheaper for higher plans · from $0.25 on paid plans',
+        );
+        // GOLD user already pays the advertised price — no hint.
+        expect(formatPricing(formatActorForWidget(twitterXScraperStoreActor, 'GOLD').currentPricingInfo)).toBe(
+            '$0.25 / 1,000 each tweet. cheaper for higher plans',
         );
     });
 
-    it('prices the badge at the GOLD tier, not the cheapest tier (#905)', () => {
+    it('hints the GOLD tier, not the cheapest tier, as the paid-plan price (#905)', () => {
         // compass/crawler-google-places real tiers. DIAMOND is $0.76 / 1,000, yet the Store
         // badge shows "from $1.50 / 1,000 scraped places" — GOLD is the best tier listed on
         // apify.com/pricing; PLATINUM/DIAMOND are enterprise-only and never shown.
@@ -137,32 +140,35 @@ describe('formatPricing()', () => {
             ],
         });
 
-        expect(price).toBe('from $1.50 / 1,000 scraped places');
+        expect(price).toBe('$4.00 / 1,000 scraped places · from $1.50 on paid plans');
     });
 
-    it('shows "from" for a single tiered event and prices it at GOLD', () => {
+    it('omits the paid-plan hint when the user already pays GOLD or less', () => {
         // apify/instagram-scraper real tiers. Store badge: "from $1.50 / 1,000 results".
-        const price = formatPricing({
-            model: 'PAY_PER_EVENT',
-            events: [
-                {
-                    title: 'Result',
-                    tieredPricing: [
-                        { tier: 'FREE', priceUsd: 0.0027 },
-                        { tier: 'BRONZE', priceUsd: 0.0023 },
-                        { tier: 'SILVER', priceUsd: 0.0019 },
-                        { tier: 'GOLD', priceUsd: 0.0015 },
-                        { tier: 'PLATINUM', priceUsd: 0.0009 },
-                        { tier: 'DIAMOND', priceUsd: 0.0005 },
-                    ],
-                },
+        const instagram = {
+            title: 'Result',
+            tieredPricing: [
+                { tier: 'FREE', priceUsd: 0.0027 },
+                { tier: 'BRONZE', priceUsd: 0.0023 },
+                { tier: 'SILVER', priceUsd: 0.0019 },
+                { tier: 'GOLD', priceUsd: 0.0015 },
+                { tier: 'PLATINUM', priceUsd: 0.0009 },
+                { tier: 'DIAMOND', priceUsd: 0.0005 },
             ],
-        });
+        };
 
-        expect(price).toBe('from $1.50 / 1,000 results');
+        expect(formatPricing({ model: 'PAY_PER_EVENT', events: [instagram] })).toBe(
+            '$2.70 / 1,000 results · from $1.50 on paid plans',
+        );
+        expect(formatPricing({ model: 'PAY_PER_EVENT', userTier: 'GOLD', events: [instagram] })).toBe(
+            '$1.50 / 1,000 results',
+        );
+        expect(formatPricing({ model: 'PAY_PER_EVENT', userTier: 'DIAMOND', events: [instagram] })).toBe(
+            '$0.50 / 1,000 results',
+        );
     });
 
-    it('matches the Store page for a multi-event Actor whose GOLD price is above its cheapest tier', () => {
+    it('hints GOLD for a multi-event Actor whose GOLD price is above its cheapest tier', () => {
         // xtdata/tiktok-user-information-scraper real tiers (from the live widget payload).
         // Store badge: "from $6.80 / 1,000 user queries" — GOLD, not the $6.00 DIAMOND tier.
         const price = formatPricing({
@@ -194,10 +200,10 @@ describe('formatPricing()', () => {
             ],
         });
 
-        expect(price).toBe('from $6.80 / 1,000 user queries');
+        expect(price).toBe('$8.00 / 1,000 user queries · from $6.80 on paid plans');
     });
 
-    it('falls back to the cheapest paid tier when GOLD is missing', () => {
+    it('hints the cheapest paid tier when GOLD is missing', () => {
         const price = formatPricing({
             model: 'PAY_PER_EVENT',
             events: [
@@ -212,10 +218,29 @@ describe('formatPricing()', () => {
             ],
         });
 
-        expect(price).toBe('from $2.00 / 1,000 results');
+        expect(price).toBe('$4.00 / 1,000 results · from $2.00 on paid plans');
     });
 
-    it('prices tiered PRICE_PER_DATASET_ITEM at GOLD like the PAY_PER_EVENT badge', () => {
+    it('falls back to the FREE tier when the user tier is not in the matrix', () => {
+        // Mirrors the server's resolveTier(): user tier → FREE → first entry.
+        const price = formatPricing({
+            model: 'PAY_PER_EVENT',
+            userTier: 'SILVER',
+            events: [
+                {
+                    title: 'Result',
+                    tieredPricing: [
+                        { tier: 'FREE', priceUsd: 0.004 },
+                        { tier: 'GOLD', priceUsd: 0.0015 },
+                    ],
+                },
+            ],
+        });
+
+        expect(price).toBe('$4.00 / 1,000 results · from $1.50 on paid plans');
+    });
+
+    it('applies the same tier rule to tiered PRICE_PER_DATASET_ITEM', () => {
         const price = formatPricing({
             model: 'PRICE_PER_DATASET_ITEM',
             unitName: 'result',
@@ -227,10 +252,10 @@ describe('formatPricing()', () => {
             ],
         });
 
-        expect(price).toBe('from $1.50 / 1,000 results');
+        expect(price).toBe('$4.00 / 1,000 results · from $1.50 on paid plans');
     });
 
-    it('prices tiered FLAT_PRICE_PER_MONTH at GOLD instead of the un-resolved base price', () => {
+    it('applies the same tier rule to tiered FLAT_PRICE_PER_MONTH instead of the un-resolved base price', () => {
         // Complete mode carries the base `pricePerUnit` (30) untouched; the badge must resolve the tier.
         const price = formatPricing({
             model: 'FLAT_PRICE_PER_MONTH',
@@ -242,7 +267,7 @@ describe('formatPricing()', () => {
             ],
         });
 
-        expect(price).toBe('$20.00/month + usage');
+        expect(price).toBe('$30.00/month + usage · from $20.00 on paid plans');
     });
 
     it('falls back to the flat price when no paid tier exists', () => {
@@ -263,7 +288,7 @@ describe('formatPricing()', () => {
         ).toBe('Pay per event');
     });
 
-    it('prices an event at or above $0.01 per event, with "from" only when other events exist', () => {
+    it('prices an event at or above $0.01 per event, never per 1,000', () => {
         const analysis = { title: 'Competitor analysis', priceUsd: 0.05 };
 
         expect(formatPricing({ model: 'PAY_PER_EVENT', events: [analysis] })).toBe('$0.05 / competitor analysis');
@@ -275,7 +300,13 @@ describe('formatPricing()', () => {
                     { ...analysis, isPrimaryEvent: true },
                 ],
             }),
-        ).toBe('from $0.05 / competitor analysis');
+        ).toBe('$0.05 / competitor analysis');
+    });
+
+    it('formats PRICE_PER_DATASET_ITEM without tiers from the base price, without "from"', () => {
+        expect(formatPricing({ model: 'PRICE_PER_DATASET_ITEM', unitName: 'page', pricePerUnit: 0.002 })).toBe(
+            '$2.00 / 1,000 pages',
+        );
     });
 
     it('formats FLAT_PRICE_PER_MONTH without tiers from the base price', () => {

--- a/tests/unit/widget.formatting.test.ts
+++ b/tests/unit/widget.formatting.test.ts
@@ -270,6 +270,26 @@ describe('formatPricing()', () => {
         expect(price).toBe('$30.00/month + usage · from $20.00 on paid plans');
     });
 
+    it('falls back to the flat price when the tier matrix is empty', () => {
+        expect(
+            formatPricing({
+                model: 'PAY_PER_EVENT',
+                events: [{ title: 'Result', priceUsd: 0.002, tieredPricing: [] }],
+            }),
+        ).toBe('$2.00 / 1,000 results');
+        expect(
+            formatPricing({
+                model: 'PRICE_PER_DATASET_ITEM',
+                unitName: 'result',
+                pricePerUnit: 0.002,
+                tieredPricing: [],
+            }),
+        ).toBe('$2.00 / 1,000 results');
+        expect(formatPricing({ model: 'FLAT_PRICE_PER_MONTH', pricePerUnit: 30, tieredPricing: [] })).toBe(
+            '$30.00/month + usage',
+        );
+    });
+
     it('falls back to the flat price when no paid tier exists', () => {
         expect(
             formatPricing({
@@ -279,13 +299,43 @@ describe('formatPricing()', () => {
         ).toBe('$2.00 / 1,000 results');
     });
 
-    it('returns Pay per event when neither a paid tier nor a flat price exists', () => {
+    it('renders a $0 tier as the real price instead of falling back to the base price', () => {
+        // Free for FREE users, paid on GOLD. The un-resolved base price (0.03) must not leak through.
+        expect(
+            formatPricing({
+                model: 'PRICE_PER_DATASET_ITEM',
+                unitName: 'result',
+                pricePerUnit: 0.03,
+                tieredPricing: [
+                    { tier: 'FREE', pricePerUnit: 0 },
+                    { tier: 'GOLD', pricePerUnit: 0.0015 },
+                ],
+            }),
+        ).toBe('$0.00 / 1,000 results');
         expect(
             formatPricing({
                 model: 'PAY_PER_EVENT',
                 events: [{ title: 'Result', tieredPricing: [{ tier: 'FREE', priceUsd: 0 }] }],
             }),
-        ).toBe('Pay per event');
+        ).toBe('$0.00 / 1,000 results');
+    });
+
+    it('falls back to the first tier when neither the user tier nor FREE is in the matrix', () => {
+        const price = formatPricing({
+            model: 'PAY_PER_EVENT',
+            userTier: 'SILVER',
+            events: [
+                {
+                    title: 'Result',
+                    tieredPricing: [
+                        { tier: 'BRONZE', priceUsd: 0.003 },
+                        { tier: 'GOLD', priceUsd: 0.0015 },
+                    ],
+                },
+            ],
+        });
+
+        expect(price).toBe('$3.00 / 1,000 results · from $1.50 on paid plans');
     });
 
     it('prices an event at or above $0.01 per event, never per 1,000', () => {

--- a/tests/unit/widget.formatting.test.ts
+++ b/tests/unit/widget.formatting.test.ts
@@ -7,9 +7,8 @@ import type { PricingInfo } from '../../src/utils/pricing_info.js';
 import { formatPricing } from '../../src/web/src/utils/formatting.js';
 
 /**
- * Mirrors xtdata/twitter-x-scraper current PAY_PER_EVENT pricing
- * (see https://github.com/apify/apify-mcp-server/issues/905).
- * Public Store page shows: "from $0.25 / 1,000 each tweet. cheaper for higher plans"
+ * Mirrors xtdata/twitter-x-scraper live PAY_PER_EVENT pricing (apify/apify-mcp-server#905).
+ * Store badge: "from $0.25 / 1,000 each tweet. cheaper for higher plans" (GOLD = Business plan).
  */
 const twitterXScraperPricing = {
     pricingModel: ACTOR_PRICING_MODEL.PAY_PER_EVENT,
@@ -52,46 +51,64 @@ const twitterXScraperStoreActor = {
     username: 'xtdata',
     title: 'X.com Twitter API Scraper',
     description: 'Scrape Twitter (X) data efficiently.',
-    isDeprecated: false,
-    modifiedAt: new Date('2026-05-03T11:04:10.172Z'),
-    categories: ['SOCIAL_MEDIA'],
-    actorReviewRating: 3.4,
-    actorReviewCount: 5,
     currentPricingInfo: twitterXScraperPricing,
-    stats: {
-        totalBuilds: 1,
-        totalRuns: 1,
-        totalUsers: 2400,
-        totalUsers30Days: 177,
-        actorReviewCount: 5,
-        actorReviewRating: 3.4,
-    },
+    stats: { totalUsers: 2400, actorReviewCount: 5, actorReviewRating: 3.4 },
 } as unknown as ActorStoreList;
 
 describe('formatPricing()', () => {
-    it('formats PAY_PER_EVENT with a single event', () => {
+    it('renders the primary event through the server pricing: own price plus the Store price (#905)', () => {
+        // FREE user pays $0.005 per tweet; the Store advertises the GOLD price, $0.25 / 1,000.
+        expect(formatPricing(formatActorForWidget(twitterXScraperStoreActor, 'FREE').currentPricingInfo)).toBe(
+            '$5.00 / 1,000 each tweet. cheaper for higher plans · from $0.25 on paid plans',
+        );
+        // GOLD user already pays the advertised price: no hint.
+        expect(formatPricing(formatActorForWidget(twitterXScraperStoreActor, 'GOLD').currentPricingInfo)).toBe(
+            '$0.25 / 1,000 each tweet. cheaper for higher plans',
+        );
+    });
+
+    it('quotes repeatable events per 1,000, like the Store, whatever the unit price', () => {
+        expect(formatPricing({ model: 'PAY_PER_EVENT', events: [{ title: 'Result', priceUsd: 0.00025 }] })).toBe(
+            '$0.25 / 1,000 results',
+        );
+        expect(
+            formatPricing({ model: 'PAY_PER_EVENT', events: [{ title: 'Competitor analysis', priceUsd: 0.05 }] }),
+        ).toBe('$50.00 / 1,000 competitor analyses');
+    });
+
+    it('quotes one-time events per run', () => {
         expect(
             formatPricing({
                 model: 'PAY_PER_EVENT',
-                events: [{ title: 'Result', priceUsd: 0.00025 }],
+                events: [{ title: 'Actor start', priceUsd: 0.0005, isOneTimeEvent: true, paidPlanPriceUsd: 0.0004 }],
             }),
-        ).toBe('$0.25 / 1,000 results');
+        ).toBe('$0.0005 per run · from $0.0004 on paid plans');
     });
 
-    it('uses the event flagged isPrimaryEvent when an actor has multiple charge events', () => {
-        // The Store pluralizes the last word of the title; "plans" is already plural.
+    it('keeps sub-cent per-1,000 prices precise instead of rounding to $0.00', () => {
+        expect(formatPricing({ model: 'PAY_PER_EVENT', events: [{ title: 'Review', priceUsd: 0.0000945 }] })).toBe(
+            '$0.0945 / 1,000 reviews',
+        );
+    });
+
+    it('uses the event flagged isPrimaryEvent when an Actor has several events', () => {
         expect(
             formatPricing({
                 model: 'PAY_PER_EVENT',
                 events: [
-                    { title: 'Actor start', priceUsd: 0.0004 },
-                    { title: 'Each tweet. Cheaper for higher plans', priceUsd: 0.00025, isPrimaryEvent: true },
+                    { title: 'Actor start', priceUsd: 0.0004, isOneTimeEvent: true },
+                    {
+                        title: 'Each tweet. Cheaper for higher plans',
+                        priceUsd: 0.005,
+                        isPrimaryEvent: true,
+                        paidPlanPriceUsd: 0.00025,
+                    },
                 ],
             }),
-        ).toBe('$0.25 / 1,000 each tweet. cheaper for higher plans');
+        ).toBe('$5.00 / 1,000 each tweet. cheaper for higher plans · from $0.25 on paid plans');
     });
 
-    it('falls back to Pay per event when multi-event PPE has no primary event', () => {
+    it('falls back to Pay per event without a primary event, events, or a price', () => {
         expect(
             formatPricing({
                 model: 'PAY_PER_EVENT',
@@ -101,265 +118,40 @@ describe('formatPricing()', () => {
                 ],
             }),
         ).toBe('Pay per event');
-    });
-
-    it('falls back to Pay per event when there are no events', () => {
         expect(formatPricing({ model: 'PAY_PER_EVENT', events: [] })).toBe('Pay per event');
         expect(formatPricing({ model: 'PAY_PER_EVENT' })).toBe('Pay per event');
+        expect(formatPricing({ model: 'PAY_PER_EVENT', events: [{ title: 'Result' }] })).toBe('Pay per event');
     });
 
-    it("shows the user's own price plus the Store's paid-plan price for a multi-event Actor (#905)", () => {
-        // FREE user pays $0.005 per tweet; the Store page advertises "from $0.25" (GOLD).
-        expect(formatPricing(formatActorForWidget(twitterXScraperStoreActor, 'FREE').currentPricingInfo)).toBe(
-            '$5.00 / 1,000 each tweet. cheaper for higher plans · from $0.25 on paid plans',
-        );
-        // GOLD user already pays the advertised price — no hint.
-        expect(formatPricing(formatActorForWidget(twitterXScraperStoreActor, 'GOLD').currentPricingInfo)).toBe(
-            '$0.25 / 1,000 each tweet. cheaper for higher plans',
+    it('renders a $0 price as $0.00', () => {
+        expect(formatPricing({ model: 'PAY_PER_EVENT', events: [{ title: 'Result', priceUsd: 0 }] })).toBe(
+            '$0.00 / 1,000 results',
         );
     });
 
-    it('hints the GOLD tier, not the cheapest tier, as the paid-plan price (#905)', () => {
-        // compass/crawler-google-places real tiers. DIAMOND is $0.76 / 1,000, yet the Store
-        // badge shows "from $1.50 / 1,000 scraped places" — GOLD is the best tier listed on
-        // apify.com/pricing; PLATINUM/DIAMOND are enterprise-only and never shown.
-        const price = formatPricing({
-            model: 'PAY_PER_EVENT',
-            events: [
-                {
-                    title: 'Scraped place',
-                    tieredPricing: [
-                        { tier: 'FREE', priceUsd: 0.004 },
-                        { tier: 'BRONZE', priceUsd: 0.003 },
-                        { tier: 'SILVER', priceUsd: 0.002 },
-                        { tier: 'GOLD', priceUsd: 0.0015 },
-                        { tier: 'PLATINUM', priceUsd: 0.00126 },
-                        { tier: 'DIAMOND', priceUsd: 0.000756 },
-                    ],
-                },
-            ],
-        });
-
-        expect(price).toBe('$4.00 / 1,000 scraped places · from $1.50 on paid plans');
-    });
-
-    it('omits the paid-plan hint when the user already pays GOLD or less', () => {
-        // apify/instagram-scraper real tiers. Store badge: "from $1.50 / 1,000 results".
-        const instagram = {
-            title: 'Result',
-            tieredPricing: [
-                { tier: 'FREE', priceUsd: 0.0027 },
-                { tier: 'BRONZE', priceUsd: 0.0023 },
-                { tier: 'SILVER', priceUsd: 0.0019 },
-                { tier: 'GOLD', priceUsd: 0.0015 },
-                { tier: 'PLATINUM', priceUsd: 0.0009 },
-                { tier: 'DIAMOND', priceUsd: 0.0005 },
-            ],
-        };
-
-        expect(formatPricing({ model: 'PAY_PER_EVENT', events: [instagram] })).toBe(
-            '$2.70 / 1,000 results · from $1.50 on paid plans',
-        );
-        expect(formatPricing({ model: 'PAY_PER_EVENT', userTier: 'GOLD', events: [instagram] })).toBe(
-            '$1.50 / 1,000 results',
-        );
-        expect(formatPricing({ model: 'PAY_PER_EVENT', userTier: 'DIAMOND', events: [instagram] })).toBe(
-            '$0.50 / 1,000 results',
-        );
-    });
-
-    it('hints GOLD for a multi-event Actor whose GOLD price is above its cheapest tier', () => {
-        // xtdata/tiktok-user-information-scraper real tiers (from the live widget payload).
-        // Store badge: "from $6.80 / 1,000 user queries" — GOLD, not the $6.00 DIAMOND tier.
-        const price = formatPricing({
-            model: 'PAY_PER_EVENT',
-            events: [
-                {
-                    title: 'Actor Start',
-                    tieredPricing: [
-                        { tier: 'FREE', priceUsd: 0.006 },
-                        { tier: 'BRONZE', priceUsd: 0.0056 },
-                        { tier: 'SILVER', priceUsd: 0.0052 },
-                        { tier: 'GOLD', priceUsd: 0.0048 },
-                        { tier: 'PLATINUM', priceUsd: 0.0044 },
-                        { tier: 'DIAMOND', priceUsd: 0.004 },
-                    ],
-                },
-                {
-                    title: 'User query',
-                    isPrimaryEvent: true,
-                    tieredPricing: [
-                        { tier: 'FREE', priceUsd: 0.008 },
-                        { tier: 'BRONZE', priceUsd: 0.0076 },
-                        { tier: 'SILVER', priceUsd: 0.0072 },
-                        { tier: 'GOLD', priceUsd: 0.0068 },
-                        { tier: 'PLATINUM', priceUsd: 0.0064 },
-                        { tier: 'DIAMOND', priceUsd: 0.006 },
-                    ],
-                },
-            ],
-        });
-
-        expect(price).toBe('$8.00 / 1,000 user queries · from $6.80 on paid plans');
-    });
-
-    it('hints the cheapest paid tier when GOLD is missing', () => {
-        const price = formatPricing({
-            model: 'PAY_PER_EVENT',
-            events: [
-                {
-                    title: 'Result',
-                    tieredPricing: [
-                        { tier: 'FREE', priceUsd: 0.004 },
-                        { tier: 'BRONZE', priceUsd: 0.003 },
-                        { tier: 'SILVER', priceUsd: 0.002 },
-                    ],
-                },
-            ],
-        });
-
-        expect(price).toBe('$4.00 / 1,000 results · from $2.00 on paid plans');
-    });
-
-    it('falls back to the FREE tier when the user tier is not in the matrix', () => {
-        // Mirrors the server's resolveTier(): user tier → FREE → first entry.
-        const price = formatPricing({
-            model: 'PAY_PER_EVENT',
-            userTier: 'SILVER',
-            events: [
-                {
-                    title: 'Result',
-                    tieredPricing: [
-                        { tier: 'FREE', priceUsd: 0.004 },
-                        { tier: 'GOLD', priceUsd: 0.0015 },
-                    ],
-                },
-            ],
-        });
-
-        expect(price).toBe('$4.00 / 1,000 results · from $1.50 on paid plans');
-    });
-
-    it('applies the same tier rule to tiered PRICE_PER_DATASET_ITEM', () => {
-        const price = formatPricing({
-            model: 'PRICE_PER_DATASET_ITEM',
-            unitName: 'result',
-            pricePerUnit: 0.004,
-            tieredPricing: [
-                { tier: 'FREE', pricePerUnit: 0.004 },
-                { tier: 'GOLD', pricePerUnit: 0.0015 },
-                { tier: 'DIAMOND', pricePerUnit: 0.0005 },
-            ],
-        });
-
-        expect(price).toBe('$4.00 / 1,000 results · from $1.50 on paid plans');
-    });
-
-    it('applies the same tier rule to tiered FLAT_PRICE_PER_MONTH instead of the un-resolved base price', () => {
-        // Complete mode carries the base `pricePerUnit` (30) untouched; the badge must resolve the tier.
-        const price = formatPricing({
-            model: 'FLAT_PRICE_PER_MONTH',
-            pricePerUnit: 30,
-            trialMinutes: 0,
-            tieredPricing: [
-                { tier: 'FREE', pricePerUnit: 30 },
-                { tier: 'GOLD', pricePerUnit: 20 },
-            ],
-        });
-
-        expect(price).toBe('$30.00/month + usage · from $20.00 on paid plans');
-    });
-
-    it('falls back to the flat price when the tier matrix is empty', () => {
-        expect(
-            formatPricing({
-                model: 'PAY_PER_EVENT',
-                events: [{ title: 'Result', priceUsd: 0.002, tieredPricing: [] }],
-            }),
-        ).toBe('$2.00 / 1,000 results');
+    it('formats PRICE_PER_DATASET_ITEM per 1,000 with the paid-plan hint when the server sets one', () => {
         expect(
             formatPricing({
                 model: 'PRICE_PER_DATASET_ITEM',
                 unitName: 'result',
-                pricePerUnit: 0.002,
-                tieredPricing: [],
+                pricePerUnit: 0.004,
+                paidPlanPricePerUnit: 0.0015,
             }),
-        ).toBe('$2.00 / 1,000 results');
-        expect(formatPricing({ model: 'FLAT_PRICE_PER_MONTH', pricePerUnit: 30, tieredPricing: [] })).toBe(
-            '$30.00/month + usage',
-        );
-    });
-
-    it('falls back to the flat price when no paid tier exists', () => {
-        expect(
-            formatPricing({
-                model: 'PAY_PER_EVENT',
-                events: [{ title: 'Result', priceUsd: 0.002, tieredPricing: [{ tier: 'FREE', priceUsd: 0.002 }] }],
-            }),
-        ).toBe('$2.00 / 1,000 results');
-    });
-
-    it('renders a $0 tier as the real price instead of falling back to the base price', () => {
-        // Free for FREE users, paid on GOLD. The un-resolved base price (0.03) must not leak through.
-        expect(
-            formatPricing({
-                model: 'PRICE_PER_DATASET_ITEM',
-                unitName: 'result',
-                pricePerUnit: 0.03,
-                tieredPricing: [
-                    { tier: 'FREE', pricePerUnit: 0 },
-                    { tier: 'GOLD', pricePerUnit: 0.0015 },
-                ],
-            }),
-        ).toBe('$0.00 / 1,000 results');
-        expect(
-            formatPricing({
-                model: 'PAY_PER_EVENT',
-                events: [{ title: 'Result', tieredPricing: [{ tier: 'FREE', priceUsd: 0 }] }],
-            }),
-        ).toBe('$0.00 / 1,000 results');
-    });
-
-    it('falls back to the first tier when neither the user tier nor FREE is in the matrix', () => {
-        const price = formatPricing({
-            model: 'PAY_PER_EVENT',
-            userTier: 'SILVER',
-            events: [
-                {
-                    title: 'Result',
-                    tieredPricing: [
-                        { tier: 'BRONZE', priceUsd: 0.003 },
-                        { tier: 'GOLD', priceUsd: 0.0015 },
-                    ],
-                },
-            ],
-        });
-
-        expect(price).toBe('$3.00 / 1,000 results · from $1.50 on paid plans');
-    });
-
-    it('prices an event at or above $0.01 per event, never per 1,000', () => {
-        const analysis = { title: 'Competitor analysis', priceUsd: 0.05 };
-
-        expect(formatPricing({ model: 'PAY_PER_EVENT', events: [analysis] })).toBe('$0.05 / competitor analysis');
-        expect(
-            formatPricing({
-                model: 'PAY_PER_EVENT',
-                events: [
-                    { title: 'Actor start', priceUsd: 0.0001 },
-                    { ...analysis, isPrimaryEvent: true },
-                ],
-            }),
-        ).toBe('$0.05 / competitor analysis');
-    });
-
-    it('formats PRICE_PER_DATASET_ITEM without tiers from the base price, without "from"', () => {
+        ).toBe('$4.00 / 1,000 results · from $1.50 on paid plans');
         expect(formatPricing({ model: 'PRICE_PER_DATASET_ITEM', unitName: 'page', pricePerUnit: 0.002 })).toBe(
             '$2.00 / 1,000 pages',
         );
     });
 
-    it('formats FLAT_PRICE_PER_MONTH without tiers from the base price', () => {
+    it('formats FLAT_PRICE_PER_MONTH with the paid-plan hint when the server sets one', () => {
+        expect(
+            formatPricing({
+                model: 'FLAT_PRICE_PER_MONTH',
+                pricePerUnit: 30,
+                trialMinutes: 0,
+                paidPlanPricePerUnit: 20,
+            }),
+        ).toBe('$30.00/month + usage · from $20.00 on paid plans');
         expect(formatPricing({ model: 'FLAT_PRICE_PER_MONTH', pricePerUnit: 30 })).toBe('$30.00/month + usage');
     });
 });

--- a/tests/unit/widget.formatting.test.ts
+++ b/tests/unit/widget.formatting.test.ts
@@ -73,21 +73,22 @@ describe('formatPricing()', () => {
         expect(
             formatPricing({
                 model: 'PAY_PER_EVENT',
-                events: [{ title: 'Each tweet', priceUsd: 0.00025 }],
+                events: [{ title: 'Result', priceUsd: 0.00025 }],
             }),
-        ).toBe('$0.25 / 1,000 each tweet');
+        ).toBe('$0.25 / 1,000 results');
     });
 
     it('uses the event flagged isPrimaryEvent when an actor has multiple charge events', () => {
+        // The Store pluralizes the last word of the title; "plans" is already plural.
         expect(
             formatPricing({
                 model: 'PAY_PER_EVENT',
                 events: [
                     { title: 'Actor start', priceUsd: 0.0004 },
-                    { title: 'Each tweet', priceUsd: 0.00025, isPrimaryEvent: true },
+                    { title: 'Each tweet. Cheaper for higher plans', priceUsd: 0.00025, isPrimaryEvent: true },
                 ],
             }),
-        ).toBe('from $0.25 / 1,000 each tweet');
+        ).toBe('from $0.25 / 1,000 each tweet. cheaper for higher plans');
     });
 
     it('falls back to Pay per event when multi-event PPE has no primary event', () => {
@@ -115,9 +116,10 @@ describe('formatPricing()', () => {
         );
     });
 
-    it('uses the true cheapest tier, not GOLD, when a higher tier is cheaper', () => {
-        // compass/crawler-google-places-shaped: price decreases monotonically per tier,
-        // DIAMOND ($0.76/1,000) is cheaper than GOLD ($2.10/1,000).
+    it('prices the badge at the GOLD tier, not the cheapest tier (#905)', () => {
+        // compass/crawler-google-places real tiers. DIAMOND is $0.76 / 1,000, yet the Store
+        // badge shows "from $1.50 / 1,000 scraped places" — GOLD is the best tier listed on
+        // apify.com/pricing; PLATINUM/DIAMOND are enterprise-only and never shown.
         const price = formatPricing({
             model: 'PAY_PER_EVENT',
             events: [
@@ -125,16 +127,158 @@ describe('formatPricing()', () => {
                     title: 'Scraped place',
                     tieredPricing: [
                         { tier: 'FREE', priceUsd: 0.004 },
-                        { tier: 'BRONZE', priceUsd: 0.004 },
-                        { tier: 'SILVER', priceUsd: 0.003 },
-                        { tier: 'GOLD', priceUsd: 0.0021 },
+                        { tier: 'BRONZE', priceUsd: 0.003 },
+                        { tier: 'SILVER', priceUsd: 0.002 },
+                        { tier: 'GOLD', priceUsd: 0.0015 },
                         { tier: 'PLATINUM', priceUsd: 0.00126 },
-                        { tier: 'DIAMOND', priceUsd: 0.00076 },
+                        { tier: 'DIAMOND', priceUsd: 0.000756 },
                     ],
                 },
             ],
         });
 
-        expect(price).toBe('from $0.76 / 1,000 scraped places');
+        expect(price).toBe('from $1.50 / 1,000 scraped places');
+    });
+
+    it('shows "from" for a single tiered event and prices it at GOLD', () => {
+        // apify/instagram-scraper real tiers. Store badge: "from $1.50 / 1,000 results".
+        const price = formatPricing({
+            model: 'PAY_PER_EVENT',
+            events: [
+                {
+                    title: 'Result',
+                    tieredPricing: [
+                        { tier: 'FREE', priceUsd: 0.0027 },
+                        { tier: 'BRONZE', priceUsd: 0.0023 },
+                        { tier: 'SILVER', priceUsd: 0.0019 },
+                        { tier: 'GOLD', priceUsd: 0.0015 },
+                        { tier: 'PLATINUM', priceUsd: 0.0009 },
+                        { tier: 'DIAMOND', priceUsd: 0.0005 },
+                    ],
+                },
+            ],
+        });
+
+        expect(price).toBe('from $1.50 / 1,000 results');
+    });
+
+    it('matches the Store page for a multi-event Actor whose GOLD price is above its cheapest tier', () => {
+        // xtdata/tiktok-user-information-scraper real tiers (from the live widget payload).
+        // Store badge: "from $6.80 / 1,000 user queries" — GOLD, not the $6.00 DIAMOND tier.
+        const price = formatPricing({
+            model: 'PAY_PER_EVENT',
+            events: [
+                {
+                    title: 'Actor Start',
+                    tieredPricing: [
+                        { tier: 'FREE', priceUsd: 0.006 },
+                        { tier: 'BRONZE', priceUsd: 0.0056 },
+                        { tier: 'SILVER', priceUsd: 0.0052 },
+                        { tier: 'GOLD', priceUsd: 0.0048 },
+                        { tier: 'PLATINUM', priceUsd: 0.0044 },
+                        { tier: 'DIAMOND', priceUsd: 0.004 },
+                    ],
+                },
+                {
+                    title: 'User query',
+                    isPrimaryEvent: true,
+                    tieredPricing: [
+                        { tier: 'FREE', priceUsd: 0.008 },
+                        { tier: 'BRONZE', priceUsd: 0.0076 },
+                        { tier: 'SILVER', priceUsd: 0.0072 },
+                        { tier: 'GOLD', priceUsd: 0.0068 },
+                        { tier: 'PLATINUM', priceUsd: 0.0064 },
+                        { tier: 'DIAMOND', priceUsd: 0.006 },
+                    ],
+                },
+            ],
+        });
+
+        expect(price).toBe('from $6.80 / 1,000 user queries');
+    });
+
+    it('falls back to the cheapest paid tier when GOLD is missing', () => {
+        const price = formatPricing({
+            model: 'PAY_PER_EVENT',
+            events: [
+                {
+                    title: 'Result',
+                    tieredPricing: [
+                        { tier: 'FREE', priceUsd: 0.004 },
+                        { tier: 'BRONZE', priceUsd: 0.003 },
+                        { tier: 'SILVER', priceUsd: 0.002 },
+                    ],
+                },
+            ],
+        });
+
+        expect(price).toBe('from $2.00 / 1,000 results');
+    });
+
+    it('prices tiered PRICE_PER_DATASET_ITEM at GOLD like the PAY_PER_EVENT badge', () => {
+        const price = formatPricing({
+            model: 'PRICE_PER_DATASET_ITEM',
+            unitName: 'result',
+            pricePerUnit: 0.004,
+            tieredPricing: [
+                { tier: 'FREE', pricePerUnit: 0.004 },
+                { tier: 'GOLD', pricePerUnit: 0.0015 },
+                { tier: 'DIAMOND', pricePerUnit: 0.0005 },
+            ],
+        });
+
+        expect(price).toBe('from $1.50 / 1,000 results');
+    });
+
+    it('prices tiered FLAT_PRICE_PER_MONTH at GOLD instead of the un-resolved base price', () => {
+        // Complete mode carries the base `pricePerUnit` (30) untouched; the badge must resolve the tier.
+        const price = formatPricing({
+            model: 'FLAT_PRICE_PER_MONTH',
+            pricePerUnit: 30,
+            trialMinutes: 0,
+            tieredPricing: [
+                { tier: 'FREE', pricePerUnit: 30 },
+                { tier: 'GOLD', pricePerUnit: 20 },
+            ],
+        });
+
+        expect(price).toBe('$20.00/month + usage');
+    });
+
+    it('falls back to the flat price when no paid tier exists', () => {
+        expect(
+            formatPricing({
+                model: 'PAY_PER_EVENT',
+                events: [{ title: 'Result', priceUsd: 0.002, tieredPricing: [{ tier: 'FREE', priceUsd: 0.002 }] }],
+            }),
+        ).toBe('$2.00 / 1,000 results');
+    });
+
+    it('returns Pay per event when neither a paid tier nor a flat price exists', () => {
+        expect(
+            formatPricing({
+                model: 'PAY_PER_EVENT',
+                events: [{ title: 'Result', tieredPricing: [{ tier: 'FREE', priceUsd: 0 }] }],
+            }),
+        ).toBe('Pay per event');
+    });
+
+    it('prices an event at or above $0.01 per event, with "from" only when other events exist', () => {
+        const analysis = { title: 'Competitor analysis', priceUsd: 0.05 };
+
+        expect(formatPricing({ model: 'PAY_PER_EVENT', events: [analysis] })).toBe('$0.05 / competitor analysis');
+        expect(
+            formatPricing({
+                model: 'PAY_PER_EVENT',
+                events: [
+                    { title: 'Actor start', priceUsd: 0.0001 },
+                    { ...analysis, isPrimaryEvent: true },
+                ],
+            }),
+        ).toBe('from $0.05 / competitor analysis');
+    });
+
+    it('formats FLAT_PRICE_PER_MONTH without tiers from the base price', () => {
+        expect(formatPricing({ model: 'FLAT_PRICE_PER_MONTH', pricePerUnit: 30 })).toBe('$30.00/month + usage');
     });
 });


### PR DESCRIPTION
## Why
Closes #905. The MCP Apps widget badge disagreed with the public Store page: multi-event PAY_PER_EVENT Actors rendered the generic "Pay per event" with no price, and the tier matrix was dropped before the widget saw it. Reported on `xtdata/twitter-x-scraper` (Store: "from $0.25 / 1,000 each tweet…").

Verified on four live Store pages: the Store badge is the API's primary event (`isPrimaryEvent`) at the **GOLD** tier (Business plan, the best tier on apify.com/pricing; PLATINUM/DIAMOND are enterprise-only and never shown), quoted per 1,000. The Store shows that "from" price because it does not know the visitor. The widget does know the user's plan, and the LLM text next to it is tier-resolved, so showing only the Store price would tell a Free user "from $0.25" for an Actor that charges them $5.00 / 1,000.

## What changed
One pricing rule, on the server. Simplified-mode pricing already resolves the user's tier; it now also carries the Store's advertised price when a paid plan is cheaper (`paidPlanPriceUsd` on the advertised event, `paidPlanPricePerUnit` for pay-per-result and rental) and passes `isPrimaryEvent` / `isOneTimeEvent` through. The widget only renders.

| User | Badge for xtdata/twitter-x-scraper |
|---|---|
| Free / anonymous | `$5.00 / 1,000 each tweet. cheaper for higher plans · from $0.25 on paid plans` |
| Business | `$0.25 / 1,000 each tweet. cheaper for higher plans` |
| several events, none flagged primary | `Pay per event` |

Text and badge quote the same way as the Store page: repeatable events and results `$5.00 / 1,000 <unit>`, one-time events (`isOneTimeEvent`, e.g. Actor start) `$0.0005 per run`, rentals `per month`, plan names Free / Starter / Scale / Business. Prices print with 2–6 decimals so `$0.0945 / 1,000` is not rounded to `$0.09`. The `search-actors` note names the number instead of "higher tiers may offer lower prices": `Prices shown are for the Free plan. Paid plans from $0.25 / 1,000 events (Each tweet…). Use fetch-actor-details for the full pricing table.` `fetch-actor-details` keeps the full table: `Free: $4.00, Starter: $3.00, Scale: $2.00, Business: $1.50, Platinum: $1.26, Diamond: $0.756 / 1,000 events`.

Contract note for apify-mcp-server-internal: widget `currentPricingInfo` keeps the pre-PR simplified shape plus three optional fields (`paidPlanPriceUsd`, `paidPlanPricePerUnit`, `isOneTimeEvent`); `search-actors` / `fetch-actor-details` structured output gains the same fields and `isPrimaryEvent`. `userTier` and tier arrays keep the tier codes; structured numbers stay raw per unit.

## Before / after
Same Free user, same live Actors, captured with mcpc against `master` and this branch. Reviewer guide with the rule, data flow, widget screenshots and per-plan table: https://claude.ai/code/artifact/fc8f8ba9-38fe-4327-b659-b03f5853d603

**Widget badge** (`search-actors-widget`, `fetch-actor-details-widget`, rendered in the real widget):

| Actor | Before | After |
|---|---|---|
| xtdata/twitter-x-scraper | `Pay per event` | `$5.00 / 1,000 each tweet. cheaper for higher plans · from $0.25 on paid plans` |
| compass/crawler-google-places | `Pay per event` | `$4.00 / 1,000 scraped places · from $1.50 on paid plans` |
| novi/tiktok-user-info-api | `Pay per event` | `$5.50 / 1,000 results · from $4.50 on paid plans` |

**`search-actors` text** (novi/tiktok-user-info-api):

```
before  - **Result**: Cost per result item returned. ($0.0055 per event)
        - **Actor start**: Flat fee for starting an Actor run. ($0.001 per event)
        Prices shown are for FREE tier. Higher tiers may offer lower prices — use fetch-actor-details to see the full pricing table.

after   - **Result**: Cost per result item returned. ($5.50 / 1,000 events)
        - **Actor start**: Flat fee for starting an Actor run. ($0.001 per run)
        Prices shown are for the Free plan. Paid plans from $4.50 / 1,000 events (Result). Use fetch-actor-details for the full pricing table.
```

**`fetch-actor-details` text** (xtdata/twitter-x-scraper):

```
before  Each tweet…  (FREE: $0.005, BRONZE: $0.0008, SILVER: $0.0006, GOLD: $0.00025, PLATINUM: $0.00025, DIAMOND: $0.00025 per event)
        Actor Start  (FREE: $0.0005, BRONZE: $0.00047, SILVER: $0.00043, GOLD: $0.0004, PLATINUM: $0.0004, DIAMOND: $0.0004 per event)

after   Each tweet…  (Free: $5.00, Starter: $0.80, Scale: $0.60, Business: $0.25, Platinum: $0.25, Diamond: $0.25 / 1,000 events)
        Actor Start  (Free: $0.0005, Starter: $0.00047, Scale: $0.00043, Business: $0.0004, Platinum: $0.0004, Diamond: $0.0004 per run)
```

**Structured output** (`search-actors`, xtdata/twitter-x-scraper, `pricingNote` elided):

```
before  {"model":"PAY_PER_EVENT","events":[{"title":"Each tweet…","priceUsd":0.005},{"title":"Actor Start","priceUsd":0.0005}]}
after   {"model":"PAY_PER_EVENT","events":[{"title":"Each tweet…","isPrimaryEvent":true,"priceUsd":0.005,"paidPlanPriceUsd":0.00025},
                                          {"title":"Actor Start","isOneTimeEvent":true,"priceUsd":0.0005}]}
```

Tier codes stay in `userTier` and `tieredPricing[].tier`; only prose uses plan names.

## Notes for reviewers (human-written)

## Proof it works
Unit: `tests/unit/widget.formatting.test.ts` renders the badge from the real twitter-x-scraper tier matrix through the server producer for Free and Business users, plus per-run, precision, fallback and rental/dataset cases; `tests/unit/utils.pricing_info.test.ts` pins every text and structured string per model and user tier.

Widgets rendered, not just tool output: the built server was probed with mcpc in apps mode (`node dist/stdio.js --ui apps`, Free user); the real `ui://widget/search-actors.html` resource and real `search-actors-widget` / `fetch-actor-details-widget` results were fed to the widget in headless Chromium through the official ext-apps `AppBridge` host API, and the badge text was read from the rendered DOM:

| Payload | Rendered badge (Free) | Store page |
|---|---|---|
| details xtdata/twitter-x-scraper | `$5.00 / 1,000 each tweet. cheaper for higher plans · from $0.25 on paid plans` | from $0.25 / 1,000 |
| details compass/crawler-google-places | `$4.00 / 1,000 scraped places · from $1.50 on paid plans` | from $1.50 / 1,000 |
| details apify/instagram-scraper | `$2.70 / 1,000 results · from $1.50 on paid plans` | from $1.50 / 1,000 |
| search "twitter x scraper xtdata" (3 Actors) | `$5.50 / 1,000 results · from $4.50`, `$8.00 / 1,000 user queries · from $6.80`, `$5.00 / 1,000 each tweet… · from $0.25 on paid plans` | — |

A Business-plan payload renders `$1.50 / 1,000 scraped places` with no hint. The actor-run widget was rendered the same way from a real `apify/hello-world` run. Zero page errors in every render. mcpc in default mode confirmed the live `search-actors` note and the `fetch-actor-details` plan table above. Two blind reviews of the final diff (staff-review, code-review); the harness is scratch for this PR, tracked under #1189.

Cross-surface check (web / API / CLI / MCP): the API is the source of truth (`eventTieredPricingUsd`, `isPrimaryEvent`, `isOneTimeEvent`); the Store renders primary event × GOLD per 1,000; MCP now shows the user's price the same way with the Store price as the hint. Outside this repo and not fixed here: `apify actors info` prices each event at the minimum over *all* tiers including FREE; `apify-client` types lack `isPrimaryEvent` / `isOneTimeEvent` / `eventTieredPricingUsd`.

AI assistance: Claude Code did the Store/API research, the fix, tests, widget render verification and this description; the original PR commits were made with Cursor. Session: https://claude.ai/code/session_01SFm5vnPSaCZzzbGKqNmtxc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFm5vnPSaCZzzbGKqNmtxc
