### PR TITLE
docs: address review feedback on AGI/x402/Skyfire wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Apify Model Context Protocol (MCP) server at [**mcp.apify.com**](https://mcp
 
 > ⚠️ **Legacy SSE transport removed.** The `https://mcp.apify.com/sse` endpoint has been removed in favor of Streamable HTTP. Migrate your client to **[`https://mcp.apify.com`](https://mcp.apify.com)** — drop the `/sse` suffix from your configuration.
 
-💰 The server also supports [agentic payments](#-agentic-payments): buy a token from [AGI](#-agi-recommended) to run any Actor, or pay per-request via [x402](#-x402) (Pay Per Event Actors only) or [Skyfire](#-skyfire) — no API token required either way.
+💰 The server also supports [agentic payments](#-agentic-payments): buy a token from [AGI](#-agi-recommended) to run any Actor, or pay per-request via [direct x402](#-direct-x402) (Pay Per Event Actors only) or [Skyfire](#-skyfire).
 
 Apify MCP Server is compatible with `Claude Code, Claude.ai, Cursor, VS Code` and any client that adheres to the Model Context Protocol.
 Check out the [MCP clients section](#-mcp-clients) for more details or visit the [MCP configuration page](https://mcp.apify.com).
@@ -40,7 +40,7 @@ Check out the [MCP clients section](#-mcp-clients) for more details or visit the
 - [💰 Agentic payments](#-agentic-payments)
   - [🪙 AGI (recommended)](#-agi-recommended)
   - [How agentic payments work](#how-agentic-payments-work)
-  - [💸 x402](#-x402)
+  - [💸 Direct x402](#-direct-x402)
   - [🔥 Skyfire](#-skyfire)
 - [🛠️ Tools, resources, and prompts](#%EF%B8%8F-tools-resources-and-prompts)
 - [📊 Telemetry](#-telemetry)
@@ -115,17 +115,19 @@ Or use the MCP bundle file (formerly known as Anthropic Desktop extension file, 
 
 # 💰 Agentic payments
 
-You can pay for Actor runs without an Apify API token using **AGI**, **x402**, or **Skyfire**.
+You can pay for Actor runs without an Apify API token using **AGI**, **direct x402**, or **Skyfire**.
 
-- **AGI** ([agi.apify.com](https://agi.apify.com)) mints a prepaid Apify API token in exchange for an x402 or MPP payment. Use the token like a normal API token against `api.apify.com` — works for any Actor, not just Pay Per Event ones. **Recommended** for new integrations; see [AGI (recommended)](#-agi-recommended) below.
-- **x402** pays with USDC on [Base](https://base.org) per request and does not require a separate platform account. It is fully supported by [`mcpc`](https://github.com/apify/mcp-cli) (`npm install -g @apify/mcpc`). We use `mcpc` because it is one of the few MCP clients that supports the latest features and the x402 protocol natively. Narrower scope than AGI: Pay Per Event Actors only.
+- **AGI** ([agi.apify.com](https://agi.apify.com)) mints a prepaid Apify API token in exchange for an x402 or MPP payment. Use the token like a normal API token against `mcp.apify.com` and `api.apify.com` — works for any Actor, not just Pay Per Event ones. **Recommended** for new integrations; see [AGI (recommended)](#-agi-recommended) below.
+- **Direct x402** pays with USDC on [Base](https://base.org) per request and does not require a separate platform account. It is fully supported by [`mcpc`](https://github.com/apify/mcp-cli) (`npm install -g @apify/mcpc`). We use `mcpc` because it is one of the few MCP clients that supports the latest features and the x402 protocol natively.
 - **Skyfire** pays with PAY tokens and requires a Skyfire account with a funded wallet. It does not require a special MCP client; the entire payment flow is handled directly through the MCP tool call parameters.
+
+> Both direct x402 and Skyfire settle per Actor run under the Pay Per Event pricing model only — no minted token, no Standby Actor support.
 
 ## 🪙 AGI (recommended)
 
-[AGI](https://agi.apify.com) (Apify Agent General Interface) is the recommended way for autonomous agents to pay for Apify usage without an account. Pay once via x402 or MPP, receive a prepaid, spend-capped Apify API token, and use it directly against `api.apify.com` (`Authorization: Bearer <token>`) — for any Actor.
+[AGI](https://agi.apify.com) (Apify Agent General Interface) is the recommended way for autonomous agents to pay for Apify usage without an account. Pay once via x402 or MPP, receive a prepaid, spend-capped Apify API token, and use it directly against `mcp.apify.com` and `api.apify.com` (`Authorization: Bearer <token>`) — for any Actor.
 
-Full protocol, supported payment methods, and current terms (minimum amount, token lifetime, refund policy) are documented at **[agi.apify.com/AGENTS.md](https://agi.apify.com/AGENTS.md)** (also served as `agi.apify.com/llms.txt`) — treat it as the single source of truth.
+Full protocol, supported payment methods, and current terms (minimum amount, token lifetime, refund policy) are documented at **[agi.apify.com/AGENTS.md](https://agi.apify.com/AGENTS.md)** — treat it as the single source of truth.
 
 ## How agentic payments work
 
@@ -133,18 +135,16 @@ Actor run costs vary, so both payment methods use a prepaid balance model. The p
 
 1. **Discovery**: The agent discovers Actors with `search-actors` or `fetch-actor-details`. Those calls are free.
 2. **Prepayment**: Before running a paid Actor tool, the agent funds a prepaid balance.
-   - **x402**: `mcpc` automatically signs a $1.00 USDC transaction.
+   - **Direct x402**: `mcpc` automatically signs a $1.00 USDC transaction.
    - **Skyfire**: The agent creates a PAY token (minimum $5.00) using Skyfire's `create-pay-token` tool.
 3. **Execution**: The agent calls the Actor tool.
-   - **x402**: Handled automatically by `mcpc` using the prepaid balance.
+   - **Direct x402**: Handled automatically by `mcpc` using the prepaid balance.
    - **Skyfire**: The agent explicitly passes the PAY token in the `skyfire-pay-id` input property.
 4. **Resolution**: The tool returns the Actor results. Unused funds stay available for later runs.
-   - **x402**: After 60 minutes of inactivity, the server refunds any unused balance to the wallet on [Base](https://base.org).
+   - **Direct x402**: After 60 minutes of inactivity, the server refunds any unused balance to the wallet on [Base](https://base.org).
    - **Skyfire**: Skyfire returns unused funds when the token expires.
 
-## 💸 x402
-
-> Narrower scope than [AGI](#-agi-recommended): Pay Per Event Actors only, no minted token — settles per request instead.
+## 💸 Direct x402
 
 The [x402 protocol](https://www.x402.org/) enables direct, machine-to-machine payments. Your MCP client can use it to pay for Actor runs with USDC on the [Base blockchain](https://base.org/), completely bypassing the need for an Apify API token.
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can pay for Actor runs without an Apify API token using **AGI**, **direct x4
 - **Direct x402** pays with USDC on [Base](https://base.org) per request and does not require a separate platform account. It is fully supported by [`mcpc`](https://github.com/apify/mcp-cli) (`npm install -g @apify/mcpc`). We use `mcpc` because it is one of the few MCP clients that supports the latest features and the x402 protocol natively.
 - **Skyfire** pays with PAY tokens and requires a Skyfire account with a funded wallet. It does not require a special MCP client; the entire payment flow is handled directly through the MCP tool call parameters.
 
-> ℹ️ **Scope:** Both direct x402 and Skyfire are limited to Pay Per Event Actors and don't support Standby Actors — and settle per run instead of minting a token.
+> ℹ️ **Scope:** Both direct x402 and Skyfire are limited to Pay Per Event Actors, don't support Standby Actors, and settle per run instead of minting a token.
 
 ## How agentic payments work
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can pay for Actor runs without an Apify API token using **AGI**, **direct x4
 - **Direct x402** pays with USDC on [Base](https://base.org) per request and does not require a separate platform account. It is fully supported by [`mcpc`](https://github.com/apify/mcp-cli) (`npm install -g @apify/mcpc`). We use `mcpc` because it is one of the few MCP clients that supports the latest features and the x402 protocol natively.
 - **Skyfire** pays with PAY tokens and requires a Skyfire account with a funded wallet. It does not require a special MCP client; the entire payment flow is handled directly through the MCP tool call parameters.
 
-> Both direct x402 and Skyfire settle per Actor run under the Pay Per Event pricing model only — no minted token, no Standby Actor support.
+> ℹ️ **Scope:** Both direct x402 and Skyfire are limited to Pay Per Event Actors and don't support Standby Actors — and settle per run instead of minting a token.
 
 ## How agentic payments work
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Check out the [MCP clients section](#-mcp-clients) for more details or visit the
 - [🤖 MCP clients](#-mcp-clients)
 - [🪄 Try Apify MCP instantly](#-try-apify-mcp-instantly)
 - [💰 Agentic payments](#-agentic-payments)
-  - [🪙 AGI (recommended)](#-agi-recommended)
   - [How agentic payments work](#how-agentic-payments-work)
+  - [🪙 AGI (recommended)](#-agi-recommended)
   - [💸 Direct x402](#-direct-x402)
   - [🔥 Skyfire](#-skyfire)
 - [🛠️ Tools, resources, and prompts](#%EF%B8%8F-tools-resources-and-prompts)
@@ -123,12 +123,6 @@ You can pay for Actor runs without an Apify API token using **AGI**, **direct x4
 
 > Both direct x402 and Skyfire settle per Actor run under the Pay Per Event pricing model only — no minted token, no Standby Actor support.
 
-## 🪙 AGI (recommended)
-
-[AGI](https://agi.apify.com) (Apify Agent General Interface) is the recommended way for autonomous agents to pay for Apify usage without an account. Pay once via x402 or MPP, receive a prepaid, spend-capped Apify API token, and use it directly against `mcp.apify.com` and `api.apify.com` (`Authorization: Bearer <token>`) — for any Actor.
-
-Full protocol, supported payment methods, and current terms (minimum amount, token lifetime, refund policy) are documented at **[agi.apify.com/AGENTS.md](https://agi.apify.com/AGENTS.md)** — treat it as the single source of truth.
-
 ## How agentic payments work
 
 Actor run costs vary, so both payment methods use a prepaid balance model. The payment flow happens in four steps:
@@ -143,6 +137,12 @@ Actor run costs vary, so both payment methods use a prepaid balance model. The p
 4. **Resolution**: The tool returns the Actor results. Unused funds stay available for later runs.
    - **Direct x402**: After 60 minutes of inactivity, the server refunds any unused balance to the wallet on [Base](https://base.org).
    - **Skyfire**: Skyfire returns unused funds when the token expires.
+
+## 🪙 AGI (recommended)
+
+[AGI](https://agi.apify.com) (Apify Agent General Interface) is the recommended way for autonomous agents to pay for Apify usage without an account. Pay once via x402 or MPP, receive a prepaid, spend-capped Apify API token, and use it directly against `mcp.apify.com` and `api.apify.com` (`Authorization: Bearer <token>`) — for any Actor.
+
+Full protocol, supported payment methods, and current terms (minimum amount, token lifetime, refund policy) are documented at **[agi.apify.com/AGENTS.md](https://agi.apify.com/AGENTS.md)** — treat it as the single source of truth.
 
 ## 💸 Direct x402
 


### PR DESCRIPTION
## What
Follow-up to #1178: fixes the reviewer's pending suggestions (drop contradictory "no API token required" clause, token works against both `mcp.apify.com` and `api.apify.com`, single source-of-truth link), consolidates the "Pay Per Event only / no Standby Actor support" caveat into one shared note instead of duplicating it across the x402 and Skyfire sections, and renames the x402 section to "Direct x402" to disambiguate it from AGI's own x402 funding rail.

## Why
Same limitation applies to both x402 and Skyfire, so a per-section callout would've duplicated text; AGI mentions x402 too (as one of its funding methods), so the standalone x402 section needed a distinct name — "Direct x402" is what we call it internally.

## Testing
`pnpm run check:agents` (README link-tree validator) passes. Docs-only change.