### PR TITLE
refactor: Add protocol-neutral MCP client context

### DIFF
--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -7,8 +7,8 @@ import { fileURLToPath } from 'node:url';
 
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { InitializeRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { InitializeRequestParams } from '@modelcontextprotocol/sdk/types.js';
+import { InitializeRequestParamsSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Request, Response } from 'express';
 import express from 'express';
 
@@ -126,13 +126,13 @@ export function createExpressApp(): express.Express {
         try {
             // Check for existing session ID
             const sessionId = req.headers['mcp-session-id'] as string | undefined;
-            const initializeRequest = getInitializeRequest(req.body);
+            const initializeMessage = extractInitializeMessage(req.body);
             let transport: StreamableHTTPServerTransport;
 
             if (sessionId && transports[sessionId]) {
                 // Reuse existing transport
                 transport = transports[sessionId];
-            } else if (!sessionId && initializeRequest) {
+            } else if (!sessionId && initializeMessage) {
                 // Extract telemetry query parameters
                 const urlParams = new URL(req.url, `http://${req.headers.host}`).searchParams;
                 const telemetryEnabledParam = urlParams.get('telemetry-enabled');
@@ -167,7 +167,9 @@ export function createExpressApp(): express.Express {
 
                 // Client info is already available here — unlike stdio.ts, which loads tools
                 // before initialization.
-                const requestOrigin = getRequestOriginForClient(buildMcpClientContext(initializeRequest.params));
+                const requestOrigin = getRequestOriginForClient(
+                    buildMcpClientContext(parseInitializeParams(initializeMessage.params)),
+                );
                 const apifyClient = new ApifyClient({ token: apifyToken, requestOrigin });
                 // Fetch actor metadata and queue mode-agnostic sources. Composed with
                 // the final mode inside the initialize request handler.
@@ -284,13 +286,30 @@ export function createExpressApp(): express.Express {
     return app;
 }
 
-function getInitializeRequest(body: unknown): InitializeRequest | undefined {
+/**
+ * Finds the `initialize` message in a (possibly batched) request body, matching on `method`
+ * alone like the pre-refactor `isInitializeRequest` did. This must stay a loose tag check: a
+ * body with `method: 'initialize'` but malformed/incomplete `params` still needs to enter the
+ * initialize branch below so the SDK's own initialize-schema validation produces the accurate
+ * protocol error, instead of falling through to the generic "Mcp-Session-Id header is required"
+ * 400 from the no-session branch.
+ */
+export function extractInitializeMessage(body: unknown): { method: string; params?: unknown } | undefined {
     const messages = Array.isArray(body) ? body : [body];
-    for (const message of messages) {
-        const result = InitializeRequestSchema.safeParse(message);
-        if (result.success) return result.data as InitializeRequest;
-    }
-    return undefined;
+    return messages.find(
+        (msg): msg is { method: string; params?: unknown } =>
+            typeof msg === 'object' && msg !== null && (msg as { method?: unknown }).method === 'initialize',
+    );
+}
+
+/**
+ * Type-safe extraction of `initialize` params for `buildMcpClientContext`/request-origin.
+ * Malformed params parse to `undefined` (client context stays unset) rather than being cast
+ * unchecked — the SDK validates the full request separately once it takes over below.
+ */
+export function parseInitializeParams(params: unknown): InitializeRequestParams | undefined {
+    const result = InitializeRequestParamsSchema.safeParse(params);
+    return result.success ? result.data : undefined;
 }
 
 // --- Entry point: start the server when run directly ---

--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { InitializeRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Request, Response } from 'express';
 import express from 'express';
 
@@ -15,6 +16,7 @@ import log from '@apify/log';
 import { parseBooleanOrNull } from '@apify/utilities';
 
 import { ApifyClient } from './apify_client.js';
+import { buildMcpClientContext } from './mcp/client_context.js';
 import { ActorsMcpServer } from './mcp/server.js';
 import { resolvePaymentProvider } from './payments/index.js';
 import { injectMcpSessionId } from './utils/mcp.js';
@@ -124,12 +126,13 @@ export function createExpressApp(): express.Express {
         try {
             // Check for existing session ID
             const sessionId = req.headers['mcp-session-id'] as string | undefined;
+            const initializeRequest = getInitializeRequest(req.body);
             let transport: StreamableHTTPServerTransport;
 
             if (sessionId && transports[sessionId]) {
                 // Reuse existing transport
                 transport = transports[sessionId];
-            } else if (!sessionId && isInitializeRequest(req.body)) {
+            } else if (!sessionId && initializeRequest) {
                 // Extract telemetry query parameters
                 const urlParams = new URL(req.url, `http://${req.headers.host}`).searchParams;
                 const telemetryEnabledParam = urlParams.get('telemetry-enabled');
@@ -162,10 +165,9 @@ export function createExpressApp(): express.Express {
                     token: apifyToken,
                 });
 
-                // req.body is this same `initialize` request (isInitializeRequest matched above),
-                // so clientInfo is already readable here — unlike stdio.ts, which loads tools
-                // before any client info exists.
-                const requestOrigin = getRequestOriginForClient(req.body as InitializeRequest);
+                // Client info is already available here — unlike stdio.ts, which loads tools
+                // before initialization.
+                const requestOrigin = getRequestOriginForClient(buildMcpClientContext(initializeRequest.params));
                 const apifyClient = new ApifyClient({ token: apifyToken, requestOrigin });
                 // Fetch actor metadata and queue mode-agnostic sources. Composed with
                 // the final mode inside the initialize request handler.
@@ -282,14 +284,13 @@ export function createExpressApp(): express.Express {
     return app;
 }
 
-// Helper function to detect initialize requests
-function isInitializeRequest(body: unknown): boolean {
-    if (Array.isArray(body)) {
-        return body.some(
-            (msg) => typeof msg === 'object' && msg !== null && 'method' in msg && msg.method === 'initialize',
-        );
+function getInitializeRequest(body: unknown): InitializeRequest | undefined {
+    const messages = Array.isArray(body) ? body : [body];
+    for (const message of messages) {
+        const result = InitializeRequestSchema.safeParse(message);
+        if (result.success) return result.data as InitializeRequest;
     }
-    return typeof body === 'object' && body !== null && 'method' in body && body.method === 'initialize';
+    return undefined;
 }
 
 // --- Entry point: start the server when run directly ---

--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -19,6 +19,10 @@ implementations, not by importing from here.
   the same `PreparedCall`; both use the shared `dispatchToolCall` switch.
   Uses the SDK `InMemoryTaskStore` only for stdio; non-stdio transports must be given
   a task store (the internal repo injects a Redis one) or the constructor throws.
+- `client_context.ts` — protocol-neutral client identity and capabilities. The server
+  snapshots it from constructor recovery data and refreshes it during `initialize`.
+  Internal helpers receive this context instead of an SDK initialize type; the raw
+  `options.initializeRequestData` remains the hosted session-recovery boundary.
 - `tool_call_engine.ts` — shared `tools/call` orchestration. `prepareToolCall()` handles
   token gate, tool resolution, payment context, AJV validation, task support, and standby/402
   pre-flight. `executeSyncToolCall()` runs the dispatch tail; `classifyToolCallError()` maps
@@ -68,6 +72,10 @@ implementations, not by importing from here.
   `getToolsForServerMode()`) is documented once in
   [`../../DEVELOPMENT.md`](../../DEVELOPMENT.md) — read it before changing
   registration in `server.ts`; not restated here.
+- **Client data has two forms.** Keep `options.initializeRequestData` unchanged for hosted
+  session recovery. Use the `McpClientContext` snapshot for client gating, request origin,
+  telemetry, resources, and scheduled tasks. Do not export the context from the package root
+  or `./internals`.
 
 ## Local commands
 

--- a/src/mcp/client_context.ts
+++ b/src/mcp/client_context.ts
@@ -1,0 +1,37 @@
+// The ext-apps package exposes `./server` via conditional exports only (no `./server/index.js`
+// wildcard), so we can't satisfy the `import/extensions` rule on this subpath.
+// eslint-disable-next-line import/extensions
+import { getUiCapability, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server';
+
+export type McpClientContext = {
+    readonly protocolVersion?: string;
+    readonly clientInfo?: {
+        readonly name: string;
+        readonly version: string;
+    };
+    readonly capabilities?: Readonly<Record<string, unknown>>;
+};
+
+type McpInitializeParams = {
+    protocolVersion?: string;
+    clientInfo?: {
+        name: string;
+        version: string;
+    };
+    capabilities?: Record<string, unknown>;
+};
+
+export function buildMcpClientContext(params: McpInitializeParams | undefined): McpClientContext | undefined {
+    if (!params) return undefined;
+
+    return {
+        ...(params.protocolVersion !== undefined && { protocolVersion: params.protocolVersion }),
+        ...(params.clientInfo !== undefined && { clientInfo: { ...params.clientInfo } }),
+        ...(params.capabilities !== undefined && { capabilities: structuredClone(params.capabilities) }),
+    };
+}
+
+export function isUiSupportedByClient(context: McpClientContext | undefined): boolean {
+    const uiCapability = getUiCapability(context?.capabilities as Parameters<typeof getUiCapability>[0]);
+    return uiCapability?.mimeTypes?.includes(RESOURCE_MIME_TYPE) ?? false;
+}

--- a/src/mcp/client_context.ts
+++ b/src/mcp/client_context.ts
@@ -2,24 +2,15 @@
 // wildcard), so we can't satisfy the `import/extensions` rule on this subpath.
 // eslint-disable-next-line import/extensions
 import { getUiCapability, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server';
+import type { ClientCapabilities, Implementation, InitializeRequestParams } from '@modelcontextprotocol/sdk/types.js';
 
 export type McpClientContext = {
     readonly protocolVersion?: string;
-    readonly clientInfo?: {
-        readonly name: string;
-        readonly version: string;
-    };
-    readonly capabilities?: Readonly<Record<string, unknown>>;
+    readonly clientInfo?: Readonly<Implementation>;
+    readonly capabilities?: Readonly<ClientCapabilities> & Readonly<Record<string, unknown>>;
 };
 
-type McpInitializeParams = {
-    protocolVersion?: string;
-    clientInfo?: {
-        name: string;
-        version: string;
-    };
-    capabilities?: Record<string, unknown>;
-};
+type McpInitializeParams = Partial<Pick<InitializeRequestParams, 'protocolVersion' | 'clientInfo' | 'capabilities'>>;
 
 export function buildMcpClientContext(params: McpInitializeParams | undefined): McpClientContext | undefined {
     if (!params) return undefined;
@@ -35,9 +26,8 @@ export function buildMcpClientContext(params: McpInitializeParams | undefined): 
 }
 
 export function isUiSupportedByClient(context: McpClientContext | undefined): boolean {
-    // `context.capabilities` is our protocol-neutral `Record<string, unknown>`; `getUiCapability` is
-    // an upstream ext-apps helper expecting its own SDK-typed capabilities shape. The runtime value is
-    // the same object either way, so this cast only crosses that type boundary.
+    // `Readonly<ClientCapabilities>` and the ext-apps helper's capabilities type describe the same
+    // runtime object; this cast only crosses their type boundary.
     const uiCapability = getUiCapability(context?.capabilities as Parameters<typeof getUiCapability>[0]);
     return uiCapability?.mimeTypes?.includes(RESOURCE_MIME_TYPE) ?? false;
 }

--- a/src/mcp/client_context.ts
+++ b/src/mcp/client_context.ts
@@ -26,12 +26,18 @@ export function buildMcpClientContext(params: McpInitializeParams | undefined): 
 
     return {
         ...(params.protocolVersion !== undefined && { protocolVersion: params.protocolVersion }),
-        ...(params.clientInfo !== undefined && { clientInfo: { ...params.clientInfo } }),
+        // The SDK's `Implementation`/`clientInfo` shape carries optional nested fields (`icons[]`,
+        // `title`, `websiteUrl`, `description`) beyond {name, version}, so clone it the same way as
+        // capabilities — a shallow spread would share those nested objects/arrays by reference.
+        ...(params.clientInfo !== undefined && { clientInfo: structuredClone(params.clientInfo) }),
         ...(params.capabilities !== undefined && { capabilities: structuredClone(params.capabilities) }),
     };
 }
 
 export function isUiSupportedByClient(context: McpClientContext | undefined): boolean {
+    // `context.capabilities` is our protocol-neutral `Record<string, unknown>`; `getUiCapability` is
+    // an upstream ext-apps helper expecting its own SDK-typed capabilities shape. The runtime value is
+    // the same object either way, so this cast only crosses that type boundary.
     const uiCapability = getUiCapability(context?.capabilities as Parameters<typeof getUiCapability>[0]);
     return uiCapability?.mimeTypes?.includes(RESOURCE_MIME_TYPE) ?? false;
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -606,12 +606,11 @@ export class ActorsMcpServer {
      * session (x402/Skyfire, no Apify token) has no client and every read fails by design.
      * Still carries the request-origin tag from the client context captured by this point.
      */
-    private resolveApifyClient(
-        params: ApifyRequestParams,
-        clientContext: McpClientContext | undefined,
-    ): ApifyClient | undefined {
+    private resolveApifyClient(params: ApifyRequestParams): ApifyClient | undefined {
         const token = this.resolveApifyToken(params._meta);
-        return token ? new ApifyClient({ token, requestOrigin: getRequestOriginForClient(clientContext) }) : undefined;
+        return token
+            ? new ApifyClient({ token, requestOrigin: getRequestOriginForClient(this.clientContext) })
+            : undefined;
     }
 
     private setupResourceHandlers(): void {
@@ -628,7 +627,7 @@ export class ActorsMcpServer {
         this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
             return await resourceService.readResource(
                 request.params.uri,
-                this.resolveApifyClient(request.params as ApifyRequestParams, this.clientContext),
+                this.resolveApifyClient(request.params as ApifyRequestParams),
             );
         });
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,10 +4,6 @@
 
 import { randomUUID } from 'node:crypto';
 
-// The ext-apps package exposes `./server` via conditional exports only (no `./server/index.js`
-// wildcard), so we can't satisfy the `import/extensions` rule on this subpath.
-// eslint-disable-next-line import/extensions
-import { getUiCapability, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server';
 import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -71,6 +67,8 @@ import { getServerInstructions } from '../utils/server-instructions/index.js';
 import { parseServerMode, resolveServerMode } from '../utils/server_mode.js';
 import { buildActorFields, getToolFullName, getToolPublicFieldOnly } from '../utils/tools.js';
 import { getActors, getToolsForServerMode, toolNamesToInput } from '../utils/tools_loader.js';
+import { buildMcpClientContext, isUiSupportedByClient } from './client_context.js';
+import type { McpClientContext } from './client_context.js';
 import { LOG_LEVEL_MAP } from './const.js';
 import { emitTaskStatusNotification, executeToolAndUpdateTask } from './task_execution.js';
 import {
@@ -81,19 +79,6 @@ import {
 } from './tool_call_engine.js';
 import { logToolCallAndTelemetry, prepareTelemetryData } from './tool_call_telemetry.js';
 import { parseInputParamsFromUrl, storeTaskResultOrSkipIfExpired } from './utils.js';
-
-/**
- * Returns true when the initialize request advertises the MCP Apps UI extension
- * with the widget MIME type. Used to resolve `'auto'` server mode.
- *
- * Uses {@link getUiCapability} from `@modelcontextprotocol/ext-apps/server` to
- * read the `io.modelcontextprotocol/ui` extension from client capabilities — the
- * canonical way per the MCP Apps spec.
- */
-function isUiSupportedByClient(request: InitializeRequest | undefined): boolean {
-    const uiCap = getUiCapability(request?.params?.capabilities);
-    return uiCap?.mimeTypes?.includes(RESOURCE_MIME_TYPE) ?? false;
-}
 
 type ToolsChangedHandler = (toolNames: string[]) => void;
 
@@ -109,6 +94,7 @@ export class ActorsMcpServer {
     public readonly options: ActorsMcpServerOptions;
     public readonly taskStore: TaskStore;
     public readonly actorStore?: ActorStore;
+    private clientContext: McpClientContext | undefined;
     /**
      * Resolved server mode. Preliminary value at construction (`'auto'` → `DEFAULT`).
      * Finalized inside the `initialize` request handler (see constructor) once the
@@ -147,6 +133,7 @@ export class ActorsMcpServer {
 
     constructor(options: ActorsMcpServerOptions = {}) {
         this.options = options;
+        this.clientContext = buildMcpClientContext(options.initializeRequestData?.params);
 
         // for stdio use in memory task store if not provided, otherwise use provided task store
         if (this.options.transportType === 'stdio' && !this.options.taskStore) {
@@ -256,7 +243,9 @@ export class ActorsMcpServer {
         )._oninitialize.bind(this.server);
 
         this.server.setRequestHandler(InitializeRequestSchema, async (request) => {
-            this.clientSupportsUi = isUiSupportedByClient(request);
+            this.clientContext = buildMcpClientContext(request.params);
+            (this.options as Record<string, unknown>).initializeRequestData = request;
+            this.clientSupportsUi = isUiSupportedByClient(this.clientContext);
 
             if (this.serverModeOption === 'auto') {
                 const resolved = resolveServerMode('auto', this.clientSupportsUi);
@@ -265,10 +254,6 @@ export class ActorsMcpServer {
                 }
                 this.serverModeResolved = true;
             }
-
-            // Setting this makes `clientKnown` true, so the queued compose below (and any later
-            // load) resolves the tool set for this client and applies the per-client blocklist.
-            (this.options as Record<string, unknown>).initializeRequestData = request;
 
             log.info('Resolved server mode for client capabilities', {
                 serverMode: this.serverMode,
@@ -294,7 +279,7 @@ export class ActorsMcpServer {
      *  recovery path). Only client-gated tools wait for this so the per-client blocklist can be
      *  applied; client-agnostic tools compose regardless. */
     private get clientKnown(): boolean {
-        return this.options.initializeRequestData != null;
+        return this.clientContext != null;
     }
 
     /**
@@ -323,11 +308,7 @@ export class ActorsMcpServer {
      * survive a load that never sees an initialize.
      */
     private isReportProblemServable(): boolean {
-        return (
-            this.telemetryEnabled &&
-            this.clientKnown &&
-            !isReportProblemBlockedForClient(this.options.initializeRequestData)
-        );
+        return this.telemetryEnabled && this.clientKnown && !isReportProblemBlockedForClient(this.clientContext);
     }
 
     private composePendingToolsForClient(): void {
@@ -624,13 +605,14 @@ export class ActorsMcpServer {
      * Token-scoped client for resources/read (the API proxy needs auth). Deliberately token-only:
      * unlike the CallTool path it does NOT forward provider/payment headers, so a payment-only
      * session (x402/Skyfire, no Apify token) has no client and every read fails by design.
-     * Still carries the request-origin tag — `initializeRequestData` is already set by this point.
+     * Still carries the request-origin tag from the client context captured by this point.
      */
-    private resolveApifyClient(params: ApifyRequestParams): ApifyClient | undefined {
+    private resolveApifyClient(
+        params: ApifyRequestParams,
+        clientContext: McpClientContext | undefined,
+    ): ApifyClient | undefined {
         const token = this.resolveApifyToken(params._meta);
-        return token
-            ? new ApifyClient({ token, requestOrigin: getRequestOriginForClient(this.options.initializeRequestData) })
-            : undefined;
+        return token ? new ApifyClient({ token, requestOrigin: getRequestOriginForClient(clientContext) }) : undefined;
     }
 
     private setupResourceHandlers(): void {
@@ -647,7 +629,7 @@ export class ActorsMcpServer {
         this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
             return await resourceService.readResource(
                 request.params.uri,
-                this.resolveApifyClient(request.params as ApifyRequestParams),
+                this.resolveApifyClient(request.params as ApifyRequestParams, this.clientContext),
             );
         });
 
@@ -840,6 +822,7 @@ export class ActorsMcpServer {
             // Keep actor context available to the outer catch.
             let actorName: string | undefined;
             let actorId: string | undefined;
+            const { clientContext } = this;
 
             // Start with the raw name so early failures still have telemetry.
             const { telemetryData, userId } = await prepareTelemetryData({
@@ -847,6 +830,7 @@ export class ActorsMcpServer {
                 mcpSessionId,
                 apifyToken,
                 apifyMcpServer: this,
+                clientContext,
             });
 
             try {
@@ -860,6 +844,7 @@ export class ActorsMcpServer {
                     isTaskRequest: Boolean(request.params.task),
                     mcpSessionId,
                     telemetryData,
+                    clientContext,
                     extra,
                 });
 
@@ -999,6 +984,7 @@ export class ActorsMcpServer {
                             actorName,
                             actorId,
                             apifyMcpServer: this,
+                            clientContext,
                         }).catch((error) =>
                             // Benign task-expiry is handled in-method (see the catch block and
                             // storeTaskResultOrSkipIfExpired); anything reaching here is genuinely unexpected.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -244,7 +244,7 @@ export class ActorsMcpServer {
 
         this.server.setRequestHandler(InitializeRequestSchema, async (request) => {
             this.clientContext = buildMcpClientContext(request.params);
-            (this.options as Record<string, unknown>).initializeRequestData = request;
+            this.options.initializeRequestData = request;
             this.clientSupportsUi = isUiSupportedByClient(this.clientContext);
 
             if (this.serverModeOption === 'auto') {
@@ -427,7 +427,6 @@ export class ActorsMcpServer {
     /**
      * Loads missing toolNames from a provided list of tool names.
      * Skips toolNames that are already loaded and loads only the missing ones.
-     * @param toolNames - Array of tool names to ensure are loaded
      */
     public async loadToolsByName(toolNames: string[], apifyClient: ApifyClient) {
         const loadedTools = new Set(this.listAllToolNames());

--- a/src/mcp/task_execution.ts
+++ b/src/mcp/task_execution.ts
@@ -14,6 +14,7 @@ import { TOOL_TYPE } from '../types.js';
 import { logHttpError, sanitizeMezmoMessage } from '../utils/logging.js';
 import { createProgressTracker } from '../utils/progress.js';
 import { buildActorFields, getToolFullName } from '../utils/tools.js';
+import type { McpClientContext } from './client_context.js';
 import type { ActorsMcpServer } from './server.js';
 import { buildToolCallErrorResult, TOOL_CALL_ERROR_KIND } from './tool_call_error_mapper.js';
 import type { ToolCallErrorResult } from './tool_call_error_mapper.js';
@@ -89,6 +90,7 @@ export async function executeToolAndUpdateTask(params: {
     actorName?: string;
     actorId?: string;
     apifyMcpServer: ActorsMcpServer;
+    clientContext: McpClientContext | undefined;
 }): Promise<void> {
     const {
         taskId,
@@ -103,6 +105,7 @@ export async function executeToolAndUpdateTask(params: {
         actorName,
         actorId,
         apifyMcpServer,
+        clientContext,
     } = params;
     let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
     // Always populate actor fields so they're tracked on both success and failure paths.
@@ -122,6 +125,7 @@ export async function executeToolAndUpdateTask(params: {
         mcpSessionId,
         apifyToken,
         apifyMcpServer,
+        clientContext,
     });
 
     const finishTaskTracking = (status: ToolStatus, diagnostics?: CallDiagnostics, result?: unknown) => {

--- a/src/mcp/tool_call_engine.ts
+++ b/src/mcp/tool_call_engine.ts
@@ -27,6 +27,7 @@ import type { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
 import { extractAjvErrorDetails } from '../utils/tool_status.js';
 import { buildActorFields, extractActorId, extractActorName, getToolFullName } from '../utils/tools.js';
+import type { McpClientContext } from './client_context.js';
 import type { ActorsMcpServer } from './server.js';
 import { buildToolCallErrorResult, TOOL_CALL_ERROR_KIND } from './tool_call_error_mapper.js';
 import type { ToolCallErrorResult } from './tool_call_error_mapper.js';
@@ -104,10 +105,12 @@ export async function prepareToolCall(params: {
     isTaskRequest: boolean;
     mcpSessionId: string | undefined;
     telemetryData: ToolCallTelemetryProperties | null;
+    clientContext: McpClientContext | undefined;
     // Used to preserve abort status for a post-resolution classified failure.
     extra?: RequestHandlerExtra<Request, Notification>;
 }): Promise<PreparedCall | InvalidToolCall | PreparedCallError> {
-    const { apifyMcpServer, apifyToken, name, meta, requestHeaders, isTaskRequest, telemetryData } = params;
+    const { apifyMcpServer, apifyToken, name, meta, requestHeaders, isTaskRequest, telemetryData, clientContext } =
+        params;
     let { args } = params;
     const { options, tools } = apifyMcpServer;
 
@@ -184,7 +187,7 @@ export async function prepareToolCall(params: {
             apifyToken,
             meta,
             requestHeaders,
-            requestOrigin: getRequestOriginForClient(options.initializeRequestData),
+            requestOrigin: getRequestOriginForClient(clientContext),
         });
 
         log.debug('Validate arguments for tool', {

--- a/src/mcp/tool_call_telemetry.ts
+++ b/src/mcp/tool_call_telemetry.ts
@@ -1,5 +1,3 @@
-import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-
 import log from '@apify/log';
 
 import { ApifyClient } from '../apify_client.js';
@@ -11,6 +9,7 @@ import { getRequestOriginForClient } from '../utils/mcp_clients.js';
 import { deriveResourceIds } from '../utils/tool_status.js';
 import { getUserInfoCached } from '../utils/userid_cache.js';
 import { getPackageVersion } from '../utils/version.js';
+import type { McpClientContext } from './client_context.js';
 import type { ActorsMcpServer } from './server.js';
 
 type PrepareTelemetryDataParams = {
@@ -18,6 +17,7 @@ type PrepareTelemetryDataParams = {
     mcpSessionId: string | undefined;
     apifyToken: string;
     apifyMcpServer: ActorsMcpServer;
+    clientContext: McpClientContext | undefined;
 };
 
 /**
@@ -26,7 +26,7 @@ type PrepareTelemetryDataParams = {
 export async function prepareTelemetryData(
     params: PrepareTelemetryDataParams,
 ): Promise<{ telemetryData: ToolCallTelemetryProperties | null; userId: string | null }> {
-    const { toolName, mcpSessionId, apifyToken, apifyMcpServer } = params;
+    const { toolName, mcpSessionId, apifyToken, apifyMcpServer, clientContext } = params;
     if (!apifyMcpServer.telemetryEnabled) {
         return { telemetryData: null, userId: null };
     }
@@ -34,20 +34,18 @@ export async function prepareTelemetryData(
     // Get userId from cache or fetch from API
     let userId: string | null = null;
     if (apifyToken) {
-        const requestOrigin = getRequestOriginForClient(apifyMcpServer.options.initializeRequestData);
+        const requestOrigin = getRequestOriginForClient(clientContext);
         const apifyClient = new ApifyClient({ token: apifyToken, requestOrigin });
         ({ userId } = await getUserInfoCached(apifyToken, apifyClient));
         log.debug('Telemetry: fetched userId', { userId, mcpSessionId });
     }
-    const capabilities = apifyMcpServer.options.initializeRequestData?.params?.capabilities;
-    const initializeParams = apifyMcpServer.options.initializeRequestData?.params as InitializeRequest['params'];
     const telemetryData: ToolCallTelemetryProperties = {
         app: 'mcp',
         app_version: getPackageVersion() || '',
-        mcp_client_name: initializeParams?.clientInfo?.name || '',
-        mcp_client_version: initializeParams?.clientInfo?.version || '',
-        mcp_protocol_version: initializeParams?.protocolVersion || '',
-        mcp_client_capabilities: capabilities || null,
+        mcp_client_name: clientContext?.clientInfo?.name || '',
+        mcp_client_version: clientContext?.clientInfo?.version || '',
+        mcp_protocol_version: clientContext?.protocolVersion || '',
+        mcp_client_capabilities: clientContext?.capabilities || null,
         mcp_session_id: mcpSessionId || '',
         transport_type: apifyMcpServer.options.transportType || '',
         tool_name: toolName,

--- a/src/utils/mcp_clients.ts
+++ b/src/utils/mcp_clients.ts
@@ -1,16 +1,15 @@
-import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-
 import { REQUEST_ORIGIN } from '../apify_client.js';
 import { APIFY_AI_CLIENT_NAME, REPORT_PROBLEM_BLOCKED_CLIENTS } from '../const.js';
+import type { McpClientContext } from '../mcp/client_context.js';
 
 /** True when `report-problem` is blocklisted for the connecting client (substring match on {@link REPORT_PROBLEM_BLOCKED_CLIENTS}). */
-export function isReportProblemBlockedForClient(initializeRequestData?: InitializeRequest): boolean {
-    const clientName = initializeRequestData?.params?.clientInfo?.name?.toLowerCase() ?? '';
+export function isReportProblemBlockedForClient(context: McpClientContext | undefined): boolean {
+    const clientName = context?.clientInfo?.name?.toLowerCase() ?? '';
     return REPORT_PROBLEM_BLOCKED_CLIENTS.some((blocked) => clientName.includes(blocked));
 }
 
 /** Apify API request origin for this client. Exact match on {@link APIFY_AI_CLIENT_NAME}; everything else is MCP. */
-export function getRequestOriginForClient(initializeRequestData?: InitializeRequest): REQUEST_ORIGIN {
-    const clientName = initializeRequestData?.params?.clientInfo?.name;
+export function getRequestOriginForClient(context: McpClientContext | undefined): REQUEST_ORIGIN {
+    const clientName = context?.clientInfo?.name;
     return clientName === APIFY_AI_CLIENT_NAME ? REQUEST_ORIGIN.APIFY_AI : REQUEST_ORIGIN.MCP;
 }

--- a/tests/unit/dev_server.test.ts
+++ b/tests/unit/dev_server.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractInitializeMessage, parseInitializeParams } from '../../src/dev_server.js';
+
+describe('extractInitializeMessage()', () => {
+    it('matches a well-formed initialize request', () => {
+        const body = {
+            method: 'initialize',
+            params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'x', version: '1' } },
+        };
+        expect(extractInitializeMessage(body)).toEqual(body);
+    });
+
+    it('matches an initialize request with malformed params (regression: must still route to the initialize branch, not the session-id 400)', () => {
+        const body = { method: 'initialize', params: { protocolVersion: 123 } };
+        expect(extractInitializeMessage(body)).toEqual(body);
+    });
+
+    it('matches an initialize request with no params at all', () => {
+        const body = { method: 'initialize' };
+        expect(extractInitializeMessage(body)).toEqual(body);
+    });
+
+    it('matches inside a batched array body', () => {
+        const body = [{ method: 'ping' }, { method: 'initialize', params: {} }];
+        expect(extractInitializeMessage(body)).toEqual(body[1]);
+    });
+
+    it('returns undefined for a non-initialize request', () => {
+        expect(extractInitializeMessage({ method: 'tools/list' })).toBeUndefined();
+        expect(extractInitializeMessage(null)).toBeUndefined();
+        expect(extractInitializeMessage('not an object')).toBeUndefined();
+    });
+});
+
+describe('parseInitializeParams()', () => {
+    it('parses well-formed params', () => {
+        const params = { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'x', version: '1' } };
+        expect(parseInitializeParams(params)).toEqual(params);
+    });
+
+    it('returns undefined for malformed or missing params instead of throwing', () => {
+        expect(parseInitializeParams({ protocolVersion: 123 })).toBeUndefined();
+        expect(parseInitializeParams(undefined)).toBeUndefined();
+    });
+});

--- a/tests/unit/mcp.client_context.test.ts
+++ b/tests/unit/mcp.client_context.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildMcpClientContext, isUiSupportedByClient } from '../../src/mcp/client_context.js';
+import { RESOURCE_MIME_TYPE } from '../../src/resources/widgets.js';
+
+describe('buildMcpClientContext()', () => {
+    it('returns undefined when initialize params are absent', () => {
+        expect(buildMcpClientContext(undefined)).toBeUndefined();
+    });
+
+    it('copies client identity and all capabilities', () => {
+        const params = {
+            protocolVersion: '2025-06-18',
+            clientInfo: { name: 'test-client', version: '1.2.3' },
+            capabilities: {
+                roots: { listChanged: true },
+                sampling: {},
+                experimental: { nested: { enabled: true } },
+            },
+        };
+
+        const context = buildMcpClientContext(params);
+        if (!context) throw new Error('client context was not built');
+
+        expect(context).toEqual(params);
+        expect(context).not.toBe(params);
+        expect(context.clientInfo).not.toBe(params.clientInfo);
+        expect(context.capabilities).not.toBe(params.capabilities);
+        expect(((context.capabilities as Record<string, unknown>).experimental as { nested: object }).nested).not.toBe(
+            params.capabilities.experimental.nested,
+        );
+    });
+
+    it('tolerates missing initialize fields', () => {
+        expect(buildMcpClientContext({})).toEqual({});
+    });
+});
+
+describe('isUiSupportedByClient()', () => {
+    it('detects the MCP Apps UI capability', () => {
+        const context = buildMcpClientContext({
+            capabilities: {
+                extensions: {
+                    'io.modelcontextprotocol/ui': {
+                        mimeTypes: [RESOURCE_MIME_TYPE],
+                    },
+                },
+            },
+        });
+
+        expect(isUiSupportedByClient(context)).toBe(true);
+    });
+
+    it('returns false without the widget MIME type', () => {
+        expect(isUiSupportedByClient(buildMcpClientContext({ capabilities: {} }))).toBe(false);
+        expect(isUiSupportedByClient(undefined)).toBe(false);
+    });
+});

--- a/tests/unit/mcp.server.report_problem_gating.test.ts
+++ b/tests/unit/mcp.server.report_problem_gating.test.ts
@@ -8,12 +8,13 @@ import { SERVER_MODE } from '../../src/types.js';
 
 type InitHandler = (req: InitializeRequest, ctx: unknown) => Promise<unknown>;
 
-function makeServer(telemetryEnabled = true): ActorsMcpServer {
+function makeServer(telemetryEnabled = true, initializeRequestData?: InitializeRequest): ActorsMcpServer {
     return new ActorsMcpServer({
         taskStore: new InMemoryTaskStore(),
         setupSigintHandler: false,
         serverMode: SERVER_MODE.DEFAULT,
         telemetry: { enabled: telemetryEnabled },
+        initializeRequestData,
     });
 }
 
@@ -99,6 +100,20 @@ describe('report-problem client gating', () => {
 
         expect(server.tools.has(HELPER_TOOLS.PROBLEM_REPORT)).toBe(true);
     });
+
+    it.each([
+        { clientName: 'test-client', isAvailable: true },
+        { clientName: 'claude-ai', isAvailable: false },
+    ])(
+        'uses constructor recovery data for client gating: $clientName available=$isAvailable',
+        async ({ clientName, isAvailable }) => {
+            const server = track(makeServer(true, makeInitializeRequest(clientName)));
+
+            await loadReportProblemByName(server);
+
+            expect(server.tools.has(HELPER_TOOLS.PROBLEM_REPORT)).toBe(isAvailable);
+        },
+    );
 
     it('hides report-problem when telemetry is disabled, even for a non-blocked client', async () => {
         // The tool's only function is forwarding submissions via telemetry; with telemetry off it

--- a/tests/unit/mcp.server.resource_request_origin.test.ts
+++ b/tests/unit/mcp.server.resource_request_origin.test.ts
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as ApifyClientModule from '../../src/apify_client.js';
 import { APIFY_AI_CLIENT_NAME } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
-import { getRequestHandler } from './helpers/mcp_server.js';
+import { getRequestHandler, makeRecorderTool } from './helpers/mcp_server.js';
 
 const { capturedClientOptions } = vi.hoisted(() => ({ capturedClientOptions: [] as unknown[] }));
 
@@ -87,6 +87,50 @@ describe('ActorsMcpServer resources/read — request-origin tagging', () => {
             ).catch(() => undefined);
 
             expect(capturedClientOptions.at(-1)).toMatchObject({ requestOrigin: 'MCP' });
+        } finally {
+            await server.close();
+        }
+    });
+});
+
+describe('ActorsMcpServer tools/call — request-origin tagging', () => {
+    it.each([
+        { isTaskRequest: false, toolName: 'sync-origin-tool' },
+        { isTaskRequest: true, toolName: 'task-origin-tool' },
+    ])('tags a $toolName client APIFY_AI', async ({ isTaskRequest, toolName }) => {
+        const server = new ActorsMcpServer({
+            taskStore: new InMemoryTaskStore(),
+            setupSigintHandler: false,
+            telemetry: { enabled: false },
+            token: 'test-token',
+            initializeRequestData: makeInitializeRequest(APIFY_AI_CLIENT_NAME),
+        });
+        try {
+            const { tool } = makeRecorderTool(toolName, {
+                taskSupport: isTaskRequest ? 'optional' : undefined,
+            });
+            server.upsertTools([tool]);
+
+            const result = await getRequestHandler(server, 'tools/call')(
+                {
+                    method: 'tools/call',
+                    params: {
+                        name: toolName,
+                        arguments: {},
+                        _meta: { mcpSessionId: 'session-id' },
+                        ...(isTaskRequest && { task: { ttl: 60_000 } }),
+                    },
+                },
+                { signal: { aborted: false }, sendNotification: vi.fn() },
+            );
+
+            expect(capturedClientOptions.at(-1)).toMatchObject({ requestOrigin: 'APIFY_AI' });
+            if (isTaskRequest) {
+                await vi.waitFor(async () => {
+                    const task = await server.taskStore.getTask((result.task as { taskId: string }).taskId);
+                    if (task?.status !== 'completed') throw new Error('task did not complete');
+                });
+            }
         } finally {
             await server.close();
         }

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -1,4 +1,5 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -6,6 +7,7 @@ import log from '@apify/log';
 
 import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../../src/const.js';
 import * as mcpClient from '../../src/mcp/client.js';
+import type { McpClientContext } from '../../src/mcp/client_context.js';
 import type { ActorsMcpServer } from '../../src/mcp/server.js';
 import type { PaymentProvider } from '../../src/payments/types.js';
 import * as telemetry from '../../src/telemetry.js';
@@ -125,6 +127,29 @@ const BASE_TELEMETRY_KEYS = [
     'tool_status',
     'transport_type',
 ];
+
+const CLIENT_CAPABILITIES = {
+    roots: { listChanged: true },
+    experimental: { feature: { enabled: true } },
+};
+
+const INITIALIZE_REQUEST = {
+    method: 'initialize',
+    params: {
+        protocolVersion: '2025-06-18',
+        clientInfo: { name: 'context-client', version: '1.2.3' },
+        capabilities: CLIENT_CAPABILITIES,
+    },
+} as InitializeRequest;
+
+function expectClientContextTelemetry(properties: Record<string, unknown>): void {
+    expect(properties).toMatchObject({
+        mcp_client_name: 'context-client',
+        mcp_client_version: '1.2.3',
+        mcp_protocol_version: '2025-06-18',
+        mcp_client_capabilities: CLIENT_CAPABILITIES,
+    });
+}
 
 /** Silence the error-path logging the failure branches emit, keeping test output clean. */
 function silenceLogs(): void {
@@ -317,6 +342,24 @@ describe('CallToolRequestSchema handler', () => {
             });
         }
     });
+
+    it('uses the complete client context for sync-call telemetry', async () => {
+        const trackSpy = vi.spyOn(telemetry, 'trackToolCall').mockImplementation(() => {});
+        await withServer(
+            async (server) => {
+                await runSync(server, makeRecorderTool('sync-context-tool').tool);
+            },
+            {
+                token: undefined,
+                telemetry: { enabled: true },
+                allowUnauthMode: true,
+                initializeRequestData: INITIALIZE_REQUEST,
+            },
+        );
+
+        expect(trackSpy.mock.calls).toHaveLength(1);
+        expectClientContextTelemetry(trackSpy.mock.calls[0][2]);
+    });
 });
 
 describe('CallToolRequestSchema handler — invalid-call rejections (characterization)', () => {
@@ -485,6 +528,50 @@ describe('executeToolAndUpdateTask()', () => {
                 expect(trackSpy.mock.calls[0][2]).not.toHaveProperty('task_id');
             });
         }
+    });
+
+    it('uses the client context captured when the task is scheduled', async () => {
+        const trackSpy = vi.spyOn(telemetry, 'trackToolCall').mockImplementation(() => {});
+        await withServer(
+            async (server) => {
+                const { tool } = makeRecorderTool('task-context-tool', { taskSupport: 'optional' });
+                server.upsertTools([tool]);
+                const handler = getRequestHandler(server, 'tools/call');
+                const response = await handler(
+                    {
+                        method: 'tools/call',
+                        params: {
+                            name: tool.name,
+                            arguments: {},
+                            _meta: { mcpSessionId: 's1' },
+                            task: { ttl: 60_000 },
+                        },
+                    },
+                    { signal: { aborted: false }, sendNotification: vi.fn() },
+                );
+
+                (server as unknown as { clientContext: McpClientContext }).clientContext = {
+                    protocolVersion: 'changed',
+                    clientInfo: { name: 'changed', version: 'changed' },
+                    capabilities: { changed: true },
+                };
+
+                await vi.waitFor(async () => {
+                    const task = await server.taskStore.getTask((response.task as { taskId: string }).taskId);
+                    if (task?.status !== 'completed') throw new Error('task did not complete');
+                    if (trackSpy.mock.calls.length === 0) throw new Error('trackToolCall spy was not called');
+                });
+            },
+            {
+                token: undefined,
+                telemetry: { enabled: true },
+                allowUnauthMode: true,
+                initializeRequestData: INITIALIZE_REQUEST,
+            },
+        );
+
+        expect(trackSpy.mock.calls).toHaveLength(1);
+        expectClientContextTelemetry(trackSpy.mock.calls[0][2]);
     });
 
     it('dispatches an ACTOR_MCP tool run as a task and surfaces a connect failure as a completed error result', async () => {

--- a/tests/unit/mcp_clients.test.ts
+++ b/tests/unit/mcp_clients.test.ts
@@ -1,32 +1,29 @@
-import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it } from 'vitest';
 
+import type { McpClientContext } from '../../src/mcp/client_context.js';
 import { getRequestOriginForClient, isReportProblemBlockedForClient } from '../../src/utils/mcp_clients.js';
 
-function initRequest(clientName?: string): InitializeRequest | undefined {
+function clientContext(clientName?: string): McpClientContext | undefined {
     if (clientName === undefined) return undefined;
     return {
-        method: 'initialize',
-        params: {
-            protocolVersion: '2025-06-18',
-            clientInfo: { name: clientName, version: '1.0.0' },
-            capabilities: {},
-        },
-    } as InitializeRequest;
+        protocolVersion: '2025-06-18',
+        clientInfo: { name: clientName, version: '1.0.0' },
+        capabilities: {},
+    };
 }
 
 describe('isReportProblemBlockedForClient', () => {
     it.each(['claude-ai', 'claude-code', 'Claude Desktop', 'Anthropic', 'anthropic-sdk'])(
         'blocks report-problem for the Anthropic client "%s"',
         (clientName) => {
-            expect(isReportProblemBlockedForClient(initRequest(clientName))).toBe(true);
+            expect(isReportProblemBlockedForClient(clientContext(clientName))).toBe(true);
         },
     );
 
     it.each(['cursor', 'test-client', 'vscode', ''])(
         'serves report-problem to the non-Anthropic client "%s"',
         (clientName) => {
-            expect(isReportProblemBlockedForClient(initRequest(clientName))).toBe(false);
+            expect(isReportProblemBlockedForClient(clientContext(clientName))).toBe(false);
         },
     );
 
@@ -37,17 +34,17 @@ describe('isReportProblemBlockedForClient', () => {
 
 describe('getRequestOriginForClient()', () => {
     it('maps the Apify Console AI chat client to APIFY_AI', () => {
-        expect(getRequestOriginForClient(initRequest('apify-console-ai-chat'))).toBe('APIFY_AI');
+        expect(getRequestOriginForClient(clientContext('apify-console-ai-chat'))).toBe('APIFY_AI');
     });
 
     it.each(['cursor', 'claude-ai', 'vscode', ''])('maps the unrelated client "%s" to MCP', (clientName) => {
-        expect(getRequestOriginForClient(initRequest(clientName))).toBe('MCP');
+        expect(getRequestOriginForClient(clientContext(clientName))).toBe('MCP');
     });
 
     it.each(['apify-console-ai-chat-v2', 'Apify-Console-AI-Chat'])(
         'maps the near-miss client "%s" to MCP (exact match only)',
         (clientName) => {
-            expect(getRequestOriginForClient(initRequest(clientName))).toBe('MCP');
+            expect(getRequestOriginForClient(clientContext(clientName))).toBe('MCP');
         },
     );
 

--- a/tests/unit/tool_call_engine.test.ts
+++ b/tests/unit/tool_call_engine.test.ts
@@ -42,6 +42,7 @@ describe('prepareToolCall()', () => {
                 isTaskRequest: false,
                 mcpSessionId: 's1',
                 telemetryData: null,
+                clientContext: undefined,
             });
             expect('message' in result).toBe(true);
             const invalid = result as InvalidToolCall;
@@ -63,6 +64,7 @@ describe('prepareToolCall()', () => {
                 isTaskRequest: false,
                 mcpSessionId: 's1',
                 telemetryData: null,
+                clientContext: undefined,
             });
             expect('message' in result).toBe(true);
             const invalid = result as InvalidToolCall;
@@ -85,6 +87,7 @@ describe('prepareToolCall()', () => {
                 isTaskRequest: false,
                 mcpSessionId: 's1',
                 telemetryData: null,
+                clientContext: undefined,
             });
             expect('message' in result).toBe(true);
             const invalid = result as InvalidToolCall;
@@ -107,6 +110,7 @@ describe('prepareToolCall()', () => {
                 isTaskRequest: false,
                 mcpSessionId: 's1',
                 telemetryData,
+                clientContext: undefined,
             });
             expect('message' in result).toBe(false);
             const prepared = result as PreparedCall;
@@ -133,6 +137,7 @@ describe('executeSyncToolCall()', () => {
             isTaskRequest: false,
             mcpSessionId: 's1',
             telemetryData: null,
+            clientContext: undefined,
         })) as PreparedCall;
         return prepared;
     }


### PR DESCRIPTION
I discussed with codex and there is a simpler solution to v2 server, it needs a bit more refactoring though.

## Summary

Closes #1145.

Introduce an internal `McpClientContext` for client identity and capabilities without coupling shared helpers to an MCP SDK generation.

## Changes

- Build the client context from constructor recovery data and `initialize` requests.
- Keep `ActorsMcpServerOptions.initializeRequestData` unchanged for hosted session recovery.
- Use the context for UI detection, client gating, request origin, telemetry, resource reads, and tool calls.
- Capture the context when scheduling asynchronous tasks.
- Remove v1 SDK request types from shared client helpers.
- Update the dev server and MCP documentation.

## Compatibility

Protocol behavior and public exports are unchanged. The hosted server `initializeRequestData` recovery contract remains intact.

This touches data consumed by the internal hosted server, so its session-recovery contract should be checked during review.

## Verification

- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run test:unit` — 1,171 passed, 1 skipped
- `pnpm run format`
- `pnpm run check:agents`