### PR TITLE
fix(actors): Prevent standby telemetry leaks

### DIFF
--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -32,6 +32,7 @@ import { wrapJsonText } from '../../utils/encode_text.js';
 import { logHttpError } from '../../utils/logging.js';
 import {
     respondAborted,
+    respondErrorNoTelemetry,
     respondRaw,
     respondServerError,
     respondUserError,
@@ -291,7 +292,8 @@ export async function checkPaymentProviderStandbyConflict(params: {
         failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
     });
 
-    return respondUserError(ActorLoadError.standbyPaymentNotSupported(normalizedActorName).message);
+    // This framework short-circuit bypasses telemetry extraction; see apify/apify-mcp-server#1085.
+    return respondErrorNoTelemetry(ActorLoadError.standbyPaymentNotSupported(normalizedActorName).message);
 }
 
 /**

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -10,6 +10,7 @@ import * as mcpClient from '../../src/mcp/client.js';
 import type { McpClientContext } from '../../src/mcp/client_context.js';
 import type { ActorsMcpServer } from '../../src/mcp/server.js';
 import type { PaymentProvider } from '../../src/payments/types.js';
+import { actorDefinitionCache } from '../../src/state.js';
 import * as telemetry from '../../src/telemetry.js';
 import * as callActor from '../../src/tools/actors/call_actor.js';
 import {
@@ -17,7 +18,7 @@ import {
     REPORT_PROBLEM_NUDGE,
     reportProblem,
 } from '../../src/tools/dev/report_problem.js';
-import type { ToolEntry, ToolInputSchema } from '../../src/types.js';
+import type { ActorDefinitionWithInfo, ToolEntry, ToolInputSchema } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
 import { compileSchema } from '../../src/utils/ajv.js';
 import * as logging from '../../src/utils/logging.js';
@@ -971,8 +972,16 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
         await withServer(
             async (server) => {
                 silenceLogs();
-                const standbyResult = { content: [{ type: 'text', text: 'standby not supported' }], isError: true };
-                vi.spyOn(callActor, 'checkPaymentProviderStandbyConflict').mockResolvedValue(standbyResult);
+                const actorName = 'apify/standby-telemetry-test';
+                actorDefinitionCache.set(actorName, {
+                    definition: { id: 'standby-actor-id', actorFullName: actorName },
+                    info: {
+                        id: 'standby-actor-id',
+                        isPublic: true,
+                        userId: 'standby-owner-id',
+                        actorStandby: { isEnabled: true },
+                    },
+                } as unknown as ActorDefinitionWithInfo);
                 vi.spyOn(getLegacyServer(server), 'notification').mockResolvedValue(undefined);
                 const { tool } = makeRecorderTool(HELPER_TOOLS.ACTOR_CALL, { taskSupport: 'optional' });
                 server.upsertTools([tool]);
@@ -984,7 +993,7 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
                         method: 'tools/call',
                         params: {
                             name: tool.name,
-                            arguments: { actor: 'apify/some-actor' },
+                            arguments: { actor: actorName },
                             _meta: { mcpSessionId: 's1' },
                         },
                     },
@@ -992,9 +1001,11 @@ describe('CallToolRequestSchema handler — task-augmented pre-flight failures',
                 );
 
                 // Task path stores the same failure as a completed result.
-                const res = await callTask(server, tool, { actor: 'apify/some-actor' });
+                const res = await callTask(server, tool, { actor: actorName });
                 const stored = await getTaskStore(server).getTaskResult(res.task.taskId);
 
+                expect(syncResult).not.toHaveProperty('toolTelemetry');
+                expect(stored).not.toHaveProperty('toolTelemetry');
                 expect(stored).toEqual(syncResult);
             },
             { paymentProvider: makePaymentProvider() },


### PR DESCRIPTION
## What changed

- build the standby payment-provider rejection with the existing no-telemetry response helper
- test the real standby result through both synchronous and task-backed tool-call handlers
- assert that neither the wire response nor the stored task result contains `toolTelemetry`

## Why

`checkPaymentProviderStandbyConflict` returns before the normal telemetry extraction step. Using `respondUserError` on that framework path exposed server-internal outcome metadata to clients and persisted the same field in terminal task results.

## Risk

The production change only swaps the response constructor for the existing standby rejection. Error text, `isError`, telemetry accounting, and standby-before-payment priority remain unchanged. The regression covers both public response paths with the real helper and an in-memory task store.

## Validation

- `pnpm exec vitest run tests/unit/mcp.server.tool_call_contracts.test.ts`
- `pnpm run test:unit` (1177 passed, 1 skipped)
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run check:agents`
- `pnpm run build:core`

## Reviewer focus

Please verify that the standby pre-flight remains a user error while `toolTelemetry` stays server-internal on both sync and task result paths.

Closes https://github.com/apify/apify-mcp-server/issues/1085