### PR TITLE
fix: Propagate auth errors instead of reporting Actor not found

### DIFF
--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -108,12 +108,14 @@ export async function fetchActorDetails(
             readmeSummary: actorInfo.readmeSummary,
         };
     } catch (error) {
-        logHttpError(error, `Failed to fetch actor details for '${actorName}'`, { actorName });
         // 404/400 is a genuine "Actor doesn't exist" — same treatment as the not-found check
         // above. Anything else (401/403/5xx) must propagate: it's a different failure class
         // (e.g. invalid token) the caller should surface as such, not as "not found".
         const statusCode = getHttpStatusCode(error);
-        if (statusCode === 404 || statusCode === 400) return null;
+        if (statusCode === 404 || statusCode === 400) {
+            logHttpError(error, `Failed to fetch actor details for '${actorName}'`, { actorName });
+            return null;
+        }
         throw error;
     }
 }

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -8,7 +8,7 @@ import type { Actor, ActorCardOptions, ActorInputSchema, ActorStoreList, Structu
 import { getActorMcpUrlCached } from './actor.js';
 import { formatActorForWidget, formatActorToActorCard, formatActorToStructuredCard } from './actor_card.js';
 import { searchActorsByKeywords } from './actor_search.js';
-import { logHttpError } from './logging.js';
+import { getHttpStatusCode, logHttpError } from './logging.js';
 import type { PricingTier } from './pricing_info.js';
 
 const ACTOR_DETAILS_PICTURE_SEARCH_LIMIT = 5;
@@ -109,7 +109,12 @@ export async function fetchActorDetails(
         };
     } catch (error) {
         logHttpError(error, `Failed to fetch actor details for '${actorName}'`, { actorName });
-        return null;
+        // 404/400 is a genuine "Actor doesn't exist" — same treatment as the not-found check
+        // above. Anything else (401/403/5xx) must propagate: it's a different failure class
+        // (e.g. invalid token) the caller should surface as such, not as "not found".
+        const statusCode = getHttpStatusCode(error);
+        if (statusCode === 404 || statusCode === 400) return null;
+        throw error;
     }
 }
 

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -204,4 +204,18 @@ describe('buildFetchActorDetailsResult()', () => {
         expect(content[0].text).toContain('# [Input schema](https://console.apify.com/actors/actor-id-1)');
         expect(content.at(-1)?.text).toBe(VERBATIM_LINKS_NUDGE);
     });
+
+    // Regression: a 401 (invalid/expired APIFY_TOKEN) must not surface as "Actor ... was not
+    // found" — that message wrongly nudges the caller to retry search-actors instead of fixing
+    // the credential. fetchActorDetails() is expected to propagate auth errors (see
+    // utils.actor_details.test.ts); this asserts the tool handler doesn't swallow them either.
+    it('propagates a 401 from fetchActorDetails instead of returning the not-found response', async () => {
+        vi.mocked(fetchActorDetails).mockRejectedValue(
+            Object.assign(new Error('Authentication token is not valid'), {
+                statusCode: 401,
+            }),
+        );
+
+        await expect(callWithToken('apify_api_test')).rejects.toMatchObject({ statusCode: 401 });
+    });
 });

--- a/tests/unit/tools.fetch_actor_details.widget.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.widget.response.test.ts
@@ -133,4 +133,18 @@ describe('fetch-actor-details-widget response', () => {
         const ok = tool.ajvValidate({ actor: 'apify/web-scraper' });
         expect(ok).toBe(true);
     });
+
+    // Regression: same fix as tools.fetch_actor_details.response.test.ts — the widget variant
+    // shares fetchActorDetails() and must not turn a 401 into the not-found response either.
+    it('propagates a 401 from fetchActorDetails instead of returning the not-found response', async () => {
+        vi.mocked(fetchActorDetails).mockRejectedValue(
+            Object.assign(new Error('Authentication token is not valid'), {
+                statusCode: 401,
+            }),
+        );
+
+        await expect(
+            (fetchActorDetailsWidget as HelperTool).call(stubInternalToolArgs({ actor: 'apify/web-scraper' })),
+        ).rejects.toMatchObject({ statusCode: 401 });
+    });
 });

--- a/tests/unit/utils.actor_details.test.ts
+++ b/tests/unit/utils.actor_details.test.ts
@@ -1,6 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { ApifyApiError } from 'apify-client';
+import type { AxiosResponse } from 'axios';
+import { describe, expect, it, vi } from 'vitest';
 
-import { typeObjectToString } from '../../src/utils/actor_details.js';
+import type { ApifyClient } from '../../src/apify_client.js';
+import { fetchActorDetails, typeObjectToString } from '../../src/utils/actor_details.js';
+
+vi.mock('../../src/utils/actor_search.js', () => ({
+    searchActorsByKeywords: vi.fn().mockResolvedValue([]),
+}));
+
+function apifyApiError(status: number, message: string): ApifyApiError {
+    return new ApifyApiError({ data: { error: { type: message, message } }, status } as AxiosResponse, 1);
+}
+
+function stubApifyClient(getActor: () => Promise<unknown>): ApifyClient {
+    return {
+        token: 'test-token',
+        actor: () => ({
+            get: getActor,
+            defaultBuild: async () => ({ get: getActor }),
+        }),
+    } as unknown as ApifyClient;
+}
 
 describe('typeObjectToString', () => {
     it('formats a flat object of string-typed fields', () => {
@@ -92,5 +113,21 @@ describe('typeObjectToString', () => {
                 },
             }),
         ).toBe('{ outer: { keep: string, tags: string[] } }');
+    });
+});
+
+describe('fetchActorDetails()', () => {
+    it('returns null on a genuine 404 (Actor does not exist)', async () => {
+        const client = stubApifyClient(() => Promise.reject(apifyApiError(404, 'Actor was not found')));
+
+        const result = await fetchActorDetails(client, 'apify/no-such-actor');
+
+        expect(result).toBeNull();
+    });
+
+    it('propagates a 401 (invalid/expired token) instead of reporting not-found', async () => {
+        const client = stubApifyClient(() => Promise.reject(apifyApiError(401, 'Authentication token is not valid')));
+
+        await expect(fetchActorDetails(client, 'apify/instagram-scraper')).rejects.toMatchObject({ statusCode: 401 });
     });
 });


### PR DESCRIPTION
## What
`fetchActorDetails()` (used by both `fetch-actor-details` and its widget variant) collapsed every error — 401, 403, 5xx, network — to `null`, identical to a genuine 404. A stale/invalid `APIFY_TOKEN` surfaced as "Actor ... was not found", nudging the caller toward `search-actors` instead of fixing the credential. Now only 404/400 return `null`; everything else propagates.

## Why
Mirrors the pattern `getActorDefinition()` (`actor_definition.ts`) already uses in this same codebase. Once the error propagates, the existing 401/403-aware catch-all (`getToolCallErrorUserText`) produces the correct auth message — no new user-facing text needed, no downstream changes required.

## Testing
- Added failing-first unit tests: `utils.actor_details.test.ts` (404 → null, 401 → throws with statusCode preserved), plus regression tests in `tools.fetch_actor_details.response.test.ts` / `.widget.response.test.ts` asserting the tool handlers don't swallow a rejected `fetchActorDetails`.
- `pnpm run type-check`, `lint`, `test:unit` (1058 passed), `format`, `check:agents` all clean.
- Live-verified via `mcpc` against a built `dist/stdio.js`, real Actor `apify/instagram-scraper`:
  - invalid token → `Authentication failed — check APIFY_TOKEN is set and valid.`
  - valid token, real Actor → normal Actor card.
  - valid token, nonexistent Actor → unchanged not-found message.