### PR TITLE
refactor: Tidy add-actor cutoff (dedup branch, tests, doc)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -500,7 +500,11 @@ export class ActorsMcpServer {
             paymentProvider: this.options.paymentProvider,
         });
 
-        // isSessionRestore: true — a stored 'add-actor' name must resolve to itself, not the PR 0 substitute.
+        // isSessionRestore: true. This replays the tool names a session already had (stored via
+        // listAllToolNames), so the add-actor cutoff must NOT rewrite them — a stored 'add-actor'
+        // resolves to itself. The live paths (loadToolsFromInput/loadToolsFromUrl, flag omitted)
+        // instead substitute call-actor for a fresh selection. Both the flag and this exception go
+        // away in PR 2, when add-actor is deleted and there is nothing left to preserve.
         this.registerFetchedActorTools(restoreInput, actorTools, actorTools.length > 0, true);
     }
 

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -217,16 +217,14 @@ export function getToolsForServerMode(
     const internalSelections: ToolEntry[] = [];
     if (selectors !== undefined && selectors.length > 0) {
         for (const sel of selectors) {
-            if (sel === 'preview') {
-                // 'preview' category is deprecated. It contained `call-actor` which is now default.
-                log.warning('Tool category "preview" is deprecated');
-                if (callActorTool) internalSelections.push(callActorTool);
-                continue;
-            }
-
-            // add-actor cutoff (PR 0): substitute call-actor for a live 'add-actor'/'experimental'
-            // selector. Skipped on restore, where `sel` may be a pre-cutoff session's own stored name.
-            if (!isSessionRestore && (sel === HELPER_TOOLS.ACTOR_ADD || sel === 'experimental')) {
+            // Selectors that resolve to call-actor: the deprecated `preview` category (always), and
+            // the add-actor cutoff (PR 0) for a live `add-actor`/`experimental` selector — skipped on
+            // restore, where `sel` may be a pre-cutoff session's own stored name.
+            if (
+                sel === 'preview' ||
+                (!isSessionRestore && (sel === HELPER_TOOLS.ACTOR_ADD || sel === 'experimental'))
+            ) {
+                if (sel === 'preview') log.warning('Tool category "preview" is deprecated');
                 if (callActorTool) internalSelections.push(callActorTool);
                 continue;
             }

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -2,6 +2,7 @@ import { ApifyClient } from 'apify-client';
 import { describe, expect, it } from 'vitest';
 
 import { HELPER_TOOLS } from '../../src/const.js';
+import { getCategoryTools } from '../../src/tools/registry.js';
 import type { ToolEntry } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
 import {
@@ -149,30 +150,26 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
 });
 
 describe('getToolsForServerMode add-actor selector cutoff (PR 0)', () => {
-    it('substitutes call-actor for a literal tools=add-actor selector on a new connection', () => {
-        const toolNames = getToolsForServerMode({ tools: [HELPER_TOOLS.ACTOR_ADD] }, [], 'default').map((t) => t.name);
+    const substitutionCases: { case: string; input: Parameters<typeof getToolsForServerMode>[0] }[] = [
+        { case: 'a literal tools=add-actor selector', input: { tools: [HELPER_TOOLS.ACTOR_ADD] } },
+        { case: 'the tools=experimental category', input: { tools: ['experimental'] } },
+        { case: 'enableAddingActors=true with no other selectors', input: { enableAddingActors: true } },
+        {
+            case: 'enableAddingActors=true alongside other selectors',
+            input: { tools: ['docs'], enableAddingActors: true },
+        },
+    ];
+    it.for(substitutionCases)('substitutes call-actor for $case on a new connection', ({ input }) => {
+        const toolNames = getToolsForServerMode(input, [], 'default').map((t) => t.name);
         expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
         expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_ADD);
     });
 
-    it('substitutes call-actor for the tools=experimental category on a new connection', () => {
-        const toolNames = getToolsForServerMode({ tools: ['experimental'] }, [], 'default').map((t) => t.name);
-        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
-        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_ADD);
-    });
-
-    it('substitutes call-actor for enableAddingActors=true with no other selectors on a new connection', () => {
-        const toolNames = getToolsForServerMode({ enableAddingActors: true }, [], 'default').map((t) => t.name);
-        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
-        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_ADD);
-    });
-
-    it('substitutes call-actor for enableAddingActors=true alongside other selectors on a new connection', () => {
-        const toolNames = getToolsForServerMode({ tools: ['docs'], enableAddingActors: true }, [], 'default').map(
-            (t) => t.name,
-        );
-        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_CALL);
-        expect(toolNames).not.toContain(HELPER_TOOLS.ACTOR_ADD);
+    it('keeps the experimental category single-member (guard for the whole-category substitution)', () => {
+        // getToolsForServerMode substitutes call-actor for the entire `experimental` selector and then
+        // stops, so a second member would be silently dropped. Revisit that branch before growing the
+        // category.
+        expect(getCategoryTools('default').experimental).toHaveLength(1);
     });
 
     it('does not duplicate call-actor when both an explicit selector and enableAddingActors resolve to it', () => {


### PR DESCRIPTION
## Why

Review follow-ups for the add-actor cutoff, stacked on #1133 (→ #1127). Small quality fixes and test coverage surfaced during review; no behavior change.

## What changed

- **Dedup:** merged the duplicated `preview` and `add-actor`/`experimental` substitution branches in `getToolsForServerMode` into one guarded block (`preview` keeps its deprecation warning).
- **Tests:** collapsed the four near-identical substitution tests into one `it.for`; added a guard test that the `experimental` category stays single-member — the whole-category substitution silently drops any extra member otherwise.
- **Docs:** documented at the `loadToolsByName` call site why session restore preserves a stored `add-actor` while live selection substitutes `call-actor`, and that both the `isSessionRestore` flag and this exception are removed in PR 2.

## Deliberately not changed (and why)

- **`isSessionRestore` positional flag / 4-param signatures** — kept; PR 2 removes the whole mechanism, so converting to an options object is churn (matches the original author's call).
- **`callActorTool` undefined → empty tool list** — not guarded: unreachable today (`call-actor` is always in the `actors` category); a defensive fallback for an impossible case isn't warranted.
- **Restore-routing test** — intentionally omitted; it would only pin the temporary `isSessionRestore` routing that PR 2 deletes.
- **`getExpectedToolNamesByCategories('experimental')` vs runtime divergence, and URL-based restore** — verified safe against the hosted server: session recovery is tool-name-based (not URL re-parse), and its contract suite already sidesteps the experimental divergence. No change needed.

## Notes for reviewers (human-written)
<!-- your own words -->

## Proof it works

Behavior-preserving refactor. type-check, lint, test:unit (1120 passed / 1 skipped), and check:agents all green locally. The merged substitution branch stays covered by the substitution `it.for` and the de-dup test.
