### PR TITLE
refactor: Harden tool-call error-mapper

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -90,6 +90,7 @@ import { getActors, getToolsForServerMode, toolNamesToInput } from '../utils/too
 import { LOG_LEVEL_MAP } from './const.js';
 import { emitTaskStatusNotification, executeToolAndUpdateTask } from './task_execution.js';
 import { buildToolCallErrorResult, TOOL_CALL_ERROR_KIND } from './tool_call_error_mapper.js';
+import type { ToolCallErrorResult } from './tool_call_error_mapper.js';
 import { logToolCallAndTelemetry, prepareTelemetryData } from './tool_call_telemetry.js';
 import { dispatchToolCall } from './tool_dispatch.js';
 import { parseInputParamsFromUrl, storeTaskResultOrSkipIfExpired } from './utils.js';
@@ -1248,52 +1249,63 @@ export class ActorsMcpServer {
                 });
                 toolStatus = errorResult.toolStatus;
 
-                // Propagate 402 Payment Required as a tool result per x402 MCP transport spec:
-                // content[0].text (JSON) + isError: true. No log here (unlike the task path). The
-                // concurrent-run limit also surfaces as 402 but is excluded by the predicate and
-                // falls through to the generic run-limit handling below.
-                if (errorResult.kind === TOOL_CALL_ERROR_KIND.PAYMENT) {
-                    callDiagnostics = errorResult.callDiagnostics;
-                    return captureResult(errorResult.response);
+                switch (errorResult.kind) {
+                    case TOOL_CALL_ERROR_KIND.PAYMENT: {
+                        // Propagate 402 Payment Required as a tool result per x402 MCP transport spec:
+                        // content[0].text (JSON) + isError: true. No log here (unlike the task path). The
+                        // concurrent-run limit also surfaces as 402 but is excluded by the predicate and
+                        // falls through to the generic run-limit handling below.
+                        callDiagnostics = errorResult.callDiagnostics;
+                        return captureResult(errorResult.response);
+                    }
+                    case TOOL_CALL_ERROR_KIND.APPROVAL: {
+                        callDiagnostics = errorResult.callDiagnostics;
+                        logHttpError(error, 'Permission approval required while calling tool', {
+                            toolName: name,
+                            mcpSessionId,
+                        });
+                        return captureResult(errorResult.response);
+                    }
+                    case TOOL_CALL_ERROR_KIND.EXECUTION: {
+                        callDiagnostics = {
+                            // Spread existing diagnostics first (e.g. validation_keyword from
+                            // failInvalidParams), then overwrite with the mapper's freshly computed fields
+                            // so they take precedence.
+                            ...callDiagnostics,
+                            ...errorResult.callDiagnostics,
+                        };
+
+                        logHttpError(error, 'Error occurred while calling tool', {
+                            toolName: name,
+                            toolStatus,
+                            mcpSessionId,
+                            failureCategory: callDiagnostics.failure_category,
+                            failureHttpStatus: callDiagnostics.failure_http_status,
+                            actorName: callDiagnostics.actor_name,
+                            validationKeyword: callDiagnostics.validation_keyword,
+                            validationPath: callDiagnostics.validation_path,
+                            validationMissingProperty: callDiagnostics.validation_missing_property,
+                            validationAdditionalProperty: callDiagnostics.validation_additional_property,
+                        });
+                        // This framework outer-catch path bypasses extractToolTelemetry (returned via
+                        // captureResult), so preserve the pre-existing wire shape { toolStatus } exactly:
+                        // reuse the local ABORTED-aware toolStatus, do NOT re-derive from the error (which
+                        // would drop ABORTED and leak failureCategory/failureHttpStatus onto the wire).
+                        return captureResult({
+                            ...respondOk(errorResult.userText),
+                            isError: true,
+                            toolTelemetry: { toolStatus },
+                        });
+                    }
+                    default:
+                        // Compile-time exhaustiveness guard (same `satisfies never` idiom as
+                        // dispatchToolCall's default arm): a new TOOL_CALL_ERROR_KIND makes `errorResult`
+                        // non-`never` here and fails to compile. Unreachable at runtime.
+                        throw new McpError(
+                            ErrorCode.InvalidParams,
+                            `Unknown tool-call error kind "${(errorResult satisfies never as ToolCallErrorResult).kind}"`,
+                        );
                 }
-
-                if (errorResult.kind === TOOL_CALL_ERROR_KIND.APPROVAL) {
-                    callDiagnostics = errorResult.callDiagnostics;
-                    logHttpError(error, 'Permission approval required while calling tool', {
-                        toolName: name,
-                        mcpSessionId,
-                    });
-                    return captureResult(errorResult.response);
-                }
-
-                callDiagnostics = {
-                    // Spread existing diagnostics first (e.g. validation_keyword from failInvalidParams),
-                    // then overwrite with the mapper's freshly computed fields so they take precedence.
-                    ...callDiagnostics,
-                    ...errorResult.callDiagnostics,
-                };
-
-                logHttpError(error, 'Error occurred while calling tool', {
-                    toolName: name,
-                    toolStatus,
-                    mcpSessionId,
-                    failureCategory: callDiagnostics.failure_category,
-                    failureHttpStatus: callDiagnostics.failure_http_status,
-                    actorName: callDiagnostics.actor_name,
-                    validationKeyword: callDiagnostics.validation_keyword,
-                    validationPath: callDiagnostics.validation_path,
-                    validationMissingProperty: callDiagnostics.validation_missing_property,
-                    validationAdditionalProperty: callDiagnostics.validation_additional_property,
-                });
-                // This framework outer-catch path bypasses extractToolTelemetry (returned via
-                // captureResult), so preserve the pre-existing wire shape { toolStatus } exactly:
-                // reuse the local ABORTED-aware toolStatus, do NOT re-derive from the error (which
-                // would drop ABORTED and leak failureCategory/failureHttpStatus onto the wire).
-                return captureResult({
-                    ...respondOk(errorResult.userText),
-                    isError: true,
-                    toolTelemetry: { toolStatus },
-                });
             } finally {
                 if (shouldTrackTelemetry) {
                     logToolCallAndTelemetry({

--- a/src/mcp/task_execution.ts
+++ b/src/mcp/task_execution.ts
@@ -2,6 +2,7 @@ import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/int
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { Notification, Request, TaskStatusNotification } from '@modelcontextprotocol/sdk/types.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 
 import log from '@apify/log';
 
@@ -15,6 +16,7 @@ import { createProgressTracker } from '../utils/progress.js';
 import { buildActorFields, getToolFullName } from '../utils/tools.js';
 import type { ActorsMcpServer } from './server.js';
 import { buildToolCallErrorResult, TOOL_CALL_ERROR_KIND } from './tool_call_error_mapper.js';
+import type { ToolCallErrorResult } from './tool_call_error_mapper.js';
 import { logToolCallAndTelemetry, prepareTelemetryData } from './tool_call_telemetry.js';
 import { dispatchToolCall } from './tool_dispatch.js';
 import {
@@ -292,98 +294,119 @@ export async function executeToolAndUpdateTask(params: {
             isAborted: Boolean(cancelWatcher.signal.aborted),
         });
 
-        // Handle 402 Payment Required — return structured x402 result so clients can auto-pay
-        if (errorResult.kind === TOOL_CALL_ERROR_KIND.PAYMENT) {
-            logHttpError(error, 'Payment required while calling tool (task mode)', { toolName: tool.name });
-            // Per MCP tasks spec: once a task is cancelled it MUST remain cancelled,
-            // so guard storeTaskResult against a cancel that raced with this 402.
-            if (
-                await skipIfTaskCancelled(', skipping 402 result storage', TOOL_STATUS.ABORTED, {
-                    ...buildActorFields(actorName, actorId),
-                })
-            )
+        switch (errorResult.kind) {
+            case TOOL_CALL_ERROR_KIND.PAYMENT: {
+                // Handle 402 Payment Required — return structured x402 result so clients can auto-pay
+                logHttpError(error, 'Payment required while calling tool (task mode)', { toolName: tool.name });
+                // Per MCP tasks spec: once a task is cancelled it MUST remain cancelled,
+                // so guard storeTaskResult against a cancel that raced with this 402.
+                if (
+                    await skipIfTaskCancelled(', skipping 402 result storage', TOOL_STATUS.ABORTED, {
+                        ...buildActorFields(actorName, actorId),
+                    })
+                )
+                    return;
+                await completeTask(
+                    'completed',
+                    errorResult.response,
+                    errorResult.toolStatus,
+                    errorResult.callDiagnostics,
+                );
                 return;
-            await completeTask('completed', errorResult.response, errorResult.toolStatus, errorResult.callDiagnostics);
-            return;
-        }
-
-        if (errorResult.kind === TOOL_CALL_ERROR_KIND.APPROVAL) {
-            logHttpError(error, 'Permission approval required while calling tool (task mode)', {
-                toolName: tool.name,
-            });
-            // Per MCP tasks spec: once a task is cancelled it MUST remain cancelled,
-            // so guard storeTaskResult against a cancel that raced with this approval error.
-            if (
-                await skipIfTaskCancelled(', skipping permission-approval result storage', TOOL_STATUS.ABORTED, {
-                    ...buildActorFields(actorName, actorId),
-                })
-            )
+            }
+            case TOOL_CALL_ERROR_KIND.APPROVAL: {
+                logHttpError(error, 'Permission approval required while calling tool (task mode)', {
+                    toolName: tool.name,
+                });
+                // Per MCP tasks spec: once a task is cancelled it MUST remain cancelled,
+                // so guard storeTaskResult against a cancel that raced with this approval error.
+                if (
+                    await skipIfTaskCancelled(', skipping permission-approval result storage', TOOL_STATUS.ABORTED, {
+                        ...buildActorFields(actorName, actorId),
+                    })
+                )
+                    return;
+                await completeTask(
+                    'completed',
+                    errorResult.response,
+                    errorResult.toolStatus,
+                    errorResult.callDiagnostics,
+                );
                 return;
-            await completeTask('completed', errorResult.response, errorResult.toolStatus, errorResult.callDiagnostics);
-            return;
-        }
+            }
+            case TOOL_CALL_ERROR_KIND.EXECUTION: {
+                toolStatus = errorResult.toolStatus;
+                callDiagnostics = errorResult.callDiagnostics;
+                // Log level follows the already-classified toolStatus:
+                //   SOFT_FAIL (e.g. 402/403 user quota, client-side issues) → softFail
+                //   FAILED/ABORTED/other                                    → error
+                if (toolStatus === TOOL_STATUS.SOFT_FAIL) {
+                    // Mezmo promotes on "error" in message/keys — use errMessage key, sanitized.
+                    const errMessage = sanitizeMezmoMessage(error instanceof Error ? error.message : String(error));
+                    log.softFail('Tool execution soft-failed for task', {
+                        taskId,
+                        toolName: tool.name,
+                        toolStatus,
+                        mcpSessionId,
+                        failureCategory: callDiagnostics.failure_category,
+                        failureHttpStatus: callDiagnostics.failure_http_status,
+                        actorName: callDiagnostics.actor_name,
+                        errMessage,
+                    });
+                } else {
+                    log.error('Error executing tool for task', {
+                        taskId,
+                        toolName: tool.name,
+                        toolStatus,
+                        mcpSessionId,
+                        failureCategory: callDiagnostics.failure_category,
+                        failureHttpStatus: callDiagnostics.failure_http_status,
+                        actorName: callDiagnostics.actor_name,
+                        error,
+                    });
+                }
+                const { userText } = errorResult;
 
-        toolStatus = errorResult.toolStatus;
-        callDiagnostics = errorResult.callDiagnostics;
-        // Log level follows the already-classified toolStatus:
-        //   SOFT_FAIL (e.g. 402/403 user quota, client-side issues) → softFail
-        //   FAILED/ABORTED/other                                    → error
-        if (toolStatus === TOOL_STATUS.SOFT_FAIL) {
-            // Mezmo promotes on "error" in message/keys — use errMessage key, sanitized.
-            const errMessage = sanitizeMezmoMessage(error instanceof Error ? error.message : String(error));
-            log.softFail('Tool execution soft-failed for task', {
-                taskId,
-                toolName: tool.name,
-                toolStatus,
-                mcpSessionId,
-                failureCategory: callDiagnostics.failure_category,
-                failureHttpStatus: callDiagnostics.failure_http_status,
-                actorName: callDiagnostics.actor_name,
-                errMessage,
-            });
-        } else {
-            log.error('Error executing tool for task', {
-                taskId,
-                toolName: tool.name,
-                toolStatus,
-                mcpSessionId,
-                failureCategory: callDiagnostics.failure_category,
-                failureHttpStatus: callDiagnostics.failure_http_status,
-                actorName: callDiagnostics.actor_name,
-                error,
-            });
-        }
-        const { userText } = errorResult;
+                // Check if task was cancelled before storing result
+                if (await skipIfTaskCancelled(', skipping result storage', toolStatus, callDiagnostics)) return;
 
-        // Check if task was cancelled before storing result
-        if (await skipIfTaskCancelled(', skipping result storage', toolStatus, callDiagnostics)) return;
-
-        log.debug('[executeToolAndUpdateTask] Storing failed result', {
-            taskId,
-            mcpSessionId,
-        });
-        // Nudge on a genuinely-failed task result (mirrors the completed path and the sync
-        // captureResult). INTERNAL_ERROR and an unknown category get the full nudge; a genuine
-        // INVALID_INPUT gets the softer nudge; payment (402) is suppressed via the HTTP status and
-        // AUTH / PERMISSION_APPROVAL_REQUIRED via NON_NUDGE_FAILURE_CATEGORIES. The 402 branch above
-        // returns before reaching here, so this only sees non-payment failures.
-        const failedResult = withReportProblemNudge({
-            result: {
-                content: [
-                    {
-                        type: 'text' as const,
-                        text: userText,
+                log.debug('[executeToolAndUpdateTask] Storing failed result', {
+                    taskId,
+                    mcpSessionId,
+                });
+                // Nudge on a genuinely-failed task result (mirrors the completed path and the sync
+                // captureResult). INTERNAL_ERROR and an unknown category get the full nudge; a genuine
+                // INVALID_INPUT gets the softer nudge; payment (402) is suppressed via the HTTP status and
+                // AUTH / PERMISSION_APPROVAL_REQUIRED via NON_NUDGE_FAILURE_CATEGORIES. The 402 branch above
+                // returns before reaching here, so this only sees non-payment failures.
+                const failedResult = withReportProblemNudge({
+                    result: {
+                        content: [
+                            {
+                                type: 'text' as const,
+                                text: userText,
+                            },
+                        ],
+                        isError: true,
+                        internalToolStatus: toolStatus,
                     },
-                ],
-                isError: true,
-                internalToolStatus: toolStatus,
-            },
-            tools: apifyMcpServer.tools,
-            failingToolName: tool.name,
-            failureCategory: callDiagnostics.failure_category,
-            failureHttpStatus: callDiagnostics.failure_http_status,
-        });
-        await completeTask('failed', failedResult, toolStatus, callDiagnostics);
+                    tools: apifyMcpServer.tools,
+                    failingToolName: tool.name,
+                    failureCategory: callDiagnostics.failure_category,
+                    failureHttpStatus: callDiagnostics.failure_http_status,
+                });
+                await completeTask('failed', failedResult, toolStatus, callDiagnostics);
+                break;
+            }
+            default:
+                // Compile-time exhaustiveness guard (same `satisfies never` idiom as dispatchToolCall's
+                // default arm): a new TOOL_CALL_ERROR_KIND makes `errorResult` non-`never` here and fails
+                // to compile. Unreachable at runtime.
+                throw new McpError(
+                    ErrorCode.InvalidParams,
+                    `Unknown tool-call error kind "${(errorResult satisfies never as ToolCallErrorResult).kind}"`,
+                );
+        }
     } finally {
         cancelWatcher.dispose();
     }

--- a/src/mcp/tool_call_error_mapper.ts
+++ b/src/mcp/tool_call_error_mapper.ts
@@ -83,7 +83,7 @@ export function buildToolCallErrorResult(error: unknown, params: ToolCallErrorPa
         };
     }
 
-    const { toolStatus, callDiagnostics } = buildExecutionDiagnostics(error, isAborted, actorName, actorId);
+    const { toolStatus, callDiagnostics } = buildExecutionDiagnostics({ error, isAborted, actorName, actorId });
     return {
         kind: TOOL_CALL_ERROR_KIND.EXECUTION,
         toolStatus,

--- a/src/mcp/tool_call_error_mapper.ts
+++ b/src/mcp/tool_call_error_mapper.ts
@@ -1,7 +1,6 @@
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
 import type { CallDiagnostics, ToolStatus } from '../types.js';
 import { isPermissionApprovalError } from '../utils/apify_errors.js';
-import { getHttpStatusCode } from '../utils/logging.js';
 import type { ToolResponse } from '../utils/mcp.js';
 import { getToolCallErrorUserText } from '../utils/mcp.js';
 import {
@@ -9,7 +8,7 @@ import {
     buildPermissionApprovalResponse,
     isX402PaymentRequiredError,
 } from '../utils/payment_errors.js';
-import { classifyFailureCategory, getToolStatusFromError } from '../utils/tool_status.js';
+import { buildExecutionDiagnostics } from '../utils/tool_status.js';
 import { buildActorFields } from '../utils/tools.js';
 
 /** Inputs the mapper can't derive itself — they differ per caller. */
@@ -57,7 +56,6 @@ export type ToolCallErrorResult =
  */
 export function buildToolCallErrorResult(error: unknown, params: ToolCallErrorParams): ToolCallErrorResult {
     const { toolName, actorName, actorId, isAborted } = params;
-    const httpStatus = getHttpStatusCode(error);
 
     if (isX402PaymentRequiredError(error)) {
         return {
@@ -85,16 +83,11 @@ export function buildToolCallErrorResult(error: unknown, params: ToolCallErrorPa
         };
     }
 
-    const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
+    const { toolStatus, callDiagnostics } = buildExecutionDiagnostics(error, isAborted, actorName, actorId);
     return {
         kind: TOOL_CALL_ERROR_KIND.EXECUTION,
-        toolStatus: getToolStatusFromError(error, isAborted),
-        callDiagnostics: {
-            failure_category: classifyFailureCategory(error),
-            ...(httpStatus !== undefined ? { failure_http_status: httpStatus } : {}),
-            failure_detail: failureDetail,
-            ...buildActorFields(actorName, actorId),
-        },
+        toolStatus,
+        callDiagnostics,
         userText: getToolCallErrorUserText(toolName, error),
     };
 }

--- a/src/mcp/tool_dispatch.ts
+++ b/src/mcp/tool_dispatch.ts
@@ -20,7 +20,7 @@ import { remoteMcpFailureDetail } from '../utils/apify_errors.js';
 import { logHttpError } from '../utils/logging.js';
 import { respondErrorNoTelemetry } from '../utils/mcp.js';
 import type { createProgressTracker } from '../utils/progress.js';
-import { applyToolTelemetry, classifyFailureCategory, getToolStatusFromError } from '../utils/tool_status.js';
+import { applyToolTelemetry, buildExecutionDiagnostics } from '../utils/tool_status.js';
 import { buildActorFields } from '../utils/tools.js';
 import { connectMCPClient } from './client.js';
 import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC } from './const.js';
@@ -193,14 +193,12 @@ export async function dispatchToolCall(params: {
 
                 result = { ...res };
             } catch (error) {
-                toolStatus = getToolStatusFromError(error, Boolean(extra.signal?.aborted));
-                const failureDetail =
-                    error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
-                callDiagnostics = {
-                    failure_category: classifyFailureCategory(error),
-                    failure_detail: failureDetail,
-                    ...buildActorFields(actorName, actorId),
-                };
+                ({ toolStatus, callDiagnostics } = buildExecutionDiagnostics(
+                    error,
+                    Boolean(extra.signal?.aborted),
+                    actorName,
+                    actorId,
+                ));
                 logHttpError(error, `Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}'`, {
                     actorId: tool.actorId,
                     toolName: tool.originToolName,

--- a/src/mcp/tool_dispatch.ts
+++ b/src/mcp/tool_dispatch.ts
@@ -193,12 +193,12 @@ export async function dispatchToolCall(params: {
 
                 result = { ...res };
             } catch (error) {
-                ({ toolStatus, callDiagnostics } = buildExecutionDiagnostics(
+                ({ toolStatus, callDiagnostics } = buildExecutionDiagnostics({
                     error,
-                    Boolean(extra.signal?.aborted),
+                    isAborted: Boolean(extra.signal?.aborted),
                     actorName,
                     actorId,
-                ));
+                }));
                 logHttpError(error, `Failed to call MCP tool '${tool.originToolName}' on Actor '${tool.actorId}'`, {
                     actorId: tool.actorId,
                     toolName: tool.originToolName,

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -102,6 +102,14 @@ export function classifyFailureCategory(error: unknown): FailureCategory {
     return FAILURE_CATEGORY.INTERNAL_ERROR;
 }
 
+/** Inputs for {@link buildExecutionDiagnostics}. */
+export type ExecutionDiagnosticsParams = {
+    error: unknown;
+    isAborted: boolean;
+    actorName: string | undefined;
+    actorId: string | undefined;
+};
+
 /**
  * Builds the execution-arm telemetry shared by the generic mapper's EXECUTION branch and the
  * ACTOR_MCP inner catch: the abort-aware `toolStatus`, plus `callDiagnostics` carrying
@@ -109,12 +117,11 @@ export function classifyFailureCategory(error: unknown): FailureCategory {
  * and the actor fields. Field set and order match the mapper's EXECUTION arm exactly. Callers add
  * their own `userText`/`response` and do their own logging.
  */
-export function buildExecutionDiagnostics(
-    error: unknown,
-    isAborted: boolean,
-    actorName: string | undefined,
-    actorId: string | undefined,
-): { toolStatus: ToolStatus; callDiagnostics: CallDiagnostics } {
+export function buildExecutionDiagnostics(params: ExecutionDiagnosticsParams): {
+    toolStatus: ToolStatus;
+    callDiagnostics: CallDiagnostics;
+} {
+    const { error, isAborted, actorName, actorId } = params;
     const httpStatus = getHttpStatusCode(error);
     const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
     return {

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -102,6 +102,32 @@ export function classifyFailureCategory(error: unknown): FailureCategory {
     return FAILURE_CATEGORY.INTERNAL_ERROR;
 }
 
+/**
+ * Builds the execution-arm telemetry shared by the generic mapper's EXECUTION branch and the
+ * ACTOR_MCP inner catch: the abort-aware `toolStatus`, plus `callDiagnostics` carrying
+ * `failure_category`, the conditional `failure_http_status`, the 200-char-truncated `failure_detail`,
+ * and the actor fields. Field set and order match the mapper's EXECUTION arm exactly. Callers add
+ * their own `userText`/`response` and do their own logging.
+ */
+export function buildExecutionDiagnostics(
+    error: unknown,
+    isAborted: boolean,
+    actorName: string | undefined,
+    actorId: string | undefined,
+): { toolStatus: ToolStatus; callDiagnostics: CallDiagnostics } {
+    const httpStatus = getHttpStatusCode(error);
+    const failureDetail = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
+    return {
+        toolStatus: getToolStatusFromError(error, isAborted),
+        callDiagnostics: {
+            failure_category: classifyFailureCategory(error),
+            ...(httpStatus !== undefined ? { failure_http_status: httpStatus } : {}),
+            failure_detail: failureDetail,
+            ...buildActorFields(actorName, actorId),
+        },
+    };
+}
+
 const MAX_VALIDATION_FIELD_LENGTH = 120;
 
 function limitField(value: string | undefined): string | undefined {

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -1,5 +1,5 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import log from '@apify/log';
@@ -10,6 +10,11 @@ import type { ActorsMcpServer } from '../../src/mcp/server.js';
 import type { PaymentProvider } from '../../src/payments/types.js';
 import * as telemetry from '../../src/telemetry.js';
 import * as callActor from '../../src/tools/actors/call_actor.js';
+import {
+    REPORT_PROBLEM_INVALID_INPUT_NUDGE,
+    REPORT_PROBLEM_NUDGE,
+    reportProblem,
+} from '../../src/tools/dev/report_problem.js';
 import type { ToolEntry, ToolInputSchema } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
 import { compileSchema } from '../../src/utils/ajv.js';
@@ -412,6 +417,88 @@ describe('executeToolAndUpdateTask()', () => {
         );
         expect(trackSpy.mock.calls).toHaveLength(1);
         expect(trackSpy.mock.calls[0][2].tool_status).toBe(TOOL_STATUS.SUCCEEDED);
+    });
+
+    it('suppresses the report-problem nudge for a 402-carrying ACTOR_MCP task failure', async () => {
+        // Pins the accepted task-mode delta. The ACTOR_MCP dispatch catch now carries
+        // failure_http_status, so a contained remote 402 reaches withReportProblemNudge with
+        // failureHttpStatus === 402 and the nudge is suppressed (402 is a billing state, not a defect).
+        // If the ACTOR_MCP path stopped carrying failure_http_status, this INVALID_INPUT failure would
+        // instead append REPORT_PROBLEM_INVALID_INPUT_NUDGE and this test would fail.
+        await withServer(async (server) => {
+            silenceLogs();
+            const rejectingClient = {
+                callTool: vi.fn().mockRejectedValue(new McpError(402 as ErrorCode, 'remote 402')),
+                close: vi.fn().mockResolvedValue(undefined),
+                setNotificationHandler: vi.fn(),
+            } as unknown as Client;
+            vi.spyOn(mcpClient, 'connectMCPClient').mockResolvedValue(rejectingClient);
+            // report-problem must be served for the nudge to be a candidate at all (spread the frozen
+            // tool so server.close() can null its ajvValidate on teardown).
+            server.upsertTools([{ ...reportProblem }]);
+            const { task, result } = await runTaskAndReadBack(server, makeActorMcpTool());
+            expect(task.status).toBe('completed');
+            expect(result.isError).toBe(true);
+            const texts = (result.content as { text: string }[]).map((c) => c.text);
+            expect(texts.some((t) => t.includes('Failed to call MCP tool'))).toBe(true);
+            expect(texts).not.toContain(REPORT_PROBLEM_NUDGE);
+            expect(texts).not.toContain(REPORT_PROBLEM_INVALID_INPUT_NUDGE);
+        });
+    });
+});
+
+describe('ACTOR_MCP remote-McpError containment (sync tools/call catch)', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    /** A stub MCP client whose `callTool` rejects with `error`; connect/close/notify are no-ops. */
+    function stubRejectingClient(error: unknown): Client {
+        return {
+            callTool: vi.fn().mockRejectedValue(error),
+            close: vi.fn().mockResolvedValue(undefined),
+            setNotificationHandler: vi.fn(),
+        } as unknown as Client;
+    }
+
+    it('contains a remote McpError as a soft-fail result instead of re-throwing on the wire', async () => {
+        // The ACTOR_MCP inner catch seals the route: without it the McpError would reach the sync
+        // outer catch, which re-throws every McpError as a JSON-RPC error — so this test fails if the
+        // inner catch is removed (the handler would reject instead of resolving with a soft-fail body).
+        await withServer(async (server) => {
+            silenceLogs();
+            vi.spyOn(mcpClient, 'connectMCPClient').mockResolvedValue(
+                stubRejectingClient(new McpError(ErrorCode.InternalError, 'remote boom')),
+            );
+            const result = await runSync(server, makeActorMcpTool());
+            expect(result.isError).toBe(true);
+            expect((result.content as { text: string }[])[0].text).toContain('Failed to call MCP tool');
+        });
+    });
+
+    it('contains a remote 402-coded McpError as a soft-fail result, never a thrown payment error', async () => {
+        // A remote McpError with code 402 would classify as PAYMENT if it reached buildToolCallErrorResult
+        // (getHttpStatusCode falls through to `.code`). The inner catch keeps it a soft-fail execution
+        // result and it never surfaces as a thrown payment error — and the telemetry carries
+        // failure_http_status, which ACTOR_MCP execution failures now report like every other path.
+        const trackSpy = vi.spyOn(telemetry, 'trackToolCall').mockImplementation(() => {});
+        await withServer(
+            async (server) => {
+                silenceLogs();
+                vi.spyOn(mcpClient, 'connectMCPClient').mockResolvedValue(
+                    stubRejectingClient(new McpError(402 as ErrorCode, 'remote 402')),
+                );
+                const result = await runSync(server, makeActorMcpTool());
+                expect(result.isError).toBe(true);
+                expect((result.content as { text: string }[])[0].text).toContain('Failed to call MCP tool');
+                // Not the x402 payment response shape (no structuredContent payload).
+                expect(result.structuredContent).toBeUndefined();
+            },
+            { token: undefined, telemetry: { enabled: true }, allowUnauthMode: true },
+        );
+        expect(trackSpy.mock.calls).toHaveLength(1);
+        const properties = trackSpy.mock.calls[0][2];
+        expect(properties.tool_status).toBe(TOOL_STATUS.SOFT_FAIL);
+        expect(properties.failure_http_status).toBe(402);
+        expect(properties.failure_category).toBe(FAILURE_CATEGORY.INVALID_INPUT);
     });
 });
 

--- a/tests/unit/utils.tool_status.test.ts
+++ b/tests/unit/utils.tool_status.test.ts
@@ -3,9 +3,11 @@ import type { ActorRun } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
+import { buildToolCallErrorResult, TOOL_CALL_ERROR_KIND } from '../../src/mcp/tool_call_error_mapper.js';
 import { buildStartRunResponse } from '../../src/tools/actors/actor_run_response.js';
 import {
     applyToolTelemetry,
+    buildExecutionDiagnostics,
     classifyFailureCategory,
     deriveResourceIds,
     extractAjvErrorDetails,
@@ -87,6 +89,47 @@ describe('classifyFailureCategory', () => {
     it('classifies the concurrent-run limit as INVALID_INPUT even when wrapped as a 5xx', () => {
         const error = Object.assign(new Error('Streamable HTTP error: cannot-start-actor-runs'), { statusCode: 500 });
         expect(classifyFailureCategory(error)).toBe(FAILURE_CATEGORY.INVALID_INPUT);
+    });
+});
+
+describe('buildExecutionDiagnostics', () => {
+    const ACTOR_NAME = 'apify/web-scraper';
+    const ACTOR_ID = 'abc123';
+
+    it('includes failure_http_status for an HTTP-range-status error', () => {
+        const error = Object.assign(new Error('server exploded'), { statusCode: 500 });
+        const { toolStatus, callDiagnostics } = buildExecutionDiagnostics(error, false, ACTOR_NAME, ACTOR_ID);
+
+        expect(toolStatus).toBe(TOOL_STATUS.FAILED);
+        expect(callDiagnostics.failure_http_status).toBe(500);
+        expect(callDiagnostics.failure_detail).toBe('server exploded');
+    });
+
+    it('omits failure_http_status when the error carries no HTTP status', () => {
+        const { callDiagnostics } = buildExecutionDiagnostics(new Error('no status'), false, ACTOR_NAME, ACTOR_ID);
+        expect(callDiagnostics).not.toHaveProperty('failure_http_status');
+        expect(callDiagnostics.failure_detail).toBe('no status');
+    });
+
+    it('truncates failure_detail to 200 chars', () => {
+        const { callDiagnostics } = buildExecutionDiagnostics(new Error('x'.repeat(300)), false, undefined, undefined);
+        expect(callDiagnostics.failure_detail).toHaveLength(200);
+    });
+
+    it('yields callDiagnostics identical to the mapper execution arm for the same error', () => {
+        // Both the ACTOR_MCP catch and the generic mapper now share this builder, so their execution
+        // diagnostics must be identical for the same input (the whole point of the extraction).
+        const error = Object.assign(new Error('server exploded'), { statusCode: 500 });
+        const fromBuilder = buildExecutionDiagnostics(error, false, ACTOR_NAME, ACTOR_ID).callDiagnostics;
+        const fromMapper = buildToolCallErrorResult(error, {
+            toolName: 'test-tool',
+            actorName: ACTOR_NAME,
+            actorId: ACTOR_ID,
+            isAborted: false,
+        });
+
+        expect(fromMapper.kind).toBe(TOOL_CALL_ERROR_KIND.EXECUTION);
+        expect(fromBuilder).toEqual(fromMapper.callDiagnostics);
     });
 });
 

--- a/tests/unit/utils.tool_status.test.ts
+++ b/tests/unit/utils.tool_status.test.ts
@@ -98,7 +98,12 @@ describe('buildExecutionDiagnostics', () => {
 
     it('includes failure_http_status for an HTTP-range-status error', () => {
         const error = Object.assign(new Error('server exploded'), { statusCode: 500 });
-        const { toolStatus, callDiagnostics } = buildExecutionDiagnostics(error, false, ACTOR_NAME, ACTOR_ID);
+        const { toolStatus, callDiagnostics } = buildExecutionDiagnostics({
+            error,
+            isAborted: false,
+            actorName: ACTOR_NAME,
+            actorId: ACTOR_ID,
+        });
 
         expect(toolStatus).toBe(TOOL_STATUS.FAILED);
         expect(callDiagnostics.failure_http_status).toBe(500);
@@ -106,13 +111,23 @@ describe('buildExecutionDiagnostics', () => {
     });
 
     it('omits failure_http_status when the error carries no HTTP status', () => {
-        const { callDiagnostics } = buildExecutionDiagnostics(new Error('no status'), false, ACTOR_NAME, ACTOR_ID);
+        const { callDiagnostics } = buildExecutionDiagnostics({
+            error: new Error('no status'),
+            isAborted: false,
+            actorName: ACTOR_NAME,
+            actorId: ACTOR_ID,
+        });
         expect(callDiagnostics).not.toHaveProperty('failure_http_status');
         expect(callDiagnostics.failure_detail).toBe('no status');
     });
 
     it('truncates failure_detail to 200 chars', () => {
-        const { callDiagnostics } = buildExecutionDiagnostics(new Error('x'.repeat(300)), false, undefined, undefined);
+        const { callDiagnostics } = buildExecutionDiagnostics({
+            error: new Error('x'.repeat(300)),
+            isAborted: false,
+            actorName: undefined,
+            actorId: undefined,
+        });
         expect(callDiagnostics.failure_detail).toHaveLength(200);
     });
 
@@ -120,7 +135,12 @@ describe('buildExecutionDiagnostics', () => {
         // Both the ACTOR_MCP catch and the generic mapper now share this builder, so their execution
         // diagnostics must be identical for the same input (the whole point of the extraction).
         const error = Object.assign(new Error('server exploded'), { statusCode: 500 });
-        const fromBuilder = buildExecutionDiagnostics(error, false, ACTOR_NAME, ACTOR_ID).callDiagnostics;
+        const fromBuilder = buildExecutionDiagnostics({
+            error,
+            isAborted: false,
+            actorName: ACTOR_NAME,
+            actorId: ACTOR_ID,
+        }).callDiagnostics;
         const fromMapper = buildToolCallErrorResult(error, {
             toolName: 'test-tool',
             actorName: ACTOR_NAME,


### PR DESCRIPTION
## Why

Closes #1104. Part of #658. Three follow-up findings from #1081: ACTOR_MCP failures omitted `failure_http_status` (telemetry drifted by path), the kind-dispatch reached EXECUTION by fall-through with no compile-time guard, and the McpError-containment invariant had no test.

## What changed

- Extracted the execution-diagnostics construction into one builder (`buildExecutionDiagnostics`, `utils/tool_status.ts`); the mapper's EXECUTION arm and the ACTOR_MCP catch both delegate, so ACTOR_MCP now reports `failure_http_status`. Not `buildToolCallErrorResult` wholesale — a 402 `McpError` must stay soft-fail, not reclassify as payment.
- Both catches dispatch via `switch (errorResult.kind)` with a `satisfies never` default; a 4th kind now fails type-check.
- Added a handler-level test driving a real rejecting `McpError` (incl. 402) through the sealed ACTOR_MCP route.

Intended side effect: an ACTOR_MCP **task-mode** 402 now suppresses the report-problem nudge (per the global 402-is-billing rule), where it previously appended it. Pinned by a test.

**internal impact:** `failure_http_status` now appears on ACTOR_MCP soft-fail telemetry — contract `apify-mcp-server-internal` consumes; may need a matching test.

## Out of scope (conscious, not gaps)

- Catch **sinks** not unified — only the diagnostics builder is shared; owned by #658.
- ACTOR_MCP `isError` TODO, the `server.ts` 1k-line ceiling, and the task-vs-sync nudge asymmetry all predate this change and are left alone.

## Notes for reviewers (human-written)

<!-- your own words -->

## Proof it works

type-check / lint / `test:unit` (1120 passed, 1 skipped) / check:agents green. The containment tests (incl. 402) and the task-mode nudge test were each shown red→green.