### PR TITLE
fix: hardcode apify/code-runtime Actor ID for full-README bypass

### DIFF
--- a/res/code_runtime_eval.md
+++ b/res/code_runtime_eval.md
@@ -1,0 +1,233 @@
+# Code Mode eval — runbook
+
+A/B experiment: does `apify/code-runtime` (Code Mode) beat normal Actor tool use
+(Manual)? Seven tests, T1–T7, spanning a range of task shapes and sizes.
+
+**This runbook is deliberately blind.** It states no expected outcome for any test, and
+no per-test hypothesis about which mode should win or why. Grade only against the
+mechanical check printed under each test. If you find yourself reasoning about which
+mode "should" have won, stop — that reasoning is not in this file for a reason.
+
+## The one variable
+
+Each test runs twice. The query, model, and tools are identical. The only difference
+is one line prepended to the query:
+
+| Mode | Line |
+|---|---|
+| Manual | `Do not use apify/code-runtime.` |
+| Code | `You must use apify/code-runtime. Do all data processing inside it.` |
+
+Both lines must compel, not permit. `Use apify/code-runtime.` was tried and does not
+work: agents read it as permission, judge the task too small to be worth a sandboxed
+script, and silently run Manual — producing a Code column that is a second Manual run.
+The compulsion is part of the variable being tested, not a hint.
+
+Do not add anything else — no output format, no procedural hints, no field names, no
+tool bans beyond the mode line. Extra instructions change agent behaviour and
+contaminate the comparison.
+
+## How to run
+
+One subagent per (test, mode), on **Sonnet 5**:
+
+```
+Agent(subagent_type: "general-purpose", model: "sonnet",
+      run_in_background: false, prompt: <preamble> + <mode line> + <query>)
+```
+
+Always set `model` explicitly. A subagent without it inherits the parent session's
+model, and token counts are model-specific — mixing models across a comparison
+invalidates it.
+
+Subagents start without the Apify MCP schemas loaded, so the preamble is:
+
+```
+The Apify MCP tools are available but their schemas are not loaded. Use ToolSearch
+with query "select:mcp__apify-dev-3001__search-actors,mcp__apify-dev-3001__fetch-actor-details,mcp__apify-dev-3001__call-actor,mcp__apify-dev-3001__get-dataset-items,mcp__apify-dev-3001__apify--code-runtime"
+to load them before use.
+```
+
+The Code Mode tool is in that list on purpose. Leaving it out makes the Code mode line
+unactionable, and whether an agent then thinks to search for it on its own becomes an
+uncontrolled variable.
+
+Run the two modes of a test back to back, so both hit the same live data.
+
+## What to record
+
+| Field | Where from |
+|---|---|
+| mode held | did the run actually use the mode it was assigned? |
+| tokens | subagent transcript (see Cost below) — not the harness `subagent_tokens` counter |
+| wall-clock | session duration for the subagent |
+| retries | count re-issued Actor calls / re-run scripts in the transcript |
+| Apify cost | `apify runs ls <actor> --limit N --desc` |
+| LLM cost | tokens × the rates below |
+| pass/fail | the test's grading check below |
+| model | Sonnet 5 — record it with every number |
+
+Check **mode held** first, before anything else. Ask the finished subagent to list the
+tool calls it made, in order. A Code run that never called `apify--code-runtime`, or a
+Manual run that did, is void — discard both modes of that test and re-run the pair. Its
+numbers are not a result, and a defected Code run looks like a narrow Code Mode win
+because it *is* a Manual run.
+
+Then grade pass/fail. A mode can win every efficiency number and still fail.
+
+## Cost
+
+Two components, both required — a mode can win on tokens and lose on Actor spend.
+
+**Tokens.** The harness's `subagent_tokens` field is a single number and is not the
+billed input/output split; pricing it directly gives the wrong answer, and can invert
+the ranking. Sum the real usage from the subagent transcript at
+`~/.claude/projects/<project>/<session>/subagents/agent-<agentId>.jsonl`:
+
+```
+jq -s '[.[] | select(.message.usage) | select(.timestamp < "<cutoff>") | .message.usage]
+  | {in:(map(.input_tokens//0)|add), cache_w:(map(.cache_creation_input_tokens//0)|add),
+     cache_r:(map(.cache_read_input_tokens//0)|add), out:(map(.output_tokens//0)|add)}' agent-<id>.jsonl
+```
+
+Set `<cutoff>` to just after the run's last turn. Follow-up messages to the subagent
+(the mode-held audit) land in the same file and must not be counted as run cost.
+
+**Rates** ($/MTok input / output). Cache write bills at 1.25× input on a 5-minute TTL,
+2× on a 1-hour TTL; cache read at 0.1× input. Record which TTL was assumed.
+
+| Model | Input | Output |
+|---|---|---|
+| Sonnet 5 | 2.00 | 10.00 |
+| Sonnet 5 (from 2026-09-01) | 3.00 | 15.00 |
+| Opus 5 / Opus 4.8 | 5.00 | 25.00 |
+
+**Apify.** `apify runs ls <actor> --limit N --desc` gives per-run usage in USD. Match
+runs by start time. Code mode bills the `apify/code-runtime` run *and* every Actor run
+it starts from inside the sandbox — sum all of them, plus any probe runs the agent made
+to discover field names. Never read these from the API with curl.
+
+## Why there are no answer keys
+
+The underlying data is live and changes between runs, so the same query minutes apart
+returns different results. A fixed answer key would measure that drift rather than the
+mode. Each test therefore has a **grading check** that holds whatever the live data
+says.
+
+---
+
+## T1
+
+```
+I'm mapping out who owns search visibility in the web-data-for-AI market. Using the
+Google Search Results Scraper (apify/google-search-scraper), search for each of
+these:
+
+best web scraping api, firecrawl alternatives, exa vs tavily, best search api for
+llm, web scraping mcp server, best crawler for rag, tavily alternatives, apify vs
+firecrawl, web search api for ai agents, best data extraction api
+
+Across all ten sets of results, which domains dominate? Give me the top 10 by how
+many times they appear, along with their average ranking position.
+```
+
+**Grading check.** The run must report roughly 7–9 organic results per query (~70–90
+total). Reporting ~10 total means it counted dataset items instead of unnesting the
+results inside them. Also check the top-10 list is genuinely ordered by appearance
+count — an entry with fewer appearances than an excluded domain is a fail.
+
+## T2
+
+```
+Using the Website Content Crawler (apify/website-content-crawler), crawl these 12
+documentation sites, about 5 pages each, and rank them by how long their average
+page is in words:
+
+docs.apify.com/academy, qdrant.tech/documentation, weaviate.io/developers/weaviate,
+milvus.io/docs, docs.trychroma.com, redis.io/docs/latest, docs.crawlee.dev,
+playwright.dev/docs/intro, docs.pytest.org/en/stable, vitest.dev/guide,
+docs.astro.build/en/getting-started, svelte.dev/docs
+```
+
+**Grading check.** All 12 sites present with a non-zero page count. A site silently
+dropped after a failed run is a fail. Note in the transcript whether the run hit the
+account memory ceiling and how it recovered.
+
+## T3
+
+```
+Using the YouTube Scraper (streamers/youtube-scraper), pull 150 videos for me — 30
+each across these topics: web scraping tutorial, playwright automation, vector
+database tutorial, rag pipeline tutorial, browser automation python.
+
+For channels that show up at least twice, give me the 10 with the best median
+engagement (likes per view), with their video count and subscriber count.
+```
+
+**Grading check.** Around 150 videos collected; every channel listed has at least 2
+videos; the reported statistic is a median, not a mean.
+
+## T4
+
+```
+Using the Google Search Results Scraper (apify/google-search-scraper), search for:
+open source observability stack, open source feature flags, open source workflow
+orchestration.
+
+Take the 10 best-ranked distinct domains across all three searches, then use the
+Website Content Crawler (apify/website-content-crawler) to crawl each of those sites
+(a few pages each) and tell me each one's homepage title and how many words of
+content it has in total.
+```
+
+**Grading check.** Exactly 10 distinct domains selected, and all 10 crawled. Far
+fewer than 10 domains means the search results were not unnested correctly. Crawling
+fewer sites than were selected means work was dropped silently.
+
+## T5
+
+```
+Compare these six vector databases for me: Milvus, Qdrant, Weaviate, Chroma,
+pgvector, FAISS.
+
+For each one, use the YouTube Scraper (streamers/youtube-scraper) to find about 10
+videos about it and total up the views, and use the Website Content Crawler
+(apify/website-content-crawler) to crawl its documentation site and measure how much
+documentation it has.
+
+Rank them by (total views / 1000) + (documentation words / 1000).
+```
+
+**Grading check.** All 6 products present, each with non-null values from both the
+video and the documentation side. A product missing one side means the join dropped
+it. Record which documentation URL each mode chose — the URLs are deliberately not
+given, so the two modes may pick differently, and that must stay separable from join
+quality.
+
+---
+
+## T6
+
+```
+Using the YouTube Scraper (streamers/youtube-scraper), search "kubernetes tutorial"
+and find me the 5 best videos that actually teach Kubernetes from scratch. Skip the
+clickbait, the paid course adverts, the conference talks and the "top 10 tools"
+listicles — I want real hands-on tutorials.
+```
+
+**Grading check — graded on the answer, not process.** Open the 5 videos each mode
+returned and count how many are genuinely hands-on beginner tutorials. Record the hit
+count out of 5 alongside the efficiency numbers. Judge each video on its own merits;
+do not let a mode's tool usage influence the count.
+
+## T7
+
+```
+Using the YouTube Scraper (streamers/youtube-scraper), what are the top 3 videos for
+"apify web scraping"? Just title, views and channel.
+```
+
+**Grading check.** 3 videos returned. This test measures cost, not correctness — it
+isolates the fixed cost of each mode on the smallest possible task, which is the
+baseline every other test's margin is measured against. Run it even though it looks
+trivial.

--- a/res/code_runtime_eval_results.md
+++ b/res/code_runtime_eval_results.md
@@ -1,0 +1,141 @@
+# Code Mode eval — results
+
+Run of [code_runtime_eval.md](./code_runtime_eval.md) on 2026-08-08. A/B: `apify/code-runtime`
+(Code) vs normal Actor tool use (Manual), 7 tests × 2 modes = 14 subagent runs.
+
+## Conditions
+
+- **Model:** Sonnet 5 for all 14 runs, set explicitly on every subagent.
+- **One variable:** the mode line prepended to an otherwise identical query.
+  Manual = `Do not use apify/code-runtime.` Code = `You must use apify/code-runtime. Do all
+  data processing inside it.` Nothing else added.
+- **Pairs run back to back** so both modes hit the same live data.
+- **Cache TTL: 5-minute, measured** — `cache_creation.ephemeral_5m_input_tokens` was 100% of
+  cache writes in every transcript, `ephemeral_1h_input_tokens` was 0. Not assumed.
+- **LLM rates** ($/MTok): in 2.00, out 10.00, cache write 2.50 (1.25×), cache read 0.20 (0.1×).
+- **Apify spend:** `apify runs ls <actor> --limit 60 --desc --json`, summed over each run's
+  transcript time window across all four actors used (website-content-crawler,
+  google-search-scraper, code-runtime, streamers/youtube-scraper). Includes runs the sandbox
+  started from inside itself, and probe runs.
+- **Token counts** come from the subagent transcripts at
+  `~/.claude/projects/<project>/<session>/subagents/agent-<id>.jsonl`, not the harness
+  `subagent_tokens` field.
+
+## Mode held — all 14 runs valid, no pair void
+
+Checked before anything else, from each transcript's `tool_use` records (the ordered list of
+calls, read from the transcript rather than asked of the agent — objective, and it keeps
+follow-up messages out of the token counts).
+
+- 7 Manual runs: zero `apify--code-runtime` calls.
+- 7 Code runs: 1–7 `apify--code-runtime` calls each.
+
+## Results
+
+| test | mode | agentId | held | wall s | out tok | total in tok | LLM $ | Apify $ | total $ | actor runs | grade |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| T1 | Manual | afa6e027c21cc1cd5 | yes | 284 | 9,393 | 1,164,980 | 0.7153 | 0.0460 | 0.7613 | gss 1 | PASS |
+| T1 | Code | ad171fef56c5f676f | yes | 151 | 7,118 | 868,452 | 0.4696 | 0.0531 | 0.5227 | gss 2, cr 1 | PASS |
+| T2 | Manual | a4a3490d7581f5721 | yes | 1055 | 53,993 | 15,012,116 | 7.4907 | 0.2977 | 7.7884 | wcc 17 | PASS |
+| T2 | Code | a02b71eb4f11614bf | yes | 702 | 19,567 | 2,979,446 | 1.1377 | 0.4874 | 1.6251 | wcc 40, cr 7 | FAIL |
+| T3 | Manual | a50248cb8c504ef6a | yes | 544 | 26,845 | 2,395,817 | 1.1652 | 0.6440 | 1.8092 | yt 3 | PASS |
+| T3 | Code | afc4196dbe9b49aba | yes | 235 | 9,935 | 1,508,011 | 0.6554 | 0.6127 | 1.2681 | yt 6, cr 4 | PASS |
+| T4 | Manual | a32cab2f420d220a2 | yes | 1226 | 43,090 | 11,288,262 | 5.6865 | 0.3222 | 6.0087 | wcc 11, gss 1 | PASS |
+| T4 | Code | a296e6218836df881 | yes | 205 | 11,794 | 1,196,498 | 0.6808 | 0.0683 | 0.7491 | wcc 10, gss 1, cr 2 | PASS |
+| T5 | Manual | a45f9f2ee355e02f9 | yes | 1089 | 46,724 | 10,453,407 | 4.6349 | 0.5581 | 5.1930 | wcc 9, yt 6 | PASS |
+| T5 | Code | ae9d9e8766107e073 | yes | 1206 | 26,762 | 5,033,228 | 1.7201 | 0.8910 | 2.6111 | wcc 12, yt 7, cr 7 | PASS |
+| T6 | Manual | a4109b6efb90a2395 | yes | 159 | 6,933 | 802,161 | 0.4142 | 0.1200 | 0.5342 | yt 1 | 5/5 hits |
+| T6 | Code | a419da6c270afc42d | yes | 183 | 11,776 | 747,616 | 0.4853 | 0.1224 | 0.6077 | yt 1, cr 1 | 4/5 hits |
+| T7 | Manual | a5534afa803110b60 | yes | 50 | 1,196 | 465,060 | 0.2469 | 0.0800 | 0.3269 | yt 1 | PASS |
+| T7 | Code | a3ed6a68f6019d878 | yes | 129 | 2,534 | 920,032 | 0.3925 | 0.0865 | 0.4790 | yt 2, cr 2 | PASS |
+
+`gss` = apify/google-search-scraper, `wcc` = apify/website-content-crawler,
+`yt` = streamers/youtube-scraper, `cr` = apify/code-runtime.
+
+### Totals
+
+| | LLM $ | Apify $ | total $ | wall s | pass |
+|---|---|---|---|---|---|
+| Manual | 20.35 | 2.07 | **22.42** | 4407 | 6/6 graded PASS, T6 5/5 |
+| Code | 5.54 | 2.32 | **7.86** | 2811 | 5/6 graded PASS, T6 4/5 |
+
+Apify spend is close to a wash (Code +$0.25 over the seven tests); the whole cost gap is LLM
+tokens. Note Code's Apify spend is higher on 4 of 7 tests despite being lower overall — T4
+alone accounts for the swing.
+
+## Retries and wasted runs
+
+| test | Manual | Code |
+|---|---|---|
+| T1 | none | 1 wasted google-search-scraper probe run (single query) |
+| T2 | 22 crawl calls for 12 sites, 8 rejected by the memory ceiling, 17 runs = 5 extra | 7 code-runtime runs (6 re-runs), 40 crawler runs = 28 extra |
+| T3 | 4 call-actor → 3 runs (1 extra) | 4 code-runtime runs (3 re-runs), 6 youtube runs (1 extra) |
+| T4 | 1 combined crawl run discarded, re-crawled per domain | no wasted actor runs, 2 code-runtime (1 recon) |
+| T5 | 20 call-actor → 15 runs (5 failed/rejected, 3 extra) | 7 code-runtime (6 re-runs), 12 crawler runs for 6 sites, 7 youtube for 6 |
+| T6 | none | none |
+| T7 | none | 1 extra youtube run, 2 code-runtime |
+
+## Per-test grading
+
+**T1** — check: ~7–9 organic results per query, top-10 ordered by appearance count.
+Manual reported 85 organic results (~8–9/query); Code 8–10/query. Both lists monotone
+descending. Manual printed 12 rows (ties at 2 appearances), which does not violate ordering.
+Both PASS.
+
+**T2** — check: all 12 sites with a non-zero page count.
+Manual 12/12: `docs.crawlee.dev` failed DNS, Manual redirected to `crawlee.dev/js/docs` and got
+7 pages. PASS.
+Code 11/12: `docs.crawlee.dev` returned 0 pages after 4 attempts across cheerio /
+playwright:firefox / playwright:chrome and both datacenter and residential proxies, and was
+excluded from the ranking. **FAIL** on the check — though it was disclosed, not silently dropped.
+**Memory ceiling:** Manual hit it 8 times (`would exceed the memory limit of 65536MB … currently
+used: 65536MB`) from launching crawls in parallel, and recovered by serializing them. Code never
+hit it.
+
+**T3** — check: ~150 videos, every listed channel ≥2 videos, statistic is a median.
+Manual 150 videos / 23 channels ≥2. Code 149 unique after dedup / 22 channels ≥2. Both stated
+median explicitly and every listed channel met the ≥2 bar. Both PASS.
+
+**T4** — check: exactly 10 distinct domains, all 10 crawled.
+Both selected 10 and crawled 10. Both PASS.
+
+**T5** — check: all 6 products non-null on both the video and documentation side.
+Both PASS, no join drops. **Both modes chose the same six documentation URLs** (milvus.io/docs,
+qdrant.tech/documentation, docs.weaviate.io/weaviate, docs.trychroma.com, pgvector GitHub README,
+FAISS GitHub wiki), so the URL-choice confound the runbook warns about did not materialise. The
+page cap differed — Manual 60/site, Code 25/site — and that is what drives the differing word
+counts, not join quality.
+
+**T6** — graded on the answer: hands-on hits out of 5. Judged from each returned video's scraped
+duration and description (YouTube pages are not readable via WebFetch; the metadata came from the
+runs' own datasets via `apify datasets get-items`).
+
+| video | dur | mode(s) | verdict |
+|---|---|---|---|
+| TechWorld with Nana — Kubernetes Tutorial for Beginners [FULL COURSE] | 3:36:55 | both | hit |
+| freeCodeCamp — Learn Kubernetes in 6 Hours | 5:53:25 | both | hit |
+| KodeKloud — Kubernetes Crash Course | 2:10:00 | both | hit |
+| DevOps Directive — Complete Kubernetes Course | 6:14:41 | Manual | hit |
+| TrainWithShubham — Kubernetes In One Shot, 3 Live Projects | 11:42:51 | Manual | hit (KIND/minikube/kubeadm setup + 3 live projects) |
+| Kunal Kushwaha — Kubernetes Tutorial for Beginners | 1:41:58 | Code | hit ("from scratch", installation + hands-on demo) |
+| Amigoscode — Kubernetes Tutorial For Beginners | 0:17:47 | Code | miss (18-min overview; description opens with a paid-academy pitch) |
+
+Manual 5/5, Code 4/5.
+
+**T7** — check: 3 videos returned. Both PASS. The sets differ: Code's #1 was a 9.98M-view Apify
+Store promo ("There's an Actor for That") that Manual's set did not include.
+
+## Confounds to carry into the next run
+
+1. **Manual aggregated locally.** On T2–T6 the Manual runs wrote crawl/video JSON to disk with
+   `Write` and processed it with `Bash` (`wc -w`, jq). The mode line does not ban that, but it
+   means dataset text passed through context, and that is inside Manual's token numbers. If the
+   intent is to measure in-context aggregation, the Manual line has to say so.
+2. **T5 page caps diverged** (60 vs 25 pages/site) with no instruction either way, so the
+   documentation-words column is not comparable across modes on that test.
+3. **Apify spend is noisy per test** — Code launched far more Actor runs on T2 and T5 while
+   spending less overall, driven almost entirely by T4. Seven tests is too few to call the Actor
+   cost dimension.
+4. **Sandbox unavailable.** All bash in the parent session ran unsandboxed (`apply-seccomp`
+   failure on nested userns), and one Manual subagent flagged the same. No effect on Actor or
+   token measurement.

--- a/res/index.md
+++ b/res/index.md
@@ -55,6 +55,14 @@ time). Pull from the backlog instead of re-sweeping.
 Keeping widget bundles small (narrow `@apify/ui-library/dist/src/...` imports, markdown stack
 cost). Re-measure when changing widget dependencies or markdown rendering.
 
+### [code_runtime_eval.md](./code_runtime_eval.md)
+Blind A/B runbook for `apify/code-runtime` (Code Mode) vs normal Actor tool use: 7 tests, the
+single mode-line variable, how to measure tokens and Apify spend, per-test grading checks.
+
+### [code_runtime_eval_results.md](./code_runtime_eval_results.md)
+Results of that runbook, 2026-08-08 on Sonnet 5: per-run cost/wall/pass table, mode-held audit,
+retry counts, and the confounds to fix before re-running.
+
 ---
 
 ## Guidelines

--- a/src/const.ts
+++ b/src/const.ts
@@ -7,6 +7,11 @@ export const ACTOR_MAX_DESCRIPTION_LENGTH = 500;
 // Actor run const
 export const ACTOR_MAX_MEMORY_MBYTES = 4_096; // If the Actor requires 8GB of memory, free users can't run actors-mcp-server and requested Actor
 
+// apify/code-runtime's README documents an exact API contract (method names/shapes) that the
+// auto-generated summary can omit — always return its full README. Hardcoded by Actor ID
+// (not an actor.json flag) so no other Actor can opt itself out of the summary.
+export const CODE_RUNTIME_ACTOR_ID = 'Ewe0VxlktEE7SChSI';
+
 // Tool output
 /**
  * Content larger than this is linked out instead of inlined, since inlining it would blow up the context

--- a/src/const.ts
+++ b/src/const.ts
@@ -8,9 +8,10 @@ export const ACTOR_MAX_DESCRIPTION_LENGTH = 500;
 export const ACTOR_MAX_MEMORY_MBYTES = 4_096; // If the Actor requires 8GB of memory, free users can't run actors-mcp-server and requested Actor
 
 // apify/code-runtime's README documents an exact API contract (method names/shapes) that the
-// auto-generated summary can omit — always return its full README. Hardcoded by Actor ID
-// (not an actor.json flag) so no other Actor can opt itself out of the summary.
-export const CODE_RUNTIME_ACTOR_ID = 'Ewe0VxlktEE7SChSI';
+// auto-generated summary can omit — always return its full README. Hardcoded by Actor name
+// (not an actor.json flag) so no other Actor can opt itself out of the summary. Actor name
+// (not ID) so this stays correct across environments (staging etc. have different IDs).
+export const CODE_RUNTIME_ACTOR_NAME = 'apify/code-runtime';
 
 // Tool output
 /**

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -1,6 +1,7 @@
 import type { Build } from 'apify-client';
 
 import type { ApifyClient } from '../apify_client.js';
+import { CODE_RUNTIME_ACTOR_ID } from '../const.js';
 import { connectMCPClient } from '../mcp/client.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { filterSchemaProperties, shortenProperties } from '../tools/actor_input_schema.js';
@@ -40,12 +41,17 @@ function typeValueToString(value: unknown): string {
 /**
  * Resolve README content with fallback: prefer readmeSummary, fall back to full readme.
  * Returns the content string and appropriate heading for text output.
+ *
+ * apify/code-runtime is hardcoded to always get its full README (see CODE_RUNTIME_ACTOR_ID) —
+ * its README documents an exact API contract (method names/shapes) that the auto-generated
+ * summary can omit, and there's no per-call way to request the raw text otherwise.
  */
-export function resolveReadmeContent(details: { readmeSummary?: string; readme: string }): {
+export function resolveReadmeContent(details: { actorInfo: { id: string }; readmeSummary?: string; readme: string }): {
     content: string;
     heading: string;
 } {
-    if (details.readmeSummary?.trim()) {
+    const forceFullReadme = details.actorInfo.id === CODE_RUNTIME_ACTOR_ID;
+    if (!forceFullReadme && details.readmeSummary?.trim()) {
         return { content: details.readmeSummary, heading: '# README summary' };
     }
     return { content: details.readme, heading: '# README' };

--- a/src/utils/actor_details.ts
+++ b/src/utils/actor_details.ts
@@ -1,7 +1,7 @@
 import type { Build } from 'apify-client';
 
 import type { ApifyClient } from '../apify_client.js';
-import { CODE_RUNTIME_ACTOR_ID } from '../const.js';
+import { CODE_RUNTIME_ACTOR_NAME } from '../const.js';
 import { connectMCPClient } from '../mcp/client.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { filterSchemaProperties, shortenProperties } from '../tools/actor_input_schema.js';
@@ -42,16 +42,23 @@ function typeValueToString(value: unknown): string {
  * Resolve README content with fallback: prefer readmeSummary, fall back to full readme.
  * Returns the content string and appropriate heading for text output.
  *
- * apify/code-runtime is hardcoded to always get its full README (see CODE_RUNTIME_ACTOR_ID) —
+ * apify/code-runtime is hardcoded to always get its full README (see CODE_RUNTIME_ACTOR_NAME) —
  * its README documents an exact API contract (method names/shapes) that the auto-generated
  * summary can omit, and there's no per-call way to request the raw text otherwise.
  */
-export function resolveReadmeContent(details: { actorInfo: { id: string }; readmeSummary?: string; readme: string }): {
+export function resolveReadmeContent(details: {
+    actorInfo: { username: string; name: string };
+    readmeSummary?: string;
+    readme: string;
+}): {
     content: string;
     heading: string;
 } {
-    const forceFullReadme = details.actorInfo.id === CODE_RUNTIME_ACTOR_ID;
-    if (!forceFullReadme && details.readmeSummary?.trim()) {
+    const actorName = `${details.actorInfo.username}/${details.actorInfo.name}`;
+    if (actorName === CODE_RUNTIME_ACTOR_NAME) {
+        return { content: details.readme, heading: '# README' };
+    }
+    if (details.readmeSummary?.trim()) {
         return { content: details.readmeSummary, heading: '# README summary' };
     }
     return { content: details.readme, heading: '# README' };

--- a/tests/unit/utils.actor_details.test.ts
+++ b/tests/unit/utils.actor_details.test.ts
@@ -3,7 +3,8 @@ import type { AxiosResponse } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ApifyClient } from '../../src/apify_client.js';
-import { fetchActorDetails, typeObjectToString } from '../../src/utils/actor_details.js';
+import { CODE_RUNTIME_ACTOR_ID } from '../../src/const.js';
+import { fetchActorDetails, resolveReadmeContent, typeObjectToString } from '../../src/utils/actor_details.js';
 
 vi.mock('../../src/utils/actor_search.js', () => ({
     searchActorsByKeywords: vi.fn().mockResolvedValue([]),
@@ -22,6 +23,47 @@ function stubApifyClient(getActor: () => Promise<unknown>): ApifyClient {
         }),
     } as unknown as ApifyClient;
 }
+
+const OTHER_ACTOR = { id: 'someOtherActorId12345' };
+const CODE_RUNTIME_ACTOR = { id: CODE_RUNTIME_ACTOR_ID };
+
+describe('resolveReadmeContent()', () => {
+    it('prefers the summary when present for a regular Actor', () => {
+        const result = resolveReadmeContent({
+            actorInfo: OTHER_ACTOR,
+            readme: '# Full',
+            readmeSummary: 'Short summary.',
+        });
+        expect(result).toEqual({ content: 'Short summary.', heading: '# README summary' });
+    });
+
+    it('falls back to the full readme when there is no summary', () => {
+        const result = resolveReadmeContent({ actorInfo: OTHER_ACTOR, readme: '# Full' });
+        expect(result).toEqual({ content: '# Full', heading: '# README' });
+    });
+
+    it('always returns the full readme for apify/code-runtime, even with a summary present', () => {
+        const result = resolveReadmeContent({
+            actorInfo: CODE_RUNTIME_ACTOR,
+            readme: '# Full',
+            readmeSummary: 'Short summary.',
+        });
+        expect(result).toEqual({ content: '# Full', heading: '# README' });
+    });
+
+    it('ignores a blank summary the same way for a regular Actor or code-runtime', () => {
+        expect(resolveReadmeContent({ actorInfo: OTHER_ACTOR, readme: '# Full', readmeSummary: '   ' })).toEqual({
+            content: '# Full',
+            heading: '# README',
+        });
+        expect(resolveReadmeContent({ actorInfo: CODE_RUNTIME_ACTOR, readme: '# Full', readmeSummary: '   ' })).toEqual(
+            {
+                content: '# Full',
+                heading: '# README',
+            },
+        );
+    });
+});
 
 describe('typeObjectToString', () => {
     it('formats a flat object of string-typed fields', () => {

--- a/tests/unit/utils.actor_details.test.ts
+++ b/tests/unit/utils.actor_details.test.ts
@@ -3,7 +3,7 @@ import type { AxiosResponse } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ApifyClient } from '../../src/apify_client.js';
-import { CODE_RUNTIME_ACTOR_ID } from '../../src/const.js';
+import { CODE_RUNTIME_ACTOR_NAME } from '../../src/const.js';
 import { fetchActorDetails, resolveReadmeContent, typeObjectToString } from '../../src/utils/actor_details.js';
 
 vi.mock('../../src/utils/actor_search.js', () => ({
@@ -24,8 +24,9 @@ function stubApifyClient(getActor: () => Promise<unknown>): ApifyClient {
     } as unknown as ApifyClient;
 }
 
-const OTHER_ACTOR = { id: 'someOtherActorId12345' };
-const CODE_RUNTIME_ACTOR = { id: CODE_RUNTIME_ACTOR_ID };
+const OTHER_ACTOR = { username: 'someone', name: 'some-other-actor' };
+const [CODE_RUNTIME_USERNAME, CODE_RUNTIME_NAME] = CODE_RUNTIME_ACTOR_NAME.split('/');
+const CODE_RUNTIME_ACTOR = { username: CODE_RUNTIME_USERNAME, name: CODE_RUNTIME_NAME };
 
 describe('resolveReadmeContent()', () => {
     it('prefers the summary when present for a regular Actor', () => {


### PR DESCRIPTION
## What
`resolveReadmeContent()` now always returns the full README for `apify/code-runtime` (matched by Actor name, `CODE_RUNTIME_ACTOR_NAME` in `const.ts`), bypassing the auto-generated summary.

## Why
`apify/code-runtime`'s README documents an exact API contract (method names/shapes) that the auto-generated summary omits — confirmed via a live eval trace where the agent fetched the README, got the summary, and still guessed the wrong dataset API. Matched by name rather than a self-declared `actor.json` flag, so no other Actor can opt itself out of summarization.

Matched by Actor name (`apify/code-runtime`) rather than Actor ID: IDs are deployment-specific (differ between local/staging/production), so a hardcoded ID would silently stop working outside production.

## Testing
Added unit tests for `resolveReadmeContent()` (regular Actor vs `apify/code-runtime`, with/without summary, blank summary). `pnpm run type-check`, `lint`, `test:unit` all pass.
