### PR TITLE
feat!: Cut off add-actor tool selection, substitute call-actor

### DIFF
--- a/.claude/agents/mcpc-tester.md
+++ b/.claude/agents/mcpc-tester.md
@@ -23,7 +23,7 @@ You are a development testing agent for the Apify MCP server. Your job is to bui
 | Session | Transport | When to use |
 |---|---|---|
 | `@stdio` | `node dist/stdio.js` | Default — core tools only |
-| `@stdio-full` | `node dist/stdio.js --tools=...` | When you need non-default tools (add-actor, all categories, specific actors) |
+| `@stdio-full` | `node dist/stdio.js --tools=...` | When you need non-default tools (call-actor via experimental, all categories, specific actors) |
 | `@dev` | `http://localhost:3001` | Widget / UI mode, or when you need **server logs** — requires `pnpm run dev` running |
 
 Server arguments come from `.mcp.json` — you cannot pass them inline. To test a different server configuration, add a new named entry to `.mcp.json` with the desired `args`, then connect it as a new session.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Here is an overview list of all the tools provided by the Apify MCP Server.
 
 Legend for the **Enabled by default** column:
 - ✅ — in the default tool set.
-- ⚡ — auto-injected when `call-actor`, `add-actor`, an Actor tool, or `get-actor-run` is present (which is true in the default configuration).
+- ⚡ — auto-injected when `call-actor`, an Actor tool, or `get-actor-run` is present (which is true in the default configuration).
 - ✅¹ — served by default, but only when telemetry is enabled and the client is not withheld: Anthropic surfaces (Claude.ai / Claude Desktop / Claude Code) or `local-agent-mode-apify`. To disable, pass an explicit `tools=` list that omits it.
 
 | Tool name | Category | Description | Enabled by default |
@@ -266,11 +266,10 @@ Legend for the **Enabled by default** column:
 | `get-key-value-store-keys`| storage | List the keys within a specific key-value store. |  |
 | `get-dataset-list` | storage | List all available datasets for the user. |  |
 | `get-key-value-store-list`| storage | List all available key-value stores for the user. |  |
-| `add-actor` | experimental | Add an Actor as a new tool for the user to call. |  |
 
 > **Note:**
 >
-> When `call-actor`, `add-actor`, an Actor tool, or `get-actor-run` is present, the server auto-injects `get-actor-run`, `get-dataset-items`, `get-key-value-store-record`, and `abort-actor-run`.
+> When `call-actor`, an Actor tool, or `get-actor-run` is present, the server auto-injects `get-actor-run`, `get-dataset-items`, `get-key-value-store-record`, and `abort-actor-run`.
 >
 > When you call an Actor — through `call-actor` or directly via an Actor tool (e.g., `apify--rag-web-browser`) — the response contains run metadata, storage IDs, and a `summary` + `nextStep`, but no dataset items. To fetch items, follow `nextStep` and call `get-dataset-items` (auto-injected), passing the `datasetId` returned from the call.
 
@@ -284,7 +283,7 @@ All tools include metadata annotations to help MCP clients and LLMs understand t
 
 ### Tools configuration
 
-The `tools` configuration parameter is used to specify loaded tools – either categories or specific tools directly, and Apify Actors. For example, `tools=storage,runs` loads two categories; `tools=add-actor` loads just one tool.
+The `tools` configuration parameter is used to specify loaded tools – either categories or specific tools directly, and Apify Actors. For example, `tools=storage,runs` loads two categories; `tools=call-actor` loads just one tool.
 
 When no query parameters are provided, the MCP server loads the following `tools` by default:
 
@@ -380,13 +379,14 @@ The v2 configuration preserves backward compatibility with v1 usage. Notes:
   - Internally they are merged into `tools` selectors.
   - Examples: `?actors=apify/rag-web-browser` ≡ `?tools=apify/rag-web-browser`; `--actors apify/rag-web-browser` ≡ `--tools apify/rag-web-browser`.
 - `enable-adding-actors` (CLI) and `enableAddingActors` (URL) are supported but deprecated.
-  - Prefer `tools=experimental` or including the specific tool `tools=add-actor`.
-  - Behavior remains: when enabled with no `tools` specified, the server exposes only `add-actor`; when categories/tools are selected, `add-actor` is also included.
+  - Prefer including the specific tool `tools=call-actor` (default via the `actors` category).
+  - `add-actor` is no longer selectable, on any surface, for new connections — `call-actor` is substituted in its place: when enabled with no `tools` specified, the server exposes only `call-actor`; when categories/tools are selected, `call-actor` is also included.
 - `enableActorAutoLoading` remains as a legacy alias for `enableAddingActors` and is mapped automatically.
 - Defaults remain compatible: when no `tools` are specified, the server loads `actors`, `docs`, and `apify/rag-web-browser`.
   - If any `tools` are specified, the defaults are not added (same as v1 intent for explicit selection).
 - `call-actor` is now included by default via the `actors` category (additive change). To exclude it, specify an explicit `tools` list without `actors`.
 - `preview` category is deprecated and removed. Use specific tool names instead.
+- `tools=add-actor` and `tools=experimental` are no longer selectable for new connections — `call-actor` is substituted at selection time. Use `tools=call-actor` (or the default `actors` category) instead.
 
 Existing URLs and commands using `?actors=...` or `--actors` continue to work unchanged.
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ The v2 configuration preserves backward compatibility with v1 usage. Notes:
   - Examples: `?actors=apify/rag-web-browser` ≡ `?tools=apify/rag-web-browser`; `--actors apify/rag-web-browser` ≡ `--tools apify/rag-web-browser`.
 - `enable-adding-actors` (CLI) and `enableAddingActors` (URL) are supported but deprecated.
   - Prefer including the specific tool `tools=call-actor` (default via the `actors` category).
-  - `add-actor` is no longer selectable, on any surface, for new connections — `call-actor` is substituted in its place: when enabled with no `tools` specified, the server exposes only `call-actor`; when categories/tools are selected, `call-actor` is also included.
+  - `add-actor` is no longer selectable for new connections on any surface — `call-actor` is substituted in its place, same enabled/alongside-other-tools behavior as before.
 - `enableActorAutoLoading` remains as a legacy alias for `enableAddingActors` and is mapped automatically.
 - Defaults remain compatible: when no `tools` are specified, the server loads `actors`, `docs`, and `apify/rag-web-browser`.
   - If any `tools` are specified, the defaults are not added (same as v1 intent for explicit selection).

--- a/evals/workflows/README.md
+++ b/evals/workflows/README.md
@@ -101,7 +101,7 @@ for (const test of tests) {
 
 **Why:**
 - MCP server supports dynamic tool registration at runtime
-- `add-actor` tool can register new Actor tools mid-conversation
+- a restored pre-cutover session may still have `add-actor` loaded and register new Actor tools mid-conversation (`add-actor` itself is no longer selectable for new sessions)
 - LLM must see updated tool list to use new tools
 
 **Implementation:**
@@ -490,7 +490,7 @@ Unlike typical function calling:
 
 ### Dynamic Tool Registration
 
-- `add-actor` dynamically registers new Actor tools
+- a restored pre-cutover session's `add-actor` could dynamically register new Actor tools (no longer selectable for new sessions)
 - Tool list NOT static
 - Must refresh after tool execution
 
@@ -526,7 +526,7 @@ Format must be exact for LLM context understanding.
 **Solution:** ✅ Isolated MCP instances per test.
 
 ### LLM can't use newly added tool
-**Symptom:** Agent uses `add-actor` but can't call new tool.<br>
+**Symptom:** Agent uses a dynamically-registered tool (e.g. a restored session's `add-actor`) but can't call new tool.<br>
 **Solution:** ✅ Dynamic tool fetching per turn.
 
 ### Judge too strict/lenient

--- a/evals/workflows/conversation_executor.ts
+++ b/evals/workflows/conversation_executor.ts
@@ -165,9 +165,8 @@ export async function executeConversation(options: ConversationExecutorOptions):
         turns.push(turn);
 
         // Refresh tools after executing tool calls
-        // Tools can change dynamically for a restored pre-cutover session (e.g. one that
-        // still has add-actor loaded); add-actor is no longer selectable for new sessions.
-        // Fetch fresh tools from MCP server for next turn
+        // Tools can still change dynamically for a restored pre-cutover session with add-actor
+        // loaded (no longer selectable for new sessions). Fetch fresh tools for next turn
         tools = mcpToolsToOpenAiTools(mcpClient.getTools());
     }
 

--- a/evals/workflows/conversation_executor.ts
+++ b/evals/workflows/conversation_executor.ts
@@ -165,7 +165,8 @@ export async function executeConversation(options: ConversationExecutorOptions):
         turns.push(turn);
 
         // Refresh tools after executing tool calls
-        // Tools can change dynamically (e.g., add-actor adds new tools)
+        // Tools can change dynamically for a restored pre-cutover session (e.g. one that
+        // still has add-actor loaded); add-actor is no longer selectable for new sessions.
         // Fetch fresh tools from MCP server for next turn
         tools = mcpToolsToOpenAiTools(mcpClient.getTools());
     }

--- a/evals/workflows/test_cases.json
+++ b/evals/workflows/test_cases.json
@@ -9,10 +9,10 @@
     },
     {
       "id": "search-add-call-python-actor",
-      "tools": ["add-actor", "actors"],
+      "tools": ["actors"],
       "category": "call",
-      "query": "Find example Python Actor and add it to the MCP server and then call it with random sample input and present the results",
-      "reference": "The agent must find apify/python-example Actor or any similar and add it to the MCP server using the add-actor tool. Then, it must call the added Actor with sample input and return the output."
+      "query": "Find example Python Actor and call it with random sample input and present the results",
+      "reference": "The agent must find apify/python-example Actor or any similar and call it using the call-actor tool with sample input, and return the output."
     },
     {
       "id": "instagram-posts",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -500,8 +500,7 @@ export class ActorsMcpServer {
             paymentProvider: this.options.paymentProvider,
         });
 
-        // `isRestore: true` — bypasses the add-actor→call-actor selector cutoff (PR 0) so a
-        // pre-cutoff session's stored `'add-actor'` name resolves to itself, not the substitute.
+        // isRestore: true — a stored 'add-actor' name must resolve to itself, not the PR 0 substitute.
         this.registerFetchedActorTools(restoreInput, actorTools, actorTools.length > 0, true);
     }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -174,7 +174,7 @@ export class ActorsMcpServer {
      * We capture the exact actor-tool slice fetched for each request so the flush composes every
      * entry against *its own* actor list rather than the accumulated union across unrelated requests.
      */
-    private pendingToolsUntilClientKnown: { input: Input; actorTools: ToolEntry[] }[] = [];
+    private pendingToolsUntilClientKnown: { input: Input; actorTools: ToolEntry[]; isRestore: boolean }[] = [];
 
     // Telemetry configuration (resolved from options and env vars, see setupTelemetry)
     public readonly telemetryEnabled: boolean;
@@ -348,8 +348,8 @@ export class ActorsMcpServer {
      * (loadActorsAsTools upserts actor tools directly; actor tools are never gated, so they need no
      * filtering.)
      */
-    private composeToolsForClient(input: Input, actorTools: ToolEntry[]): ToolEntry[] {
-        const tools = getToolsForServerMode(input, actorTools, this.serverMode);
+    private composeToolsForClient(input: Input, actorTools: ToolEntry[], isRestore = false): ToolEntry[] {
+        const tools = getToolsForServerMode(input, actorTools, this.serverMode, isRestore);
         if (this.isReportProblemServable()) return tools;
         return tools.filter((tool) => tool.name !== HELPER_TOOLS.PROBLEM_REPORT);
     }
@@ -374,8 +374,8 @@ export class ActorsMcpServer {
     private composePendingToolsForClient(): void {
         if (this.pendingToolsUntilClientKnown.length === 0) return;
 
-        const tools = this.pendingToolsUntilClientKnown.flatMap(({ input, actorTools }) =>
-            this.composeToolsForClient(input, actorTools),
+        const tools = this.pendingToolsUntilClientKnown.flatMap(({ input, actorTools, isRestore }) =>
+            this.composeToolsForClient(input, actorTools, isRestore),
         );
 
         this.pendingToolsUntilClientKnown = [];
@@ -468,15 +468,20 @@ export class ActorsMcpServer {
      * (notify only when actor tools were fetched), while `loadToolsFromUrl` and `loadToolsFromInput`
      * pass `false` and defer to the post-initialize reconcile. See `composePendingToolsForClient`.
      */
-    private registerFetchedActorTools(input: Input, actorTools: ToolEntry[], shouldNotify: boolean): void {
+    private registerFetchedActorTools(
+        input: Input,
+        actorTools: ToolEntry[],
+        shouldNotify: boolean,
+        isRestore = false,
+    ): void {
         if (!this.serverModeResolved) {
-            this.pendingToolsUntilClientKnown.push({ input, actorTools });
+            this.pendingToolsUntilClientKnown.push({ input, actorTools, isRestore });
             if (actorTools.length > 0) this.upsertTools(actorTools, shouldNotify);
             return;
         }
-        const tools = this.composeToolsForClient(input, actorTools);
+        const tools = this.composeToolsForClient(input, actorTools, isRestore);
         if (tools.length > 0) this.upsertTools(tools, shouldNotify);
-        if (!this.clientKnown) this.pendingToolsUntilClientKnown.push({ input, actorTools });
+        if (!this.clientKnown) this.pendingToolsUntilClientKnown.push({ input, actorTools, isRestore });
     }
 
     /**
@@ -495,7 +500,9 @@ export class ActorsMcpServer {
             paymentProvider: this.options.paymentProvider,
         });
 
-        this.registerFetchedActorTools(restoreInput, actorTools, actorTools.length > 0);
+        // `isRestore: true` — bypasses the add-actor→call-actor selector cutoff (PR 0) so a
+        // pre-cutoff session's stored `'add-actor'` name resolves to itself, not the substitute.
+        this.registerFetchedActorTools(restoreInput, actorTools, actorTools.length > 0, true);
     }
 
     /**

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -101,13 +101,13 @@ const argv = yargs(hideBin(process.argv))
         type: 'boolean',
         default: false,
         describe: `Enable dynamically adding Actors as tools based on user requests. Can also be set via ENABLE_ADDING_ACTORS environment variable.
-Deprecated: use tools add-actor instead.`,
+Deprecated: use tools call-actor instead.`,
     })
     .option('enableActorAutoLoading', {
         type: 'boolean',
         default: false,
         hidden: true,
-        describe: 'Deprecated: Use tools add-actor instead.',
+        describe: 'Deprecated: Use tools call-actor instead.',
     })
     .options('tools', {
         type: 'string',

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -180,12 +180,9 @@ export function toolNamesToInput(toolNames: string[]): Input {
 /**
  * Compose the final tool list from pre-fetched actor tools and the original input for the given mode.
  *
- * @param isRestore - `true` when `input` was reconstructed from a session's already-stored tool
- * names (`toolNamesToInput()`, via `loadToolsByName()`), as opposed to a live tool selector on a
- * new connection. A stored name legitimately contains the literal string `'add-actor'` for
- * sessions that predate the PR 0 cutoff below — restore must resolve it to itself, not
- * re-run it through the same substitution a fresh selector gets. Defaults to `false` (a live
- * selector) for every other caller.
+ * @param isRestore - `true` for a session restore (`toolNamesToInput()` via `loadToolsByName()`),
+ * as opposed to a live selector. A restored session's stored name can be `'add-actor'` from before
+ * the PR 0 cutoff below — it must resolve to itself, not get substituted like a fresh selector.
  */
 export function getToolsForServerMode(
     input: Input,
@@ -227,11 +224,8 @@ export function getToolsForServerMode(
                 continue;
             }
 
-            // `add-actor` cutoff (PR 0): a fresh `tools=add-actor` selector or the `experimental`
-            // category (whose sole member is `add-actor`) resolves to `call-actor` instead, on
-            // every new connection. A restored session's own stored `'add-actor'` name is not a
-            // live selector — it falls through to the unchanged lookups below and resolves to
-            // itself, exactly as before this cutoff.
+            // add-actor cutoff (PR 0): substitute call-actor for a live 'add-actor'/'experimental'
+            // selector. Skipped on restore, where `sel` may be a pre-cutoff session's own stored name.
             if (!isRestore && (sel === HELPER_TOOLS.ACTOR_ADD || sel === 'experimental')) {
                 if (callActorTool) internalSelections.push(callActorTool);
                 continue;
@@ -262,10 +256,8 @@ export function getToolsForServerMode(
     // Internal tools
     if (selectors !== undefined) {
         result.push(...internalSelections);
-        // `enableAddingActors` cutoff (PR 0): a live selector never sets this on a restored
-        // session's input (`toolNamesToInput()` never populates it), so this branch only ever
-        // runs for a new connection — ensure `call-actor` (add-actor's substitute) is available
-        // alongside selected tools.
+        // enableAddingActors cutoff (PR 0): substitute call-actor for add-actor. Restore inputs never
+        // set this flag (toolNamesToInput() doesn't), so this only fires for a live connection.
         if (addActorEnabled && !selectorsExplicitEmpty && !actorsExplicitlyEmpty) {
             const hasCallActor = result.some((e) => e.name === callActorTool?.name);
             if (callActorTool && !hasCallActor) result.push(callActorTool);

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -9,7 +9,6 @@ import log from '@apify/log';
 
 import { defaults, HELPER_TOOLS, type HelperToolName } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
-import { addActor } from '../tools/actors/add_actor.js';
 import { reportProblem } from '../tools/dev/report_problem.js';
 import { getActorsAsTools } from '../tools/index.js';
 import {
@@ -178,11 +177,21 @@ export function toolNamesToInput(toolNames: string[]): Input {
     return input;
 }
 
-/** Compose the final tool list from pre-fetched actor tools and the original input for the given mode. */
+/**
+ * Compose the final tool list from pre-fetched actor tools and the original input for the given mode.
+ *
+ * @param isRestore - `true` when `input` was reconstructed from a session's already-stored tool
+ * names (`toolNamesToInput()`, via `loadToolsByName()`), as opposed to a live tool selector on a
+ * new connection. A stored name legitimately contains the literal string `'add-actor'` for
+ * sessions that predate the PR 0 cutoff below — restore must resolve it to itself, not
+ * re-run it through the same substitution a fresh selector gets. Defaults to `false` (a live
+ * selector) for every other caller.
+ */
 export function getToolsForServerMode(
     input: Input,
     actorTools: ToolEntry[],
     mode: SERVER_MODE = SERVER_MODE.DEFAULT,
+    isRestore = false,
 ): ToolEntry[] {
     // Build mode-resolved categories — tools are already the correct variant for this mode
     const categories = getCategoryTools(mode);
@@ -204,6 +213,8 @@ export function getToolsForServerMode(
         }
     }
 
+    const callActorTool = toolsByName.get(HELPER_TOOLS.ACTOR_CALL);
+
     // Walk selectors for internal picks (mode-specific). Actor-name classification
     // happened in `resolveActorsToLoad`; we don't need to partition again here.
     const internalSelections: ToolEntry[] = [];
@@ -212,7 +223,16 @@ export function getToolsForServerMode(
             if (sel === 'preview') {
                 // 'preview' category is deprecated. It contained `call-actor` which is now default.
                 log.warning('Tool category "preview" is deprecated');
-                const callActorTool = toolsByName.get(HELPER_TOOLS.ACTOR_CALL);
+                if (callActorTool) internalSelections.push(callActorTool);
+                continue;
+            }
+
+            // `add-actor` cutoff (PR 0): a fresh `tools=add-actor` selector or the `experimental`
+            // category (whose sole member is `add-actor`) resolves to `call-actor` instead, on
+            // every new connection. A restored session's own stored `'add-actor'` name is not a
+            // live selector — it falls through to the unchanged lookups below and resolves to
+            // itself, exactly as before this cutoff.
+            if (!isRestore && (sel === HELPER_TOOLS.ACTOR_ADD || sel === 'experimental')) {
                 if (callActorTool) internalSelections.push(callActorTool);
                 continue;
             }
@@ -242,14 +262,17 @@ export function getToolsForServerMode(
     // Internal tools
     if (selectors !== undefined) {
         result.push(...internalSelections);
-        // If add-actor mode is enabled, ensure add-actor tool is available alongside selected tools.
+        // `enableAddingActors` cutoff (PR 0): a live selector never sets this on a restored
+        // session's input (`toolNamesToInput()` never populates it), so this branch only ever
+        // runs for a new connection — ensure `call-actor` (add-actor's substitute) is available
+        // alongside selected tools.
         if (addActorEnabled && !selectorsExplicitEmpty && !actorsExplicitlyEmpty) {
-            const hasAddActor = result.some((e) => e.name === addActor.name);
-            if (!hasAddActor) result.push(addActor);
+            const hasCallActor = result.some((e) => e.name === callActorTool?.name);
+            if (callActorTool && !hasCallActor) result.push(callActorTool);
         }
     } else if (addActorEnabled && !actorsExplicitlyEmpty) {
-        // No selectors: either expose only add-actor (when enabled), or default categories
-        result.push(addActor);
+        // No selectors: either expose only call-actor (add-actor substitution, when enabled) or default categories
+        if (callActorTool) result.push(callActorTool);
     } else if (!actorsExplicitlyEmpty) {
         // Use mode-resolved default categories
         for (const cat of toolCategoriesEnabledByDefault) {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -4,7 +4,6 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import type { ClientCapabilities } from '@modelcontextprotocol/sdk/types.js';
 import { expect } from 'vitest';
 
-import { HELPER_TOOLS } from '../src/const.js';
 import type { TelemetryEnv, ToolCategory } from '../src/types.js';
 
 export type McpClientOptions = {
@@ -155,20 +154,6 @@ export async function createMcpStdioClient(options?: McpClientOptions): Promise<
     await client.connect(transport);
 
     return client;
-}
-
-/**
- * Adds an Actor as a tool using the ADD_ACTOR helper tool.
- * @param client - MCP client instance
- * @param actor - Actor ID or full name in the format "username/name", e.g., "apify/rag-web-browser".
- */
-export async function addActor(client: Client, actor: string): Promise<void> {
-    await client.callTool({
-        name: HELPER_TOOLS.ACTOR_ADD,
-        arguments: {
-            actor,
-        },
-    });
 }
 
 /**

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import log from '@apify/log';
 
 import { ApifyClient } from '../../src/apify_client.js';
+import { HELPER_TOOLS } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/index.js';
 import { actorNameToToolName } from '../../src/tools/actor_tool_naming.js';
 import { addActor } from '../../src/tools/actors/add_actor.js';
@@ -39,10 +40,11 @@ describe('MCP server internals integration tests', () => {
         actorsMcpServer.upsertTools(newTool);
 
         const names = actorsMcpServer.listAllToolNames();
-        // enableAddingActors=true seeds add-actor + 4 auto-injected helpers (get-actor-run, dataset, kv, abort);
-        // then ACTOR_NORMAL_MODE is added on top.
+        // enableAddingActors=true seeds call-actor (add-actor is substituted at selection time for new
+        // connections, PR 0) + 4 auto-injected helpers (get-actor-run, dataset, kv, abort); then
+        // ACTOR_NORMAL_MODE is added on top.
         const expectedToolNames = [
-            addActor.name,
+            HELPER_TOOLS.ACTOR_CALL,
             'get-actor-run',
             'get-dataset-items',
             'get-key-value-store-record',
@@ -59,9 +61,40 @@ describe('MCP server internals integration tests', () => {
         expectArrayWeakEquals(actorsMcpServer.listAllToolNames(), expectedToolNames);
     });
 
+    // PR 0 restore-path race (see tools_loader.ts's `getToolsForServerMode` isRestore param): a
+    // pre-cutoff session's stored tool names can legitimately contain the literal string 'add-actor'.
+    // Restoring that session must resolve it to itself, not run it through the same
+    // add-actor→call-actor substitution a live selector gets on this exact code path
+    // (`toolNamesToInput()`/`loadToolsByName()` → `getToolsForServerMode()`).
+    it("restores a pre-cutoff session's stored add-actor name to itself, not call-actor", async () => {
+        const actorsMcpServer = new ActorsMcpServer({
+            setupSigintHandler: false,
+            taskStore: new InMemoryTaskStore(),
+            serverMode: SERVER_MODE.DEFAULT,
+        });
+        const apifyClient = new ApifyClient({ token: process.env.APIFY_TOKEN });
+
+        // Simulate a session that loaded add-actor before the PR 0 cutoff — seed it directly via
+        // upsertTools, bypassing the loader (which would now substitute call-actor for any live selector).
+        actorsMcpServer.upsertTools([addActor]);
+        const names = actorsMcpServer.listAllToolNames();
+        expectArrayWeakEquals([addActor.name], names);
+
+        // Simulate the session being dropped from local memory (e.g. a different node in a multi-node
+        // deployment) and restored from the stored tool name list.
+        actorsMcpServer.tools.clear();
+        expect(actorsMcpServer.listAllToolNames()).toEqual([]);
+
+        await actorsMcpServer.loadToolsByName(names, apifyClient);
+
+        // Must resolve to itself — restore is not a live selector, so the substitution must not fire.
+        expectArrayWeakEquals(actorsMcpServer.listAllToolNames(), [addActor.name]);
+    });
+
     it('should notify tools changed handler on tool modifications', async () => {
         let latestTools: string[] = [];
-        // enableAddingActors=true seeds add-actor + 4 auto-injected helpers (get-actor-run, dataset, kv, abort)
+        // enableAddingActors=true seeds call-actor (add-actor substituted, PR 0) + 4 auto-injected helpers
+        // (get-actor-run, dataset, kv, abort)
         const numberOfTools = 5;
 
         let toolNotificationCount = 0;
@@ -89,8 +122,8 @@ describe('MCP server internals integration tests', () => {
         expect(toolNotificationCount).toBe(1);
         expect(latestTools.length).toBe(numberOfTools + 1);
         expect(latestTools).toContain(actor);
-        expect(latestTools).toContain(addActor.name);
-        // No default actors are present when only add-actor is enabled by default
+        expect(latestTools).toContain(HELPER_TOOLS.ACTOR_CALL);
+        // No default actors are present when only call-actor (add-actor substituted) is enabled by default
 
         // Remove the Actor
         actorsMCPServer.removeToolsByName([actorNameToToolName(actor)], true);
@@ -99,14 +132,15 @@ describe('MCP server internals integration tests', () => {
         expect(toolNotificationCount).toBe(2);
         expect(latestTools.length).toBe(numberOfTools);
         expect(latestTools).not.toContain(actor);
-        expect(latestTools).toContain(addActor.name);
+        expect(latestTools).toContain(HELPER_TOOLS.ACTOR_CALL);
         // No default actors are present by default in this mode
     });
 
     it('should stop notifying after unregistering tools changed handler', async () => {
         let latestTools: string[] = [];
         let notificationCount = 0;
-        // enableAddingActors=true seeds add-actor + 4 auto-injected helpers (get-actor-run, dataset, kv, abort)
+        // enableAddingActors=true seeds call-actor (add-actor substituted, PR 0) + 4 auto-injected helpers
+        // (get-actor-run, dataset, kv, abort)
         const numberOfTools = 5;
         const onToolsChanged = (tools: string[]) => {
             latestTools = tools;

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -11,7 +11,7 @@ import { addActor } from '../../src/tools/actors/add_actor.js';
 import { getActorsAsTools } from '../../src/tools/index.js';
 import type { Input } from '../../src/types.js';
 import { SERVER_MODE } from '../../src/types.js';
-import { loadToolsFromInput } from '../../src/utils/tools_loader.js';
+import { AUTO_INJECTED_TOOLS, loadToolsFromInput } from '../../src/utils/tools_loader.js';
 import { ACTOR_NORMAL_MODE } from '../const.js';
 import { expectArrayWeakEquals } from '../helpers.js';
 
@@ -88,7 +88,10 @@ describe('MCP server internals integration tests', () => {
         await actorsMcpServer.loadToolsByName(names, apifyClient);
 
         // Must resolve to itself — restore is not a live selector, so the substitution must not fire.
-        expectArrayWeakEquals(actorsMcpServer.listAllToolNames(), [addActor.name]);
+        // add-actor's presence auto-injects the run/storage helpers (pre-existing tools_loader
+        // behavior, unrelated to this PR) — the restored set is add-actor plus those, not add-actor alone.
+        const expectedToolNames = [addActor.name, ...AUTO_INJECTED_TOOLS.map((t) => t.name)];
+        expectArrayWeakEquals(actorsMcpServer.listAllToolNames(), expectedToolNames);
     });
 
     it('should notify tools changed handler on tool modifications', async () => {

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -40,9 +40,8 @@ describe('MCP server internals integration tests', () => {
         actorsMcpServer.upsertTools(newTool);
 
         const names = actorsMcpServer.listAllToolNames();
-        // enableAddingActors=true seeds call-actor (add-actor is substituted at selection time for new
-        // connections, PR 0) + 4 auto-injected helpers (get-actor-run, dataset, kv, abort); then
-        // ACTOR_NORMAL_MODE is added on top.
+        // enableAddingActors=true now seeds call-actor (add-actor substituted, PR 0) + 4
+        // auto-injected helpers; then ACTOR_NORMAL_MODE is added on top.
         const expectedToolNames = [
             HELPER_TOOLS.ACTOR_CALL,
             'get-actor-run',
@@ -61,11 +60,8 @@ describe('MCP server internals integration tests', () => {
         expectArrayWeakEquals(actorsMcpServer.listAllToolNames(), expectedToolNames);
     });
 
-    // PR 0 restore-path race (see tools_loader.ts's `getToolsForServerMode` isRestore param): a
-    // pre-cutoff session's stored tool names can legitimately contain the literal string 'add-actor'.
-    // Restoring that session must resolve it to itself, not run it through the same
-    // add-actor→call-actor substitution a live selector gets on this exact code path
-    // (`toolNamesToInput()`/`loadToolsByName()` → `getToolsForServerMode()`).
+    // PR 0 restore-path race: a pre-cutoff session's stored names can contain 'add-actor'. Restore
+    // must resolve it to itself, not the add-actor→call-actor substitution a live selector gets.
     it("restores a pre-cutoff session's stored add-actor name to itself, not call-actor", async () => {
         const actorsMcpServer = new ActorsMcpServer({
             setupSigintHandler: false,
@@ -74,30 +70,27 @@ describe('MCP server internals integration tests', () => {
         });
         const apifyClient = new ApifyClient({ token: process.env.APIFY_TOKEN });
 
-        // Simulate a session that loaded add-actor before the PR 0 cutoff — seed it directly via
-        // upsertTools, bypassing the loader (which would now substitute call-actor for any live selector).
+        // Simulate a pre-cutoff session: seed add-actor directly, bypassing the loader (which would
+        // now substitute call-actor for a live selector).
         actorsMcpServer.upsertTools([addActor]);
         const names = actorsMcpServer.listAllToolNames();
         expectArrayWeakEquals([addActor.name], names);
 
-        // Simulate the session being dropped from local memory (e.g. a different node in a multi-node
-        // deployment) and restored from the stored tool name list.
+        // Simulate the session being restored from its stored tool name list (e.g. on another node).
         actorsMcpServer.tools.clear();
         expect(actorsMcpServer.listAllToolNames()).toEqual([]);
 
         await actorsMcpServer.loadToolsByName(names, apifyClient);
 
-        // Must resolve to itself — restore is not a live selector, so the substitution must not fire.
-        // add-actor's presence auto-injects the run/storage helpers (pre-existing tools_loader
-        // behavior, unrelated to this PR) — the restored set is add-actor plus those, not add-actor alone.
+        // Resolves to itself, plus add-actor's usual auto-injected run/storage helpers (pre-existing,
+        // unrelated to this PR) — not the call-actor substitution.
         const expectedToolNames = [addActor.name, ...AUTO_INJECTED_TOOLS.map((t) => t.name)];
         expectArrayWeakEquals(actorsMcpServer.listAllToolNames(), expectedToolNames);
     });
 
     it('should notify tools changed handler on tool modifications', async () => {
         let latestTools: string[] = [];
-        // enableAddingActors=true seeds call-actor (add-actor substituted, PR 0) + 4 auto-injected helpers
-        // (get-actor-run, dataset, kv, abort)
+        // enableAddingActors=true seeds call-actor (add-actor substituted, PR 0) + 4 auto-injected helpers.
         const numberOfTools = 5;
 
         let toolNotificationCount = 0;
@@ -142,8 +135,7 @@ describe('MCP server internals integration tests', () => {
     it('should stop notifying after unregistering tools changed handler', async () => {
         let latestTools: string[] = [];
         let notificationCount = 0;
-        // enableAddingActors=true seeds call-actor (add-actor substituted, PR 0) + 4 auto-injected helpers
-        // (get-actor-run, dataset, kv, abort)
+        // enableAddingActors=true seeds call-actor (add-actor substituted, PR 0) + 4 auto-injected helpers.
         const numberOfTools = 5;
         const onToolsChanged = (tools: string[]) => {
             latestTools = tools;

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -780,10 +780,25 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(outputText).not.toContain('This Actor is rental');
             });
 
-            // Four add-actor-specific cases (list-changed notification, its own error strings, x402
-            // rejection, MCP-server proxy registration) removed — unreachable now add-actor is
-            // substituted (PR 0). Unit coverage stays in tests/unit/tools.add_actor.test.ts until PR 2;
-            // x402/actor:tool coverage lives in the tests below, via call-actor.
+            it('should return an Actor-not-found error when calling a non-existent actor via call-actor', async () => {
+                client = await createClientFn({ tools: ['actors'] });
+                const nonExistentActor = 'apify/this-actor-does-not-exist';
+                const result = await client.callTool({
+                    name: HELPER_TOOLS.ACTOR_CALL,
+                    arguments: { actor: nonExistentActor, input: {} },
+                });
+                expect(result).toBeDefined();
+                expect(result.isError).toBe(true);
+                const content = result.content as { text: string }[];
+                expect(content.length).toBeGreaterThan(0);
+                expect(content[0].text).toContain(nonExistentActor);
+                expect(content[0].text).toContain('was not found');
+            });
+
+            // Three add-actor-specific cases (list-changed notification, x402 rejection, MCP-server
+            // proxy registration) removed — unreachable now add-actor is substituted (PR 0). Unit
+            // coverage stays in tests/unit/tools.add_actor.test.ts until PR 2; x402/actor:tool
+            // coverage lives in the tests below, via call-actor.
 
             // Regression: `call-actor` declares an `outputSchema` (since #415), but the MCP-server pass-through
             // path in `handleMcpToolCall` returns `{ content }` only — no `structuredContent`. SDK ≥ 1.11.4

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -1675,25 +1675,29 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
             });
 
             // The `dev` category holds only report-problem, which is telemetry-gated (off in this suite),
-            // so it can't load standalone here; its gating is covered by unit tests. Exclude it from the
+            // so it can't load standalone here; its gating is covered by unit tests. `experimental`'s
+            // sole member (add-actor) is substituted for call-actor at selection time for any new
+            // connection (PR 0), so its raw registry members no longer match what a live selector
+            // loads — covered instead by the dedicated substitution tests above. Exclude both from the
             // category sweep.
-            it.for(Object.keys(getCategoryTools('default')).filter((category) => category !== 'dev'))(
-                'should load correct tools for %s category',
-                async (category) => {
-                    client = await createClientFn({
-                        tools: [category as ToolCategory],
-                    });
+            it.for(
+                Object.keys(getCategoryTools('default')).filter(
+                    (category) => category !== 'dev' && category !== 'experimental',
+                ),
+            )('should load correct tools for %s category', async (category) => {
+                client = await createClientFn({
+                    tools: [category as ToolCategory],
+                });
 
-                    const loadedTools = await client.listTools();
-                    const toolNames = getToolNames(loadedTools);
+                const loadedTools = await client.listTools();
+                const toolNames = getToolNames(loadedTools);
 
-                    const expectedToolNames = getExpectedToolNamesByCategories([category as ToolCategory]);
-                    // Only assert that all tools from the selected category are present.
-                    for (const expectedToolName of expectedToolNames) {
-                        expect(toolNames).toContain(expectedToolName);
-                    }
-                },
-            );
+                const expectedToolNames = getExpectedToolNamesByCategories([category as ToolCategory]);
+                // Only assert that all tools from the selected category are present.
+                for (const expectedToolName of expectedToolNames) {
+                    expect(toolNames).toContain(expectedToolName);
+                }
+            });
 
             it('should include call-actor (add-actor substituted) when experimental category is selected even if enableAddingActors is false', async () => {
                 client = await createClientFn({

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -330,8 +330,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 client = await createClientFn({ enableAddingActors: false, tools: ['experimental'] });
 
                 const names = getToolNames(await client.listTools());
-                // experimental category's sole member (add-actor) resolves to call-actor for a new connection (PR 0) +
-                // auto-injected helpers (get-actor-run, storage, abort).
+                // experimental's sole member (add-actor) resolves to call-actor (PR 0) + auto-injected helpers.
                 expect(names).toHaveLength(1 + AUTO_INJECTED_TOOL_NAMES.length);
                 expect(names).toContain('call-actor');
                 expect(names).not.toContain('add-actor');
@@ -538,9 +537,8 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const selectedToolName = actorNameToToolName(ACTOR_NORMAL_MODE);
                 client = await createClientFn({ enableAddingActors: true, tools: ['actors'] });
                 const names = getToolNames(await client.listTools());
-                // actors category (already includes call-actor) + auto-injected helpers (get-actor-run, dataset, kv, abort).
-                // enableAddingActors's add-actor substitute (call-actor, PR 0) is already present via the actors
-                // category, so it adds no further tool.
+                // actors category (already has call-actor) + auto-injected helpers. enableAddingActors's
+                // substitute (call-actor, PR 0) is already there, so it adds nothing further.
                 const numberOfTools = getCategoryTools('default').actors.length + AUTO_INJECTED_TOOL_NAMES.length;
                 expect(names).toHaveLength(numberOfTools);
                 // get-actor-run should be automatically included when call-actor is present
@@ -782,13 +780,10 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(outputText).not.toContain('This Actor is rental');
             });
 
-            // add-actor's own dynamic-registration behavior (tools-changed notification, its specific
-            // error strings, x402 standby rejection, Actorized-MCP-server proxy-tool registration) is no
-            // longer reachable via any new connection (add-actor is substituted by call-actor at
-            // selection time, PR 0) — those four cases were removed here. add-actor's own `call()` logic
-            // stays covered at the unit level (tests/unit/tools.add_actor.test.ts) until PR 2 deletes it;
-            // the x402/standby-rejection and MCP-server actor:tool call paths are covered here via
-            // call-actor directly (see the `actor:tool` pass-through test below).
+            // Four add-actor-specific cases (list-changed notification, its own error strings, x402
+            // rejection, MCP-server proxy registration) removed — unreachable now add-actor is
+            // substituted (PR 0). Unit coverage stays in tests/unit/tools.add_actor.test.ts until PR 2;
+            // x402/actor:tool coverage lives in the tests below, via call-actor.
 
             // Regression: `call-actor` declares an `outputSchema` (since #415), but the MCP-server pass-through
             // path in `handleMcpToolCall` returns `{ content }` only — no `structuredContent`. SDK ≥ 1.11.4
@@ -1675,11 +1670,9 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
             });
 
             // The `dev` category holds only report-problem, which is telemetry-gated (off in this suite),
-            // so it can't load standalone here; its gating is covered by unit tests. `experimental`'s
-            // sole member (add-actor) is substituted for call-actor at selection time for any new
-            // connection (PR 0), so its raw registry members no longer match what a live selector
-            // loads — covered instead by the dedicated substitution tests above. Exclude both from the
-            // category sweep.
+            // so it can't load standalone here; its gating is covered by unit tests. `experimental` is
+            // excluded too — its sole member (add-actor) is substituted for call-actor (PR 0), covered
+            // by the dedicated substitution tests above instead.
             it.for(
                 Object.keys(getCategoryTools('default')).filter(
                     (category) => category !== 'dev' && category !== 'experimental',
@@ -1768,8 +1761,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 { retry: 2 },
                 async () => {
                     const selectedToolName = actorNameToToolName(ACTOR_NORMAL_MODE);
-                    // Load the Actor directly at connection time (add-actor's dynamic registration
-                    // is no longer selectable for new connections, PR 0).
+                    // Load the Actor at connection time — add-actor's dynamic add is gone (PR 0).
                     client = await createClientFn({ actors: [ACTOR_NORMAL_MODE] });
 
                     const api = new ApifyClient({ token: process.env.APIFY_TOKEN as string });

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -1,6 +1,6 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { CallToolResultSchema, ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import Ajv from 'ajv';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
@@ -22,7 +22,7 @@ import type { SERVER_MODE, ToolCategory, ToolEntry } from '../../src/types.js';
 import { getExpectedToolNamesByCategories } from '../../src/utils/tool_categories_helpers.js';
 import { AUTO_INJECTED_TOOLS } from '../../src/utils/tools_loader.js';
 import { ACTOR_EXAMPLE_MCP_SERVER, ACTOR_NORMAL_MODE, DEFAULT_ACTOR_NAMES, getDefaultToolNames } from '../const.js';
-import { addActor, type McpClientOptions } from '../helpers.js';
+import type { McpClientOptions } from '../helpers.js';
 import { assertStatusMessagePropagated, captureInflightActorRunId, waitForRunAborted } from './utils/task_waits.js';
 
 const AUTO_INJECTED_TOOL_NAMES = AUTO_INJECTED_TOOLS.map((t) => t.name);
@@ -75,18 +75,6 @@ function buildExampleMcpServerAddToolContent(firstNumber: number, secondNumber: 
             text: `The sum of ${firstNumber} and ${secondNumber} is ${firstNumber + secondNumber}`,
         },
     ];
-}
-
-async function callNormalModeTestActor(client: Client, selectedToolName: string) {
-    const result = await client.callTool({
-        name: selectedToolName,
-        arguments: {
-            firstNumber: 1,
-            secondNumber: 2,
-        },
-    });
-
-    expectNormalModeTestStructuredContent(result);
 }
 
 function validateStructuredOutput(result: unknown, toolOutputSchema: unknown, toolName: string): void {
@@ -297,12 +285,13 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
             });
 
-            it('should auto-inject storage and abort tools when enableAddingActors is true', async () => {
+            it('should substitute call-actor for add-actor and auto-inject storage/abort tools when enableAddingActors is true', async () => {
                 client = await createClientFn({ enableAddingActors: true });
                 const names = getToolNames(await client.listTools());
-                // add-actor triggers auto-injected helpers (get-actor-run, storage, abort).
+                // call-actor (substituted for add-actor, PR 0) triggers auto-injected helpers (get-actor-run, storage, abort).
                 expect(names.length).toEqual(1 + AUTO_INJECTED_TOOL_NAMES.length);
-                expect(names).toContain('add-actor');
+                expect(names).toContain('call-actor');
+                expect(names).not.toContain('add-actor');
                 expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
                 await client.close();
             });
@@ -337,13 +326,15 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 await client.close();
             });
 
-            it('should override enableAddingActors false with experimental tool category', async () => {
+            it('should override enableAddingActors false with experimental tool category (substituted to call-actor)', async () => {
                 client = await createClientFn({ enableAddingActors: false, tools: ['experimental'] });
 
                 const names = getToolNames(await client.listTools());
-                // experimental category provides add-actor + auto-injected helpers (get-actor-run, storage, abort).
+                // experimental category's sole member (add-actor) resolves to call-actor for a new connection (PR 0) +
+                // auto-injected helpers (get-actor-run, storage, abort).
                 expect(names).toHaveLength(1 + AUTO_INJECTED_TOOL_NAMES.length);
-                expect(names).toContain('add-actor');
+                expect(names).toContain('call-actor');
+                expect(names).not.toContain('add-actor');
                 expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
 
                 await client.close();
@@ -466,24 +457,24 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 await client.close();
             });
 
-            it('should handle mixed categories and specific tools in tools param', async () => {
+            it('should handle mixed categories and specific tools in tools param (add-actor substituted to call-actor)', async () => {
                 client = await createClientFn({
                     tools: ['docs', 'fetch-actor-details', 'add-actor'],
                 });
                 const names = getToolNames(await client.listTools());
 
-                // docs (2) + fetch-actor-details + add-actor + auto-injected helpers
+                // docs (2) + fetch-actor-details + call-actor (add-actor substituted, PR 0) + auto-injected helpers
                 expect(names).toHaveLength(4 + AUTO_INJECTED_TOOL_NAMES.length);
 
                 // Should include: docs category + specific tools
                 expect(names).toContain('search-apify-docs'); // from docs category
                 expect(names).toContain('fetch-apify-docs'); // from docs category
                 expect(names).toContain('fetch-actor-details'); // specific tool
-                expect(names).toContain('add-actor'); // specific tool
+                expect(names).toContain('call-actor'); // add-actor substituted (PR 0)
 
-                // Should NOT include other actors category tools
+                // Should NOT include other actors category tools, nor add-actor itself
                 expect(names).not.toContain('search-actors');
-                expect(names).not.toContain('call-actor');
+                expect(names).not.toContain('add-actor');
             });
 
             it('should load only docs tools', async () => {
@@ -519,31 +510,38 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 await client.close();
             });
 
-            it('should add Actor dynamically and call it directly', async () => {
+            it('should substitute call-actor for add-actor when enableAddingActors is true, and call the Actor directly (no add step)', async () => {
                 const selectedToolName = actorNameToToolName(ACTOR_NORMAL_MODE);
                 client = await createClientFn({ enableAddingActors: true });
                 const names = getToolNames(await client.listTools());
                 expect(names).toHaveLength(1 + AUTO_INJECTED_TOOL_NAMES.length);
-                expect(names).toContain('add-actor');
+                expect(names).toContain(HELPER_TOOLS.ACTOR_CALL);
+                expect(names).not.toContain('add-actor');
                 expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
                 expect(names).not.toContain(selectedToolName);
-                // Add Actor dynamically
-                await addActor(client, ACTOR_NORMAL_MODE);
 
-                // add-actor + auto-injected + newly added actor
-                const namesAfterAdd = getToolNames(await client.listTools());
-                expect(namesAfterAdd.length).toEqual(2 + AUTO_INJECTED_TOOL_NAMES.length);
-                expect(namesAfterAdd).toContain(selectedToolName);
-                expectToolNamesToContain(namesAfterAdd, AUTO_INJECTED_TOOL_NAMES);
-                await callNormalModeTestActor(client, selectedToolName);
+                // No dynamic "add" step exists anymore (PR 0) — call-actor calls any Actor by name directly.
+                const result = await client.callTool({
+                    name: HELPER_TOOLS.ACTOR_CALL,
+                    arguments: {
+                        actor: ACTOR_NORMAL_MODE,
+                        input: {
+                            firstNumber: 1,
+                            secondNumber: 2,
+                        },
+                    },
+                });
+                expectNormalModeTestStructuredContent(result);
             });
 
             it('should call Actor dynamically via generic call-actor tool without need to add it first', async () => {
                 const selectedToolName = actorNameToToolName(ACTOR_NORMAL_MODE);
                 client = await createClientFn({ enableAddingActors: true, tools: ['actors'] });
                 const names = getToolNames(await client.listTools());
-                // actors category + add-actor + auto-injected helpers (get-actor-run, dataset, kv, abort)
-                const numberOfTools = getCategoryTools('default').actors.length + 1 + AUTO_INJECTED_TOOL_NAMES.length;
+                // actors category (already includes call-actor) + auto-injected helpers (get-actor-run, dataset, kv, abort).
+                // enableAddingActors's add-actor substitute (call-actor, PR 0) is already present via the actors
+                // category, so it adds no further tool.
+                const numberOfTools = getCategoryTools('default').actors.length + AUTO_INJECTED_TOOL_NAMES.length;
                 expect(names).toHaveLength(numberOfTools);
                 // get-actor-run should be automatically included when call-actor is present
                 expect(names).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
@@ -784,82 +782,13 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(outputText).not.toContain('This Actor is rental');
             });
 
-            it('should notify client about tool list changed', async () => {
-                client = await createClientFn({ enableAddingActors: true });
-
-                // This flag is set to true when a 'notifications/tools/list_changed' notification is received,
-                // indicating that the tool list has been updated dynamically.
-                let hasReceivedNotification = false;
-                client.setNotificationHandler(ToolListChangedNotificationSchema, async (notification) => {
-                    if (notification.method === 'notifications/tools/list_changed') {
-                        hasReceivedNotification = true;
-                    }
-                });
-                // Add Actor dynamically
-                await client.callTool({ name: HELPER_TOOLS.ACTOR_ADD, arguments: { actor: ACTOR_NORMAL_MODE } });
-
-                expect(hasReceivedNotification).toBe(true);
-            });
-
-            it('should return error when adding a non-existent actor', async () => {
-                client = await createClientFn({ enableAddingActors: true });
-                const nonExistentActor = 'apify/this-actor-does-not-exist';
-                const result = await client.callTool({
-                    name: HELPER_TOOLS.ACTOR_ADD,
-                    arguments: { actor: nonExistentActor },
-                });
-                expect(result).toBeDefined();
-                expect(result.isError).toBe(true);
-                const content = result.content as { text: string }[];
-                expect(content.length).toBeGreaterThan(0);
-                expect(content[0].text).toContain('was not found');
-            });
-
-            it.runIf(options.transport === 'streamable-http')(
-                'should return error when adding a standby Actor in x402 payment mode',
-                async () => {
-                    client = await createClientFn({ enableAddingActors: true, payment: 'x402' });
-                    const result = await client.callTool({
-                        name: HELPER_TOOLS.ACTOR_ADD,
-                        arguments: { actor: ACTOR_EXAMPLE_MCP_SERVER },
-                    });
-                    expect(result).toBeDefined();
-                    expect(result.isError).toBe(true);
-                    const content = result.content as { text: string }[];
-                    expect(content.length).toBeGreaterThan(0);
-                    expect(content[0].text).toContain('standby Actor, which is not supported in agentic payment mode');
-                    await client.close();
-                },
-            );
-
-            it('should be able to add and call Actorized MCP server', async () => {
-                client = await createClientFn({ enableAddingActors: true });
-
-                // example-mcp-server exposes a single `add` tool. The proxy registers it under a
-                // hashed prefix (see `getProxyMCPServerToolName`) — match the `-add` suffix while
-                // excluding the unrelated `add-actor` helper present in the seed tools.
-                const isProxiedAddTool = (name: string) => name.endsWith('-add');
-
-                const toolNamesBefore = getToolNames(await client.listTools());
-                expect(toolNamesBefore.filter(isProxiedAddTool)).toHaveLength(0);
-
-                // Add Actorized MCP server
-                await addActor(client, ACTOR_EXAMPLE_MCP_SERVER);
-
-                const toolNamesAfter = getToolNames(await client.listTools());
-                const proxiedAddTools = toolNamesAfter.filter(isProxiedAddTool);
-                expect(proxiedAddTools).toHaveLength(1);
-
-                const result = await client.callTool({
-                    name: proxiedAddTools[0],
-                    arguments: {
-                        firstNumber: 2,
-                        secondNumber: 3,
-                    },
-                });
-                expect(result.content).toEqual(buildExampleMcpServerAddToolContent(2, 3));
-                expect(result.isError ?? false).toBe(false);
-            });
+            // add-actor's own dynamic-registration behavior (tools-changed notification, its specific
+            // error strings, x402 standby rejection, Actorized-MCP-server proxy-tool registration) is no
+            // longer reachable via any new connection (add-actor is substituted by call-actor at
+            // selection time, PR 0) — those four cases were removed here. add-actor's own `call()` logic
+            // stays covered at the unit level (tests/unit/tools.add_actor.test.ts) until PR 2 deletes it;
+            // the x402/standby-rejection and MCP-server actor:tool call paths are covered here via
+            // call-actor directly (see the `actor:tool` pass-through test below).
 
             // Regression: `call-actor` declares an `outputSchema` (since #415), but the MCP-server pass-through
             // path in `handleMcpToolCall` returns `{ content }` only — no `structuredContent`. SDK ≥ 1.11.4
@@ -1766,7 +1695,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 },
             );
 
-            it('should include add-actor when experimental category is selected even if enableAddingActors is false', async () => {
+            it('should include call-actor (add-actor substituted) when experimental category is selected even if enableAddingActors is false', async () => {
                 client = await createClientFn({
                     enableAddingActors: false,
                     tools: ['experimental'],
@@ -1775,10 +1704,11 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const loadedTools = await client.listTools();
                 const toolNames = getToolNames(loadedTools);
 
-                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_ADD);
+                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
+                expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_ADD);
             });
 
-            it('should include add-actor when enableAddingActors is false and add-actor is selected directly', async () => {
+            it('should include call-actor (add-actor substituted) when enableAddingActors is false and add-actor is selected directly', async () => {
                 client = await createClientFn({
                     enableAddingActors: false,
                     tools: [HELPER_TOOLS.ACTOR_ADD],
@@ -1787,8 +1717,9 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 const loadedTools = await client.listTools();
                 const toolNames = getToolNames(loadedTools);
 
-                // Must include add-actor since it was selected directly
-                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_ADD);
+                // Must include call-actor since add-actor was selected directly and is substituted (PR 0)
+                expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
+                expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_ADD);
             });
 
             it('should handle multiple tool category keys input correctly', async () => {
@@ -1833,8 +1764,9 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 { retry: 2 },
                 async () => {
                     const selectedToolName = actorNameToToolName(ACTOR_NORMAL_MODE);
-                    client = await createClientFn({ enableAddingActors: true });
-                    await addActor(client, ACTOR_NORMAL_MODE);
+                    // Load the Actor directly at connection time (add-actor's dynamic registration
+                    // is no longer selectable for new connections, PR 0).
+                    client = await createClientFn({ actors: [ACTOR_NORMAL_MODE] });
 
                     const api = new ApifyClient({ token: process.env.APIFY_TOKEN as string });
                     const actor = await api.actor(ACTOR_NORMAL_MODE).get();
@@ -1935,11 +1867,12 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
             );
 
             it.runIf(options.transport === 'stdio')(
-                'should respect ENABLE_ADDING_ACTORS env var and auto-inject storage tools alongside add-actor',
+                'should respect ENABLE_ADDING_ACTORS env var and auto-inject storage tools alongside call-actor (add-actor substituted)',
                 async () => {
                     client = await createClientFn({ enableAddingActors: true, useEnv: true });
                     const names = getToolNames(await client.listTools());
-                    expectToolNamesToContain(names, ['add-actor', ...AUTO_INJECTED_TOOL_NAMES]);
+                    expectToolNamesToContain(names, ['call-actor', ...AUTO_INJECTED_TOOL_NAMES]);
+                    expect(names).not.toContain('add-actor');
 
                     await client.close();
                 },

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -148,6 +148,51 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
     );
 });
 
+describe('getToolsForServerMode add-actor selector cutoff (PR 0)', () => {
+    it('substitutes call-actor for a literal tools=add-actor selector on a new connection', () => {
+        const toolNames = getToolsForServerMode({ tools: [HELPER_TOOLS.ACTOR_ADD] }, [], 'default').map((t) => t.name);
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_ADD);
+    });
+
+    it('substitutes call-actor for the tools=experimental category on a new connection', () => {
+        const toolNames = getToolsForServerMode({ tools: ['experimental'] }, [], 'default').map((t) => t.name);
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_ADD);
+    });
+
+    it('substitutes call-actor for enableAddingActors=true with no other selectors on a new connection', () => {
+        const toolNames = getToolsForServerMode({ enableAddingActors: true }, [], 'default').map((t) => t.name);
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_ADD);
+    });
+
+    it('substitutes call-actor for enableAddingActors=true alongside other selectors on a new connection', () => {
+        const toolNames = getToolsForServerMode({ tools: ['docs'], enableAddingActors: true }, [], 'default').map(
+            (t) => t.name,
+        );
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_ADD);
+    });
+
+    it('does not duplicate call-actor when both an explicit selector and enableAddingActors resolve to it', () => {
+        const toolNames = getToolsForServerMode(
+            { tools: [HELPER_TOOLS.ACTOR_CALL], enableAddingActors: true },
+            [],
+            'default',
+        ).map((t) => t.name);
+        expect(toolNames.filter((n) => n === HELPER_TOOLS.ACTOR_CALL)).toHaveLength(1);
+    });
+
+    it("resolves a restored session's stored add-actor name to itself (isRestore bypass)", () => {
+        const toolNames = getToolsForServerMode({ tools: [HELPER_TOOLS.ACTOR_ADD] }, [], 'default', true).map(
+            (t) => t.name,
+        );
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_ADD);
+        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_CALL);
+    });
+});
+
 describe('getToolsForServerMode report-problem default injection', () => {
     // report-problem lives in the `dev` category but is injected into the default (no-selectors)
     // candidate set. Server-side servability gating is applied later in composeToolsForClient; here


### PR DESCRIPTION
## What

`add-actor` is no longer selectable for **new** connections — `call-actor` is substituted at all three surfaces: literal `tools=add-actor`, `tools=experimental` category, both `enableAddingActors=true` sites. `add-actor`'s implementation and notify/Redis plumbing stay untouched; deletion is a later PR, once sessions age out via TTL.

Restore path: a pre-cutoff session's stored `'add-actor'` name must resolve to itself, not get substituted. Fixed with an `isRestore` param threaded through `getToolsForServerMode()`/`composeToolsForClient()`/`registerFetchedActorTools()`, set only by `loadToolsByName()`. Kept as a positional bool (not an options object) since it's removed entirely in PR 2, not worth converting the signature twice.

Breaking change — tagged `feat!`/`BREAKING CHANGE:`.

## Testing

- New: 4 substitution-surface unit tests + de-dup + `isRestore` bypass test; 1 restore round-trip integration test.
- ~15 existing tests rewritten to expect `call-actor`. 3 removed (no `call-actor` equivalent: notification, x402-via-add-actor, MCP-server-proxy — covered elsewhere via `call-actor`). Non-existent-actor case restored, rewritten onto `call-actor`.
- type-check/lint/test:unit/format/check:agents green locally. CI's integration-tests job (real `APIFY_TOKEN`) ran and passed.

## Docs

`README.md`, `evals/workflows/*`, `stdio.ts` help text.

Closes #1129
