### PR TITLE
refactor!: Separate legacy MCP wiring from ActorsMcpServer

### DIFF
--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -10,74 +10,23 @@ implementations, not by importing from here.
 
 ## Files
 
-- `server.ts` — `ActorsMcpServer`: the **shared-Apify-behavior facade**. Owns the tool
-  registry + loaders, server-mode resolution, MCP Apps capability detection, `actorStore`,
-  telemetry config, widgets, the neutral prompt/resource services, and token/client
-  resolution. Implements `LegacyMcpServerHost` and constructs exactly one `LegacyMcpServer`
-  (the v1 adapter), delegating all v1 protocol work to it. `applyInitialize()` runs the
-  shared initialize steps (client-context refresh → `'auto'` mode resolution → pending-tool
-  flush → widget resolution) the adapter delegates to before returning `InitializeResult`.
-  `connect()` resolves widgets then brings the adapter's transport up; `close()` takes the
-  adapter down then clears the tool map (reverse-of-connect order — a deliberate reorder vs
-  the pre-refactor tools-then-server order). Raw `.server` / `.taskStore` are NOT on the
-  facade — they moved to the adapter.
-- `legacy_server.ts` — `LegacyMcpServer` + the `LegacyMcpServerHost` interface: the v1 SDK
-  adapter. **Package-private** — not exported from `index.ts` / `index_internals.ts`,
-  constructed only by `ActorsMcpServer`. Owns the SDK `Server`, the `taskStore`, every
-  request handler (`initialize` handshake, logging proxy + setLevel, error handling + SIGINT,
-  tools/list + tools/call, prompts, resources, tasks), notifications, and `toLegacyMcpError`.
-  Reads shared state through `LegacyMcpServerHost` (implemented by the facade); never imports
-  the concrete facade class. The `CallToolRequest` handler decodes the wire request, pulls
-  plain values off the host/`extra`, and drives `tool_call_engine.ts` (prepare → sync tail /
-  task path → `dispatchToolCall`), then records telemetry. `InvalidToolCall` is mapped to the
-  v1 softFail → logging notification → `McpError` sequence; `McpError` is re-thrown, while
-  task-creation failures are classified as tool results. The task path reuses the same
-  `PreparedCall`; both use the shared `dispatchToolCall` switch. Uses the SDK `InMemoryTaskStore`
-  only for stdio; non-stdio transports must be given a task store (the internal repo injects a
-  Redis one) or the constructor throws.
-- `client_context.ts` — protocol-neutral client identity and capabilities. The server
-  snapshots it from constructor recovery data and refreshes it during `initialize`.
-  Internal helpers receive this context instead of an SDK initialize type; the raw
-  `options.initializeRequestData` remains the hosted session-recovery boundary.
-- `errors.ts` — protocol-neutral domain errors `InvalidParamsError`/`InternalError`
-  (plain `Error` subclasses with `data?: unknown`, zero SDK imports). The prompt and
-  resource services throw these; `legacy_server.ts`'s `toLegacyMcpError` maps each 1:1 to
-  `McpError(ErrorCode.InvalidParams | InternalError, message, data)` in the
-  `resources/read` and `prompts/get` handler bodies — the single v1 seam, so wire
-  output stays byte-identical. A future v2 adapter supplies its own projection.
+- `server.ts` — `ActorsMcpServer`, the shared facade for tools, server mode, services,
+  widgets, payments, and telemetry. It constructs and delegates v1 work to `LegacyMcpServer`.
+- `legacy_server.ts` — package-private v1 SDK adapter for handlers, Tasks, errors,
+  notifications, logging, and transport lifecycle. It reads shared state through
+  `LegacyMcpServerHost`.
+- `client_context.ts` — protocol-neutral client identity and capabilities.
+- `errors.ts` — protocol-neutral domain errors mapped by each protocol adapter.
 - `tool_call_engine.ts` — shared `tools/call` orchestration. `prepareToolCall()` handles
-  token gate, tool resolution, payment context, AJV validation, task support, and standby/402
-  pre-flight. `executeSyncToolCall()` runs the dispatch tail; `classifyToolCallError()` maps
-  non-protocol errors to tool results. Protocol errors are not constructed here, and escaped
-  `McpError`s remain JSON-RPC errors.
+  preparation; `executeSyncToolCall()` runs synchronous calls.
 - `client.ts` — `connectMCPClient(url, token)`: transport negotiation.
 - `proxy.ts` — MCP-in-MCP: `getMCPServerID(url)`.
 - `actors.ts` — `getActorMCPServerPath()`: parses an Actor's `webServerMcpPath`.
 - `utils.ts` — `processParamsGetTools()`: turns `?actors=` URL params into tools.
-- `tool_call_error_mapper.ts` — `buildToolCallErrorResult()`: pure classifier shared by the
-  engine's `classifyToolCallError()` (`tool_call_engine.ts`, reached from `legacy_server.ts`'s
-  tools/call catch and from `executeSyncToolCall`) and the `task_execution.ts` catch. Maps an
-  error to a `kind: 'payment' | 'approval'
-  | 'execution'` result (status, diagnostics, response/userText). Never throws, logs,
-  or writes the store — the catch blocks own logging and store writes. For payment/approval
-  the mapper returns the ready-to-send `response`; the catch builds the wire result only for
-  the execution `userText`.
-- `tool_dispatch.ts` — `dispatchToolCall()`: the single exhaustive `switch (tool.type)`
-  (INTERNAL / ACTOR_MCP / ACTOR) both the sync handler and the task path run. Plain function
-  taking neutral values (`signal`, `sendNotification`, `emitLog`, `actorStore`,
-  `paymentProvider`, `loadedToolNames`, …), not the facade. The required `emitLog` parameter
-  sends ACTOR_MCP connect-failure notifications.
-- `tool_call_telemetry.ts` — `prepareTelemetryData()` / `logToolCallAndTelemetry()`: shared by
-  the sync `CallToolRequestSchema` handler and the task path. Plain functions taking the
-  resolved telemetry config (`telemetryEnabled` / `telemetryEnv` / `transportType`) as neutral
-  values, not the facade.
-- `task_execution.ts` — `executeToolAndUpdateTask()` / `emitTaskStatusNotification()`: the
-  long-running-task path (legacy-only). `executeToolAndUpdateTask()` takes the legacy
-  `taskStore` / `server` plus neutral values (`tools`, `actorStore`, `paymentProvider`,
-  `loadedToolNames`, telemetry config, `sendNotification`), not the facade, and builds its
-  abort signal from its own cancel watcher. `emitTaskStatusNotification()` takes
-  `taskStore`/`server` directly and also keeps two call sites in `legacy_server.ts` (the
-  `tasks/cancel` handler and the pre-flight `setImmediate` failure path).
+- `tool_call_error_mapper.ts` — shared tool-call error classification.
+- `tool_dispatch.ts` — neutral dispatch for internal, Actor MCP, and Actor tools.
+- `tool_call_telemetry.ts` — shared tool-call telemetry preparation and logging.
+- `task_execution.ts` — legacy long-running task execution and status notifications.
 - `const.ts` — the invariant constants below (the single source for these values).
 
 ## Gotchas & invariants

--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -10,22 +10,38 @@ implementations, not by importing from here.
 
 ## Files
 
-- `server.ts` — `ActorsMcpServer`: tool/prompt/resource/task registration, the
-  `initialize` handshake, MCP Apps capability detection, `CallToolRequest` handling.
-  The `CallToolRequest` handler prepares calls with `tool_call_engine.ts`, runs the
-  sync tail, and records telemetry. `InvalidToolCall` is mapped to the v1
-  softFail → logging notification → `McpError` sequence; `McpError` is re-thrown,
-  while task-creation failures are classified as tool results. The task path reuses
-  the same `PreparedCall`; both use the shared `dispatchToolCall` switch.
-  Uses the SDK `InMemoryTaskStore` only for stdio; non-stdio transports must be given
-  a task store (the internal repo injects a Redis one) or the constructor throws.
+- `server.ts` — `ActorsMcpServer`: the **shared-Apify-behavior facade**. Owns the tool
+  registry + loaders, server-mode resolution, MCP Apps capability detection, `actorStore`,
+  telemetry config, widgets, the neutral prompt/resource services, and token/client
+  resolution. Implements `LegacyMcpServerHost` and constructs exactly one `LegacyMcpServer`
+  (the v1 adapter), delegating all v1 protocol work to it. `applyInitialize()` runs the
+  shared initialize steps (client-context refresh → `'auto'` mode resolution → pending-tool
+  flush → widget resolution) the adapter delegates to before returning `InitializeResult`.
+  `connect()` resolves widgets then brings the adapter's transport up; `close()` takes the
+  adapter down then clears the tool map (reverse-of-connect order — a deliberate reorder vs
+  the pre-refactor tools-then-server order). Raw `.server` / `.taskStore` are NOT on the
+  facade — they moved to the adapter.
+- `legacy_server.ts` — `LegacyMcpServer` + the `LegacyMcpServerHost` interface: the v1 SDK
+  adapter. **Package-private** — not exported from `index.ts` / `index_internals.ts`,
+  constructed only by `ActorsMcpServer`. Owns the SDK `Server`, the `taskStore`, every
+  request handler (`initialize` handshake, logging proxy + setLevel, error handling + SIGINT,
+  tools/list + tools/call, prompts, resources, tasks), notifications, and `toLegacyMcpError`.
+  Reads shared state through `LegacyMcpServerHost` (implemented by the facade); never imports
+  the concrete facade class. The `CallToolRequest` handler decodes the wire request, pulls
+  plain values off the host/`extra`, and drives `tool_call_engine.ts` (prepare → sync tail /
+  task path → `dispatchToolCall`), then records telemetry. `InvalidToolCall` is mapped to the
+  v1 softFail → logging notification → `McpError` sequence; `McpError` is re-thrown, while
+  task-creation failures are classified as tool results. The task path reuses the same
+  `PreparedCall`; both use the shared `dispatchToolCall` switch. Uses the SDK `InMemoryTaskStore`
+  only for stdio; non-stdio transports must be given a task store (the internal repo injects a
+  Redis one) or the constructor throws.
 - `client_context.ts` — protocol-neutral client identity and capabilities. The server
   snapshots it from constructor recovery data and refreshes it during `initialize`.
   Internal helpers receive this context instead of an SDK initialize type; the raw
   `options.initializeRequestData` remains the hosted session-recovery boundary.
 - `errors.ts` — protocol-neutral domain errors `InvalidParamsError`/`InternalError`
   (plain `Error` subclasses with `data?: unknown`, zero SDK imports). The prompt and
-  resource services throw these; `server.ts`'s `toLegacyMcpError` maps each 1:1 to
+  resource services throw these; `legacy_server.ts`'s `toLegacyMcpError` maps each 1:1 to
   `McpError(ErrorCode.InvalidParams | InternalError, message, data)` in the
   `resources/read` and `prompts/get` handler bodies — the single v1 seam, so wire
   output stays byte-identical. A future v2 adapter supplies its own projection.
@@ -38,29 +54,40 @@ implementations, not by importing from here.
 - `proxy.ts` — MCP-in-MCP: `getMCPServerID(url)`.
 - `actors.ts` — `getActorMCPServerPath()`: parses an Actor's `webServerMcpPath`.
 - `utils.ts` — `processParamsGetTools()`: turns `?actors=` URL params into tools.
-- `tool_call_error_mapper.ts` — `buildToolCallErrorResult()`: pure classifier both
-  `server.ts` tool-call catches share. Maps an error to a `kind: 'payment' | 'approval'
+- `tool_call_error_mapper.ts` — `buildToolCallErrorResult()`: pure classifier shared by the
+  engine's `classifyToolCallError()` (`tool_call_engine.ts`, reached from `legacy_server.ts`'s
+  tools/call catch and from `executeSyncToolCall`) and the `task_execution.ts` catch. Maps an
+  error to a `kind: 'payment' | 'approval'
   | 'execution'` result (status, diagnostics, response/userText). Never throws, logs,
   or writes the store — the catch blocks own logging and store writes. For payment/approval
   the mapper returns the ready-to-send `response`; the catch builds the wire result only for
   the execution `userText`.
 - `tool_dispatch.ts` — `dispatchToolCall()`: the single exhaustive `switch (tool.type)`
-  (INTERNAL / ACTOR_MCP / ACTOR) both the sync handler and the task path run. Plain
-  function taking the `ActorsMcpServer` instance; touches no class state beyond `.server`.
-  The optional `emitLog` parameter sends ACTOR_MCP connect-failure notifications.
+  (INTERNAL / ACTOR_MCP / ACTOR) both the sync handler and the task path run. Plain function
+  taking neutral values (`signal`, `sendNotification`, `emitLog`, `actorStore`,
+  `paymentProvider`, `loadedToolNames`, …), not the facade. The required `emitLog` parameter
+  sends ACTOR_MCP connect-failure notifications.
 - `tool_call_telemetry.ts` — `prepareTelemetryData()` / `logToolCallAndTelemetry()`: shared by
   the sync `CallToolRequestSchema` handler and the task path. Plain functions taking the
-  `ActorsMcpServer` instance (as `apifyMcpServer`), reading `telemetryEnabled`/`telemetryEnv`
-  and `options.*` off it — both are `public readonly` on `ActorsMcpServer`.
+  resolved telemetry config (`telemetryEnabled` / `telemetryEnv` / `transportType`) as neutral
+  values, not the facade.
 - `task_execution.ts` — `executeToolAndUpdateTask()` / `emitTaskStatusNotification()`: the
-  long-running-task path. `executeToolAndUpdateTask()` takes the `ActorsMcpServer` instance
-  (as `apifyMcpServer`); `emitTaskStatusNotification()` takes `taskStore`/`server` directly
-  and also keeps two call sites in `server.ts` (the `tasks/cancel` handler and the pre-flight
-  `setImmediate` failure path).
+  long-running-task path (legacy-only). `executeToolAndUpdateTask()` takes the legacy
+  `taskStore` / `server` plus neutral values (`tools`, `actorStore`, `paymentProvider`,
+  `loadedToolNames`, telemetry config, `sendNotification`), not the facade, and builds its
+  abort signal from its own cancel watcher. `emitTaskStatusNotification()` takes
+  `taskStore`/`server` directly and also keeps two call sites in `legacy_server.ts` (the
+  `tasks/cancel` handler and the pre-flight `setImmediate` failure path).
 - `const.ts` — the invariant constants below (the single source for these values).
 
 ## Gotchas & invariants
 
+- **Facade → adapter, one direction only.** `ActorsMcpServer` (facade) constructs and delegates
+  to `LegacyMcpServer` (adapter). The adapter reads shared state only through the
+  `LegacyMcpServerHost` interface and never imports the concrete facade class; the shared
+  synchronous execution modules (`tool_call_engine.ts`, `tool_dispatch.ts`) take plain values and
+  import no `ActorsMcpServer`, v1 `RequestHandlerExtra`, or v1 `McpError`, and nothing shared
+  imports `LegacyMcpServer`. Keep it that way so a second protocol adapter reuses one Apify core.
 - **Tool names: capped + hash-deduped.** Names are capped at `MAX_TOOL_NAME_LENGTH`;
   over-length or colliding names get a `TOOL_NAME_HASH_LENGTH` hash suffix so the
   exposed set stays unique within the limit (the hashing is in `../tools/actor_tool_naming.ts`).

--- a/src/mcp/legacy_server.ts
+++ b/src/mcp/legacy_server.ts
@@ -1,11 +1,6 @@
 /**
- * Legacy (v1 SDK) MCP wiring extracted from `ActorsMcpServer`.
- *
- * `LegacyMcpServer` owns the v1 SDK `Server`, every request handler (initialize, logging, tools,
- * prompts, resources, tasks), notifications, error mapping, SIGINT + transport lifecycle. It reads
- * shared Apify state through the narrow {@link LegacyMcpServerHost} interface (implemented by
- * `ActorsMcpServer`), never importing the concrete facade class. This adapter is package-private —
- * not exported from `index.ts` / `index_internals.ts`.
+ * Package-private v1 SDK adapter: owns the SDK `Server`, request handlers, notifications, and
+ * transport lifecycle, reading shared Apify state through {@link LegacyMcpServerHost}.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -94,19 +89,11 @@ export interface LegacyMcpServerHost {
     readonly options: ActorsMcpServerOptions;
     readonly promptService: ReturnType<typeof createPromptService>;
     readonly resourceService: ReturnType<typeof createResourceService>;
-    listToolNames(): string[];
-    listAllToolNames(): string[];
     resolveApifyToken(meta?: ApifyRequestParams['_meta']): string | undefined;
     resolveApifyClient(params: ApifyRequestParams): ApifyClient | undefined;
     getServerInstructions(): string;
     applyInitialize(request: InitializeRequest): Promise<void>;
 }
-
-type LegacyMcpServerOptions = {
-    setupSigintHandler: boolean;
-    taskStore?: TaskStore;
-    transportType?: 'stdio' | 'http';
-};
 
 /**
  * v1 SDK adapter. One per serving unit, constructed only by `ActorsMcpServer`.
@@ -118,14 +105,15 @@ export class LegacyMcpServer {
     private sigintHandler: (() => Promise<void>) | undefined;
     private currentLogLevel = 'info';
 
-    constructor(host: LegacyMcpServerHost, options: LegacyMcpServerOptions) {
+    constructor(host: LegacyMcpServerHost) {
         this.host = host;
+        const { taskStore, transportType, setupSigintHandler = true } = host.options;
 
         // for stdio use in memory task store if not provided, otherwise use provided task store
-        if (options.transportType === 'stdio' && !options.taskStore) {
+        if (transportType === 'stdio' && !taskStore) {
             this.taskStore = new InMemoryTaskStore();
-        } else if (options.taskStore) {
-            this.taskStore = options.taskStore;
+        } else if (taskStore) {
+            this.taskStore = taskStore;
         } else {
             throw new Error('Task store must be provided for non-stdio transport types');
         }
@@ -154,7 +142,7 @@ export class LegacyMcpServer {
         });
         this.setupInitializeHandler();
         this.setupLoggingProxy();
-        this.setupErrorHandling(options.setupSigintHandler);
+        this.setupErrorHandling(setupSigintHandler);
         this.setupLoggingHandlers();
         this.setupToolHandlers();
         this.setupPromptHandlers();
@@ -425,9 +413,6 @@ export class LegacyMcpServer {
             const { clientContext, actorStore } = this.host;
             const { paymentProvider, allowUnauthMode } = this.host.options;
             // Plain values pulled from the host/request, threaded into the shared engine.
-            // Snapshotting the tool names here equals the pre-refactor per-call read: the tool
-            // registry is only mutated during connection setup, never mid-session.
-            const loadedToolNames = this.host.listToolNames();
             const { signal, sendNotification } = extra;
             const emitLog = async (msg: { level: string; data?: unknown }) =>
                 this.server.sendLoggingMessage(msg as Parameters<typeof this.server.sendLoggingMessage>[0]);
@@ -456,7 +441,6 @@ export class LegacyMcpServer {
                     tools: this.host.tools,
                     paymentProvider,
                     allowUnauthMode,
-                    loadedToolNames,
                     signal,
                 });
 
@@ -600,7 +584,6 @@ export class LegacyMcpServer {
                             tools: this.host.tools,
                             actorStore,
                             paymentProvider,
-                            loadedToolNames,
                             telemetryEnabled: this.host.telemetryEnabled,
                             telemetryEnv: this.host.telemetryEnv,
                             transportType: this.host.options.transportType,
@@ -626,7 +609,6 @@ export class LegacyMcpServer {
                     tools: this.host.tools,
                     actorStore,
                     paymentProvider,
-                    loadedToolNames,
                     signal,
                     sendNotification,
                     emitLog,

--- a/src/mcp/legacy_server.ts
+++ b/src/mcp/legacy_server.ts
@@ -1,0 +1,688 @@
+/**
+ * Legacy (v1 SDK) MCP wiring extracted from `ActorsMcpServer`.
+ *
+ * `LegacyMcpServer` owns the v1 SDK `Server`, every request handler (initialize, logging, tools,
+ * prompts, resources, tasks), notifications, error mapping, SIGINT + transport lifecycle. It reads
+ * shared Apify state through the narrow {@link LegacyMcpServerHost} interface (implemented by
+ * `ActorsMcpServer`), never importing the concrete facade class. This adapter is package-private —
+ * not exported from `index.ts` / `index_internals.ts`.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
+import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { InitializeRequest, InitializeResult, Task } from '@modelcontextprotocol/sdk/types.js';
+import {
+    CallToolRequestSchema,
+    CancelTaskRequestSchema,
+    ErrorCode,
+    GetPromptRequestSchema,
+    GetTaskPayloadRequestSchema,
+    GetTaskRequestSchema,
+    InitializeRequestSchema,
+    ListPromptsRequestSchema,
+    ListResourcesRequestSchema,
+    ListResourceTemplatesRequestSchema,
+    ListTasksRequestSchema,
+    ListToolsRequestSchema,
+    McpError,
+    ReadResourceRequestSchema,
+    RELATED_TASK_META_KEY,
+    SetLevelRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import log from '@apify/log';
+
+import type { ApifyClient } from '../apify_client.js';
+import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
+import type { createPromptService } from '../prompts/prompt_service.js';
+import type { createResourceService } from '../resources/resource_service.js';
+import { getServerInfo } from '../server_card.js';
+import { withReportProblemNudge } from '../tools/dev/report_problem.js';
+import type {
+    ActorsMcpServerOptions,
+    ActorStore,
+    ApifyRequestParams,
+    CallDiagnostics,
+    SERVER_MODE,
+    TelemetryEnv,
+    ToolEntry,
+    ToolStatus,
+} from '../types.js';
+import { isMcpClientFaultMessage, sanitizeMezmoMessage } from '../utils/logging.js';
+import { getServerInstructions } from '../utils/server-instructions/index.js';
+import { buildActorFields, getToolFullName, getToolPublicFieldOnly } from '../utils/tools.js';
+import type { McpClientContext } from './client_context.js';
+import { LOG_LEVEL_MAP } from './const.js';
+import { InternalError, InvalidParamsError } from './errors.js';
+import { emitTaskStatusNotification, executeToolAndUpdateTask } from './task_execution.js';
+import {
+    buildPreflightFailureOutcome,
+    classifyToolCallError,
+    executeSyncToolCall,
+    prepareToolCall,
+} from './tool_call_engine.js';
+import { logToolCallAndTelemetry, prepareTelemetryData } from './tool_call_telemetry.js';
+import { storeTaskResultOrSkipIfExpired } from './utils.js';
+
+/**
+ * Legacy protocol boundary: project a service's domain error to its v1 `McpError`, copying `message`
+ * and `data` unchanged so the wire output (code, message, presence of `data`) is byte-identical.
+ * Non-domain errors pass through untouched.
+ */
+function toLegacyMcpError(error: unknown): unknown {
+    if (error instanceof InvalidParamsError) return new McpError(ErrorCode.InvalidParams, error.message, error.data);
+    if (error instanceof InternalError) return new McpError(ErrorCode.InternalError, error.message, error.data);
+    return error;
+}
+
+/**
+ * Read-facing view of the shared `ActorsMcpServer` facade that the legacy adapter depends on. Keeps
+ * the coupling one-directional and greppable: the adapter reads live shared state (tools mutate after
+ * construction) and neutral services, and never sees the concrete facade class.
+ */
+export interface LegacyMcpServerHost {
+    readonly tools: Map<string, ToolEntry>;
+    readonly serverMode: SERVER_MODE;
+    readonly actorStore?: ActorStore;
+    readonly clientContext: McpClientContext | undefined;
+    readonly telemetryEnabled: boolean;
+    readonly telemetryEnv: TelemetryEnv;
+    readonly options: ActorsMcpServerOptions;
+    readonly promptService: ReturnType<typeof createPromptService>;
+    readonly resourceService: ReturnType<typeof createResourceService>;
+    listToolNames(): string[];
+    listAllToolNames(): string[];
+    resolveApifyToken(meta?: ApifyRequestParams['_meta']): string | undefined;
+    resolveApifyClient(params: ApifyRequestParams): ApifyClient | undefined;
+    getServerInstructions(): string;
+    applyInitialize(request: InitializeRequest): Promise<void>;
+}
+
+type LegacyMcpServerOptions = {
+    setupSigintHandler: boolean;
+    taskStore?: TaskStore;
+    transportType?: 'stdio' | 'http';
+};
+
+/**
+ * v1 SDK adapter. One per serving unit, constructed only by `ActorsMcpServer`.
+ */
+export class LegacyMcpServer {
+    public readonly server: Server;
+    public readonly taskStore: TaskStore;
+    private readonly host: LegacyMcpServerHost;
+    private sigintHandler: (() => Promise<void>) | undefined;
+    private currentLogLevel = 'info';
+
+    constructor(host: LegacyMcpServerHost, options: LegacyMcpServerOptions) {
+        this.host = host;
+
+        // for stdio use in memory task store if not provided, otherwise use provided task store
+        if (options.transportType === 'stdio' && !options.taskStore) {
+            this.taskStore = new InMemoryTaskStore();
+        } else if (options.taskStore) {
+            this.taskStore = options.taskStore;
+        } else {
+            throw new Error('Task store must be provided for non-stdio transport types');
+        }
+
+        this.server = new Server(getServerInfo(), {
+            capabilities: {
+                tools: {
+                    listChanged: true,
+                },
+                // Declare long-running task support
+                tasks: {
+                    list: {},
+                    cancel: {},
+                    requests: {
+                        tools: {
+                            call: {},
+                        },
+                    },
+                },
+                // Declared but unused — some clients (e.g. Claude Desktop) fail without it.
+                resources: {},
+                prompts: {},
+                logging: {},
+            },
+            instructions: getServerInstructions(),
+        });
+        this.setupInitializeHandler();
+        this.setupLoggingProxy();
+        this.setupErrorHandling(options.setupSigintHandler);
+        this.setupLoggingHandlers();
+        this.setupToolHandlers();
+        this.setupPromptHandlers();
+        // Handle resource requests so clients like Claude Desktop don't fail.
+        this.setupResourceHandlers();
+        this.setupTaskHandlers();
+    }
+
+    /**
+     * Override the SDK's `initialize` request handler to run mode resolution and
+     * pending-source flush before `InitializeResult` is sent. Delegates boilerplate
+     * (protocolVersion, capabilities, instructions) to the SDK's captured `_oninitialize`.
+     *
+     * Not using `server.oninitialized`: the SDK dispatches notification handlers
+     * fire-and-forget (separate microtask), so a follow-up `tools/list` can race past them.
+     * The request handler guarantees tools are final before the response and the first `tools/list`.
+     */
+    private setupInitializeHandler() {
+        // Capture the SDK's default initialize handler installed in its constructor.
+        // Private-field access on the SDK Server — verified against
+        // @modelcontextprotocol/sdk ^1.25.x (see package.json). On SDK bumps, re-check
+        // `@modelcontextprotocol/sdk/shared/protocol.js` for a still-named `_oninitialize`;
+        // if renamed or made non-delegable, rebuild the InitializeResult shape here
+        // (protocolVersion, serverInfo, capabilities, instructions) instead of delegating.
+        // The capability-gating unit tests construct a server and act as a canary.
+        // eslint-disable-next-line no-underscore-dangle
+        const sdkInitHandler = (
+            this.server as unknown as {
+                _oninitialize(req: InitializeRequest): Promise<InitializeResult>;
+            }
+        )._oninitialize.bind(this.server);
+
+        this.server.setRequestHandler(InitializeRequestSchema, async (request) => {
+            await this.host.applyInitialize(request);
+
+            const result = await sdkInitHandler(request);
+            // Tools are final here (applyInitialize flushed pending tools, applying the per-client
+            // blocklist), so tool presence is the ground truth for whether to advertise
+            // report-problem in the instructions.
+            result.instructions = this.host.getServerInstructions();
+            return result;
+        });
+    }
+
+    private setupErrorHandling(setupSIGINTHandler = true): void {
+        this.server.onerror = (error) => {
+            // Known client faults are expected noise, not server bugs — softFail so they don't
+            // flood Mezmo error alerts. The fault patterns live in utils/logging.ts.
+            const message = error.message ?? '';
+            if (isMcpClientFaultMessage(message)) {
+                // Sanitize the errMessage value to preserve the soft-fail level (Mezmo promotes
+                // entries whose message contains "error").
+                log.softFail('MCP client fault, request could not be handled', {
+                    errMessage: sanitizeMezmoMessage(message),
+                });
+            } else {
+                log.error('[MCP Error]', { error });
+            }
+        };
+        if (setupSIGINTHandler) {
+            const handler = async () => {
+                await this.server.close();
+                process.exit(0);
+            };
+            process.once('SIGINT', handler);
+            this.sigintHandler = handler;
+        }
+    }
+
+    private setupLoggingProxy(): void {
+        const originalSendLoggingMessage = this.server.sendLoggingMessage.bind(this.server);
+
+        // Filter outgoing log messages below the client's requested level.
+        this.server.sendLoggingMessage = async (params: { level: string; data?: unknown; [key: string]: unknown }) => {
+            const messageLevelValue = LOG_LEVEL_MAP[params.level] ?? -1; // Unknown levels get -1, discard
+            const currentLevelValue = LOG_LEVEL_MAP[this.currentLogLevel] ?? LOG_LEVEL_MAP.info; // Default to info if invalid
+            if (messageLevelValue >= currentLevelValue) {
+                await originalSendLoggingMessage(params as Parameters<typeof originalSendLoggingMessage>[0]);
+            }
+        };
+    }
+
+    private setupLoggingHandlers(): void {
+        this.server.setRequestHandler(SetLevelRequestSchema, (request) => {
+            const { level } = request.params;
+            if (LOG_LEVEL_MAP[level] !== undefined) {
+                this.currentLogLevel = level;
+            }
+            // Sending empty result based on MCP spec
+            return {};
+        });
+    }
+
+    private setupResourceHandlers(): void {
+        const { resourceService } = this.host;
+
+        this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
+            return await resourceService.listResources();
+        });
+
+        this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+            try {
+                return await resourceService.readResource(
+                    request.params.uri,
+                    this.host.resolveApifyClient(request.params as ApifyRequestParams),
+                );
+            } catch (error) {
+                throw toLegacyMcpError(error);
+            }
+        });
+
+        this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+            return await resourceService.listResourceTemplates();
+        });
+    }
+
+    /**
+     * Sets up MCP request handlers for prompts. The prompt service throws domain errors; the
+     * boundary maps them to `McpError` so wire output is unchanged.
+     */
+    private setupPromptHandlers(): void {
+        const { promptService } = this.host;
+        this.server.setRequestHandler(ListPromptsRequestSchema, () => promptService.listPrompts());
+        this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+            try {
+                return promptService.getPrompt(request.params.name, request.params.arguments);
+            } catch (error) {
+                throw toLegacyMcpError(error);
+            }
+        });
+    }
+
+    /**
+     * Fetches a task by ID, softFail-logging and throwing a client-facing McpError if it doesn't exist.
+     */
+    private async getTaskOrThrow(taskId: string, mcpSessionId: string | undefined, logTag: string): Promise<Task> {
+        const task = await this.taskStore.getTask(taskId, mcpSessionId);
+        if (!task) {
+            // Client error (invalid/unknown taskId) — softFail to avoid polluting error logs.
+            log.softFail(`[${logTag}] Task not found`, { taskId, mcpSessionId, statusCode: 404 });
+            throw new McpError(ErrorCode.InvalidParams, `Task "${taskId}" not found`);
+        }
+        return task;
+    }
+
+    /**
+     * Sets up MCP request handlers for long-running tasks.
+     * Each handler reads `_meta.mcpSessionId` (injected at the transport layer) to isolate
+     * per-session task stores.
+     */
+    private setupTaskHandlers(): void {
+        // List tasks
+        this.server.setRequestHandler(ListTasksRequestSchema, async (request) => {
+            const params = (request.params || {}) as ApifyRequestParams & { cursor?: string };
+            const { cursor } = params;
+            const mcpSessionId = params._meta?.mcpSessionId;
+            log.debug('[ListTasksRequestSchema] Listing tasks', { mcpSessionId });
+            const result = await this.taskStore.listTasks(cursor, mcpSessionId);
+            return { tasks: result.tasks, nextCursor: result.nextCursor };
+        });
+
+        // Get task status
+        this.server.setRequestHandler(GetTaskRequestSchema, async (request) => {
+            const params = (request.params || {}) as ApifyRequestParams & { taskId: string };
+            const { taskId } = params;
+            const mcpSessionId = params._meta?.mcpSessionId;
+            log.debug('[GetTaskRequestSchema] Getting task status', { taskId, mcpSessionId });
+            return await this.getTaskOrThrow(taskId, mcpSessionId, 'GetTaskRequestSchema');
+        });
+
+        // Get task result payload
+        this.server.setRequestHandler(GetTaskPayloadRequestSchema, async (request) => {
+            const params = (request.params || {}) as ApifyRequestParams & { taskId: string };
+            const { taskId } = params;
+            const mcpSessionId = params._meta?.mcpSessionId;
+            log.debug('[GetTaskPayloadRequestSchema] Getting task result', { taskId, mcpSessionId });
+            const task = await this.getTaskOrThrow(taskId, mcpSessionId, 'GetTaskPayloadRequestSchema');
+            if (task.status !== 'completed' && task.status !== 'failed') {
+                throw new McpError(
+                    ErrorCode.InvalidParams,
+                    `Task "${taskId}" is not completed yet. Current status: ${task.status}`,
+                );
+            }
+            const result = await this.taskStore.getTaskResult(taskId, mcpSessionId);
+            // taskId is not in the result body — _meta.related-task lets clients correlate them
+            return {
+                ...result,
+                _meta: {
+                    ...(result._meta as Record<string, unknown>),
+                    [RELATED_TASK_META_KEY]: { taskId },
+                },
+            };
+        });
+
+        // Cancel task
+        this.server.setRequestHandler(CancelTaskRequestSchema, async (request) => {
+            const params = (request.params || {}) as ApifyRequestParams & { taskId: string };
+            const { taskId } = params;
+            const mcpSessionId = params._meta?.mcpSessionId;
+            log.debug('[CancelTaskRequestSchema] Cancelling task', { taskId, mcpSessionId });
+
+            const task = await this.getTaskOrThrow(taskId, mcpSessionId, 'CancelTaskRequestSchema');
+            if (task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled') {
+                // Client error (cancel on terminal task) — softFail to avoid polluting error logs.
+                log.softFail('[CancelTaskRequestSchema] Task already in terminal state', {
+                    taskId,
+                    mcpSessionId,
+                    status: task.status,
+                    statusCode: 409,
+                });
+                throw new McpError(
+                    ErrorCode.InvalidParams,
+                    `Cannot cancel task "${taskId}" with status "${task.status}"`,
+                );
+            }
+            await this.taskStore.updateTaskStatus(taskId, 'cancelled', 'Cancelled by client', mcpSessionId);
+            const updatedTask = await this.taskStore.getTask(taskId, mcpSessionId);
+            log.debug('[CancelTaskRequestSchema] Task cancelled successfully', { taskId, mcpSessionId });
+            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
+            return updatedTask!;
+        });
+    }
+
+    private setupToolHandlers(): void {
+        // Handles the request to list tools.
+        this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+            const tools = Array.from(this.host.tools.values()).map((tool) =>
+                getToolPublicFieldOnly(tool, {
+                    mode: this.host.serverMode,
+                    filterWidgetMeta: true,
+                }),
+            );
+            return { tools };
+        });
+
+        /**
+         * Handles the request to call a tool. `extra` carries request-scoped helpers such as
+         * `sendNotification`. Throws {@link McpError} to mirror the MCP SDK's McpServer error codes.
+         */
+        this.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+            const params = request.params as ApifyRequestParams & { name: string; arguments?: Record<string, unknown> };
+            // Keep telemetry on the decoded arguments.
+            // eslint-disable-next-line prefer-const
+            let { name, arguments: args, _meta: meta } = params;
+            const progressToken = meta?.progressToken;
+            const apifyToken = this.host.resolveApifyToken(meta) as string;
+            // Injected upstream; required for long-running tasks — the task store keys on it and
+            // there is no other channel to pass it.
+            const mcpSessionId = meta?.mcpSessionId;
+            if (!mcpSessionId) {
+                log.error('MCP Session ID is missing in tool call request. This should never happen.');
+                throw new Error('MCP Session ID is required for tool calls');
+            }
+            const startTime = Date.now();
+            let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
+            let callDiagnostics: CallDiagnostics = {};
+            let shouldTrackTelemetry = true;
+            let resolvedToolName = name;
+            // Set only on the pre-flight task path — the one task-mode flow whose telemetry rides
+            // this handler's `finally` — so its `Tool call completed` log line keeps the taskId the
+            // async path logs via finishTaskTracking.
+            let preflightTaskId: string | undefined;
+            // The nudge must be included in the measured result.
+            let toolResult: unknown = null;
+            // Keep actor context available to the outer catch.
+            let actorName: string | undefined;
+            let actorId: string | undefined;
+            const { clientContext, actorStore } = this.host;
+            const { paymentProvider, allowUnauthMode } = this.host.options;
+            // Plain values pulled from the host/request, threaded into the shared engine.
+            // Snapshotting the tool names here equals the pre-refactor per-call read: the tool
+            // registry is only mutated during connection setup, never mid-session.
+            const loadedToolNames = this.host.listToolNames();
+            const { signal, sendNotification } = extra;
+            const emitLog = async (msg: { level: string; data?: unknown }) =>
+                this.server.sendLoggingMessage(msg as Parameters<typeof this.server.sendLoggingMessage>[0]);
+
+            // Start with the raw name so early failures still have telemetry.
+            const { telemetryData, userId } = await prepareTelemetryData({
+                toolName: name,
+                mcpSessionId,
+                apifyToken,
+                clientContext,
+                telemetryEnabled: this.host.telemetryEnabled,
+                transportType: this.host.options.transportType,
+            });
+
+            try {
+                const prepared = await prepareToolCall({
+                    apifyToken,
+                    name,
+                    args,
+                    meta,
+                    requestHeaders: extra.requestInfo?.headers,
+                    isTaskRequest: Boolean(request.params.task),
+                    mcpSessionId,
+                    telemetryData,
+                    clientContext,
+                    tools: this.host.tools,
+                    paymentProvider,
+                    allowUnauthMode,
+                    loadedToolNames,
+                    signal,
+                });
+
+                if ('result' in prepared) {
+                    // The engine already classified this post-resolution failure.
+                    resolvedToolName = prepared.resolvedToolName;
+                    args = prepared.decodedArgs;
+                    toolStatus = prepared.toolStatus;
+                    callDiagnostics = prepared.callDiagnostics;
+                    toolResult = prepared.result;
+                    return prepared.result;
+                }
+
+                if ('message' in prepared) {
+                    // Reproduce v1's invalid-params tail and preserve telemetry fields.
+                    resolvedToolName = prepared.resolvedToolName ?? resolvedToolName;
+                    if (prepared.decodedArgs) args = prepared.decodedArgs;
+                    toolStatus = prepared.toolStatus;
+                    callDiagnostics = prepared.callDiagnostics;
+                    log.softFail(prepared.message, {
+                        mcpSessionId,
+                        failureCategory: prepared.callDiagnostics.failure_category,
+                        actorName: prepared.callDiagnostics.actor_name,
+                        validationKeyword: prepared.callDiagnostics.validation_keyword,
+                        validationPath: prepared.callDiagnostics.validation_path,
+                        validationMissingProperty: prepared.callDiagnostics.validation_missing_property,
+                        validationAdditionalProperty: prepared.callDiagnostics.validation_additional_property,
+                        ...prepared.logFields,
+                    });
+                    await this.server.sendLoggingMessage({ level: 'error', data: prepared.message });
+                    throw new McpError(ErrorCode.InvalidParams, prepared.message);
+                }
+
+                const { tool, toolArgs, logSafeArgs, apifyClient, standbyRejection, paymentRequiredResult } = prepared;
+                actorName = prepared.actorName;
+                actorId = prepared.actorId;
+                resolvedToolName = getToolFullName(tool);
+                // Telemetry uses the decoded arguments.
+                args = prepared.decodedArgs;
+
+                // TODO: we should split this huge method into smaller parts as it is slowly getting out of hand
+                // Handle long-running task request
+                if (request.params.task) {
+                    const task = await this.taskStore.createTask(
+                        {
+                            ttl: request.params.task.ttl,
+                        },
+                        `call-tool-${name}-${randomUUID()}`,
+                        request,
+                        mcpSessionId,
+                    );
+                    log.debug('Created task for tool execution', {
+                        taskId: task.taskId,
+                        toolName: tool.name,
+                        mcpSessionId,
+                    });
+
+                    // Pre-flight failure is already known — the outcome needs no work. Resolve the
+                    // task synchronously: store the failure as the terminal `completed` result and emit
+                    // exactly one `completed` status notification (no `updateTaskStatus('working')`, so no
+                    // `working` notification). Standby rejection wins over the generic payment-required
+                    // short-circuit, matching the sync path's precedence. Telemetry rides the handler's
+                    // outer `finally` (shouldTrackTelemetry stays true), firing once with the sync-path
+                    // properties plus the taskId on the log line.
+                    const preflightResult = standbyRejection ?? paymentRequiredResult;
+                    if (preflightResult) {
+                        const outcome = buildPreflightFailureOutcome(
+                            standbyRejection,
+                            paymentRequiredResult,
+                            actorName,
+                            actorId,
+                        );
+                        toolStatus = outcome.toolStatus;
+                        callDiagnostics = outcome.callDiagnostics;
+                        preflightTaskId = task.taskId;
+                        try {
+                            await storeTaskResultOrSkipIfExpired(
+                                this.taskStore,
+                                tool.name,
+                                task.taskId,
+                                'completed',
+                                outcome.result,
+                                mcpSessionId,
+                            );
+                        } catch (error) {
+                            // A store failure (not expiry) would otherwise fall through to the generic
+                            // catch and return a task-less tool result the client rejects as a
+                            // CreateTaskResult parse error; surface it as a protocol error instead.
+                            // The pre-flight outcome left toolStatus=SOFT_FAIL, but a genuine store
+                            // outage is a hard failure — correct it before throwing so the handler
+                            // `finally` logs FAILED/INTERNAL_ERROR, not the stale pre-flight SOFT_FAIL.
+                            toolStatus = TOOL_STATUS.FAILED;
+                            callDiagnostics = {
+                                failure_category: FAILURE_CATEGORY.INTERNAL_ERROR,
+                                ...buildActorFields(actorName, actorId),
+                            };
+                            throw new McpError(
+                                ErrorCode.InternalError,
+                                `Failed to store the pre-flight result for task "${task.taskId}": ${
+                                    error instanceof Error ? error.message : String(error)
+                                }`,
+                            );
+                        }
+                        // Defer so the client sees the CreateTaskResult (and learns the taskId) before
+                        // the terminal status notification — the async path's post-response ordering.
+                        // emitTaskStatusNotification never throws and no-ops if the task expired.
+                        setImmediate(() => {
+                            void emitTaskStatusNotification(task.taskId, mcpSessionId, this.taskStore, this.server);
+                        });
+                        // Measure the nudged result without changing the stored result.
+                        toolResult = withReportProblemNudge({
+                            result: outcome.result,
+                            tools: this.host.tools,
+                            failingToolName: resolvedToolName,
+                            failureCategory: callDiagnostics.failure_category,
+                            failureHttpStatus: callDiagnostics.failure_http_status,
+                        });
+                        // createTask returned status `working`; synthesize the terminal status instead of
+                        // re-fetching — if the task expired before the result store (the one case
+                        // storeTaskResultOrSkipIfExpired tolerates), a re-fetch would come back empty and a
+                        // `working` fallback would contradict the tasks/get 404 the client sees next.
+                        return { task: { ...task, status: 'completed' as const } };
+                    }
+
+                    // Execute the tool asynchronously and update task status
+                    setImmediate(() => {
+                        executeToolAndUpdateTask({
+                            taskId: task.taskId,
+                            tool,
+                            toolArgs,
+                            logSafeArgs,
+                            apifyClient,
+                            apifyToken,
+                            progressToken,
+                            mcpSessionId,
+                            actorName,
+                            actorId,
+                            clientContext,
+                            taskStore: this.taskStore,
+                            server: this.server,
+                            tools: this.host.tools,
+                            actorStore,
+                            paymentProvider,
+                            loadedToolNames,
+                            telemetryEnabled: this.host.telemetryEnabled,
+                            telemetryEnv: this.host.telemetryEnv,
+                            transportType: this.host.options.transportType,
+                            sendNotification,
+                        }).catch((error) =>
+                            // Benign task-expiry is handled in-method (see the catch block and
+                            // storeTaskResultOrSkipIfExpired); anything reaching here is genuinely unexpected.
+                            log.error('executeToolAndUpdateTask failed unexpectedly', { taskId: task.taskId, error }),
+                        );
+                    });
+
+                    // Return the task immediately; execution continues asynchronously
+                    shouldTrackTelemetry = false;
+                    return { task };
+                }
+
+                // Sync path: run the shared dispatch tail and project its neutral outcome by identity.
+                const outcome = await executeSyncToolCall(prepared, {
+                    apifyToken,
+                    toolName: name,
+                    mcpSessionId,
+                    progressToken,
+                    tools: this.host.tools,
+                    actorStore,
+                    paymentProvider,
+                    loadedToolNames,
+                    signal,
+                    sendNotification,
+                    emitLog,
+                });
+                toolStatus = outcome.toolStatus;
+                callDiagnostics = outcome.callDiagnostics;
+                toolResult = outcome.result;
+                return outcome.result;
+            } catch (error) {
+                // Match v1: classify task-creation failures, but re-throw protocol errors as JSON-RPC.
+                if (error instanceof McpError) {
+                    throw error;
+                }
+                const outcome = classifyToolCallError(error, {
+                    tools: this.host.tools,
+                    toolName: name,
+                    failingToolName: resolvedToolName,
+                    actorName,
+                    actorId,
+                    isAborted: Boolean(extra.signal?.aborted),
+                    mcpSessionId,
+                });
+                toolStatus = outcome.toolStatus;
+                callDiagnostics = outcome.callDiagnostics;
+                toolResult = outcome.result;
+                return outcome.result;
+            } finally {
+                if (shouldTrackTelemetry) {
+                    logToolCallAndTelemetry({
+                        toolName: resolvedToolName,
+                        mcpSessionId,
+                        toolStatus,
+                        startTime,
+                        telemetryData,
+                        userId,
+                        callDiagnostics,
+                        args,
+                        result: toolResult,
+                        taskId: preflightTaskId,
+                        telemetryEnv: this.host.telemetryEnv,
+                    });
+                }
+            }
+        });
+    }
+
+    async connect(transport: Transport): Promise<void> {
+        await this.server.connect(transport);
+    }
+
+    async close(): Promise<void> {
+        if (this.sigintHandler) {
+            process.removeListener('SIGINT', this.sigintHandler);
+            this.sigintHandler = undefined;
+        }
+        // Closing the server also removes its event handlers.
+        await this.server.close();
+    }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,110 +2,58 @@
  * Model Context Protocol (MCP) server for Apify Actors
  */
 
-import { randomUUID } from 'node:crypto';
-
-import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
-import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { InitializeRequest, InitializeResult, Task } from '@modelcontextprotocol/sdk/types.js';
-import {
-    CallToolRequestSchema,
-    CancelTaskRequestSchema,
-    ErrorCode,
-    GetPromptRequestSchema,
-    GetTaskPayloadRequestSchema,
-    GetTaskRequestSchema,
-    InitializeRequestSchema,
-    ListPromptsRequestSchema,
-    ListResourcesRequestSchema,
-    ListResourceTemplatesRequestSchema,
-    ListTasksRequestSchema,
-    ListToolsRequestSchema,
-    McpError,
-    ReadResourceRequestSchema,
-    RELATED_TASK_META_KEY,
-    SetLevelRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import type { ValidateFunction } from 'ajv';
 
 import log from '@apify/log';
 import { parseBooleanOrNull } from '@apify/utilities';
 
 import { ApifyClient } from '../apify_client.js';
-import {
-    DEFAULT_TELEMETRY_ENABLED,
-    DEFAULT_TELEMETRY_ENV,
-    FAILURE_CATEGORY,
-    HELPER_TOOLS,
-    TOOL_STATUS,
-} from '../const.js';
+import { DEFAULT_TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENV, HELPER_TOOLS } from '../const.js';
 import { prompts } from '../prompts/index.js';
 import { createPromptService } from '../prompts/prompt_service.js';
 import { createResourceService } from '../resources/resource_service.js';
 import type { AvailableWidget } from '../resources/widgets.js';
 import { resolveAvailableWidgets } from '../resources/widgets.js';
-import { getServerInfo } from '../server_card.js';
 import { getTelemetryEnv } from '../telemetry.js';
-import { withReportProblemNudge } from '../tools/dev/report_problem.js';
 import type {
     ActorsMcpServerOptions,
     ActorStore,
     ApifyRequestParams,
-    CallDiagnostics,
     Input,
     ServerModeOption,
     TelemetryEnv,
     ToolEntry,
-    ToolStatus,
 } from '../types.js';
 import { SERVER_MODE, TOOL_TYPE } from '../types.js';
-import { isMcpClientFaultMessage, sanitizeMezmoMessage } from '../utils/logging.js';
 import { getRequestOriginForClient, isReportProblemBlockedForClient } from '../utils/mcp_clients.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
 import { parseServerMode, resolveServerMode } from '../utils/server_mode.js';
-import { buildActorFields, getToolFullName, getToolPublicFieldOnly } from '../utils/tools.js';
 import { getActors, getToolsForServerMode, toolNamesToInput } from '../utils/tools_loader.js';
 import { buildMcpClientContext, isUiSupportedByClient } from './client_context.js';
 import type { McpClientContext } from './client_context.js';
-import { LOG_LEVEL_MAP } from './const.js';
-import { InternalError, InvalidParamsError } from './errors.js';
-import { emitTaskStatusNotification, executeToolAndUpdateTask } from './task_execution.js';
-import {
-    buildPreflightFailureOutcome,
-    classifyToolCallError,
-    executeSyncToolCall,
-    prepareToolCall,
-} from './tool_call_engine.js';
-import { logToolCallAndTelemetry, prepareTelemetryData } from './tool_call_telemetry.js';
-import { parseInputParamsFromUrl, storeTaskResultOrSkipIfExpired } from './utils.js';
+import { LegacyMcpServer } from './legacy_server.js';
+import type { LegacyMcpServerHost } from './legacy_server.js';
+import { parseInputParamsFromUrl } from './utils.js';
 
 /**
- * Legacy protocol boundary: project a service's domain error to its v1 `McpError`, copying `message`
- * and `data` unchanged so the wire output (code, message, presence of `data`) is byte-identical.
- * Non-domain errors pass through untouched.
+ * Create Apify MCP server.
+ *
+ * The shared-Apify-behavior facade: it owns the tool registry + loaders, server-mode resolution,
+ * `actorStore`, telemetry config, widgets, prompt/resource services, and token/client resolution,
+ * and constructs exactly one {@link LegacyMcpServer} (the v1 SDK adapter), delegating all v1
+ * protocol work to it. It implements {@link LegacyMcpServerHost} so the adapter reads shared state
+ * through a narrow contract.
  */
-function toLegacyMcpError(error: unknown): unknown {
-    if (error instanceof InvalidParamsError) return new McpError(ErrorCode.InvalidParams, error.message, error.data);
-    if (error instanceof InternalError) return new McpError(ErrorCode.InternalError, error.message, error.data);
-    return error;
-}
-
-/**
- * Create Apify MCP server
- */
-export class ActorsMcpServer {
-    public readonly server: Server;
+export class ActorsMcpServer implements LegacyMcpServerHost {
     public readonly tools: Map<string, ToolEntry>;
-    private sigintHandler: (() => Promise<void>) | undefined;
-    private currentLogLevel = 'info';
     public readonly options: ActorsMcpServerOptions;
-    public readonly taskStore: TaskStore;
     public readonly actorStore?: ActorStore;
-    private clientContext: McpClientContext | undefined;
+    public clientContext: McpClientContext | undefined;
     /**
      * Resolved server mode. Preliminary value at construction (`'auto'` → `DEFAULT`).
-     * Finalized inside the `initialize` request handler (see constructor) once the
+     * Finalized inside the `initialize` request handler (see {@link applyInitialize}) once the
      * client's capabilities are known. Effectively set-once per connection.
      */
     public serverMode: SERVER_MODE;
@@ -133,24 +81,22 @@ export class ActorsMcpServer {
     public readonly telemetryEnabled: boolean;
     public readonly telemetryEnv: TelemetryEnv;
 
+    // Neutral prompt/resource services; the legacy adapter wires SDK handlers to these.
+    public readonly promptService: ReturnType<typeof createPromptService>;
+    public readonly resourceService: ReturnType<typeof createResourceService>;
+
     // List of widgets that are ready to be served
     private availableWidgets: Map<string, AvailableWidget> = new Map();
 
     /** Set in the initialize handler once client capabilities are known. */
     public clientSupportsUi = false;
 
+    // The v1 SDK adapter. Package-private: constructed here and never exposed on the public surface.
+    private readonly legacyServer: LegacyMcpServer;
+
     constructor(options: ActorsMcpServerOptions = {}) {
         this.options = options;
         this.clientContext = buildMcpClientContext(options.initializeRequestData?.params);
-
-        // for stdio use in memory task store if not provided, otherwise use provided task store
-        if (this.options.transportType === 'stdio' && !this.options.taskStore) {
-            this.taskStore = new InMemoryTaskStore();
-        } else if (this.options.taskStore) {
-            this.taskStore = this.options.taskStore;
-        } else {
-            throw new Error('Task store must be provided for non-stdio transport types');
-        }
         this.actorStore = options.actorStore;
         // Constructor is an ingestion boundary for programmatic callers. Normalize via
         // parseServerMode so that runtime-invalid values ('openai' alias, stray strings)
@@ -166,42 +112,24 @@ export class ActorsMcpServer {
         this.serverMode = resolveServerMode(this.serverModeOption, false);
         this.serverModeResolved = this.serverModeOption !== 'auto';
 
-        const { setupSigintHandler = true } = options;
-        this.server = new Server(getServerInfo(), {
-            capabilities: {
-                tools: {
-                    listChanged: true,
-                },
-                // Declare long-running task support
-                tasks: {
-                    list: {},
-                    cancel: {},
-                    requests: {
-                        tools: {
-                            call: {},
-                        },
-                    },
-                },
-                // Declared but unused — some clients (e.g. Claude Desktop) fail without it.
-                resources: {},
-                prompts: {},
-                logging: {},
-            },
-            instructions: getServerInstructions(),
-        });
         const { telemetryEnabled, telemetryEnv } = this.setupTelemetry();
         this.telemetryEnabled = telemetryEnabled;
         this.telemetryEnv = telemetryEnv;
-        this.setupInitializeHandler();
-        this.setupLoggingProxy();
         this.tools = new Map();
-        this.setupErrorHandling(setupSigintHandler);
-        this.setupLoggingHandlers();
-        this.setupToolHandlers();
-        this.setupPromptHandlers();
-        // Handle resource requests so clients like Claude Desktop don't fail.
-        this.setupResourceHandlers();
-        this.setupTaskHandlers();
+
+        this.promptService = createPromptService(prompts);
+        this.resourceService = createResourceService({
+            paymentProvider: this.options.paymentProvider,
+            getMode: () => this.serverMode,
+            getAvailableWidgets: () => this.availableWidgets,
+        });
+
+        const { setupSigintHandler = true } = options;
+        this.legacyServer = new LegacyMcpServer(this, {
+            setupSigintHandler,
+            taskStore: options.taskStore,
+            transportType: options.transportType,
+        });
     }
 
     /**
@@ -227,60 +155,47 @@ export class ActorsMcpServer {
     }
 
     /**
-     * Override the SDK's `initialize` request handler to run mode resolution and
-     * pending-source flush before `InitializeResult` is sent. Delegates boilerplate
-     * (protocolVersion, capabilities, instructions) to the SDK's captured `_oninitialize`.
+     * Runs the shared initialize steps the legacy adapter delegates to before it returns the
+     * `InitializeResult`: refresh the client context from the wire request, capture the raw request
+     * for hosted session recovery, resolve `'auto'` server mode against client capabilities, flush
+     * pending tool sources, and resolve widgets. The adapter delegates the SDK boilerplate and
+     * overwrites `instructions` afterwards (see {@link getServerInstructions}).
      *
-     * Not using `server.oninitialized`: the SDK dispatches notification handlers
-     * fire-and-forget (separate microtask), so a follow-up `tools/list` can race past them.
-     * The request handler guarantees tools are final before the response and the first `tools/list`.
+     * Ordering is load-bearing: mode before compose, compose before widgets/instructions.
+     * `composePendingToolsForClient` runs before the instructions are read so tool presence reflects
+     * the final composed set.
      */
-    private setupInitializeHandler() {
-        // Capture the SDK's default initialize handler installed in its constructor.
-        // Private-field access on the SDK Server — verified against
-        // @modelcontextprotocol/sdk ^1.25.x (see package.json). On SDK bumps, re-check
-        // `@modelcontextprotocol/sdk/shared/protocol.js` for a still-named `_oninitialize`;
-        // if renamed or made non-delegable, rebuild the InitializeResult shape here
-        // (protocolVersion, serverInfo, capabilities, instructions) instead of delegating.
-        // The capability-gating unit tests construct a server and act as a canary.
-        // eslint-disable-next-line no-underscore-dangle
-        const sdkInitHandler = (
-            this.server as unknown as {
-                _oninitialize(req: InitializeRequest): Promise<InitializeResult>;
+    public async applyInitialize(request: InitializeRequest): Promise<void> {
+        this.clientContext = buildMcpClientContext(request.params);
+        this.options.initializeRequestData = request;
+        this.clientSupportsUi = isUiSupportedByClient(this.clientContext);
+
+        if (this.serverModeOption === 'auto') {
+            const resolved = resolveServerMode('auto', this.clientSupportsUi);
+            if (resolved !== this.serverMode) {
+                this.serverMode = resolved;
             }
-        )._oninitialize.bind(this.server);
+            this.serverModeResolved = true;
+        }
 
-        this.server.setRequestHandler(InitializeRequestSchema, async (request) => {
-            this.clientContext = buildMcpClientContext(request.params);
-            this.options.initializeRequestData = request;
-            this.clientSupportsUi = isUiSupportedByClient(this.clientContext);
-
-            if (this.serverModeOption === 'auto') {
-                const resolved = resolveServerMode('auto', this.clientSupportsUi);
-                if (resolved !== this.serverMode) {
-                    this.serverMode = resolved;
-                }
-                this.serverModeResolved = true;
-            }
-
-            log.info('Resolved server mode for client capabilities', {
-                serverMode: this.serverMode,
-                serverModeOption: this.serverModeOption,
-                clientSupportsUi: this.clientSupportsUi,
-                capabilities: request?.params?.capabilities,
-            });
-
-            this.composePendingToolsForClient();
-
-            await this.resolveWidgets();
-
-            const result = await sdkInitHandler(request);
-            // Tools are final here (composePendingToolsForClient ran above, applying the per-client
-            // blocklist), so tool presence is the ground truth for whether to advertise
-            // report-problem in the instructions.
-            result.instructions = getServerInstructions(this.serverMode, this.tools.has(HELPER_TOOLS.PROBLEM_REPORT));
-            return result;
+        log.info('Resolved server mode for client capabilities', {
+            serverMode: this.serverMode,
+            serverModeOption: this.serverModeOption,
+            clientSupportsUi: this.clientSupportsUi,
+            capabilities: request?.params?.capabilities,
         });
+
+        this.composePendingToolsForClient();
+
+        await this.resolveWidgets();
+    }
+
+    /**
+     * Server instructions for the current connection: mode plus whether report-problem is loaded.
+     * Read by the legacy adapter after `applyInitialize`, when the tool set is final.
+     */
+    public getServerInstructions(): string {
+        return getServerInstructions(this.serverMode, this.tools.has(HELPER_TOOLS.PROBLEM_REPORT));
     }
 
     /** True once the connecting client is known (set in the initialize handler, or hydrated by a
@@ -479,62 +394,13 @@ export class ActorsMcpServer {
         return false;
     }
 
-    private setupErrorHandling(setupSIGINTHandler = true): void {
-        this.server.onerror = (error) => {
-            // Known client faults are expected noise, not server bugs — softFail so they don't
-            // flood Mezmo error alerts. The fault patterns live in utils/logging.ts.
-            const message = error.message ?? '';
-            if (isMcpClientFaultMessage(message)) {
-                // Sanitize the errMessage value to preserve the soft-fail level (Mezmo promotes
-                // entries whose message contains "error").
-                log.softFail('MCP client fault, request could not be handled', {
-                    errMessage: sanitizeMezmoMessage(message),
-                });
-            } else {
-                log.error('[MCP Error]', { error });
-            }
-        };
-        if (setupSIGINTHandler) {
-            const handler = async () => {
-                await this.server.close();
-                process.exit(0);
-            };
-            process.once('SIGINT', handler);
-            this.sigintHandler = handler;
-        }
-    }
-
-    private setupLoggingProxy(): void {
-        const originalSendLoggingMessage = this.server.sendLoggingMessage.bind(this.server);
-
-        // Filter outgoing log messages below the client's requested level.
-        this.server.sendLoggingMessage = async (params: { level: string; data?: unknown; [key: string]: unknown }) => {
-            const messageLevelValue = LOG_LEVEL_MAP[params.level] ?? -1; // Unknown levels get -1, discard
-            const currentLevelValue = LOG_LEVEL_MAP[this.currentLogLevel] ?? LOG_LEVEL_MAP.info; // Default to info if invalid
-            if (messageLevelValue >= currentLevelValue) {
-                await originalSendLoggingMessage(params as Parameters<typeof originalSendLoggingMessage>[0]);
-            }
-        };
-    }
-
-    private setupLoggingHandlers(): void {
-        this.server.setRequestHandler(SetLevelRequestSchema, (request) => {
-            const { level } = request.params;
-            if (LOG_LEVEL_MAP[level] !== undefined) {
-                this.currentLogLevel = level;
-            }
-            // Sending empty result based on MCP spec
-            return {};
-        });
-    }
-
     /**
      * Token sources in order: per-request `_meta.apifyToken` (stdio inline) > server-instance
      * option (set by the transport from `Authorization` header or stdio env). No env fallback:
      * dev_server / production must extract the token from request headers so payment
      * mode (no token) behaves identically to production.
      */
-    private resolveApifyToken(meta?: ApifyRequestParams['_meta']): string | undefined {
+    public resolveApifyToken(meta?: ApifyRequestParams['_meta']): string | undefined {
         return meta?.apifyToken || this.options.token;
     }
 
@@ -544,415 +410,11 @@ export class ActorsMcpServer {
      * session (x402/Skyfire, no Apify token) has no client and every read fails by design.
      * Still carries the request-origin tag from the client context captured by this point.
      */
-    private resolveApifyClient(params: ApifyRequestParams): ApifyClient | undefined {
+    public resolveApifyClient(params: ApifyRequestParams): ApifyClient | undefined {
         const token = this.resolveApifyToken(params._meta);
         return token
             ? new ApifyClient({ token, requestOrigin: getRequestOriginForClient(this.clientContext) })
             : undefined;
-    }
-
-    private setupResourceHandlers(): void {
-        const resourceService = createResourceService({
-            paymentProvider: this.options.paymentProvider,
-            getMode: () => this.serverMode,
-            getAvailableWidgets: () => this.availableWidgets,
-        });
-
-        this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
-            return await resourceService.listResources();
-        });
-
-        this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-            try {
-                return await resourceService.readResource(
-                    request.params.uri,
-                    this.resolveApifyClient(request.params as ApifyRequestParams),
-                );
-            } catch (error) {
-                throw toLegacyMcpError(error);
-            }
-        });
-
-        this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
-            return await resourceService.listResourceTemplates();
-        });
-    }
-
-    /**
-     * Sets up MCP request handlers for prompts. The prompt service throws domain errors; the
-     * boundary maps them to `McpError` so wire output is unchanged.
-     */
-    private setupPromptHandlers(): void {
-        const promptService = createPromptService(prompts);
-        this.server.setRequestHandler(ListPromptsRequestSchema, () => promptService.listPrompts());
-        this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
-            try {
-                return promptService.getPrompt(request.params.name, request.params.arguments);
-            } catch (error) {
-                throw toLegacyMcpError(error);
-            }
-        });
-    }
-
-    /**
-     * Fetches a task by ID, softFail-logging and throwing a client-facing McpError if it doesn't exist.
-     */
-    private async getTaskOrThrow(taskId: string, mcpSessionId: string | undefined, logTag: string): Promise<Task> {
-        const task = await this.taskStore.getTask(taskId, mcpSessionId);
-        if (!task) {
-            // Client error (invalid/unknown taskId) — softFail to avoid polluting error logs.
-            log.softFail(`[${logTag}] Task not found`, { taskId, mcpSessionId, statusCode: 404 });
-            throw new McpError(ErrorCode.InvalidParams, `Task "${taskId}" not found`);
-        }
-        return task;
-    }
-
-    /**
-     * Sets up MCP request handlers for long-running tasks.
-     * Each handler reads `_meta.mcpSessionId` (injected at the transport layer) to isolate
-     * per-session task stores.
-     */
-    private setupTaskHandlers(): void {
-        // List tasks
-        this.server.setRequestHandler(ListTasksRequestSchema, async (request) => {
-            const params = (request.params || {}) as ApifyRequestParams & { cursor?: string };
-            const { cursor } = params;
-            const mcpSessionId = params._meta?.mcpSessionId;
-            log.debug('[ListTasksRequestSchema] Listing tasks', { mcpSessionId });
-            const result = await this.taskStore.listTasks(cursor, mcpSessionId);
-            return { tasks: result.tasks, nextCursor: result.nextCursor };
-        });
-
-        // Get task status
-        this.server.setRequestHandler(GetTaskRequestSchema, async (request) => {
-            const params = (request.params || {}) as ApifyRequestParams & { taskId: string };
-            const { taskId } = params;
-            const mcpSessionId = params._meta?.mcpSessionId;
-            log.debug('[GetTaskRequestSchema] Getting task status', { taskId, mcpSessionId });
-            return await this.getTaskOrThrow(taskId, mcpSessionId, 'GetTaskRequestSchema');
-        });
-
-        // Get task result payload
-        this.server.setRequestHandler(GetTaskPayloadRequestSchema, async (request) => {
-            const params = (request.params || {}) as ApifyRequestParams & { taskId: string };
-            const { taskId } = params;
-            const mcpSessionId = params._meta?.mcpSessionId;
-            log.debug('[GetTaskPayloadRequestSchema] Getting task result', { taskId, mcpSessionId });
-            const task = await this.getTaskOrThrow(taskId, mcpSessionId, 'GetTaskPayloadRequestSchema');
-            if (task.status !== 'completed' && task.status !== 'failed') {
-                throw new McpError(
-                    ErrorCode.InvalidParams,
-                    `Task "${taskId}" is not completed yet. Current status: ${task.status}`,
-                );
-            }
-            const result = await this.taskStore.getTaskResult(taskId, mcpSessionId);
-            // taskId is not in the result body — _meta.related-task lets clients correlate them
-            return {
-                ...result,
-                _meta: {
-                    ...(result._meta as Record<string, unknown>),
-                    [RELATED_TASK_META_KEY]: { taskId },
-                },
-            };
-        });
-
-        // Cancel task
-        this.server.setRequestHandler(CancelTaskRequestSchema, async (request) => {
-            const params = (request.params || {}) as ApifyRequestParams & { taskId: string };
-            const { taskId } = params;
-            const mcpSessionId = params._meta?.mcpSessionId;
-            log.debug('[CancelTaskRequestSchema] Cancelling task', { taskId, mcpSessionId });
-
-            const task = await this.getTaskOrThrow(taskId, mcpSessionId, 'CancelTaskRequestSchema');
-            if (task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled') {
-                // Client error (cancel on terminal task) — softFail to avoid polluting error logs.
-                log.softFail('[CancelTaskRequestSchema] Task already in terminal state', {
-                    taskId,
-                    mcpSessionId,
-                    status: task.status,
-                    statusCode: 409,
-                });
-                throw new McpError(
-                    ErrorCode.InvalidParams,
-                    `Cannot cancel task "${taskId}" with status "${task.status}"`,
-                );
-            }
-            await this.taskStore.updateTaskStatus(taskId, 'cancelled', 'Cancelled by client', mcpSessionId);
-            const updatedTask = await this.taskStore.getTask(taskId, mcpSessionId);
-            log.debug('[CancelTaskRequestSchema] Task cancelled successfully', { taskId, mcpSessionId });
-            await emitTaskStatusNotification(taskId, mcpSessionId, this.taskStore, this.server);
-            return updatedTask!;
-        });
-    }
-
-    private setupToolHandlers(): void {
-        // Handles the request to list tools.
-        this.server.setRequestHandler(ListToolsRequestSchema, async () => {
-            const tools = Array.from(this.tools.values()).map((tool) =>
-                getToolPublicFieldOnly(tool, {
-                    mode: this.serverMode,
-                    filterWidgetMeta: true,
-                }),
-            );
-            return { tools };
-        });
-
-        /**
-         * Handles the request to call a tool. `extra` carries request-scoped helpers such as
-         * `sendNotification`. Throws {@link McpError} to mirror the MCP SDK's McpServer error codes.
-         */
-        this.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
-            const params = request.params as ApifyRequestParams & { name: string; arguments?: Record<string, unknown> };
-            // Keep telemetry on the decoded arguments.
-            // eslint-disable-next-line prefer-const
-            let { name, arguments: args, _meta: meta } = params;
-            const progressToken = meta?.progressToken;
-            const apifyToken = this.resolveApifyToken(meta) as string;
-            // Injected upstream; required for long-running tasks — the task store keys on it and
-            // there is no other channel to pass it.
-            const mcpSessionId = meta?.mcpSessionId;
-            if (!mcpSessionId) {
-                log.error('MCP Session ID is missing in tool call request. This should never happen.');
-                throw new Error('MCP Session ID is required for tool calls');
-            }
-            const startTime = Date.now();
-            let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
-            let callDiagnostics: CallDiagnostics = {};
-            let shouldTrackTelemetry = true;
-            let resolvedToolName = name;
-            // Set only on the pre-flight task path — the one task-mode flow whose telemetry rides
-            // this handler's `finally` — so its `Tool call completed` log line keeps the taskId the
-            // async path logs via finishTaskTracking.
-            let preflightTaskId: string | undefined;
-            // The nudge must be included in the measured result.
-            let toolResult: unknown = null;
-            // Keep actor context available to the outer catch.
-            let actorName: string | undefined;
-            let actorId: string | undefined;
-            const { clientContext } = this;
-
-            // Start with the raw name so early failures still have telemetry.
-            const { telemetryData, userId } = await prepareTelemetryData({
-                toolName: name,
-                mcpSessionId,
-                apifyToken,
-                apifyMcpServer: this,
-                clientContext,
-            });
-
-            try {
-                const prepared = await prepareToolCall({
-                    apifyMcpServer: this,
-                    apifyToken,
-                    name,
-                    args,
-                    meta,
-                    requestHeaders: extra.requestInfo?.headers,
-                    isTaskRequest: Boolean(request.params.task),
-                    mcpSessionId,
-                    telemetryData,
-                    clientContext,
-                    extra,
-                });
-
-                if ('result' in prepared) {
-                    // The engine already classified this post-resolution failure.
-                    resolvedToolName = prepared.resolvedToolName;
-                    args = prepared.decodedArgs;
-                    toolStatus = prepared.toolStatus;
-                    callDiagnostics = prepared.callDiagnostics;
-                    toolResult = prepared.result;
-                    return prepared.result;
-                }
-
-                if ('message' in prepared) {
-                    // Reproduce v1's invalid-params tail and preserve telemetry fields.
-                    resolvedToolName = prepared.resolvedToolName ?? resolvedToolName;
-                    if (prepared.decodedArgs) args = prepared.decodedArgs;
-                    toolStatus = prepared.toolStatus;
-                    callDiagnostics = prepared.callDiagnostics;
-                    log.softFail(prepared.message, {
-                        mcpSessionId,
-                        failureCategory: prepared.callDiagnostics.failure_category,
-                        actorName: prepared.callDiagnostics.actor_name,
-                        validationKeyword: prepared.callDiagnostics.validation_keyword,
-                        validationPath: prepared.callDiagnostics.validation_path,
-                        validationMissingProperty: prepared.callDiagnostics.validation_missing_property,
-                        validationAdditionalProperty: prepared.callDiagnostics.validation_additional_property,
-                        ...prepared.logFields,
-                    });
-                    await this.server.sendLoggingMessage({ level: 'error', data: prepared.message });
-                    throw new McpError(ErrorCode.InvalidParams, prepared.message);
-                }
-
-                const { tool, toolArgs, logSafeArgs, apifyClient, standbyRejection, paymentRequiredResult } = prepared;
-                actorName = prepared.actorName;
-                actorId = prepared.actorId;
-                resolvedToolName = getToolFullName(tool);
-                // Telemetry uses the decoded arguments.
-                args = prepared.decodedArgs;
-
-                // TODO: we should split this huge method into smaller parts as it is slowly getting out of hand
-                // Handle long-running task request
-                if (request.params.task) {
-                    const task = await this.taskStore.createTask(
-                        {
-                            ttl: request.params.task.ttl,
-                        },
-                        `call-tool-${name}-${randomUUID()}`,
-                        request,
-                        mcpSessionId,
-                    );
-                    log.debug('Created task for tool execution', {
-                        taskId: task.taskId,
-                        toolName: tool.name,
-                        mcpSessionId,
-                    });
-
-                    // Pre-flight failure is already known — the outcome needs no work. Resolve the
-                    // task synchronously: store the failure as the terminal `completed` result and emit
-                    // exactly one `completed` status notification (no `updateTaskStatus('working')`, so no
-                    // `working` notification). Standby rejection wins over the generic payment-required
-                    // short-circuit, matching the sync path's precedence. Telemetry rides the handler's
-                    // outer `finally` (shouldTrackTelemetry stays true), firing once with the sync-path
-                    // properties plus the taskId on the log line.
-                    const preflightResult = standbyRejection ?? paymentRequiredResult;
-                    if (preflightResult) {
-                        const outcome = buildPreflightFailureOutcome(
-                            standbyRejection,
-                            paymentRequiredResult,
-                            actorName,
-                            actorId,
-                        );
-                        toolStatus = outcome.toolStatus;
-                        callDiagnostics = outcome.callDiagnostics;
-                        preflightTaskId = task.taskId;
-                        try {
-                            await storeTaskResultOrSkipIfExpired(
-                                this.taskStore,
-                                tool.name,
-                                task.taskId,
-                                'completed',
-                                outcome.result,
-                                mcpSessionId,
-                            );
-                        } catch (error) {
-                            // A store failure (not expiry) would otherwise fall through to the generic
-                            // catch and return a task-less tool result the client rejects as a
-                            // CreateTaskResult parse error; surface it as a protocol error instead.
-                            // The pre-flight outcome left toolStatus=SOFT_FAIL, but a genuine store
-                            // outage is a hard failure — correct it before throwing so the handler
-                            // `finally` logs FAILED/INTERNAL_ERROR, not the stale pre-flight SOFT_FAIL.
-                            toolStatus = TOOL_STATUS.FAILED;
-                            callDiagnostics = {
-                                failure_category: FAILURE_CATEGORY.INTERNAL_ERROR,
-                                ...buildActorFields(actorName, actorId),
-                            };
-                            throw new McpError(
-                                ErrorCode.InternalError,
-                                `Failed to store the pre-flight result for task "${task.taskId}": ${
-                                    error instanceof Error ? error.message : String(error)
-                                }`,
-                            );
-                        }
-                        // Defer so the client sees the CreateTaskResult (and learns the taskId) before
-                        // the terminal status notification — the async path's post-response ordering.
-                        // emitTaskStatusNotification never throws and no-ops if the task expired.
-                        setImmediate(() => {
-                            void emitTaskStatusNotification(task.taskId, mcpSessionId, this.taskStore, this.server);
-                        });
-                        // Measure the nudged result without changing the stored result.
-                        toolResult = withReportProblemNudge({
-                            result: outcome.result,
-                            tools: this.tools,
-                            failingToolName: resolvedToolName,
-                            failureCategory: callDiagnostics.failure_category,
-                            failureHttpStatus: callDiagnostics.failure_http_status,
-                        });
-                        // createTask returned status `working`; synthesize the terminal status instead of
-                        // re-fetching — if the task expired before the result store (the one case
-                        // storeTaskResultOrSkipIfExpired tolerates), a re-fetch would come back empty and a
-                        // `working` fallback would contradict the tasks/get 404 the client sees next.
-                        return { task: { ...task, status: 'completed' as const } };
-                    }
-
-                    // Execute the tool asynchronously and update task status
-                    setImmediate(() => {
-                        executeToolAndUpdateTask({
-                            taskId: task.taskId,
-                            tool,
-                            toolArgs,
-                            logSafeArgs,
-                            apifyClient,
-                            apifyToken,
-                            progressToken,
-                            extra,
-                            mcpSessionId,
-                            actorName,
-                            actorId,
-                            apifyMcpServer: this,
-                            clientContext,
-                        }).catch((error) =>
-                            // Benign task-expiry is handled in-method (see the catch block and
-                            // storeTaskResultOrSkipIfExpired); anything reaching here is genuinely unexpected.
-                            log.error('executeToolAndUpdateTask failed unexpectedly', { taskId: task.taskId, error }),
-                        );
-                    });
-
-                    // Return the task immediately; execution continues asynchronously
-                    shouldTrackTelemetry = false;
-                    return { task };
-                }
-
-                // Sync path: run the shared dispatch tail and project its neutral outcome by identity.
-                const outcome = await executeSyncToolCall(prepared, {
-                    apifyMcpServer: this,
-                    apifyToken,
-                    toolName: name,
-                    mcpSessionId,
-                    progressToken,
-                    extra,
-                });
-                toolStatus = outcome.toolStatus;
-                callDiagnostics = outcome.callDiagnostics;
-                toolResult = outcome.result;
-                return outcome.result;
-            } catch (error) {
-                // Match v1: classify task-creation failures, but re-throw protocol errors as JSON-RPC.
-                if (error instanceof McpError) {
-                    throw error;
-                }
-                const outcome = classifyToolCallError(error, {
-                    apifyMcpServer: this,
-                    toolName: name,
-                    failingToolName: resolvedToolName,
-                    actorName,
-                    actorId,
-                    isAborted: Boolean(extra.signal?.aborted),
-                    mcpSessionId,
-                });
-                toolStatus = outcome.toolStatus;
-                callDiagnostics = outcome.callDiagnostics;
-                toolResult = outcome.result;
-                return outcome.result;
-            } finally {
-                if (shouldTrackTelemetry) {
-                    logToolCallAndTelemetry({
-                        toolName: resolvedToolName,
-                        mcpSessionId,
-                        toolStatus,
-                        startTime,
-                        telemetryData,
-                        userId,
-                        callDiagnostics,
-                        args,
-                        result: toolResult,
-                        taskId: preflightTaskId,
-                        apifyMcpServer: this,
-                    });
-                }
-            }
-        });
     }
 
     /**
@@ -1004,22 +466,25 @@ export class ActorsMcpServer {
 
     async connect(transport: Transport): Promise<void> {
         await this.resolveWidgets();
-        await this.server.connect(transport);
+        await this.legacyServer.connect(transport);
     }
 
     async close(): Promise<void> {
-        if (this.sigintHandler) {
-            process.removeListener('SIGINT', this.sigintHandler);
-            this.sigintHandler = undefined;
-        }
-        // Clear all tools and null their compiled schemas.
+        // Reverse-of-connect (LIFO) teardown: take the transport/server down first (SIGINT removal +
+        // server close are the adapter's transport-lifecycle responsibility), then clear the shared
+        // tool map. This intentionally reverses the pre-refactor tools-then-server order; it is
+        // unobservable because `close()` only runs on a quiesced serving unit.
+        await this.legacyServer.close();
+        this.clearTools();
+    }
+
+    /** Clear all tools and null their compiled schemas. */
+    private clearTools(): void {
         for (const tool of this.tools.values()) {
             if (tool.ajvValidate && typeof tool.ajvValidate === 'function') {
                 (tool as { ajvValidate: ValidateFunction<unknown> | null }).ajvValidate = null;
             }
         }
         this.tools.clear();
-        // Closing the server also removes its event handlers.
-        await this.server.close();
     }
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -50,13 +50,13 @@ export class ActorsMcpServer implements LegacyMcpServerHost {
     public readonly tools: Map<string, ToolEntry>;
     public readonly options: ActorsMcpServerOptions;
     public readonly actorStore?: ActorStore;
-    public clientContext: McpClientContext | undefined;
+    private _clientContext: McpClientContext | undefined;
     /**
      * Resolved server mode. Preliminary value at construction (`'auto'` → `DEFAULT`).
      * Finalized inside the `initialize` request handler (see {@link applyInitialize}) once the
      * client's capabilities are known. Effectively set-once per connection.
      */
-    public serverMode: SERVER_MODE;
+    private _serverMode: SERVER_MODE;
     /**
      * Raw option captured from `options.serverMode` (or the legacy `uiMode`). Re-resolved
      * inside the initialize handler when set to `'auto'`; explicit `'default'`/`'apps'`
@@ -94,9 +94,17 @@ export class ActorsMcpServer implements LegacyMcpServerHost {
     // The v1 SDK adapter. Package-private: constructed here and never exposed on the public surface.
     private readonly legacyServer: LegacyMcpServer;
 
+    public get clientContext(): McpClientContext | undefined {
+        return this._clientContext;
+    }
+
+    public get serverMode(): SERVER_MODE {
+        return this._serverMode;
+    }
+
     constructor(options: ActorsMcpServerOptions = {}) {
         this.options = options;
-        this.clientContext = buildMcpClientContext(options.initializeRequestData?.params);
+        this._clientContext = buildMcpClientContext(options.initializeRequestData?.params);
         this.actorStore = options.actorStore;
         // Constructor is an ingestion boundary for programmatic callers. Normalize via
         // parseServerMode so that runtime-invalid values ('openai' alias, stray strings)
@@ -109,7 +117,7 @@ export class ActorsMcpServer implements LegacyMcpServerHost {
             rawServerMode !== undefined ? parseServerMode(rawServerMode) : parseServerMode(legacyUiMode);
         // Preliminary resolution — re-resolved inside the initialize handler once
         // client capabilities are known (only for 'auto').
-        this.serverMode = resolveServerMode(this.serverModeOption, false);
+        this._serverMode = resolveServerMode(this.serverModeOption, false);
         this.serverModeResolved = this.serverModeOption !== 'auto';
 
         const { telemetryEnabled, telemetryEnv } = this.setupTelemetry();
@@ -124,12 +132,7 @@ export class ActorsMcpServer implements LegacyMcpServerHost {
             getAvailableWidgets: () => this.availableWidgets,
         });
 
-        const { setupSigintHandler = true } = options;
-        this.legacyServer = new LegacyMcpServer(this, {
-            setupSigintHandler,
-            taskStore: options.taskStore,
-            transportType: options.transportType,
-        });
+        this.legacyServer = new LegacyMcpServer(this);
     }
 
     /**
@@ -166,14 +169,14 @@ export class ActorsMcpServer implements LegacyMcpServerHost {
      * the final composed set.
      */
     public async applyInitialize(request: InitializeRequest): Promise<void> {
-        this.clientContext = buildMcpClientContext(request.params);
+        this._clientContext = buildMcpClientContext(request.params);
         this.options.initializeRequestData = request;
         this.clientSupportsUi = isUiSupportedByClient(this.clientContext);
 
         if (this.serverModeOption === 'auto') {
             const resolved = resolveServerMode('auto', this.clientSupportsUi);
-            if (resolved !== this.serverMode) {
-                this.serverMode = resolved;
+            if (resolved !== this._serverMode) {
+                this._serverMode = resolved;
             }
             this.serverModeResolved = true;
         }
@@ -472,8 +475,7 @@ export class ActorsMcpServer implements LegacyMcpServerHost {
     async close(): Promise<void> {
         // Reverse-of-connect (LIFO) teardown: take the transport/server down first (SIGINT removal +
         // server close are the adapter's transport-lifecycle responsibility), then clear the shared
-        // tool map. This intentionally reverses the pre-refactor tools-then-server order; it is
-        // unobservable because `close()` only runs on a quiesced serving unit.
+        // tool map. The order is unobservable because `close()` only runs on a quiesced serving unit.
         await this.legacyServer.close();
         this.clearTools();
     }

--- a/src/mcp/task_execution.ts
+++ b/src/mcp/task_execution.ts
@@ -8,7 +8,7 @@ import type { ApifyClient } from '../apify_client.js';
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { withReportProblemNudge } from '../tools/dev/report_problem.js';
-import type { ActorStore, CallDiagnostics, TelemetryEnv, ToolEntry, ToolStatus } from '../types.js';
+import type { ActorStore, CallDiagnostics, TelemetryEnv, ToolEntry, ToolStatus, TransportType } from '../types.js';
 import { TOOL_TYPE } from '../types.js';
 import { logHttpError, sanitizeMezmoMessage } from '../utils/logging.js';
 import { createProgressTracker } from '../utils/progress.js';
@@ -76,6 +76,8 @@ export async function emitTaskStatusNotification(
  * @param params.sendNotification - Progress-notification sink for the running tool
  */
 
+// TODO(#1156): collapse this flat param list (and its siblings in tool_call_engine.ts and
+// tool_dispatch.ts) into lifetime-scoped session/request context objects.
 export async function executeToolAndUpdateTask(params: {
     taskId: string;
     tool: ToolEntry;
@@ -93,10 +95,9 @@ export async function executeToolAndUpdateTask(params: {
     tools: Map<string, ToolEntry>;
     actorStore?: ActorStore;
     paymentProvider?: PaymentProvider;
-    loadedToolNames: readonly string[];
     telemetryEnabled: boolean;
     telemetryEnv: TelemetryEnv;
-    transportType?: 'stdio' | 'http';
+    transportType?: TransportType;
     sendNotification: (notification: ServerNotification) => Promise<void>;
 }): Promise<void> {
     const {
@@ -116,7 +117,6 @@ export async function executeToolAndUpdateTask(params: {
         tools,
         actorStore,
         paymentProvider,
-        loadedToolNames,
         telemetryEnabled,
         telemetryEnv,
         transportType,
@@ -257,7 +257,7 @@ export async function executeToolAndUpdateTask(params: {
             emitLog,
             actorStore,
             paymentProvider,
-            loadedToolNames,
+            tools,
             actorName,
             actorId,
             taskMode: true,

--- a/src/mcp/task_execution.ts
+++ b/src/mcp/task_execution.ts
@@ -1,21 +1,19 @@
 import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
-import type { Notification, Request, TaskStatusNotification } from '@modelcontextprotocol/sdk/types.js';
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { ServerNotification, TaskStatusNotification } from '@modelcontextprotocol/sdk/types.js';
 
 import log from '@apify/log';
 
 import type { ApifyClient } from '../apify_client.js';
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
+import type { PaymentProvider } from '../payments/types.js';
 import { withReportProblemNudge } from '../tools/dev/report_problem.js';
-import type { CallDiagnostics, ToolEntry, ToolStatus } from '../types.js';
+import type { ActorStore, CallDiagnostics, TelemetryEnv, ToolEntry, ToolStatus } from '../types.js';
 import { TOOL_TYPE } from '../types.js';
 import { logHttpError, sanitizeMezmoMessage } from '../utils/logging.js';
 import { createProgressTracker } from '../utils/progress.js';
 import { buildActorFields, getToolFullName } from '../utils/tools.js';
 import type { McpClientContext } from './client_context.js';
-import type { ActorsMcpServer } from './server.js';
 import { buildToolCallErrorResult, TOOL_CALL_ERROR_KIND } from './tool_call_error_mapper.js';
 import type { ToolCallErrorResult } from './tool_call_error_mapper.js';
 import { logToolCallAndTelemetry, prepareTelemetryData } from './tool_call_telemetry.js';
@@ -70,11 +68,12 @@ export async function emitTaskStatusNotification(
  * @param params.apifyClient - ApifyClient configured with payment headers or the standard token
  * @param params.apifyToken - Apify API token
  * @param params.progressToken - Progress token for notifications
- * @param params.extra - Extra request handler context
  * @param params.mcpSessionId - MCP session ID for telemetry
  * @param params.actorName - Actor name, used for telemetry and error diagnostics
  * @param params.actorId - Actor ID, used for telemetry and error diagnostics
- * @param params.apifyMcpServer - The ActorsMcpServer instance (task store, server, tools, telemetry config)
+ * @param params.taskStore - Task store (legacy) for status/result persistence
+ * @param params.server - v1 SDK server (legacy) for task-status notifications and logging
+ * @param params.sendNotification - Progress-notification sink for the running tool
  */
 
 export async function executeToolAndUpdateTask(params: {
@@ -85,12 +84,20 @@ export async function executeToolAndUpdateTask(params: {
     apifyClient: ApifyClient;
     apifyToken: string;
     progressToken: string | number | undefined;
-    extra: RequestHandlerExtra<Request, Notification>;
     mcpSessionId: string | undefined;
     actorName?: string;
     actorId?: string;
-    apifyMcpServer: ActorsMcpServer;
     clientContext: McpClientContext | undefined;
+    taskStore: TaskStore;
+    server: Server;
+    tools: Map<string, ToolEntry>;
+    actorStore?: ActorStore;
+    paymentProvider?: PaymentProvider;
+    loadedToolNames: readonly string[];
+    telemetryEnabled: boolean;
+    telemetryEnv: TelemetryEnv;
+    transportType?: 'stdio' | 'http';
+    sendNotification: (notification: ServerNotification) => Promise<void>;
 }): Promise<void> {
     const {
         taskId,
@@ -100,13 +107,23 @@ export async function executeToolAndUpdateTask(params: {
         apifyClient,
         apifyToken,
         progressToken,
-        extra,
         mcpSessionId,
         actorName,
         actorId,
-        apifyMcpServer,
         clientContext,
+        taskStore,
+        server,
+        tools,
+        actorStore,
+        paymentProvider,
+        loadedToolNames,
+        telemetryEnabled,
+        telemetryEnv,
+        transportType,
+        sendNotification,
     } = params;
+    const emitLog = async (msg: { level: string; data?: unknown }) =>
+        server.sendLoggingMessage(msg as Parameters<typeof server.sendLoggingMessage>[0]);
     let toolStatus: ToolStatus = TOOL_STATUS.SUCCEEDED;
     // Always populate actor fields so they're tracked on both success and failure paths.
     let callDiagnostics: CallDiagnostics = { ...buildActorFields(actorName, actorId) };
@@ -124,7 +141,8 @@ export async function executeToolAndUpdateTask(params: {
         toolName: getToolFullName(tool),
         mcpSessionId,
         apifyToken,
-        apifyMcpServer,
+        telemetryEnabled,
+        transportType,
         clientContext,
     });
 
@@ -140,7 +158,7 @@ export async function executeToolAndUpdateTask(params: {
             callDiagnostics: diagnostics,
             args: toolArgs,
             result,
-            apifyMcpServer,
+            telemetryEnv,
         });
     };
 
@@ -152,15 +170,8 @@ export async function executeToolAndUpdateTask(params: {
         status: ToolStatus,
         diagnostics: CallDiagnostics | undefined,
     ): Promise<void> => {
-        await storeTaskResultOrSkipIfExpired(
-            apifyMcpServer.taskStore,
-            tool.name,
-            taskId,
-            storeStatus,
-            taskResult,
-            mcpSessionId,
-        );
-        await emitTaskStatusNotification(taskId, mcpSessionId, apifyMcpServer.taskStore, apifyMcpServer.server);
+        await storeTaskResultOrSkipIfExpired(taskStore, tool.name, taskId, storeStatus, taskResult, mcpSessionId);
+        await emitTaskStatusNotification(taskId, mcpSessionId, taskStore, server);
         finishTaskTracking(status, diagnostics, taskResult);
     };
 
@@ -172,7 +183,7 @@ export async function executeToolAndUpdateTask(params: {
         status: ToolStatus,
         diagnostics?: CallDiagnostics,
     ): Promise<boolean> => {
-        if (!(await isTaskCancelled(taskId, mcpSessionId, apifyMcpServer.taskStore))) return false;
+        if (!(await isTaskCancelled(taskId, mcpSessionId, taskStore))) return false;
         log.debug(`[executeToolAndUpdateTask] Task was cancelled${logSuffix}`, { taskId, mcpSessionId });
         finishTaskTracking(status, diagnostics);
         return true;
@@ -183,13 +194,12 @@ export async function executeToolAndUpdateTask(params: {
     // Actor run stops instead of consuming compute until natural completion.
     // Per MCP tasks spec, request-level aborts (client disconnect,
     // notifications/cancelled for the original request ID) MUST NOT cancel
-    // the task — `extra.signal` is intentionally not chained here.
+    // the task — the request signal is intentionally not chained here.
     const cancelWatcher = createTaskCancellationWatcher({
         taskId,
         mcpSessionId,
-        taskStore: apifyMcpServer.taskStore,
+        taskStore,
     });
-    const taskExtra = { ...extra, signal: cancelWatcher.signal };
 
     try {
         log.debug('[executeToolAndUpdateTask] Updating task status to working', {
@@ -202,7 +212,7 @@ export async function executeToolAndUpdateTask(params: {
         // apart from a genuine store error.
         // noinspection ExceptionCaughtLocallyJS
         try {
-            await apifyMcpServer.taskStore.updateTaskStatus(taskId, 'working', undefined, mcpSessionId);
+            await taskStore.updateTaskStatus(taskId, 'working', undefined, mcpSessionId);
         } catch (err) {
             if (
                 await skipIfTaskCancelled(' before execution started, skipping', TOOL_STATUS.ABORTED, {
@@ -212,7 +222,7 @@ export async function executeToolAndUpdateTask(params: {
                 return;
             throw err;
         }
-        await emitTaskStatusNotification(taskId, mcpSessionId, apifyMcpServer.taskStore, apifyMcpServer.server);
+        await emitTaskStatusNotification(taskId, mcpSessionId, taskStore, server);
 
         // Execute the tool and get the result
         let result: Record<string, unknown> = {};
@@ -221,8 +231,8 @@ export async function executeToolAndUpdateTask(params: {
         // TODO(TC-3): cancel arriving while this is scheduled throws cancelled → working;
         // currently swallowed by progress.ts's tick catch — guard or catch explicitly.
         const onStatusMessage = async (message: string) => {
-            await apifyMcpServer.taskStore.updateTaskStatus(taskId, 'working', message, mcpSessionId);
-            await emitTaskStatusNotification(taskId, mcpSessionId, apifyMcpServer.taskStore, apifyMcpServer.server);
+            await taskStore.updateTaskStatus(taskId, 'working', message, mcpSessionId);
+            await emitTaskStatusNotification(taskId, mcpSessionId, taskStore, server);
         };
 
         // ACTOR_MCP never reads the tracker (matching the sync path, which passes null for it);
@@ -231,19 +241,23 @@ export async function executeToolAndUpdateTask(params: {
         const progressTracker =
             tool.type === TOOL_TYPE.ACTOR_MCP
                 ? null
-                : createProgressTracker(progressToken, extra.sendNotification, taskId, onStatusMessage);
+                : createProgressTracker(progressToken, sendNotification, taskId, onStatusMessage);
         const dispatchResult = await dispatchToolCall({
             tool,
             toolArgs,
             logSafeArgs,
             apifyToken,
             apifyClient,
-            apifyMcpServer,
             mcpSessionId,
             progressToken,
             progressTracker,
             shouldForwardNotifications: false,
-            extra: taskExtra,
+            signal: cancelWatcher.signal,
+            sendNotification,
+            emitLog,
+            actorStore,
+            paymentProvider,
+            loadedToolNames,
             actorName,
             actorId,
             taskMode: true,
@@ -260,7 +274,7 @@ export async function executeToolAndUpdateTask(params: {
         // synchronous CallTool path, which task-mode calls like call-actor bypass).
         result = withReportProblemNudge({
             result,
-            tools: apifyMcpServer.tools,
+            tools,
             failingToolName: tool.name,
             failureCategory: callDiagnostics.failure_category,
             failureHttpStatus: callDiagnostics.failure_http_status,
@@ -394,7 +408,7 @@ export async function executeToolAndUpdateTask(params: {
                         isError: true,
                         internalToolStatus: toolStatus,
                     },
-                    tools: apifyMcpServer.tools,
+                    tools,
                     failingToolName: tool.name,
                     failureCategory: callDiagnostics.failure_category,
                     failureHttpStatus: callDiagnostics.failure_http_status,
@@ -406,8 +420,7 @@ export async function executeToolAndUpdateTask(params: {
                 // Compile-time exhaustiveness guard (same `satisfies never` idiom as dispatchToolCall's
                 // default arm): a new TOOL_CALL_ERROR_KIND makes `errorResult` non-`never` here and fails
                 // to compile. Unreachable at runtime.
-                throw new McpError(
-                    ErrorCode.InvalidParams,
+                throw new Error(
                     `Unknown tool-call error kind "${(errorResult satisfies never as ToolCallErrorResult).kind}"`,
                 );
         }

--- a/src/mcp/tool_call_engine.ts
+++ b/src/mcp/tool_call_engine.ts
@@ -105,7 +105,6 @@ export async function prepareToolCall(params: {
     tools: Map<string, ToolEntry>;
     paymentProvider?: PaymentProvider;
     allowUnauthMode?: boolean;
-    loadedToolNames: readonly string[];
     // Used to preserve abort status for a post-resolution classified failure.
     signal?: AbortSignal;
 }): Promise<PreparedCall | InvalidToolCall | PreparedCallError> {
@@ -120,7 +119,6 @@ export async function prepareToolCall(params: {
         tools,
         paymentProvider,
         allowUnauthMode,
-        loadedToolNames,
     } = params;
     let { args } = params;
 
@@ -140,7 +138,7 @@ export async function prepareToolCall(params: {
     const toolEntry = Array.from(tools.values()).find((t) => t.name === newName || getToolFullName(t) === newName);
 
     if (!toolEntry) {
-        const availableTools = loadedToolNames;
+        const availableTools = Array.from(tools.keys());
         return {
             message: dedent`
                 Tool "${name}" was not found.
@@ -300,7 +298,6 @@ export async function executeSyncToolCall(
         tools: Map<string, ToolEntry>;
         actorStore?: ActorStore;
         paymentProvider?: PaymentProvider;
-        loadedToolNames: readonly string[];
         signal: AbortSignal;
         sendNotification: (notification: ServerNotification) => Promise<void>;
         emitLog: (msg: { level: string; data?: unknown }) => Promise<void>;
@@ -314,7 +311,6 @@ export async function executeSyncToolCall(
         tools,
         actorStore,
         paymentProvider,
-        loadedToolNames,
         signal,
         sendNotification,
         emitLog,
@@ -366,7 +362,7 @@ export async function executeSyncToolCall(
             emitLog,
             actorStore,
             paymentProvider,
-            loadedToolNames,
+            tools,
             actorName,
             actorId,
             taskMode: false,

--- a/src/mcp/tool_call_engine.ts
+++ b/src/mcp/tool_call_engine.ts
@@ -3,9 +3,7 @@
  * Returns neutral outcomes; the shell constructs protocol errors and side-channel notifications.
  */
 
-import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
-import type { Notification, Request } from '@modelcontextprotocol/sdk/types.js';
-import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import dedent from 'dedent';
 
 import log from '@apify/log';
@@ -13,22 +11,21 @@ import log from '@apify/log';
 import type { ApifyClient } from '../apify_client.js';
 import { ALLOWED_TASK_TOOL_EXECUTION_MODES, FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../const.js';
 import { prepareToolCallContext } from '../payments/helpers.js';
-import type { PaymentMeta, RequestHeaders } from '../payments/types.js';
+import type { PaymentMeta, PaymentProvider, RequestHeaders } from '../payments/types.js';
 import { decodeDotPropertyNames } from '../tools/actor_input_schema.js';
 import { legacyToolNameToNew } from '../tools/actor_tool_naming.js';
 import { checkPaymentProviderStandbyConflict } from '../tools/actors/call_actor.js';
 import { withReportProblemNudge } from '../tools/dev/report_problem.js';
-import type { CallDiagnostics, ToolCallTelemetryProperties, ToolEntry, ToolStatus } from '../types.js';
+import type { ActorStore, CallDiagnostics, ToolCallTelemetryProperties, ToolEntry, ToolStatus } from '../types.js';
 import { TOOL_TYPE } from '../types.js';
 import { logHttpError } from '../utils/logging.js';
 import { respondOk } from '../utils/mcp.js';
 import { getRequestOriginForClient } from '../utils/mcp_clients.js';
 import type { buildPaymentRequiredResponse } from '../utils/payment_errors.js';
 import { createProgressTracker } from '../utils/progress.js';
-import { extractAjvErrorDetails } from '../utils/tool_status.js';
+import { extractAjvErrorDetails, isMcpError } from '../utils/tool_status.js';
 import { buildActorFields, extractActorId, extractActorName, getToolFullName } from '../utils/tools.js';
 import type { McpClientContext } from './client_context.js';
-import type { ActorsMcpServer } from './server.js';
 import { buildToolCallErrorResult, TOOL_CALL_ERROR_KIND } from './tool_call_error_mapper.js';
 import type { ToolCallErrorResult } from './tool_call_error_mapper.js';
 import { dispatchToolCall } from './tool_dispatch.js';
@@ -96,7 +93,6 @@ export function buildPreflightFailureOutcome(
 
 /** Prepares a call; protocol errors are left to the shell. */
 export async function prepareToolCall(params: {
-    apifyMcpServer: ActorsMcpServer;
     apifyToken: string;
     name: string;
     args: Record<string, unknown> | undefined;
@@ -106,15 +102,29 @@ export async function prepareToolCall(params: {
     mcpSessionId: string | undefined;
     telemetryData: ToolCallTelemetryProperties | null;
     clientContext: McpClientContext | undefined;
+    tools: Map<string, ToolEntry>;
+    paymentProvider?: PaymentProvider;
+    allowUnauthMode?: boolean;
+    loadedToolNames: readonly string[];
     // Used to preserve abort status for a post-resolution classified failure.
-    extra?: RequestHandlerExtra<Request, Notification>;
+    signal?: AbortSignal;
 }): Promise<PreparedCall | InvalidToolCall | PreparedCallError> {
-    const { apifyMcpServer, apifyToken, name, meta, requestHeaders, isTaskRequest, telemetryData, clientContext } =
-        params;
+    const {
+        apifyToken,
+        name,
+        meta,
+        requestHeaders,
+        isTaskRequest,
+        telemetryData,
+        clientContext,
+        tools,
+        paymentProvider,
+        allowUnauthMode,
+        loadedToolNames,
+    } = params;
     let { args } = params;
-    const { options, tools } = apifyMcpServer;
 
-    if (!apifyToken && !options.paymentProvider?.allowsUnauthenticated && !options.allowUnauthMode) {
+    if (!apifyToken && !paymentProvider?.allowsUnauthenticated && !allowUnauthMode) {
         return {
             message: dedent`
                 Apify API token is required but was not provided.
@@ -130,7 +140,7 @@ export async function prepareToolCall(params: {
     const toolEntry = Array.from(tools.values()).find((t) => t.name === newName || getToolFullName(t) === newName);
 
     if (!toolEntry) {
-        const availableTools = apifyMcpServer.listToolNames();
+        const availableTools = loadedToolNames;
         return {
             message: dedent`
                 Tool "${name}" was not found.
@@ -181,7 +191,7 @@ export async function prepareToolCall(params: {
             apifyClient,
             paymentRequiredResult,
         } = prepareToolCallContext({
-            provider: options.paymentProvider,
+            provider: paymentProvider,
             tool,
             args: args as Record<string, unknown>,
             apifyToken,
@@ -239,7 +249,6 @@ export async function prepareToolCall(params: {
         }
 
         // Standby Actors need a specific rejection instead of a generic 402 in both modes.
-        const { paymentProvider } = options;
         const isCallActorTool = tool.name === HELPER_TOOLS.ACTOR_CALL || tool.name === HELPER_TOOLS.ACTOR_CALL_WIDGET;
         const actorArg = (toolArgs as { actor?: unknown } | undefined)?.actor;
 
@@ -266,14 +275,14 @@ export async function prepareToolCall(params: {
         };
     } catch (error) {
         // Keep protocol errors as JSON-RPC errors; classify other failures with actor context.
-        if (error instanceof McpError) throw error;
+        if (isMcpError(error)) throw error;
         const outcome = classifyToolCallError(error, {
-            apifyMcpServer,
+            tools,
             toolName: name,
             failingToolName: resolvedToolName,
             actorName,
             actorId,
-            isAborted: Boolean(params.extra?.signal?.aborted),
+            isAborted: Boolean(params.signal?.aborted),
             mcpSessionId: params.mcpSessionId,
         });
         return { ...outcome, resolvedToolName, decodedArgs };
@@ -284,15 +293,32 @@ export async function prepareToolCall(params: {
 export async function executeSyncToolCall(
     prepared: PreparedCall,
     params: {
-        apifyMcpServer: ActorsMcpServer;
         apifyToken: string;
         toolName: string;
         mcpSessionId: string | undefined;
         progressToken: string | number | undefined;
-        extra: RequestHandlerExtra<Request, Notification>;
+        tools: Map<string, ToolEntry>;
+        actorStore?: ActorStore;
+        paymentProvider?: PaymentProvider;
+        loadedToolNames: readonly string[];
+        signal: AbortSignal;
+        sendNotification: (notification: ServerNotification) => Promise<void>;
+        emitLog: (msg: { level: string; data?: unknown }) => Promise<void>;
     },
 ): Promise<ToolCallOutcome> {
-    const { apifyMcpServer, apifyToken, toolName, mcpSessionId, progressToken, extra } = params;
+    const {
+        apifyToken,
+        toolName,
+        mcpSessionId,
+        progressToken,
+        tools,
+        actorStore,
+        paymentProvider,
+        loadedToolNames,
+        signal,
+        sendNotification,
+        emitLog,
+    } = params;
     const { tool, toolArgs, logSafeArgs, apifyClient, actorName, actorId, standbyRejection, paymentRequiredResult } =
         prepared;
     const resolvedToolName = getToolFullName(tool);
@@ -300,7 +326,7 @@ export async function executeSyncToolCall(
     const nudge = (result: unknown, callDiagnostics: CallDiagnostics): Record<string, unknown> =>
         withReportProblemNudge({
             result,
-            tools: apifyMcpServer.tools,
+            tools,
             failingToolName: resolvedToolName,
             failureCategory: callDiagnostics.failure_category,
             failureHttpStatus: callDiagnostics.failure_http_status,
@@ -322,7 +348,7 @@ export async function executeSyncToolCall(
         tool.type === TOOL_TYPE.ACTOR ||
         (tool.type === TOOL_TYPE.INTERNAL &&
             (tool.name === HELPER_TOOLS.ACTOR_CALL || tool.name === HELPER_TOOLS.ACTOR_RUNS_GET));
-    const progressTracker = progressTrackerOptIn ? createProgressTracker(progressToken, extra.sendNotification) : null;
+    const progressTracker = progressTrackerOptIn ? createProgressTracker(progressToken, sendNotification) : null;
 
     try {
         const dispatchResult = await dispatchToolCall({
@@ -331,12 +357,16 @@ export async function executeSyncToolCall(
             logSafeArgs,
             apifyToken,
             apifyClient,
-            apifyMcpServer,
             mcpSessionId,
             progressToken,
             progressTracker,
             shouldForwardNotifications: true,
-            extra,
+            signal,
+            sendNotification,
+            emitLog,
+            actorStore,
+            paymentProvider,
+            loadedToolNames,
             actorName,
             actorId,
             taskMode: false,
@@ -348,14 +378,14 @@ export async function executeSyncToolCall(
         };
     } catch (error) {
         // Protocol errors stay JSON-RPC errors; a 402-coded McpError must not become a payment result.
-        if (error instanceof McpError) throw error;
+        if (isMcpError(error)) throw error;
         return classifyToolCallError(error, {
-            apifyMcpServer,
+            tools,
             toolName,
             failingToolName: resolvedToolName,
             actorName,
             actorId,
-            isAborted: Boolean(extra.signal?.aborted),
+            isAborted: Boolean(signal.aborted),
             mcpSessionId,
         });
     }
@@ -365,7 +395,7 @@ export async function executeSyncToolCall(
 export function classifyToolCallError(
     error: unknown,
     params: {
-        apifyMcpServer: ActorsMcpServer;
+        tools: Map<string, ToolEntry>;
         toolName: string;
         failingToolName: string;
         actorName: string | undefined;
@@ -374,12 +404,12 @@ export function classifyToolCallError(
         mcpSessionId: string | undefined;
     },
 ): ToolCallOutcome {
-    const { apifyMcpServer, toolName, failingToolName, actorName, actorId, isAborted, mcpSessionId } = params;
+    const { tools, toolName, failingToolName, actorName, actorId, isAborted, mcpSessionId } = params;
 
     const nudge = (result: unknown, callDiagnostics: CallDiagnostics): Record<string, unknown> =>
         withReportProblemNudge({
             result,
-            tools: apifyMcpServer.tools,
+            tools,
             failingToolName,
             failureCategory: callDiagnostics.failure_category,
             failureHttpStatus: callDiagnostics.failure_http_status,

--- a/src/mcp/tool_call_telemetry.ts
+++ b/src/mcp/tool_call_telemetry.ts
@@ -3,7 +3,13 @@ import log from '@apify/log';
 import { ApifyClient } from '../apify_client.js';
 import { HELPER_TOOLS, TOOL_STATUS } from '../const.js';
 import { buildReportedProblemProperties, trackReportedProblem, trackToolCall } from '../telemetry.js';
-import type { CallDiagnostics, TelemetryEnv, ToolCallTelemetryProperties, ToolStatus } from '../types.js';
+import type {
+    CallDiagnostics,
+    TelemetryEnv,
+    ToolCallTelemetryProperties,
+    ToolStatus,
+    TransportType,
+} from '../types.js';
 import { computeToolResponseBytes } from '../utils/mcp.js';
 import { getRequestOriginForClient } from '../utils/mcp_clients.js';
 import { deriveResourceIds } from '../utils/tool_status.js';
@@ -16,7 +22,7 @@ type PrepareTelemetryDataParams = {
     mcpSessionId: string | undefined;
     apifyToken: string;
     telemetryEnabled: boolean;
-    transportType?: 'stdio' | 'http';
+    transportType?: TransportType;
     clientContext: McpClientContext | undefined;
 };
 

--- a/src/mcp/tool_call_telemetry.ts
+++ b/src/mcp/tool_call_telemetry.ts
@@ -3,20 +3,20 @@ import log from '@apify/log';
 import { ApifyClient } from '../apify_client.js';
 import { HELPER_TOOLS, TOOL_STATUS } from '../const.js';
 import { buildReportedProblemProperties, trackReportedProblem, trackToolCall } from '../telemetry.js';
-import type { CallDiagnostics, ToolCallTelemetryProperties, ToolStatus } from '../types.js';
+import type { CallDiagnostics, TelemetryEnv, ToolCallTelemetryProperties, ToolStatus } from '../types.js';
 import { computeToolResponseBytes } from '../utils/mcp.js';
 import { getRequestOriginForClient } from '../utils/mcp_clients.js';
 import { deriveResourceIds } from '../utils/tool_status.js';
 import { getUserInfoCached } from '../utils/userid_cache.js';
 import { getPackageVersion } from '../utils/version.js';
 import type { McpClientContext } from './client_context.js';
-import type { ActorsMcpServer } from './server.js';
 
 type PrepareTelemetryDataParams = {
     toolName: string;
     mcpSessionId: string | undefined;
     apifyToken: string;
-    apifyMcpServer: ActorsMcpServer;
+    telemetryEnabled: boolean;
+    transportType?: 'stdio' | 'http';
     clientContext: McpClientContext | undefined;
 };
 
@@ -26,8 +26,8 @@ type PrepareTelemetryDataParams = {
 export async function prepareTelemetryData(
     params: PrepareTelemetryDataParams,
 ): Promise<{ telemetryData: ToolCallTelemetryProperties | null; userId: string | null }> {
-    const { toolName, mcpSessionId, apifyToken, apifyMcpServer, clientContext } = params;
-    if (!apifyMcpServer.telemetryEnabled) {
+    const { toolName, mcpSessionId, apifyToken, telemetryEnabled, transportType, clientContext } = params;
+    if (!telemetryEnabled) {
         return { telemetryData: null, userId: null };
     }
 
@@ -47,7 +47,7 @@ export async function prepareTelemetryData(
         mcp_protocol_version: clientContext?.protocolVersion || '',
         mcp_client_capabilities: clientContext?.capabilities || null,
         mcp_session_id: mcpSessionId || '',
-        transport_type: apifyMcpServer.options.transportType || '',
+        transport_type: transportType || '',
         tool_name: toolName,
         tool_status: TOOL_STATUS.SUCCEEDED, // Will be updated in finally
         tool_exec_time_ms: 0, // Will be calculated in finally
@@ -73,7 +73,7 @@ type LogToolCallAndTelemetryParams = {
     callDiagnostics?: CallDiagnostics;
     args?: Record<string, unknown>;
     result?: unknown;
-    apifyMcpServer: ActorsMcpServer;
+    telemetryEnv: TelemetryEnv;
 };
 
 export function logToolCallAndTelemetry(params: LogToolCallAndTelemetryParams): void {
@@ -111,7 +111,7 @@ export function logToolCallAndTelemetry(params: LogToolCallAndTelemetryParams): 
             // threads them back. Applied uniformly, last. See deriveResourceIds.
             ...deriveResourceIds(params.args, params.result),
         };
-        trackToolCall(params.userId, params.apifyMcpServer.telemetryEnv, finalizedTelemetryData);
+        trackToolCall(params.userId, params.telemetryEnv, finalizedTelemetryData);
 
         // A successful report-problem call also emits a dedicated feedback event carrying the
         // submission. A downstream Segment destination fans it out to Slack/GitHub.
@@ -122,7 +122,7 @@ export function logToolCallAndTelemetry(params: LogToolCallAndTelemetryParams): 
         ) {
             trackReportedProblem(
                 params.userId,
-                params.apifyMcpServer.telemetryEnv,
+                params.telemetryEnv,
                 buildReportedProblemProperties(finalizedTelemetryData, params.args),
             );
         }

--- a/src/mcp/tool_dispatch.ts
+++ b/src/mcp/tool_dispatch.ts
@@ -54,7 +54,8 @@ export async function dispatchToolCall(params: {
     emitLog: (msg: { level: string; data?: unknown }) => Promise<void>;
     actorStore?: ActorStore;
     paymentProvider?: PaymentProvider;
-    loadedToolNames: readonly string[];
+    /** The live tool registry; tool args derive `loadedToolNames` from it at call time. */
+    tools: Map<string, ToolEntry>;
     actorName?: string;
     actorId?: string;
     taskMode: boolean;
@@ -77,7 +78,7 @@ export async function dispatchToolCall(params: {
         emitLog,
         actorStore,
         paymentProvider,
-        loadedToolNames,
+        tools,
         actorName,
         actorId,
         taskMode,
@@ -105,7 +106,7 @@ export async function dispatchToolCall(params: {
                     apifyClient,
                     actorStore,
                     paymentProvider,
-                    loadedToolNames,
+                    loadedToolNames: Array.from(tools.keys()),
                     progressTracker,
                     mcpSessionId,
                     taskMode,

--- a/src/mcp/tool_dispatch.ts
+++ b/src/mcp/tool_dispatch.ts
@@ -1,20 +1,15 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
-import type { Notification, Request } from '@modelcontextprotocol/sdk/types.js';
-import {
-    CallToolResultSchema,
-    ErrorCode,
-    McpError,
-    ServerNotificationSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+import type { ServerNotification } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResultSchema, ServerNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 import dedent from 'dedent';
 
 import log from '@apify/log';
 
 import type { ApifyClient } from '../apify_client.js';
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
+import type { PaymentProvider } from '../payments/types.js';
 import { actorExecutor } from '../tools/actors/actor_executor.js';
-import type { CallDiagnostics, ToolEntry, ToolStatus } from '../types.js';
+import type { ActorStore, CallDiagnostics, ToolEntry, ToolStatus } from '../types.js';
 import { TOOL_TYPE } from '../types.js';
 import { remoteMcpFailureDetail } from '../utils/apify_errors.js';
 import { logHttpError } from '../utils/logging.js';
@@ -24,7 +19,6 @@ import { applyToolTelemetry, buildExecutionDiagnostics } from '../utils/tool_sta
 import { buildActorFields } from '../utils/tools.js';
 import { connectMCPClient } from './client.js';
 import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC } from './const.js';
-import type { ActorsMcpServer } from './server.js';
 
 /**
  * Runs a validated tool call through the single tool-type dispatch switch and returns the raw
@@ -38,11 +32,12 @@ import type { ActorsMcpServer } from './server.js';
  * `extractToolTelemetry` (via `applyToolTelemetry`) runs once here, in the INTERNAL and ACTOR
  * cases, and strips `toolTelemetry` in place, so callers must not re-strip. ACTOR_MCP sets
  * telemetry manually instead. The caller constructs `progressTracker`; dispatch consumes it and stops
- * it in the branch `finally`. The abort source is `extra.signal`: the request signal for sync; the
- * task caller passes a `taskExtra` whose `signal` is the cancel watcher's, so a client disconnect
- * never cancels a task. `shouldForwardNotifications` gates only the ACTOR_MCP raw-notification
- * forwarder (true for sync, false for task, whose originating request is already answered).
- * `taskMode` is a passthrough to `tool.call` / `executeActorTool`, never a dispatch selector.
+ * it in the branch `finally`. The abort source is the `signal` param: the request signal for sync; the
+ * task caller passes the cancel watcher's signal, so a client disconnect never cancels a task.
+ * `shouldForwardNotifications` gates only the ACTOR_MCP raw-notification forwarder (true for sync,
+ * false for task, whose originating request is already answered). `taskMode` is a passthrough to
+ * `tool.call` / `executeActorTool`, never a dispatch selector. `emitLog` (required) is the
+ * side-channel for ACTOR_MCP connect failures; shells without a transport may pass a no-op.
  */
 export async function dispatchToolCall(params: {
     tool: ToolEntry;
@@ -50,20 +45,22 @@ export async function dispatchToolCall(params: {
     logSafeArgs: unknown;
     apifyToken: string;
     apifyClient: ApifyClient;
-    apifyMcpServer: ActorsMcpServer;
     mcpSessionId: string | undefined;
     progressToken: string | number | undefined;
     progressTracker: ReturnType<typeof createProgressTracker>;
     shouldForwardNotifications: boolean;
-    extra: RequestHandlerExtra<Request, Notification>;
+    signal: AbortSignal;
+    sendNotification: (notification: ServerNotification) => Promise<void>;
+    emitLog: (msg: { level: string; data?: unknown }) => Promise<void>;
+    actorStore?: ActorStore;
+    paymentProvider?: PaymentProvider;
+    loadedToolNames: readonly string[];
     actorName?: string;
     actorId?: string;
     taskMode: boolean;
     // Caller-supplied log decoration (task mode: ' for task' suffix + taskId field), applied
     // mechanically to the per-branch "Calling …" lines — no effect on dispatch behavior.
     logContext?: { messageSuffix: string; fields: Record<string, unknown> };
-    // Side-channel for ACTOR_MCP connect failures; shells without a transport may pass a no-op.
-    emitLog?: (msg: { level: string; data?: unknown }) => Promise<void>;
 }): Promise<{ result: Record<string, unknown>; toolStatus: ToolStatus; callDiagnostics: CallDiagnostics }> {
     const {
         tool,
@@ -71,20 +68,20 @@ export async function dispatchToolCall(params: {
         logSafeArgs,
         apifyToken,
         apifyClient,
-        apifyMcpServer,
         mcpSessionId,
         progressToken,
         progressTracker,
         shouldForwardNotifications,
-        extra,
+        signal,
+        sendNotification,
+        emitLog,
+        actorStore,
+        paymentProvider,
+        loadedToolNames,
         actorName,
         actorId,
         taskMode,
         logContext,
-        emitLog = async (msg) =>
-            apifyMcpServer.server.sendLoggingMessage(
-                msg as Parameters<typeof apifyMcpServer.server.sendLoggingMessage>[0],
-            ),
     } = params;
 
     let result: Record<string, unknown> = {};
@@ -103,11 +100,12 @@ export async function dispatchToolCall(params: {
                 });
                 const res = (await tool.call({
                     args: toolArgs,
-                    extra,
-                    apifyMcpServer,
-                    mcpServer: apifyMcpServer.server,
+                    signal,
                     apifyToken,
                     apifyClient,
+                    actorStore,
+                    paymentProvider,
+                    loadedToolNames,
                     progressTracker,
                     mcpSessionId,
                     taskMode,
@@ -158,7 +156,7 @@ export async function dispatchToolCall(params: {
                                 mcpSessionId,
                                 notification,
                             });
-                            await extra.sendNotification(notification);
+                            await sendNotification(notification);
                         });
                     }
                 }
@@ -201,7 +199,7 @@ export async function dispatchToolCall(params: {
             } catch (error) {
                 ({ toolStatus, callDiagnostics } = buildExecutionDiagnostics({
                     error,
-                    isAborted: Boolean(extra.signal?.aborted),
+                    isAborted: Boolean(signal.aborted),
                     actorName,
                     actorId,
                 }));
@@ -234,7 +232,7 @@ export async function dispatchToolCall(params: {
                     apifyClient,
                     callOptions: { memory: tool.memoryMbytes },
                     progressTracker,
-                    abortSignal: extra.signal,
+                    abortSignal: signal,
                     mcpSessionId,
                     datasetItemsSchema: tool.datasetItemsSchema,
                     taskMode,
@@ -271,11 +269,8 @@ export async function dispatchToolCall(params: {
             // non-`never` here and fails `satisfies never` at compile time. Unreachable at runtime —
             // ToolEntry is a closed 3-way union. Unlike the pre-extraction fall-through (which also
             // listed available tools, called log.softFail, and sent a logging message before
-            // throwing), this just throws InvalidParams with no side effects.
-            throw new McpError(
-                ErrorCode.InvalidParams,
-                `Unknown tool type "${(tool satisfies never as ToolEntry).type}"`,
-            );
+            // throwing), this just throws with no side effects.
+            throw new Error(`Unknown tool type "${(tool satisfies never as ToolEntry).type}"`);
     }
 
     return { result, toolStatus, callDiagnostics };

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -567,7 +567,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<Tool
 
         resolvedActorId = extractActorId(resolution.actor);
         const { apifyClient } = toolArgs;
-        const abortSignal = toolArgs.extra.signal;
+        const abortSignal = toolArgs.signal;
 
         if (abortSignal?.aborted) return respondAborted();
 

--- a/src/tools/actors/fetch_actor_details.ts
+++ b/src/tools/actors/fetch_actor_details.ts
@@ -208,7 +208,7 @@ export function buildActorDetailsTextResponse(options: {
  * Returns the same text + structured response in both modes.
  */
 export async function buildFetchActorDetailsResult(toolArgs: InternalToolArgs): Promise<ToolResponse> {
-    const { args, apifyToken, apifyClient, apifyMcpServer, mcpSessionId } = toolArgs;
+    const { args, apifyToken, apifyClient, actorStore, paymentProvider, mcpSessionId } = toolArgs;
     const parsed = fetchActorDetailsToolArgsSchema.parse(args);
     const actorName = fixActorNameInputAndLog(parsed.actor, { mcpSessionId, route: HELPER_TOOLS.ACTOR_GET_DETAILS });
 
@@ -230,18 +230,12 @@ export async function buildFetchActorDetailsResult(toolArgs: InternalToolArgs): 
 
     let actorOutputSchema: Record<string, unknown> | null | undefined;
     if (resolvedOutput.outputSchema) {
-        actorOutputSchema = apifyMcpServer.actorStore
-            ? await apifyMcpServer.actorStore.getActorOutputSchemaAsTypeObject(actorName).catch(() => null)
+        actorOutputSchema = actorStore
+            ? await actorStore.getActorOutputSchemaAsTypeObject(actorName).catch(() => null)
             : null;
     }
     const mcpToolsMessage = resolvedOutput.mcpTools
-        ? await getMcpToolsMessage(
-              actorName,
-              apifyClient,
-              apifyToken,
-              apifyMcpServer?.options.paymentProvider,
-              mcpSessionId,
-          )
+        ? await getMcpToolsMessage(actorName, apifyClient, apifyToken, paymentProvider, mcpSessionId)
         : undefined;
 
     // NOTE: Data duplication between texts and structuredContent is intentional and required.

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -166,7 +166,7 @@ export const searchActors: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyClient, apifyMcpServer } = toolArgs;
+        const { args, apifyToken, apifyClient, paymentProvider } = toolArgs;
         const parsed = searchActorsBaseArgsSchema.parse(args);
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
@@ -176,7 +176,7 @@ export const searchActors: ToolEntry = Object.freeze({
                 apifyClient,
                 limit: parsed.limit,
                 offset: parsed.offset,
-                paymentProvider: apifyMcpServer.options.paymentProvider,
+                paymentProvider,
             }),
             getUserInfoCached(apifyToken, apifyClient),
         ]);

--- a/src/tools/runs/get_actor_run.ts
+++ b/src/tools/runs/get_actor_run.ts
@@ -126,7 +126,7 @@ export const getActorRun: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyClient: client, apifyToken, progressTracker, mcpSessionId, extra } = toolArgs;
+        const { args, apifyClient: client, apifyToken, progressTracker, mcpSessionId, signal } = toolArgs;
         const parsed = getActorRunArgs.parse(args);
 
         try {
@@ -135,7 +135,7 @@ export const getActorRun: ToolEntry = Object.freeze({
                 waitSecs: parsed.waitSecs,
                 client,
                 progressTracker,
-                abortSignal: extra?.signal,
+                abortSignal: signal,
                 mcpSessionId,
             });
 

--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -90,7 +90,7 @@ export const getDatasetItems: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyClient: client, apifyToken, apifyMcpServer } = toolArgs;
+        const { args, apifyClient: client, apifyToken, loadedToolNames } = toolArgs;
         const parsed = getDatasetItemsArgs.parse(args);
 
         const fields = parseCommaSeparatedList(parsed.fields);
@@ -132,7 +132,7 @@ export const getDatasetItems: ToolEntry = Object.freeze({
             itemCount: v.items.length,
             totalItemCount: v.total,
             offset,
-            loadedToolNames: apifyMcpServer.listToolNames(),
+            loadedToolNames,
         });
         return buildStorageResponse({ structuredContent, summary, nextStep, apifyConsoleUrl });
     },

--- a/src/tools/storage/storage_helpers.ts
+++ b/src/tools/storage/storage_helpers.ts
@@ -24,7 +24,7 @@ export async function catchNotFound<T>(promise: Promise<T>): Promise<T | null> {
     }
 }
 
-function suggestTool(toolName: string, loadedToolNames: string[]): string | undefined {
+function suggestTool(toolName: string, loadedToolNames: readonly string[]): string | undefined {
     return loadedToolNames.includes(toolName) ? toolName : undefined;
 }
 
@@ -104,7 +104,7 @@ export function buildDatasetItemsSummaryNextStep(params: {
     totalItemCount: number;
     offset: number;
     /** Active loaded tool set; gates the terminal get-dataset reference (see #1007). */
-    loadedToolNames: string[];
+    loadedToolNames: readonly string[];
 }): { summary: string; nextStep: string } {
     const { datasetId, itemCount, totalItemCount, offset, loadedToolNames } = params;
     if (offset + itemCount < totalItemCount) {

--- a/src/tools/widgets/search_actors_widget.ts
+++ b/src/tools/widgets/search_actors_widget.ts
@@ -59,7 +59,7 @@ export const searchActorsWidget: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyClient, apifyMcpServer } = toolArgs;
+        const { args, apifyToken, apifyClient, paymentProvider } = toolArgs;
         const parsed = searchActorsWidgetArgsSchema.parse(args);
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
@@ -69,7 +69,7 @@ export const searchActorsWidget: ToolEntry = Object.freeze({
                 apifyClient,
                 limit: parsed.limit,
                 offset: parsed.offset,
-                paymentProvider: apifyMcpServer.options.paymentProvider,
+                paymentProvider,
             }),
             getUserInfoCached(apifyToken, apifyClient),
         ]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,5 @@
 import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
-import type { InitializeRequest, Notification, Prompt, Request, ToolSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { InitializeRequest, Prompt, ToolSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { ValidateFunction } from 'ajv';
 import type {
     Actor as ActorOutdated,
@@ -15,7 +13,6 @@ import type z from 'zod';
 
 import type { ApifyClient } from './apify_client.js';
 import type { FAILURE_CATEGORY, TELEMETRY_ENV, TOOL_STATUS } from './const.js';
-import type { ActorsMcpServer } from './mcp/server.js';
 import type { PaymentProvider } from './payments/types.js';
 import type { CATEGORY_NAMES } from './tools/registry.js';
 import type { ToolResponse } from './utils/mcp.js';
@@ -142,29 +139,24 @@ export type ActorTool = ToolBase & {
 };
 
 /**
- * Arguments passed to internal tool calls.
- * Contains both the tool arguments and server references.
+ * Arguments passed to internal tool calls. Protocol-neutral: plain values the tool bodies read,
+ * no v1 SDK request context or facade reference.
  */
 export type InternalToolArgs = {
     /** Arguments passed to the tool (payment fields already stripped by the server) */
     args: Record<string, unknown>;
-    /** MCP request `_meta` field — used by payment providers that read from metadata (e.g., x402) */
-    meta?: Record<string, unknown>;
-    /** Extra data given to request handlers.
-     *
-     * Can be used to send notifications from the server to the client.
-     *
-     * For more details see: https://github.com/modelcontextprotocol/typescript-sdk/blob/f822c1255edcf98c4e73b9bf17a9dd1b03f86716/src/shared/protocol.ts#L102
-     */
-    extra: RequestHandlerExtra<Request, Notification>;
-    /** Reference to the Apify MCP server instance */
-    apifyMcpServer: ActorsMcpServer;
-    /** Reference to the MCP server instance */
-    mcpServer: Server;
+    /** Abort signal for the call: the request signal for sync calls, the cancel-watcher signal for tasks. */
+    signal: AbortSignal;
     /** Apify API token */
     apifyToken: string;
     /** ApifyClient pre-configured with payment headers (if applicable) or standard token. */
     apifyClient: ApifyClient;
+    /** External store for Actor metadata (output schemas); only set in hosted deployments. */
+    actorStore?: ActorStore;
+    /** Payment provider for agentic payment modes (Skyfire, x402), when configured. */
+    paymentProvider?: PaymentProvider;
+    /** Names of all currently loaded tools. */
+    loadedToolNames: readonly string[];
     /** Optional progress tracker for long running internal tools, like call-actor */
     progressTracker?: ProgressTracker | null;
     /** MCP session ID for logging context */

--- a/src/types.ts
+++ b/src/types.ts
@@ -541,6 +541,11 @@ export type ActorStore = {
 };
 
 /**
+ * How the server is connected: 'stdio' (direct/local) or 'http' (remote HTTP streamable).
+ */
+export type TransportType = 'stdio' | 'http';
+
+/**
  * Options for configuring the ActorsMcpServer instance.
  */
 export type ActorsMcpServerOptions = {
@@ -592,7 +597,7 @@ export type ActorsMcpServerOptions = {
      * - 'stdio': Direct/local stdio connection
      * - 'http': Remote HTTP streamable connection
      */
-    transportType?: 'stdio' | 'http';
+    transportType?: TransportType;
     /**
      * Apify API token for authentication
      * Primarily used by stdio transport when token is read from ~/.apify/auth.json file

--- a/src/utils/tool_status.ts
+++ b/src/utils/tool_status.ts
@@ -51,6 +51,14 @@ export function deriveResourceIds(args: Record<string, unknown> | undefined, res
 }
 
 /**
+ * Neutral predicate: true if `error` is an SDK `McpError`. Lets the shared orchestration modules
+ * keep the exact `instanceof McpError` behavior without importing the SDK error type themselves.
+ */
+export function isMcpError(error: unknown): boolean {
+    return error instanceof McpError;
+}
+
+/**
  * Central helper to classify an error into a ToolStatus value.
  *
  * - TOOL_STATUS.ABORTED   → the client explicitly aborted Request.

--- a/tests/unit/helpers/mcp_server.ts
+++ b/tests/unit/helpers/mcp_server.ts
@@ -1,4 +1,6 @@
+import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { ApifyApiError } from 'apify-client';
 import type { AxiosResponse } from 'axios';
 
@@ -20,16 +22,30 @@ export type HandlerFn = (
 ) => Promise<Record<string, unknown>>;
 
 /**
+ * Reach the legacy adapter's SDK `Server` through the facade's private `legacyServer` field. The
+ * v1 wiring moved off `ActorsMcpServer` into `LegacyMcpServer`; this cast keeps the reach into that
+ * SDK-owned seam centralized so an SDK/structure change only needs one fix.
+ */
+export function getLegacyServer(server: unknown): Server {
+    return (server as { legacyServer: { server: Server } }).legacyServer.server;
+}
+
+/** Reach the legacy adapter's task store through the facade's private `legacyServer` field. */
+export function getTaskStore(server: unknown): TaskStore {
+    return (server as { legacyServer: { taskStore: TaskStore } }).legacyServer.taskStore;
+}
+
+/**
  * Returns the real request handler the SDK registered for `method` (e.g. 'tools/call',
- * 'tasks/result'), reached through the server's private `_requestHandlers` map so a test can invoke
- * it directly. Throws if the handler is not registered. This reach into an SDK-internal seam is
- * centralized here so an SDK upgrade only needs one fix.
+ * 'tasks/result'), reached through the adapter server's private `_requestHandlers` map so a test can
+ * invoke it directly. Throws if the handler is not registered. This reach into an SDK-internal seam
+ * is centralized here so an SDK upgrade only needs one fix.
  */
 export function getRequestHandler(server: unknown, method: string): HandlerFn {
     // eslint-disable-next-line no-underscore-dangle
-    const handler = (server as { server: { _requestHandlers: Map<string, HandlerFn> } }).server._requestHandlers.get(
-        method,
-    );
+    const handler = (
+        getLegacyServer(server) as unknown as { _requestHandlers: Map<string, HandlerFn> }
+    )._requestHandlers.get(method);
     if (!handler) throw new Error(`Handler "${method}" not registered`);
     return handler;
 }

--- a/tests/unit/helpers/tool_context.ts
+++ b/tests/unit/helpers/tool_context.ts
@@ -39,9 +39,10 @@ export function stubToolCallContext(
         args,
         apifyToken: 'test-token',
         apifyClient: client,
-        extra: {},
-        mcpServer: {},
-        apifyMcpServer: { options: { paymentProvider: undefined }, listToolNames: () => Object.values(HELPER_TOOLS) },
+        signal: new AbortController().signal,
+        paymentProvider: undefined,
+        actorStore: undefined,
+        loadedToolNames: Object.values(HELPER_TOOLS),
     } as unknown as InternalToolArgs;
 }
 

--- a/tests/unit/mcp.server.error_handling.test.ts
+++ b/tests/unit/mcp.server.error_handling.test.ts
@@ -7,7 +7,7 @@ import log from '@apify/log';
 
 import { TOOL_STATUS } from '../../src/const.js';
 import { getToolCallErrorUserText } from '../../src/utils/mcp.js';
-import { getRequestHandler, makeThrowingTool, withServer } from './helpers/mcp_server.js';
+import { getLegacyServer, getRequestHandler, makeThrowingTool, withServer } from './helpers/mcp_server.js';
 
 /**
  * Covers the `server.onerror` wiring in `setupErrorHandling()`: client faults softFail with a
@@ -22,13 +22,13 @@ describe('ActorsMcpServer onerror', () => {
             const softFail = vi.spyOn(log, 'softFail').mockImplementation(() => log);
             const errorLog = vi.spyOn(log, 'error').mockImplementation(() => log);
 
-            server.server.onerror?.(new Error('Parse error: Invalid JSON-RPC message'));
+            getLegacyServer(server).onerror?.(new Error('Parse error: Invalid JSON-RPC message'));
             expect(errorLog).not.toHaveBeenCalled();
             expect(softFail).toHaveBeenCalledWith('MCP client fault, request could not be handled', {
                 errMessage: 'Parse failure: Invalid JSON-RPC message',
             });
 
-            server.server.onerror?.(new Error('Unexpected internal failure'));
+            getLegacyServer(server).onerror?.(new Error('Unexpected internal failure'));
             expect(errorLog).toHaveBeenCalledTimes(1);
         });
     });

--- a/tests/unit/mcp.server.report_problem_gating.test.ts
+++ b/tests/unit/mcp.server.report_problem_gating.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { HELPER_TOOLS } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
 import { SERVER_MODE } from '../../src/types.js';
+import { getLegacyServer } from './helpers/mcp_server.js';
 
 type InitHandler = (req: InitializeRequest, ctx: unknown) => Promise<unknown>;
 
@@ -31,7 +32,7 @@ function makeInitializeRequest(clientName: string): InitializeRequest {
 
 async function dispatchInitialize(server: ActorsMcpServer, clientName: string): Promise<void> {
     const handler = (
-        server.server as unknown as {
+        getLegacyServer(server) as unknown as {
             // eslint-disable-next-line no-underscore-dangle
             _requestHandlers: Map<string, InitHandler>;
         }

--- a/tests/unit/mcp.server.report_problem_nudge.test.ts
+++ b/tests/unit/mcp.server.report_problem_nudge.test.ts
@@ -12,6 +12,7 @@ import type { ToolEntry, ToolInputSchema } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
 import { compileSchema } from '../../src/utils/ajv.js';
 import { respondUserError } from '../../src/utils/mcp.js';
+import { getRequestHandler } from './helpers/mcp_server.js';
 
 // The ACTOR branch of the tools/call handler runs actorExecutor.executeActorTool (a module
 // singleton), not the tool's own call(). Mock it so we can return an isError result without a network.
@@ -37,12 +38,7 @@ function makeActorTool(): ToolEntry {
 }
 
 function getToolCallHandler(server: ActorsMcpServer): HandlerFn {
-    const handler = (
-        server as unknown as { server: { _requestHandlers: Map<string, HandlerFn> } }
-    ).server._requestHandlers // eslint-disable-next-line no-underscore-dangle
-        .get('tools/call');
-    if (!handler) throw new Error('tools/call handler not registered');
-    return handler;
+    return getRequestHandler(server, 'tools/call');
 }
 
 // Dispatch a sync tools/call for the direct actor tool, with report-problem served and the

--- a/tests/unit/mcp.server.resource_request_origin.test.ts
+++ b/tests/unit/mcp.server.resource_request_origin.test.ts
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as ApifyClientModule from '../../src/apify_client.js';
 import { APIFY_AI_CLIENT_NAME } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
-import { getRequestHandler, makeRecorderTool } from './helpers/mcp_server.js';
+import { getRequestHandler, getTaskStore, makeRecorderTool } from './helpers/mcp_server.js';
 
 const { capturedClientOptions } = vi.hoisted(() => ({ capturedClientOptions: [] as unknown[] }));
 
@@ -127,7 +127,7 @@ describe('ActorsMcpServer tools/call — request-origin tagging', () => {
             expect(capturedClientOptions.at(-1)).toMatchObject({ requestOrigin: 'APIFY_AI' });
             if (isTaskRequest) {
                 await vi.waitFor(async () => {
-                    const task = await server.taskStore.getTask((result.task as { taskId: string }).taskId);
+                    const task = await getTaskStore(server).getTask((result.task as { taskId: string }).taskId);
                     if (task?.status !== 'completed') throw new Error('task did not complete');
                 });
             }

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -22,7 +22,9 @@ import { TOOL_TYPE } from '../../src/types.js';
 import { compileSchema } from '../../src/utils/ajv.js';
 import * as logging from '../../src/utils/logging.js';
 import {
+    getLegacyServer,
     getRequestHandler,
+    getTaskStore,
     makePaymentRequiredError,
     makePermissionApprovalError,
     makeRecorderTool,
@@ -215,13 +217,13 @@ async function runTaskAndReadBack(server: ActorsMcpServer, tool: ToolEntry) {
         { signal: { aborted: false }, sendNotification: vi.fn() },
     )) as { task: { taskId: string } };
     const task = await vi.waitFor(async () => {
-        const current = await server.taskStore.getTask(res.task.taskId);
+        const current = await getTaskStore(server).getTask(res.task.taskId);
         if (!current || !TERMINAL_STATUSES.has(current.status)) {
             throw new Error(`Task ${res.task.taskId} did not reach a terminal status`);
         }
         return current;
     });
-    const result = await server.taskStore.getTaskResult(res.task.taskId);
+    const result = await getTaskStore(server).getTaskResult(res.task.taskId);
     return { task, result: result as Record<string, unknown> };
 }
 
@@ -279,7 +281,7 @@ describe('CallToolRequestSchema handler', () => {
             // failInvalidParams awaits sendLoggingMessage before throwing McpError; the harness has
             // no transport (notification would throw "Not connected"), so stub it to observe the
             // real InvalidParams rejection.
-            vi.spyOn(server.server, 'sendLoggingMessage').mockResolvedValue(undefined);
+            vi.spyOn(getLegacyServer(server), 'sendLoggingMessage').mockResolvedValue(undefined);
             const handler = getRequestHandler(server, 'tools/call');
             await expect(
                 handler(
@@ -310,7 +312,7 @@ describe('CallToolRequestSchema handler', () => {
             tool.inputSchema = schema as ToolInputSchema;
             tool.ajvValidate = compileSchema(schema);
             server.upsertTools([tool]);
-            vi.spyOn(server.server, 'sendLoggingMessage').mockResolvedValue(undefined);
+            vi.spyOn(getLegacyServer(server), 'sendLoggingMessage').mockResolvedValue(undefined);
             const handler = getRequestHandler(server, 'tools/call');
             await expect(
                 handler(
@@ -370,7 +372,7 @@ describe('CallToolRequestSchema handler — invalid-call rejections (characteriz
         // Existing invalid-params tests only stub sendLoggingMessage; none asserts it fired.
         await withServer(async (server) => {
             silenceLogs();
-            const sendLogSpy = vi.spyOn(server.server, 'sendLoggingMessage').mockResolvedValue(undefined);
+            const sendLogSpy = vi.spyOn(getLegacyServer(server), 'sendLoggingMessage').mockResolvedValue(undefined);
             const handler = getRequestHandler(server, 'tools/call');
             await expect(
                 handler(
@@ -393,7 +395,7 @@ describe('CallToolRequestSchema handler — invalid-call rejections (characteriz
                 silenceLogs();
                 const { tool, received } = makeRecorderTool('auth-required-tool');
                 server.upsertTools([tool]);
-                vi.spyOn(server.server, 'sendLoggingMessage').mockResolvedValue(undefined);
+                vi.spyOn(getLegacyServer(server), 'sendLoggingMessage').mockResolvedValue(undefined);
                 const handler = getRequestHandler(server, 'tools/call');
                 await expect(
                     handler(
@@ -416,7 +418,7 @@ describe('CallToolRequestSchema handler — invalid-call rejections (characteriz
     it('rejects a call to an unknown tool name as an InvalidParams protocol error', async () => {
         await withServer(async (server) => {
             silenceLogs();
-            vi.spyOn(server.server, 'sendLoggingMessage').mockResolvedValue(undefined);
+            vi.spyOn(getLegacyServer(server), 'sendLoggingMessage').mockResolvedValue(undefined);
             const handler = getRequestHandler(server, 'tools/call');
             await expect(
                 handler(
@@ -438,7 +440,7 @@ describe('CallToolRequestSchema handler — invalid-call rejections (characteriz
             silenceLogs();
             const { tool, received } = makeRecorderTool('missing-args-tool');
             server.upsertTools([tool]);
-            vi.spyOn(server.server, 'sendLoggingMessage').mockResolvedValue(undefined);
+            vi.spyOn(getLegacyServer(server), 'sendLoggingMessage').mockResolvedValue(undefined);
             const handler = getRequestHandler(server, 'tools/call');
             await expect(
                 handler(
@@ -557,7 +559,7 @@ describe('executeToolAndUpdateTask()', () => {
                 };
 
                 await vi.waitFor(async () => {
-                    const task = await server.taskStore.getTask((response.task as { taskId: string }).taskId);
+                    const task = await getTaskStore(server).getTask((response.task as { taskId: string }).taskId);
                     if (task?.status !== 'completed') throw new Error('task did not complete');
                     if (trackSpy.mock.calls.length === 0) throw new Error('trackToolCall spy was not called');
                 });
@@ -583,7 +585,7 @@ describe('executeToolAndUpdateTask()', () => {
             silenceLogs();
             vi.spyOn(mcpClient, 'connectMCPClient').mockResolvedValue(null);
             // The connect-failure branch logs via the transport; the harness has none, so stub it.
-            vi.spyOn(server.server, 'sendLoggingMessage').mockResolvedValue(undefined);
+            vi.spyOn(getLegacyServer(server), 'sendLoggingMessage').mockResolvedValue(undefined);
             const { task, result } = await runTaskAndReadBack(server, makeActorMcpTool());
             expect(task.status).toBe('completed');
             expect(result.isError).toBe(true);
@@ -813,7 +815,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
         await withServer(
             async (server) => {
                 silenceLogs();
-                const notifySpy = vi.spyOn(server.server, 'notification').mockResolvedValue(undefined);
+                const notifySpy = vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
                 const { tool, received } = makeRecorderTool('payment-tool', {
                     paymentRequired: true,
                     taskSupport: 'optional',
@@ -825,7 +827,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
                 // The tool implementation never ran.
                 expect(received.called).toBe(false);
                 // Stored result carries the x402 payload intact.
-                const stored = (await server.taskStore.getTaskResult(res.task.taskId)) as Record<string, unknown>;
+                const stored = (await getTaskStore(server).getTaskResult(res.task.taskId)) as Record<string, unknown>;
                 expect(stored.isError).toBe(true);
                 expect(stored.structuredContent).toEqual(X402_PAYLOAD);
                 // Exactly one status notification, `completed`, emitted after the response.
@@ -841,7 +843,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
         await withServer(
             async (server) => {
                 silenceLogs();
-                vi.spyOn(server.server, 'notification').mockResolvedValue(undefined);
+                vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
                 const handler = getRequestHandler(server, 'tools/call');
 
                 // Non-task sync path returns the paymentRequiredResult directly.
@@ -861,7 +863,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
                     taskSupport: 'optional',
                 }).tool;
                 const res = await callTask(server, taskTool, {});
-                const stored = await server.taskStore.getTaskResult(res.task.taskId);
+                const stored = await getTaskStore(server).getTaskResult(res.task.taskId);
 
                 expect(stored).toEqual(syncResult);
             },
@@ -877,13 +879,13 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
                 const standbySpy = vi
                     .spyOn(callActor, 'checkPaymentProviderStandbyConflict')
                     .mockResolvedValue(standbyResult);
-                const notifySpy = vi.spyOn(server.server, 'notification').mockResolvedValue(undefined);
+                const notifySpy = vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
                 const { tool, received } = makeRecorderTool(HELPER_TOOLS.ACTOR_CALL, { taskSupport: 'optional' });
                 const res = await callTask(server, tool, { actor: 'apify/some-actor' });
 
                 expect(res.task.status).toBe('completed');
                 expect(received.called).toBe(false);
-                const stored = await server.taskStore.getTaskResult(res.task.taskId);
+                const stored = await getTaskStore(server).getTaskResult(res.task.taskId);
                 expect(stored).toEqual(standbyResult);
                 await flushDeferredNotification();
                 expect(statusNotificationStatuses(notifySpy)).toEqual(['completed']);
@@ -900,7 +902,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
                 silenceLogs();
                 const standbyResult = { content: [{ type: 'text', text: 'standby not supported' }], isError: true };
                 vi.spyOn(callActor, 'checkPaymentProviderStandbyConflict').mockResolvedValue(standbyResult);
-                vi.spyOn(server.server, 'notification').mockResolvedValue(undefined);
+                vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
                 // paymentRequired + missing skyfire-pay-id would also yield paymentRequiredResult.
                 const { tool } = makeRecorderTool(HELPER_TOOLS.ACTOR_CALL, {
                     paymentRequired: true,
@@ -908,7 +910,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
                 });
                 const res = await callTask(server, tool, { actor: 'apify/some-actor' });
 
-                const stored = (await server.taskStore.getTaskResult(res.task.taskId)) as Record<string, unknown>;
+                const stored = (await getTaskStore(server).getTaskResult(res.task.taskId)) as Record<string, unknown>;
                 // Standby result wins — not the x402 payment payload.
                 expect(stored).toEqual(standbyResult);
                 expect(stored.structuredContent).toBeUndefined();
@@ -922,7 +924,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
         await withServer(
             async (server) => {
                 silenceLogs();
-                vi.spyOn(server.server, 'notification').mockResolvedValue(undefined);
+                vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
                 const { tool } = makeRecorderTool('payment-tool', { paymentRequired: true, taskSupport: 'optional' });
                 await callTask(server, tool, {});
             },
@@ -945,7 +947,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
                 silenceLogs();
                 const standbyResult = { content: [{ type: 'text', text: 'standby not supported' }], isError: true };
                 vi.spyOn(callActor, 'checkPaymentProviderStandbyConflict').mockResolvedValue(standbyResult);
-                vi.spyOn(server.server, 'notification').mockResolvedValue(undefined);
+                vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
                 const { tool } = makeRecorderTool(HELPER_TOOLS.ACTOR_CALL, { taskSupport: 'optional' });
                 await callTask(server, tool, { actor: 'apify/some-actor' });
             },
@@ -971,7 +973,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
                 silenceLogs();
                 const standbyResult = { content: [{ type: 'text', text: 'standby not supported' }], isError: true };
                 vi.spyOn(callActor, 'checkPaymentProviderStandbyConflict').mockResolvedValue(standbyResult);
-                vi.spyOn(server.server, 'notification').mockResolvedValue(undefined);
+                vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
                 const { tool } = makeRecorderTool(HELPER_TOOLS.ACTOR_CALL, { taskSupport: 'optional' });
                 server.upsertTools([tool]);
                 const handler = getRequestHandler(server, 'tools/call');
@@ -991,7 +993,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
 
                 // Task path stores the same failure as a completed result.
                 const res = await callTask(server, tool, { actor: 'apify/some-actor' });
-                const stored = await server.taskStore.getTaskResult(res.task.taskId);
+                const stored = await getTaskStore(server).getTaskResult(res.task.taskId);
 
                 expect(stored).toEqual(syncResult);
             },
@@ -1005,8 +1007,8 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
         await withServer(
             async (server) => {
                 silenceLogs();
-                vi.spyOn(server.server, 'notification').mockResolvedValue(undefined);
-                vi.spyOn(server.taskStore, 'storeTaskResult').mockRejectedValue(new Error('store unavailable'));
+                vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
+                vi.spyOn(getTaskStore(server), 'storeTaskResult').mockRejectedValue(new Error('store unavailable'));
                 const { tool } = makeRecorderTool('payment-tool', { paymentRequired: true, taskSupport: 'optional' });
                 server.upsertTools([tool]);
                 const handler = getRequestHandler(server, 'tools/call');
@@ -1037,7 +1039,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
             async (server) => {
                 const infoSpy = vi.spyOn(log, 'info').mockImplementation(() => log);
                 silenceLogs();
-                vi.spyOn(server.server, 'notification').mockResolvedValue(undefined);
+                vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
                 const { tool } = makeRecorderTool('payment-tool', { paymentRequired: true, taskSupport: 'optional' });
                 const res = await callTask(server, tool, {});
                 const completedCall = infoSpy.mock.calls.find(([message]) => message === 'Tool call completed');
@@ -1054,11 +1056,11 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
         await withServer(
             async (server) => {
                 silenceLogs();
-                const notifySpy = vi.spyOn(server.server, 'notification').mockResolvedValue(undefined);
-                vi.spyOn(server.taskStore, 'storeTaskResult').mockRejectedValue(
+                const notifySpy = vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
+                vi.spyOn(getTaskStore(server), 'storeTaskResult').mockRejectedValue(
                     new Error('Task with ID some-task not found'),
                 );
-                vi.spyOn(server.taskStore, 'getTask').mockResolvedValue(null);
+                vi.spyOn(getTaskStore(server), 'getTask').mockResolvedValue(null);
                 const { tool, received } = makeRecorderTool('payment-tool', {
                     paymentRequired: true,
                     taskSupport: 'optional',
@@ -1125,7 +1127,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
             async (server) => {
                 silenceLogs();
                 vi.spyOn(logging, 'logHttpError').mockImplementation(() => {});
-                vi.spyOn(server.taskStore, 'createTask').mockRejectedValue(new Error('store down'));
+                vi.spyOn(getTaskStore(server), 'createTask').mockRejectedValue(new Error('store down'));
                 const { tool, received } = makeRecorderTool('create-task-fail-tool', {
                     taskSupport: 'optional',
                 });

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -552,7 +552,7 @@ describe('executeToolAndUpdateTask()', () => {
                     { signal: { aborted: false }, sendNotification: vi.fn() },
                 );
 
-                (server as unknown as { clientContext: McpClientContext }).clientContext = {
+                (server as unknown as { _clientContext: McpClientContext })._clientContext = {
                     protocolVersion: 'changed',
                     clientInfo: { name: 'changed', version: 'changed' },
                     capabilities: { changed: true },

--- a/tests/unit/mcp.task_notifications.test.ts
+++ b/tests/unit/mcp.task_notifications.test.ts
@@ -3,7 +3,7 @@ import { RELATED_TASK_META_KEY } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
 
 import { emitTaskStatusNotification } from '../../src/mcp/task_execution.js';
-import { getRequestHandler, withServer } from './helpers/mcp_server.js';
+import { getRequestHandler, getTaskStore, withServer } from './helpers/mcp_server.js';
 
 // Helper to create a minimal TaskStore mock
 function makeTaskStore(task: Record<string, unknown> | undefined) {
@@ -114,8 +114,8 @@ describe('tasks/result _meta.related-task injection', () => {
 
     it('injects _meta.related-task into tasks/result response (MUST)', async () => {
         await withServer(async (server) => {
-            const task = await server.taskStore.createTask({ ttl: 60_000 }, 'req-1', fakeRequest as never);
-            await server.taskStore.storeTaskResult(
+            const task = await getTaskStore(server).createTask({ ttl: 60_000 }, 'req-1', fakeRequest as never);
+            await getTaskStore(server).storeTaskResult(
                 task.taskId,
                 'completed',
                 { content: [{ type: 'text', text: 'done' }] },
@@ -136,9 +136,9 @@ describe('tasks/result _meta.related-task injection', () => {
 
     it('merges _meta.related-task with existing _meta keys', async () => {
         await withServer(async (server) => {
-            const task = await server.taskStore.createTask({ ttl: 60_000 }, 'req-2', fakeRequest as never);
+            const task = await getTaskStore(server).createTask({ ttl: 60_000 }, 'req-2', fakeRequest as never);
             const existingMeta = { 'com.apify/ActorRun': { runId: 'run-abc' } };
-            await server.taskStore.storeTaskResult(
+            await getTaskStore(server).storeTaskResult(
                 task.taskId,
                 'completed',
                 {

--- a/tests/unit/tool_call_engine.test.ts
+++ b/tests/unit/tool_call_engine.test.ts
@@ -1,22 +1,29 @@
-import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
-import type { Notification, Request } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import log from '@apify/log';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
+import type { ActorsMcpServer } from '../../src/mcp/server.js';
 import type { InvalidToolCall, PreparedCall } from '../../src/mcp/tool_call_engine.js';
 import { executeSyncToolCall, prepareToolCall } from '../../src/mcp/tool_call_engine.js';
 import type { ToolCallTelemetryProperties } from '../../src/types.js';
 import { makePaymentRequiredError, makeRecorderTool, makeThrowingTool, withServer } from './helpers/mcp_server.js';
 
-/** Builds request context for direct engine tests. */
-function fakeExtra(aborted = false): RequestHandlerExtra<Request, Notification> {
+/** An abort signal for direct engine tests, optionally already aborted. */
+function makeSignal(aborted = false): AbortSignal {
+    const controller = new AbortController();
+    if (aborted) controller.abort();
+    return controller.signal;
+}
+
+/** Server-derived plain values that `prepareToolCall` reads. */
+function prepareFields(server: ActorsMcpServer) {
     return {
-        signal: { aborted },
-        sendNotification: vi.fn(),
-        requestInfo: { headers: {} },
-    } as unknown as RequestHandlerExtra<Request, Notification>;
+        tools: server.tools,
+        paymentProvider: server.options.paymentProvider,
+        allowUnauthMode: server.options.allowUnauthMode,
+        loadedToolNames: server.listToolNames(),
+    };
 }
 
 /** Suppresses expected failure logs. */
@@ -33,7 +40,7 @@ describe('prepareToolCall()', () => {
     it('returns InvalidToolCall with AUTH category when no token is provided', async () => {
         await withServer(async (server) => {
             const result = await prepareToolCall({
-                apifyMcpServer: server,
+                ...prepareFields(server),
                 apifyToken: '',
                 name: 'anything',
                 args: {},
@@ -55,7 +62,7 @@ describe('prepareToolCall()', () => {
     it('returns InvalidToolCall for an unknown tool name', async () => {
         await withServer(async (server) => {
             const result = await prepareToolCall({
-                apifyMcpServer: server,
+                ...prepareFields(server),
                 apifyToken: 'fake-token',
                 name: 'does-not-exist',
                 args: {},
@@ -78,7 +85,7 @@ describe('prepareToolCall()', () => {
             const { tool } = makeRecorderTool('recorder-tool');
             server.upsertTools([tool]);
             const result = await prepareToolCall({
-                apifyMcpServer: server,
+                ...prepareFields(server),
                 apifyToken: 'fake-token',
                 name: 'recorder-tool',
                 args: undefined,
@@ -101,7 +108,7 @@ describe('prepareToolCall()', () => {
             server.upsertTools([tool]);
             const telemetryData = { tool_name: 'recorder-tool' } as unknown as ToolCallTelemetryProperties;
             const result = await prepareToolCall({
-                apifyMcpServer: server,
+                ...prepareFields(server),
                 apifyToken: 'fake-token',
                 name: 'recorder-tool',
                 args: {},
@@ -125,10 +132,10 @@ describe('prepareToolCall()', () => {
 describe('executeSyncToolCall()', () => {
     afterEach(() => vi.restoreAllMocks());
 
-    async function prepare(server: Parameters<Parameters<typeof withServer>[0]>[0], name: string, tool: unknown) {
+    async function prepare(server: ActorsMcpServer, name: string, tool: unknown) {
         server.upsertTools([tool as never]);
         const prepared = (await prepareToolCall({
-            apifyMcpServer: server,
+            ...prepareFields(server),
             apifyToken: 'fake-token',
             name,
             args: {},
@@ -142,18 +149,28 @@ describe('executeSyncToolCall()', () => {
         return prepared;
     }
 
+    /** Server-derived plain values that `executeSyncToolCall` reads. */
+    function syncParams(server: ActorsMcpServer, toolName: string, aborted = false) {
+        return {
+            apifyToken: 'fake-token',
+            toolName,
+            mcpSessionId: 's1',
+            progressToken: undefined,
+            tools: server.tools,
+            actorStore: server.actorStore,
+            paymentProvider: server.options.paymentProvider,
+            loadedToolNames: server.listToolNames(),
+            signal: makeSignal(aborted),
+            sendNotification: vi.fn(),
+            emitLog: vi.fn(),
+        };
+    }
+
     it('returns a success outcome for a normal dispatch', async () => {
         await withServer(async (server) => {
             const { tool } = makeRecorderTool('recorder-tool');
             const prepared = await prepare(server, 'recorder-tool', tool);
-            const outcome = await executeSyncToolCall(prepared, {
-                apifyMcpServer: server,
-                apifyToken: 'fake-token',
-                toolName: 'recorder-tool',
-                mcpSessionId: 's1',
-                progressToken: undefined,
-                extra: fakeExtra(),
-            });
+            const outcome = await executeSyncToolCall(prepared, syncParams(server, 'recorder-tool'));
             expect(outcome.toolStatus).toBe(TOOL_STATUS.SUCCEEDED);
             expect((outcome.result.content as { text: string }[])[0].text).toBe('ok');
         });
@@ -164,14 +181,7 @@ describe('executeSyncToolCall()', () => {
             silenceLogs();
             const tool = makeThrowingTool({ name: 'payment-throwing-tool', error: makePaymentRequiredError() });
             const prepared = await prepare(server, 'payment-throwing-tool', tool);
-            const outcome = await executeSyncToolCall(prepared, {
-                apifyMcpServer: server,
-                apifyToken: 'fake-token',
-                toolName: 'payment-throwing-tool',
-                mcpSessionId: 's1',
-                progressToken: undefined,
-                extra: fakeExtra(),
-            });
+            const outcome = await executeSyncToolCall(prepared, syncParams(server, 'payment-throwing-tool'));
             expect(outcome.toolStatus).toBe(TOOL_STATUS.SOFT_FAIL);
             expect(outcome.callDiagnostics.failure_http_status).toBe(402);
             expect(outcome.result.isError).toBe(true);
@@ -183,14 +193,7 @@ describe('executeSyncToolCall()', () => {
             silenceLogs();
             const tool = makeThrowingTool({ name: 'aborting-tool', error: new Error('boom') });
             const prepared = await prepare(server, 'aborting-tool', tool);
-            const outcome = await executeSyncToolCall(prepared, {
-                apifyMcpServer: server,
-                apifyToken: 'fake-token',
-                toolName: 'aborting-tool',
-                mcpSessionId: 's1',
-                progressToken: undefined,
-                extra: fakeExtra(true),
-            });
+            const outcome = await executeSyncToolCall(prepared, syncParams(server, 'aborting-tool', true));
             expect(outcome.toolStatus).toBe(TOOL_STATUS.ABORTED);
             expect(outcome.result.isError).toBe(true);
             expect(outcome.result.toolTelemetry).toEqual({ toolStatus: TOOL_STATUS.ABORTED });

--- a/tests/unit/tool_call_engine.test.ts
+++ b/tests/unit/tool_call_engine.test.ts
@@ -22,7 +22,6 @@ function prepareFields(server: ActorsMcpServer) {
         tools: server.tools,
         paymentProvider: server.options.paymentProvider,
         allowUnauthMode: server.options.allowUnauthMode,
-        loadedToolNames: server.listToolNames(),
     };
 }
 
@@ -159,7 +158,6 @@ describe('executeSyncToolCall()', () => {
             tools: server.tools,
             actorStore: server.actorStore,
             paymentProvider: server.options.paymentProvider,
-            loadedToolNames: server.listToolNames(),
             signal: makeSignal(aborted),
             sendNotification: vi.fn(),
             emitLog: vi.fn(),

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -374,7 +374,7 @@ describe('get-actor-run default response', () => {
 
         const result = await (getActorRun as HelperTool).call({
             ...stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client),
-            extra: { signal: controller.signal } as InternalToolArgs['extra'],
+            signal: controller.signal,
         });
 
         // Cancelled requests return no payload per MCP spec — see `getActorRun`.

--- a/tests/unit/tools.search_actors.fixtures.ts
+++ b/tests/unit/tools.search_actors.fixtures.ts
@@ -30,9 +30,9 @@ export function stubInternalToolArgs(args: Record<string, unknown>): InternalToo
     return {
         args,
         apifyToken: 'test-token',
-        extra: {} as InternalToolArgs['extra'],
-        mcpServer: {} as InternalToolArgs['mcpServer'],
         apifyClient: {} as InternalToolArgs['apifyClient'],
-        apifyMcpServer: { options: { paymentProvider: undefined } } as InternalToolArgs['apifyMcpServer'],
+        signal: new AbortController().signal,
+        paymentProvider: undefined,
+        loadedToolNames: [],
     };
 }


### PR DESCRIPTION
## Why

Closes #1147. Part of #1128.

`ActorsMcpServer` combined two concerns: shared Apify behavior (tools, `actorStore`, server-mode, prompts/resources, widgets, payments, telemetry) and sessionful v1 SDK wiring (the SDK `Server`, request handlers, initialize, Tasks, logging, notifications, errors, transport lifecycle). PR #1143 showed that adding a second (stateless) serving unit forced the dependency direction backwards — shared tool execution reached up into the class (`apifyMcpServer.server`, `.tools`, `extra`, `McpError`). This extraction fixes the direction so #1140 can expose both protocol eras through `dev_server.ts` while reusing one Apify core.

**Breaking:** the raw v1 `.server` and `.taskStore` are no longer public on `ActorsMcpServer` — they move to the private adapter. Runtime-safe for `apify-mcp-server-internal` (it reads neither; verified against its `new ActorsMcpServer(...)` call sites, which use only `.options.initializeRequestData`, `.loadToolsByName()`, `.loadToolsFromUrl()`, `.listAllToolNames()`, `.connect()`). External TypeScript consumers touching those two members break at compile time — hence `refactor!`.

## What changed

All v1 SDK wiring moved verbatim into a new package-private `LegacyMcpServer` (`src/mcp/legacy_server.ts`). `ActorsMcpServer` keeps the shared Apify behavior, constructs exactly one adapter, and delegates `connect()`/`close()` to it via a narrow `LegacyMcpServerHost` interface — the adapter never imports the concrete facade, and shared modules never import the adapter. Shared tool execution (`tool_call_engine`, `tool_dispatch`, `tool_call_telemetry`, `task_execution`) now takes plain values; `InternalToolArgs` drops `extra`/`apifyMcpServer`/`mcpServer`. No v2 SDK dependency and no stateless routing were added (that is #1140).

Behavior is preserved byte-for-byte: tool names, results, error codes/messages/data, notifications, Tasks, telemetry, and timing are unchanged. `close()` teardown is the deliberate reverse-of-connect order (close the transport, then clear the tool map).

## Notes for reviewers (human-written)

The huge diff is because of server.ts -> legacy_server.ts
I checked it (also with Claude), all the changes seems to be ok.

## Proof it works

A live `mcpc` probe built both this branch and the pre-change `master` server, then diffed their MCP output byte-for-byte: `initialize`, `tools/list` (all default-mode tools), `prompts/list`, `resources/list` + `read`, `tools/call` happy paths, a live Actor round-trip (`call-actor` → `get-dataset-items` → `get-key-value-store-record` → `resources/read`), every error path (invalid tool name, invalid arguments, resource 404, unknown prompt, tool-level `SOFT_FAIL`), `logging/setLevel`, and the task-mode pre-flight path were all identical (only per-run IDs/timestamps differed). The unit suite is unchanged at 1177 passed + 1 skipped, and `type-check`/`lint`/`check:agents`/`format:check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zHfSwpr57aUaxYjxAgsof

---
_Generated by [Claude Code](https://claude.ai/code/session_017zHfSwpr57aUaxYjxAgsof)_