### PR TITLE
chore: Skip .shepherd in AGENTS.md link check

### DIFF
--- a/scripts/check-agents-links.mjs
+++ b/scripts/check-agents-links.mjs
@@ -9,7 +9,7 @@ import { dirname, join, relative, resolve } from 'node:path';
 
 const root = process.cwd();
 const rootDoc = join(root, 'AGENTS.md');
-const SKIP = new Set(['node_modules', 'dist', 'coverage', '.git']);
+const SKIP = new Set(['node_modules', 'dist', 'coverage', '.git', '.shepherd']);
 
 // `withFileTypes` reports the entry kind without a stat() that would follow — and
 // throw on — a broken symlink, so the walk never crashes on one.


### PR DESCRIPTION
## Why

`scripts/check-agents-links.mjs` walks the whole tree for files named `AGENTS.md` with no `.shepherd/` exclusion. Run data under `.shepherd/` is gitignored and can contain scratch copies of docs — the walker treats them as repo docs and fails `check:agents` on content that is never committed (hit during the #1084 shepherd run, which had to rename a scratch copy to dodge the check).

## What changed

Before: `SKIP = ['node_modules', 'dist', 'coverage', '.git']`. Now: `.shepherd` added to the set. One line.

## Notes for reviewers (human-written)

## Proof it works

Planted `.shepherd/proof-test/AGENTS.md` containing a broken link, ran `pnpm run check:agents`: passes with "7 docs" — the decoy is invisible to the walker (pre-fix it would be an 8th doc failing on the broken link). Decoy removed after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MfTtEvQ9MYhydr8qSUopw

---
_Generated by [Claude Code](https://claude.ai/code/session_018MfTtEvQ9MYhydr8qSUopw)_