### PR TITLE
fix(server-card): declare conditional authentication as optional

### DIFF
--- a/server.json
+++ b/server.json
@@ -14,8 +14,8 @@
       "headers": [
         {
           "name": "Authorization",
-          "description": "Apify API token for authentication with Apify platform services. For example 'Bearer <apify-api-token>'",
-          "isRequired": true,
+          "description": "Optional Apify API token. Required for the default tool set and non-public tools. Anonymous access is available with ?tools=search-actors,fetch-actor-details,search-apify-docs,fetch-apify-docs.",
+          "isRequired": false,
           "isSecret": true
         }
       ]

--- a/src/server_card.ts
+++ b/src/server_card.ts
@@ -55,7 +55,7 @@ export function getServerCard(): ServerCard {
             tools: { listChanged: true },
         },
         authentication: {
-            required: true,
+            required: false,
             schemes: ['bearer', 'oauth2'],
         },
         tools: 'dynamic',

--- a/tests/unit/server_card.test.ts
+++ b/tests/unit/server_card.test.ts
@@ -6,7 +6,17 @@ import { getServerCard, getServerInfo } from '../../src/server_card.js';
 import { readJsonFile } from '../../src/utils/generic.js';
 import { getPackageVersion } from '../../src/utils/version.js';
 
-const serverJson = readJsonFile<{ description: string }>(import.meta.url, '../../server.json');
+const serverJson = readJsonFile<{
+    description: string;
+    remotes: {
+        headers: {
+            name: string;
+            description: string;
+            isRequired: boolean;
+            isSecret: boolean;
+        }[];
+    }[];
+}>(import.meta.url, '../../server.json');
 
 describe('getServerCard', () => {
     it('should return a valid MCP server card object', () => {
@@ -38,11 +48,21 @@ describe('getServerCard', () => {
         expect(card.capabilities.tools.listChanged).toBe(true);
     });
 
-    it('should require authentication with bearer and oauth2 schemes', () => {
+    it('declares authentication as optional with bearer and oauth2 schemes', () => {
         const card = getServerCard();
 
-        expect(card.authentication.required).toBe(true);
+        expect(card.authentication.required).toBe(false);
         expect(card.authentication.schemes).toEqual(['bearer', 'oauth2']);
+    });
+
+    it('declares the authorization header as optional for selected public tools', () => {
+        const authorizationHeader = serverJson.remotes[0].headers.find((header) => header.name === 'Authorization');
+
+        expect(authorizationHeader).toMatchObject({
+            isRequired: false,
+            isSecret: true,
+        });
+        expect(authorizationHeader?.description).toContain('?tools=');
     });
 
     it('should declare tools as dynamic', () => {


### PR DESCRIPTION
## Problem

The server card declares `authentication.required: true`, and `server.json` marks the `Authorization` header as required. This is inaccurate for the hosted `?tools=` surface, where `search-actors`, `fetch-actor-details`, `search-apify-docs`, and `fetch-apify-docs` work without an Apify token.

## Solution

Declare authentication as optional in both discovery metadata formats and document that a token remains required for the default tool set and non-public tools. This keeps the metadata aligned with the existing runtime authorization policy without changing access control.

## Changes

- Set server-card authentication to optional while retaining bearer and OAuth2 schemes.
- Mark the `Authorization` header in `server.json` as optional and document the anonymous `?tools=` surface.
- Add unit coverage for both metadata declarations.

## Testing

- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run test:unit`
- `pnpm run format:check`
- `pnpm run check:agents`
- Manual metadata and authorization-policy check: public tools remain anonymous; default and private tools still require a token.

## Notes for Reviewer

This PR intentionally does not change runtime authentication. `isApiTokenRequired()` continues to require a token when no tool selection is supplied or when any non-public tool is selected. The private hosted-server repository may need its matching server-card assertion updated when this change is released.

Fixes #1170