### PR TITLE
fix: SoftFail observed Mezmo client and upstream noise

### DIFF
--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,4 +1,5 @@
 import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ZodError } from 'zod';
 
 import log from '@apify/log';
 
@@ -53,6 +54,7 @@ export function sanitizeMezmoMessage(message: string): string {
 const MCP_CLIENT_FAULT_MESSAGES: ReadonlySet<string> = new Set([
     'Bad Request: Server not initialized',
     'Invalid Request: Only one initialization request is allowed',
+    'Invalid Request: Server already initialized',
     'Not Acceptable: Client must accept text/event-stream',
     'Not Acceptable: Client must accept both application/json and text/event-stream',
     'Parse error: Invalid JSON',
@@ -67,7 +69,34 @@ const MCP_CLIENT_FAULT_PREFIXES: readonly string[] = [
     'Failed to send response: Error: No connection established for request ID:', // send-path wrap of the above
     'Failed to send response: Error: Not connected', // send-path wrap
     'Invalid state: Controller is already closed', // Node web-streams ERR_INVALID_STATE
+    // Clients/proxies sometimes send duplicate mcp-protocol-version headers; Headers.get joins them
+    // with ", " so a supported version becomes e.g. "2025-11-25, 2025-11-25" and fails includes().
+    'Bad Request: Unsupported protocol version:',
 ];
+
+/**
+ * Remote Actor MCP / docs transport failures observed in production Mezmo. Often wrapped as
+ * HTTP 500 by the MCP SDK ("Streamable HTTP error: …"). Match as substrings, case-insensitive.
+ * Do not broaden without a real log sample.
+ */
+const TRANSIENT_UPSTREAM_MESSAGE_PATTERNS: readonly RegExp[] = [/socket hang up/i, /gateway time-?out/i];
+
+/**
+ * True when an error is a Zod parse failure (our ZodError, or SDK Zod 4's `$ZodError` shape).
+ * Untrusted Actor MCP `tools/list` payloads that omit `inputSchema` land here — Actor bug, not ours.
+ */
+function isZodValidationError(error: unknown): boolean {
+    if (error instanceof ZodError) return true;
+    if (typeof error !== 'object' || error === null) return false;
+    const { name, issues } = error as { name?: unknown; issues?: unknown };
+    return (name === 'ZodError' || name === '$ZodError') && Array.isArray(issues);
+}
+
+/** True when the failure matches an observed transient upstream/network message. */
+function isTransientUpstreamError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return TRANSIENT_UPSTREAM_MESSAGE_PATTERNS.some((pattern) => pattern.test(message));
+}
 
 /** True when an MCP SDK `onerror` message is a known client fault that should softFail, not error. */
 export function isMcpClientFaultMessage(message: string): boolean {
@@ -101,6 +130,8 @@ function getMcpErrorCode(error: unknown): number | undefined {
 /**
  * Logs HTTP or MCP errors at the appropriate level:
  * - Client errors (HTTP < 500, or JSON-RPC client/transient codes) → softFail (no stack).
+ * - Zod validation / SchemaTooLarge / Actor run-limit → softFail (untrusted input or billing).
+ * - Transient upstream (socket hang up, gateway timeout) → softFail.
  * - Server errors (HTTP >= 500, or JSON-RPC server codes) → exception (with stack).
  * - Anything unclassifiable → error.
  *
@@ -122,6 +153,22 @@ export function logHttpError<T extends object>(error: unknown, message: string, 
     // Oversized untrusted input schema — a property of the Actor's schema, not a server fault.
     if (error instanceof SchemaTooLargeError) {
         log.softFail(message, { errMessage: softErrMessage, ...data });
+        return;
+    }
+
+    // Zod parse failures on untrusted remote MCP payloads (e.g. tools/list missing inputSchema).
+    if (isZodValidationError(error)) {
+        log.softFail(message, { errMessage: softErrMessage, ...data });
+        return;
+    }
+
+    // Transient upstream/network: docs CDN / Actor MCP socket hang up or gateway timeout.
+    if (isTransientUpstreamError(error)) {
+        log.softFail(message, {
+            errMessage: softErrMessage,
+            ...(statusCode !== undefined ? { statusCode } : {}),
+            ...data,
+        });
         return;
     }
 

--- a/tests/unit/utils.logging.test.ts
+++ b/tests/unit/utils.logging.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ZodError } from 'zod';
 
 import log from '@apify/log';
 
@@ -16,6 +17,7 @@ describe('isMcpClientFaultMessage', () => {
         for (const message of [
             'Bad Request: Server not initialized',
             'Invalid Request: Only one initialization request is allowed',
+            'Invalid Request: Server already initialized',
             'Not Acceptable: Client must accept text/event-stream',
             'Not Acceptable: Client must accept both application/json and text/event-stream',
             'Parse error: Invalid JSON',
@@ -34,6 +36,11 @@ describe('isMcpClientFaultMessage', () => {
         ).toBe(true);
         expect(isMcpClientFaultMessage('Failed to send response: Error: Not connected')).toBe(true);
         expect(isMcpClientFaultMessage('Invalid state: Controller is already closed')).toBe(true);
+        expect(
+            isMcpClientFaultMessage(
+                'Bad Request: Unsupported protocol version: 2025-11-25, 2025-11-25 (supported versions: 2025-11-25)',
+            ),
+        ).toBe(true);
     });
 
     it('does not match substrings or near-misses (avoids catching other libraries)', () => {
@@ -42,6 +49,7 @@ describe('isMcpClientFaultMessage', () => {
         expect(isMcpClientFaultMessage('Database connection: Not connected to replica')).toBe(false);
         expect(isMcpClientFaultMessage('Parse error: Invalid YAML')).toBe(false);
         expect(isMcpClientFaultMessage('Server not initialized yet, retrying')).toBe(false);
+        expect(isMcpClientFaultMessage('Unsupported protocol version in docs')).toBe(false);
     });
 });
 
@@ -90,6 +98,65 @@ describe('logHttpError', () => {
         expect(softFail).toHaveBeenCalledTimes(1);
         expect(exception).not.toHaveBeenCalled();
         expect(error).not.toHaveBeenCalled();
+    });
+
+    it('soft-fails Zod validation failures from untrusted MCP tools/list payloads', () => {
+        const softFail = vi.spyOn(log, 'softFail').mockImplementation(() => log);
+        const exception = vi.spyOn(log, 'exception').mockImplementation(() => log);
+        const error = vi.spyOn(log, 'error').mockImplementation(() => log);
+
+        logHttpError(new ZodError([]), `Failed to list MCP tools for Actor 'red.cars/example'`);
+
+        expect(softFail).toHaveBeenCalledTimes(1);
+        expect(exception).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+    });
+
+    it('soft-fails Zod-shaped errors even when name is $ZodError (SDK / Zod 4)', () => {
+        const softFail = vi.spyOn(log, 'softFail').mockImplementation(() => log);
+        const errorLog = vi.spyOn(log, 'error').mockImplementation(() => log);
+        const zodShaped = Object.assign(new Error('Invalid input'), { name: '$ZodError', issues: [] });
+
+        logHttpError(zodShaped, `Failed to list MCP tools for Actor 'red.cars/example'`);
+
+        expect(softFail).toHaveBeenCalledTimes(1);
+        expect(errorLog).not.toHaveBeenCalled();
+    });
+
+    it('soft-fails remote transport failures (socket hang up) even when wrapped as HTTP 500', () => {
+        const softFail = vi.spyOn(log, 'softFail').mockImplementation(() => log);
+        const exception = vi.spyOn(log, 'exception').mockImplementation(() => log);
+        const error = Object.assign(
+            new Error('Streamable HTTP error: Error POSTing to endpoint: Error: socket hang up'),
+            { statusCode: 500 },
+        );
+
+        logHttpError(error, 'Failed to load tools from MCP server');
+
+        expect(exception).not.toHaveBeenCalled();
+        expect(softFail).toHaveBeenCalledTimes(1);
+    });
+
+    it('soft-fails gateway timeouts from upstream docs or Actor MCP', () => {
+        const softFail = vi.spyOn(log, 'softFail').mockImplementation(() => log);
+        const exception = vi.spyOn(log, 'exception').mockImplementation(() => log);
+        const error = Object.assign(new Error('HTTP 504 Gateway Time-out'), { statusCode: 504 });
+
+        logHttpError(error, 'Failed to fetch the documentation page');
+
+        expect(exception).not.toHaveBeenCalled();
+        expect(softFail).toHaveBeenCalledTimes(1);
+    });
+
+    it('still exceptions genuine upstream 500s that are not transport noise', () => {
+        const softFail = vi.spyOn(log, 'softFail').mockImplementation(() => log);
+        const exception = vi.spyOn(log, 'exception').mockImplementation(() => log);
+        const error = Object.assign(new Error('Internal server failure in Apify API'), { statusCode: 500 });
+
+        logHttpError(error, 'Failed to get Actor run');
+
+        expect(softFail).not.toHaveBeenCalled();
+        expect(exception).toHaveBeenCalledTimes(1);
     });
 });
 


### PR DESCRIPTION
## Why

Production Mezmo is full of ERROR/exception entries that are not our server bugs — MCP client misbehavior and remote Actor/docs failures. They drown real alerts. Ad-hoc from recent hosted logs (Jul 13–20).

Observed patterns being downgraded:

1. `Bad Request: Unsupported protocol version: 2025-11-25, 2025-11-25` — client/proxy sends a duplicated `mcp-protocol-version` header
2. `Invalid Request: Server already initialized` — client re-sends `initialize` on a live session
3. `$ZodError` / missing `tools[n].inputSchema` — Actor MCP `tools/list` returns non-spec tools (e.g. `red.cars/counterparty-due-diligence-mcp`)
4. `Streamable HTTP error: … socket hang up` when loading Actor MCP tools (e.g. `jiri.spilka/playwright-mcp-server`, `lulzasaur/marketplace-search-mcp`)
5. `Gateway timeout` / `HTTP 504 Gateway Time-out` — Actor MCP standby (`mrbridge/espn-mcp-server`) and `fetch-apify-docs` against docs.apify.com

## What changed

Before: those cases hit `log.error` / `log.exception` via `server.onerror` or `logHttpError`.
Now: they softFail — same allowlist path as the other known MCP client faults, plus Zod validation and the two observed transport message substrings (`socket hang up`, `gateway time-out`). No client-facing behavior change. Not broadened to speculative codes (502/503, ECONNRESET, etc.).

## Notes for reviewers (human-written)
