### PR TITLE
refactor: Clarify isSessionRestore naming and post-review cleanup

### DIFF
--- a/.claude/agents/mcpc-tester.md
+++ b/.claude/agents/mcpc-tester.md
@@ -23,7 +23,7 @@ You are a development testing agent for the Apify MCP server. Your job is to bui
 | Session | Transport | When to use |
 |---|---|---|
 | `@stdio` | `node dist/stdio.js` | Default — core tools only |
-| `@stdio-full` | `node dist/stdio.js --tools=...` | When you need non-default tools (call-actor via experimental, all categories, specific actors) |
+| `@stdio-full` | `node dist/stdio.js --tools=...` | When you need non-default tools (extra categories like runs/storage, specific actors) |
 | `@dev` | `http://localhost:3001` | Widget / UI mode, or when you need **server logs** — requires `pnpm run dev` running |
 
 Server arguments come from `.mcp.json` — you cannot pass them inline. To test a different server configuration, add a new named entry to `.mcp.json` with the desired `args`, then connect it as a new session.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -347,9 +347,6 @@ export class ActorsMcpServer {
      * and re-added by the initialize flush. Used by every input-driven load path and the flush.
      * (loadActorsAsTools upserts actor tools directly; actor tools are never gated, so they need no
      * filtering.)
-     *
-     * @param isSessionRestore - forwarded to `getToolsForServerMode`; keeps a restored session's stored
-     * `add-actor` name resolving to itself instead of being substituted with `call-actor`.
      */
     private composeToolsForClient(input: Input, actorTools: ToolEntry[], isSessionRestore = false): ToolEntry[] {
         const tools = getToolsForServerMode(input, actorTools, this.serverMode, isSessionRestore);
@@ -470,9 +467,6 @@ export class ActorsMcpServer {
      * Callers pass different `shouldNotify` values: `loadToolsByName` forwards `actorTools.length > 0`
      * (notify only when actor tools were fetched), while `loadToolsFromUrl` and `loadToolsFromInput`
      * pass `false` and defer to the post-initialize reconcile. See `composePendingToolsForClient`.
-     *
-     * @param isSessionRestore - forwarded through to `getToolsForServerMode` (only `loadToolsByName`
-     * passes `true`) so a restored session's stored `add-actor` name resolves to itself.
      */
     private registerFetchedActorTools(
         input: Input,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -174,7 +174,7 @@ export class ActorsMcpServer {
      * We capture the exact actor-tool slice fetched for each request so the flush composes every
      * entry against *its own* actor list rather than the accumulated union across unrelated requests.
      */
-    private pendingToolsUntilClientKnown: { input: Input; actorTools: ToolEntry[]; isRestore: boolean }[] = [];
+    private pendingToolsUntilClientKnown: { input: Input; actorTools: ToolEntry[]; isSessionRestore: boolean }[] = [];
 
     // Telemetry configuration (resolved from options and env vars, see setupTelemetry)
     public readonly telemetryEnabled: boolean;
@@ -347,9 +347,12 @@ export class ActorsMcpServer {
      * and re-added by the initialize flush. Used by every input-driven load path and the flush.
      * (loadActorsAsTools upserts actor tools directly; actor tools are never gated, so they need no
      * filtering.)
+     *
+     * @param isSessionRestore - forwarded to `getToolsForServerMode`; keeps a restored session's stored
+     * `add-actor` name resolving to itself instead of being substituted with `call-actor`.
      */
-    private composeToolsForClient(input: Input, actorTools: ToolEntry[], isRestore = false): ToolEntry[] {
-        const tools = getToolsForServerMode(input, actorTools, this.serverMode, isRestore);
+    private composeToolsForClient(input: Input, actorTools: ToolEntry[], isSessionRestore = false): ToolEntry[] {
+        const tools = getToolsForServerMode(input, actorTools, this.serverMode, isSessionRestore);
         if (this.isReportProblemServable()) return tools;
         return tools.filter((tool) => tool.name !== HELPER_TOOLS.PROBLEM_REPORT);
     }
@@ -374,8 +377,8 @@ export class ActorsMcpServer {
     private composePendingToolsForClient(): void {
         if (this.pendingToolsUntilClientKnown.length === 0) return;
 
-        const tools = this.pendingToolsUntilClientKnown.flatMap(({ input, actorTools, isRestore }) =>
-            this.composeToolsForClient(input, actorTools, isRestore),
+        const tools = this.pendingToolsUntilClientKnown.flatMap(({ input, actorTools, isSessionRestore }) =>
+            this.composeToolsForClient(input, actorTools, isSessionRestore),
         );
 
         this.pendingToolsUntilClientKnown = [];
@@ -467,21 +470,24 @@ export class ActorsMcpServer {
      * Callers pass different `shouldNotify` values: `loadToolsByName` forwards `actorTools.length > 0`
      * (notify only when actor tools were fetched), while `loadToolsFromUrl` and `loadToolsFromInput`
      * pass `false` and defer to the post-initialize reconcile. See `composePendingToolsForClient`.
+     *
+     * @param isSessionRestore - forwarded through to `getToolsForServerMode` (only `loadToolsByName`
+     * passes `true`) so a restored session's stored `add-actor` name resolves to itself.
      */
     private registerFetchedActorTools(
         input: Input,
         actorTools: ToolEntry[],
         shouldNotify: boolean,
-        isRestore = false,
+        isSessionRestore = false,
     ): void {
         if (!this.serverModeResolved) {
-            this.pendingToolsUntilClientKnown.push({ input, actorTools, isRestore });
+            this.pendingToolsUntilClientKnown.push({ input, actorTools, isSessionRestore });
             if (actorTools.length > 0) this.upsertTools(actorTools, shouldNotify);
             return;
         }
-        const tools = this.composeToolsForClient(input, actorTools, isRestore);
+        const tools = this.composeToolsForClient(input, actorTools, isSessionRestore);
         if (tools.length > 0) this.upsertTools(tools, shouldNotify);
-        if (!this.clientKnown) this.pendingToolsUntilClientKnown.push({ input, actorTools, isRestore });
+        if (!this.clientKnown) this.pendingToolsUntilClientKnown.push({ input, actorTools, isSessionRestore });
     }
 
     /**
@@ -500,7 +506,7 @@ export class ActorsMcpServer {
             paymentProvider: this.options.paymentProvider,
         });
 
-        // isRestore: true — a stored 'add-actor' name must resolve to itself, not the PR 0 substitute.
+        // isSessionRestore: true — a stored 'add-actor' name must resolve to itself, not the PR 0 substitute.
         this.registerFetchedActorTools(restoreInput, actorTools, actorTools.length > 0, true);
     }
 

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -82,7 +82,6 @@ function getTokenFromAuthFile(): string | undefined {
     }
 }
 
-// Configure logging, set to ERROR
 log.setLevel(log.LEVELS.ERROR);
 const packageVersion = getPackageVersion() ?? '0.0.0';
 
@@ -100,8 +99,7 @@ const argv = yargs(hideBin(process.argv))
     .option('enable-adding-actors', {
         type: 'boolean',
         default: false,
-        describe: `Enable dynamically adding Actors as tools based on user requests. Can also be set via ENABLE_ADDING_ACTORS environment variable.
-Deprecated: use tools call-actor instead.`,
+        describe: `Deprecated: no longer adds Actors dynamically — substitutes call-actor. Use tools call-actor instead. Can also be set via ENABLE_ADDING_ACTORS environment variable.`,
     })
     .option('enableActorAutoLoading', {
         type: 'boolean',

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -44,9 +44,6 @@ import { getPackageVersion } from './utils/version.js';
 
 // Keeping this type here and not types.ts since
 // it is only relevant to the CLI/STDIO transport in this file
-/**
- * Type for command line arguments
- */
 type CliArgs = {
     actors?: string;
     enableAddingActors: boolean;
@@ -155,9 +152,7 @@ Only used when --telemetry-enabled is true`,
 
 // Respect either the new flag or the deprecated one
 const enableAddingActors = Boolean(argv.enableAddingActors || argv.enableActorAutoLoading);
-// Split actors argument, trim whitespace, and filter out empty strings
 const actorList = argv.actors !== undefined ? parseCommaSeparatedList(argv.actors) : undefined;
-// Split tools argument, trim whitespace, and filter out empty strings
 const toolCategoryKeys = argv.tools !== undefined ? parseCommaSeparatedList(argv.tools) : undefined;
 
 // Propagate log.error to console.error for easier debugging

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,9 @@ export type Input = {
      * @deprecated Use `enableAddingActors` instead.
      */
     enableActorAutoLoading?: boolean | string;
+    /**
+     * @deprecated No longer adds Actors dynamically; substitutes `call-actor`. Use `tools: ['call-actor']` instead.
+     */
     enableAddingActors?: boolean | string;
     maxActorMemoryBytes?: number;
     /**

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -180,7 +180,7 @@ export function toolNamesToInput(toolNames: string[]): Input {
 /**
  * Compose the final tool list from pre-fetched actor tools and the original input for the given mode.
  *
- * @param isRestore - `true` for a session restore (`toolNamesToInput()` via `loadToolsByName()`),
+ * @param isSessionRestore - `true` for a session restore (`toolNamesToInput()` via `loadToolsByName()`),
  * as opposed to a live selector. A restored session's stored name can be `'add-actor'` from before
  * the PR 0 cutoff below — it must resolve to itself, not get substituted like a fresh selector.
  */
@@ -188,7 +188,7 @@ export function getToolsForServerMode(
     input: Input,
     actorTools: ToolEntry[],
     mode: SERVER_MODE = SERVER_MODE.DEFAULT,
-    isRestore = false,
+    isSessionRestore = false,
 ): ToolEntry[] {
     // Build mode-resolved categories — tools are already the correct variant for this mode
     const categories = getCategoryTools(mode);
@@ -226,7 +226,7 @@ export function getToolsForServerMode(
 
             // add-actor cutoff (PR 0): substitute call-actor for a live 'add-actor'/'experimental'
             // selector. Skipped on restore, where `sel` may be a pre-cutoff session's own stored name.
-            if (!isRestore && (sel === HELPER_TOOLS.ACTOR_ADD || sel === 'experimental')) {
+            if (!isSessionRestore && (sel === HELPER_TOOLS.ACTOR_ADD || sel === 'experimental')) {
                 if (callActorTool) internalSelections.push(callActorTool);
                 continue;
             }

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -285,7 +285,7 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 });
             });
 
-            it('should substitute call-actor for add-actor and auto-inject storage/abort tools when enableAddingActors is true', async () => {
+            it('substitutes call-actor for add-actor and auto-injects the run/storage/abort helpers when enableAddingActors is true', async () => {
                 client = await createClientFn({ enableAddingActors: true });
                 const names = getToolNames(await client.listTools());
                 // call-actor (substituted for add-actor, PR 0) triggers auto-injected helpers (get-actor-run, storage, abort).
@@ -794,11 +794,6 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
                 expect(content[0].text).toContain(nonExistentActor);
                 expect(content[0].text).toContain('was not found');
             });
-
-            // Three add-actor-specific cases (list-changed notification, x402 rejection, MCP-server
-            // proxy registration) removed — unreachable now add-actor is substituted (PR 0). Unit
-            // coverage stays in tests/unit/tools.add_actor.test.ts until PR 2; x402/actor:tool
-            // coverage lives in the tests below, via call-actor.
 
             // Regression: `call-actor` declares an `outputSchema` (since #415), but the MCP-server pass-through
             // path in `handleMcpToolCall` returns `{ content }` only — no `structuredContent`. SDK ≥ 1.11.4

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -184,7 +184,7 @@ describe('getToolsForServerMode add-actor selector cutoff (PR 0)', () => {
         expect(toolNames.filter((n) => n === HELPER_TOOLS.ACTOR_CALL)).toHaveLength(1);
     });
 
-    it("resolves a restored session's stored add-actor name to itself (isRestore bypass)", () => {
+    it("resolves a restored session's stored add-actor name to itself (isSessionRestore bypass)", () => {
         const toolNames = getToolsForServerMode({ tools: [HELPER_TOOLS.ACTOR_ADD] }, [], 'default', true).map(
             (t) => t.name,
         );


### PR DESCRIPTION
## Why

Follow-up refactor from the review of #1127 — naming clarity and comment hygiene only, no behavior change. Stacked on #1127 (targets its branch).

## What changed

- Rename `isRestore` → `isSessionRestore` — the old name didn't say "restore of what"; it flags a session restore.
- Drop the redundant `@param isSessionRestore` JSDoc on the two forwarding methods (it duplicated `getToolsForServerMode` and left half-documented param lists).
- Mark `enableAddingActors` `@deprecated` (type + CLI help) — post-cutoff it only substitutes `call-actor`, so it adds nothing over `tools: ['call-actor']`.
- Fix stale text: a mislabeled integration-test name, a misleading `mcpc-tester.md` example ("call-actor via experimental" is a no-op now), and outdated `--enable-adding-actors` help.
- Trim `server.ts` comments that restated the code, plus one inaccurate `@param`.

## Notes for reviewers (human-written)
<!-- Your own words. -->

## Proof it works

Behavior-preserving refactor. `type-check`, `lint`, `test:unit` (1119 passed / 1 skipped), and `check:agents` all green. Base #1127 was separately mcpc-probed (add-actor absent, call-actor substituted at every surface).
