### PR TITLE
refactor(tools): Improve Actor loader names

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,7 +37,7 @@ Key entry points:
 
 Tool loading is intentionally split into two phases in [`src/utils/tools_loader.ts`](./src/utils/tools_loader.ts):
 
-- `getActors()` — async, mode-agnostic. Fetches Actor metadata and preserves the caller's requested tool/actor selection without choosing any mode-dependent tool variants.
+- `getActorsFromInput()` — async, mode-agnostic. Fetches Actor metadata and preserves the caller's requested tool/actor selection without choosing any mode-dependent tool variants.
 - `getToolsForServerMode()` — sync, mode-dependent. Takes the pre-fetched sources plus a resolved `SERVER_MODE` and produces the concrete tool entries to expose to the client.
 - `loadToolsFromInput()` in `tools_loader.ts` — convenience wrapper running both phases back-to-back with an explicit `SERVER_MODE`. **Not to be confused with** `ActorsMcpServer.loadToolsFromInput()` (the public method), which queues sources when mode is still `'auto'` and registers them onto the server — call the server method from transport entry points, the plain function only when you already have a resolved mode.
 

--- a/res/refactoring-sweep-2026-07.md
+++ b/res/refactoring-sweep-2026-07.md
@@ -63,7 +63,7 @@ fetch/enrichment; wait/orchestration (`raceAbort`, `waitForRunWithProgress`). Me
 ### `internals.js` export narrowing (M/L, cross-repo)
 
 `index_internals.ts` exports raw tool-catalog functions the hosted repo consumes directly
-(`getDefaultTools`, `getCategoryTools`, `getActorsAsTools`, `processParamsGetTools`,
+(`getDefaultTools`, `getCategoryTools`, `fetchActorsAsTools`, `processParamsGetTools`,
 `getToolPublicFieldOnly`, …) against the stated "expose methods on `ActorsMcpServer`"
 policy, plus deprecated aliases awaiting internal migration (`addActor as addTool`,
 `redactSkyfirePayId` — see #604, `HelperTools`). Convert one export at a time to a server

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -33,7 +33,7 @@ directory you're editing.
 - `prompts/` — the prompt registry (`index.ts`) plus `prompt_service.ts`
   (`createPromptService`, throws protocol-neutral domain errors); no child doc.
 
-**Two-phase tool loading** (mode-agnostic `getActors()` vs mode-dependent
+**Two-phase tool loading** (mode-agnostic `getActorsFromInput()` vs mode-dependent
 `getToolsForServerMode()`) is documented once in
 [`../DEVELOPMENT.md`](../DEVELOPMENT.md) — read it before touching tool loading.
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -23,7 +23,7 @@ export const ACTOR_LOAD_ERROR_KIND = {
 export type ActorLoadErrorKind = (typeof ACTOR_LOAD_ERROR_KIND)[keyof typeof ACTOR_LOAD_ERROR_KIND];
 
 /**
- * Surfaced (not thrown) by `getActorsAsTools` in the `errors[]` field when an
+ * Surfaced (not thrown) by `fetchActorsAsTools` in the `errors[]` field when an
  * Actor cannot be loaded for a *sanitized*, user-safe reason. The single-Actor
  * caller (`call-actor`) reads `errors[0]` and forwards the message to the agent;
  * bulk callers ignore the array.

--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -72,7 +72,7 @@ Two MCP protocol revisions are served, each by its own adapter:
   **timeout** returns `null` with no SSE fallback (a timeout means unreachable, not
   the wrong transport). `getActorMCPServerPath()` prioritizes the `/mcp` streamable
   endpoint when an Actor lists several.
-- **Two-phase tool loading** (mode-agnostic `getActors()` vs mode-dependent
+- **Two-phase tool loading** (mode-agnostic `getActorsFromInput()` vs mode-dependent
   `getToolsForServerMode()`) is documented once in
   [`../../DEVELOPMENT.md`](../../DEVELOPMENT.md) — read it before changing
   registration in `server.ts`; not restated here.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -32,7 +32,7 @@ import { SERVER_MODE, TOOL_TYPE } from '../types.js';
 import { getRequestOriginForClient, isReportProblemBlockedForClient } from '../utils/mcp_clients.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
 import { parseServerMode, resolveServerMode } from '../utils/server_mode.js';
-import { getActors, getToolsForServerMode, toolNamesToInput } from '../utils/tools_loader.js';
+import { getActorsFromInput, getToolsForServerMode, toolNamesToInput } from '../utils/tools_loader.js';
 import { buildMcpClientContext, isUiSupportedByClient } from './client_context.js';
 import type { McpClientContext } from './client_context.js';
 import { LegacyMcpServer } from './legacy_server.js';
@@ -448,7 +448,7 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
         if (missingToolNames.length === 0) return;
 
         const restoreInput = toolNamesToInput(missingToolNames);
-        const actorTools = await getActors(restoreInput, apifyClient, {
+        const actorTools = await getActorsFromInput(restoreInput, apifyClient, {
             actorStore: this.actorStore,
             paymentProvider: this.options.paymentProvider,
         });
@@ -459,7 +459,7 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
     /** Load tools from URL params. Used by SSE and HTTP entry points. */
     public async loadToolsFromUrl(url: string, apifyClient: ApifyClient) {
         const input = parseInputParamsFromUrl(url);
-        const actorTools = await getActors(input, apifyClient, {
+        const actorTools = await getActorsFromInput(input, apifyClient, {
             actorStore: this.actorStore,
             paymentProvider: this.options.paymentProvider,
         });
@@ -469,12 +469,12 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
     }
 
     /**
-     * Two-phase: getActors (async, client-agnostic fetch) then the buffer-or-compose gate.
-     * Don't move the getActors await into the initialize handler — clients time out waiting for
+     * Two-phase: getActorsFromInput (async, client-agnostic fetch) then the buffer-or-compose gate.
+     * Don't move the getActorsFromInput await into the initialize handler — clients time out waiting for
      * InitializeResult; the queue buffers already-fetched data, not network work. See #721.
      */
     public async loadToolsFromInput(input: Input, apifyClient: ApifyClient): Promise<void> {
-        const actorTools = await getActors(input, apifyClient, {
+        const actorTools = await getActorsFromInput(input, apifyClient, {
             actorStore: this.actorStore,
             paymentProvider: this.options.paymentProvider,
         });

--- a/src/tools/actor_tool_naming.ts
+++ b/src/tools/actor_tool_naming.ts
@@ -15,7 +15,7 @@ export function isActorInfoMcpServer(actorInfo: ActorInfo): boolean {
 /**
  * Whether this Actor must be excluded from tool surfaces and rejected on
  * `call-actor` when the session uses a third-party payment provider (x402, Skyfire).
- * List-time filtering in `getActorsAsTools` and the call-time guard in
+ * List-time filtering in `fetchActorsAsTools` and the call-time guard in
  * `checkPaymentProviderStandbyConflict` must use this — not MCP URL presence alone.
  */
 export function isActorBlockedUnderPaymentProvider(actorInfo: ActorInfo): boolean {

--- a/src/tools/actors/actor_tools_factory.ts
+++ b/src/tools/actors/actor_tools_factory.ts
@@ -272,12 +272,12 @@ export function fixActorNameInput(actorName: string): string {
 }
 
 /**
- * Result type for {@link getActorsAsTools}: every requested name produces
+ * Result type for {@link fetchActorsAsTools}: every requested name produces
  * either a successful load (contributing to `tools` — a single Actor can fan
  * out into multiple tools for MCP-server Actors) or an `ActorLoadError`
  * describing why the load failed.
  *
- * Bulk callers (`getActors`, server load-helpers) typically only read
+ * Bulk callers (`getActorsFromInput`, server load-helpers) typically only read
  * `tools`. The single-Actor caller (`call-actor`) reads `errors[0]` to surface
  * the precise reason back to the agent.
  */
@@ -300,7 +300,7 @@ export type ActorsAsToolsResult = {
  * tool call. Filtering at list time keeps the advertised tool surface
  * honest so agents never discover a tool that can only fail later.
  */
-export async function getActorsAsTools(
+export async function fetchActorsAsTools(
     actorIdsOrNames: string[],
     apifyClient: ApifyClient,
     options?: {

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -49,7 +49,7 @@ import {
     CALL_ACTOR_WAIT_SECS_DEFAULT,
     fetchActorRunData,
 } from './actor_run_response.js';
-import { fixActorNameInputAndLog, getActorsAsTools } from './actor_tools_factory.js';
+import { fetchActorsAsTools, fixActorNameInputAndLog } from './actor_tools_factory.js';
 
 // ---------------------------------------------------------------------------
 // Shared call-actor description building blocks
@@ -393,7 +393,7 @@ export async function resolveAndValidateActor(params: {
     const { actorName, input, toolArgs } = params;
     const { apifyClient } = toolArgs;
 
-    const { tools, errors } = await getActorsAsTools([actorName], apifyClient, {
+    const { tools, errors } = await fetchActorsAsTools([actorName], apifyClient, {
         mcpSessionId: toolArgs.mcpSessionId,
     });
 
@@ -481,7 +481,7 @@ export async function resolveAndValidateActor(params: {
  *
  * Returns either an early response (error or MCP tool result) or the parsed context for mode-specific execution.
  *
- * Applies the same `actor` string normalization as `getActorsAsTools` **before** MCP URL lookup and routing so
+ * Applies the same `actor` string normalization as `fetchActorsAsTools` **before** MCP URL lookup and routing so
  * clients cannot pass a clean-enough id for definition fetch but a dirty id to `apifyClient.actor()` (see Mezmo:
  * e.g. trailing `` ` `` on `apify/rag-web-browser`).
  */

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,7 +2,7 @@ import { HELPER_TOOLS } from '../const.js';
 import type { ToolCategory, ToolEntry } from '../types.js';
 import { SERVER_MODE } from '../types.js';
 import { getExpectedToolsByCategories } from '../utils/tool_categories_helpers.js';
-import { getActorsAsTools } from './actors/actor_tools_factory.js';
+import { fetchActorsAsTools } from './actors/actor_tools_factory.js';
 import type { ActorsAsToolsResult } from './actors/actor_tools_factory.js';
 import {
     CATEGORY_NAME_SET,
@@ -46,5 +46,5 @@ export function getUnauthEnabledToolCategories(): ToolCategory[] {
 }
 
 // Export actor-related tools
-export { getActorsAsTools };
+export { fetchActorsAsTools };
 export type { ActorsAsToolsResult };

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -1,5 +1,5 @@
 /**
- * Two-phase tool loading: {@link getActors} fetches Actor metadata (async, mode-agnostic);
+ * Two-phase tool loading: {@link getActorsFromInput} fetches Actor metadata (async, mode-agnostic);
  * {@link loadToolsFromInput} runs both in sequence.
  */
 
@@ -10,7 +10,7 @@ import log from '@apify/log';
 import { defaults, HELPER_TOOLS, type HelperToolName, RETIRED_SELECTOR_NAMES } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
 import { reportProblem } from '../tools/dev/report_problem.js';
-import { getActorsAsTools } from '../tools/index.js';
+import { fetchActorsAsTools } from '../tools/index.js';
 import {
     CATEGORY_NAME_SET,
     CATEGORY_NAMES,
@@ -137,16 +137,16 @@ function resolveActorsToLoad(input: Input): string[] {
  *
  * Pass `paymentProvider` for sessions authenticated via an external payment
  * provider (x402, Skyfire) so standby/MCP-server Actors are filtered out —
- * see `getActorsAsTools` for the full rationale.
+ * see `fetchActorsAsTools` for the full rationale.
  */
-export async function getActors(
+export async function getActorsFromInput(
     input: Input,
     apifyClient: ApifyClient,
     options?: { actorStore?: ActorStore; paymentProvider?: PaymentProvider },
 ): Promise<ToolEntry[]> {
     const actorNames = resolveActorsToLoad(input);
     if (actorNames.length === 0) return [];
-    const { tools } = await getActorsAsTools(actorNames, apifyClient, options);
+    const { tools } = await fetchActorsAsTools(actorNames, apifyClient, options);
     return tools;
 }
 
@@ -222,7 +222,7 @@ export function getToolsForServerMode(
                 internalSelections.push(internalByName);
                 continue;
             }
-            // Internal tool from another mode → skip silently (getActors already
+            // Internal tool from another mode → skip silently (getActorsFromInput already
             // routed it away from actor names).
             if (ALL_INTERNAL_TOOL_NAMES.has(sel)) {
                 log.debug(`Skipping selector "${sel}" — it is an internal tool from another mode (current: "${mode}")`);
@@ -299,13 +299,13 @@ export function getToolsForServerMode(
     return result.filter((entry) => !seen.has(entry.name) && seen.add(entry.name));
 }
 
-/** Convenience wrapper: {@link getActors} + {@link getToolsForServerMode} in sequence. */
+/** Convenience wrapper: {@link getActorsFromInput} + {@link getToolsForServerMode} in sequence. */
 export async function loadToolsFromInput(
     input: Input,
     apifyClient: ApifyClient,
     mode: SERVER_MODE = SERVER_MODE.DEFAULT,
     actorStore?: ActorStore,
 ): Promise<ToolEntry[]> {
-    const actorTools = await getActors(input, apifyClient, { actorStore });
+    const actorTools = await getActorsFromInput(input, apifyClient, { actorStore });
     return getToolsForServerMode(input, actorTools, mode);
 }

--- a/tests/integration/internals.test.ts
+++ b/tests/integration/internals.test.ts
@@ -6,7 +6,7 @@ import log from '@apify/log';
 import { ApifyClient } from '../../src/apify_client.js';
 import { HELPER_TOOLS } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/index.js';
-import { getActorsAsTools } from '../../src/tools/index.js';
+import { fetchActorsAsTools } from '../../src/tools/index.js';
 import { SERVER_MODE } from '../../src/types.js';
 import { AUTO_INJECTED_TOOLS, loadToolsFromInput } from '../../src/utils/tools_loader.js';
 import { ACTOR_NORMAL_MODE } from '../const.js';
@@ -33,7 +33,7 @@ describe('MCP server internals integration tests', () => {
         );
         actorsMcpServer.upsertTools(initialTools);
 
-        const { tools: newTool } = await getActorsAsTools([ACTOR_NORMAL_MODE], apifyClient);
+        const { tools: newTool } = await fetchActorsAsTools([ACTOR_NORMAL_MODE], apifyClient);
         actorsMcpServer.upsertTools(newTool);
 
         const names = actorsMcpServer.listAllToolNames();
@@ -67,7 +67,7 @@ describe('MCP server internals integration tests', () => {
         const apifyClient = new ApifyClient({ token: process.env.APIFY_TOKEN });
 
         // Simulate a session that already has an actor tool loaded, bypassing the loader.
-        const { tools } = await getActorsAsTools([ACTOR_NORMAL_MODE], apifyClient);
+        const { tools } = await fetchActorsAsTools([ACTOR_NORMAL_MODE], apifyClient);
         actorsMcpServer.upsertTools(tools);
         const names = actorsMcpServer.listAllToolNames();
         expectArrayWeakEquals([ACTOR_NORMAL_MODE], names);

--- a/tests/unit/dev_server.test.ts
+++ b/tests/unit/dev_server.test.ts
@@ -19,15 +19,15 @@ import {
     parseInitializeParams,
 } from '../../src/dev_server.js';
 import type * as ToolsLoaderModule from '../../src/utils/tools_loader.js';
-import { getActors } from '../../src/utils/tools_loader.js';
+import { getActorsFromInput } from '../../src/utils/tools_loader.js';
 import { makeArgsRecorderTool, readJsonRpcPayload, STATELESS_PROTOCOL_VERSION } from './helpers/mcp_server.js';
 
 vi.mock('../../src/utils/tools_loader.js', async (importOriginal) => {
     const actual = await importOriginal<typeof ToolsLoaderModule>();
-    return { ...actual, getActors: vi.fn() };
+    return { ...actual, getActorsFromInput: vi.fn() };
 });
 
-const getActorsMock = vi.mocked(getActors);
+const getActorsFromInputMock = vi.mocked(getActorsFromInput);
 
 /** The per-request `_meta` envelope that makes a request 2026-07-28 traffic. */
 const ENVELOPE = {
@@ -134,7 +134,7 @@ const DEV_URL = '/?telemetry-enabled=false';
 /**
  * Runs `run` against the dev server's real Express app, listening on an ephemeral loopback port, so
  * era routing and the stateless branch behind it are exercised through the same POST route a client
- * hits. Nothing leaves the machine: `getActors` is mocked, so no Actor metadata is fetched.
+ * hits. Nothing leaves the machine: `getActorsFromInput` is mocked, so no Actor metadata is fetched.
  */
 async function withDevServer<T>(run: (post: PostFn, port: number) => Promise<T>): Promise<T> {
     const httpServer: HttpServer = createExpressApp().listen(0, '127.0.0.1');
@@ -189,11 +189,11 @@ describe('createExpressApp() era routing', () => {
     });
 
     beforeEach(() => {
-        getActorsMock.mockResolvedValue([]);
+        getActorsFromInputMock.mockResolvedValue([]);
     });
 
     afterEach(() => {
-        getActorsMock.mockReset();
+        getActorsFromInputMock.mockReset();
         vi.restoreAllMocks();
     });
 
@@ -287,7 +287,7 @@ describe('createExpressApp() era routing', () => {
 
     it('passes the bearer token to the stateless adapter as auth info', async () => {
         const { tool, received } = makeArgsRecorderTool();
-        getActorsMock.mockResolvedValue([tool]);
+        getActorsFromInputMock.mockResolvedValue([tool]);
 
         await withDevServer(async (post) => {
             const { body, headers } = statelessRequest(
@@ -307,7 +307,7 @@ describe('createExpressApp() era routing', () => {
 
     it('sends no auth info in payment mode, so the client-supplied token is used', async () => {
         const { tool, received } = makeArgsRecorderTool();
-        getActorsMock.mockResolvedValue([tool]);
+        getActorsFromInputMock.mockResolvedValue([tool]);
 
         await withDevServer(async (post) => {
             const { body, headers } = statelessRequest(
@@ -371,7 +371,7 @@ describe('createExpressApp() era routing', () => {
             expect(result?.instructions).toBeTruthy();
             // And it costs no Actor-metadata fetch: neither capabilities nor the configuration-level
             // instructions read the tool set.
-            expect(getActorsMock).not.toHaveBeenCalled();
+            expect(getActorsFromInputMock).not.toHaveBeenCalled();
         });
     });
 });

--- a/tests/unit/mcp.server.capability_gating.test.ts
+++ b/tests/unit/mcp.server.capability_gating.test.ts
@@ -12,17 +12,17 @@ import { searchActorsWidget } from '../../src/tools/widgets/search_actors_widget
 import type { ServerModeOption } from '../../src/types.js';
 import { SERVER_MODE } from '../../src/types.js';
 import type * as ToolsLoaderModule from '../../src/utils/tools_loader.js';
-import { getActors } from '../../src/utils/tools_loader.js';
+import { getActorsFromInput } from '../../src/utils/tools_loader.js';
 import { getRequestHandler } from './helpers/mcp_server.js';
 
-// Stub getActors so tests can produce a non-empty actorTools array without a network
+// Stub getActorsFromInput so tests can produce a non-empty actorTools array without a network
 // fetch to the Apify platform. getToolsForServerMode / toolNamesToInput stay real.
 vi.mock('../../src/utils/tools_loader.js', async (importOriginal) => {
     const actual = await importOriginal<typeof ToolsLoaderModule>();
-    return { ...actual, getActors: vi.fn() };
+    return { ...actual, getActorsFromInput: vi.fn() };
 });
 
-const getActorsMock = vi.mocked(getActors);
+const getActorsFromInputMock = vi.mocked(getActorsFromInput);
 
 function makeInitializeRequest(supportsUi: boolean): InitializeRequest {
     const extensions = supportsUi ? { 'io.modelcontextprotocol/ui': { mimeTypes: [RESOURCE_MIME_TYPE] } } : {};
@@ -56,9 +56,9 @@ async function dispatchInitialize(server: ActorsMcpServer, request: InitializeRe
 describe('ActorsMcpServer initialize handler', () => {
     const servers: ActorsMcpServer[] = [];
 
-    // Default: no actor tools resolved, matching the real getActors() behavior for
+    // Default: no actor tools resolved, matching the real getActorsFromInput() behavior for
     // inputs that only reference HELPER_TOOLS names (used by the pre-existing tests below).
-    getActorsMock.mockResolvedValue([]);
+    getActorsFromInputMock.mockResolvedValue([]);
 
     afterEach(async () => {
         while (servers.length > 0) {
@@ -66,8 +66,8 @@ describe('ActorsMcpServer initialize handler', () => {
             server?.tools.clear();
             await server?.close();
         }
-        getActorsMock.mockReset();
-        getActorsMock.mockResolvedValue([]);
+        getActorsFromInputMock.mockReset();
+        getActorsFromInputMock.mockResolvedValue([]);
     });
 
     const track = (server: ActorsMcpServer): ActorsMcpServer => {

--- a/tests/unit/mcp.server.report_problem_gating.test.ts
+++ b/tests/unit/mcp.server.report_problem_gating.test.ts
@@ -42,7 +42,7 @@ async function dispatchInitialize(server: ActorsMcpServer, clientName: string): 
     await handler(makeInitializeRequest(clientName), {});
 }
 
-// report-problem carries no actor name, so getActors short-circuits and never touches the client —
+// report-problem carries no actor name, so getActorsFromInput short-circuits and never touches the client —
 // this drives the real compose path (getToolsForServerMode + blocklist filter) without any network.
 async function loadReportProblemByName(server: ActorsMcpServer): Promise<void> {
     await server.loadToolsByName([HELPER_TOOLS.PROBLEM_REPORT], {} as never);

--- a/tests/unit/mcp.server.tool_sources.test.ts
+++ b/tests/unit/mcp.server.tool_sources.test.ts
@@ -6,15 +6,15 @@ import { ActorsMcpServer } from '../../src/mcp/server.js';
 import type { Input } from '../../src/types.js';
 import { SERVER_MODE } from '../../src/types.js';
 import type * as ToolsLoaderModule from '../../src/utils/tools_loader.js';
-import { getActors } from '../../src/utils/tools_loader.js';
+import { getActorsFromInput } from '../../src/utils/tools_loader.js';
 
-// Stub getActors so a load runs without a network fetch to the Apify platform.
+// Stub getActorsFromInput so a load runs without a network fetch to the Apify platform.
 vi.mock('../../src/utils/tools_loader.js', async (importOriginal) => {
     const actual = await importOriginal<typeof ToolsLoaderModule>();
-    return { ...actual, getActors: vi.fn() };
+    return { ...actual, getActorsFromInput: vi.fn() };
 });
 
-vi.mocked(getActors).mockResolvedValue([]);
+vi.mocked(getActorsFromInput).mockResolvedValue([]);
 
 /** `toolSources` is private and has no reader yet; read it directly to assert it stays bounded. */
 function toolSourceKeys(server: ActorsMcpServer): string[] {

--- a/tests/unit/mcp.stateless.request_context.test.ts
+++ b/tests/unit/mcp.stateless.request_context.test.ts
@@ -16,14 +16,14 @@ import type { Input, ToolEntry, ToolInputSchema } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
 import { compileSchema } from '../../src/utils/ajv.js';
 import type * as ToolsLoaderModule from '../../src/utils/tools_loader.js';
-import { getActors } from '../../src/utils/tools_loader.js';
+import { getActorsFromInput } from '../../src/utils/tools_loader.js';
 import { getRequestHandler, makeRecorderTool, withServer, withStatelessServer } from './helpers/mcp_server.js';
 
-// Stub getActors so a facade can be given tool sources without a network fetch. The compose path
+// Stub getActorsFromInput so a facade can be given tool sources without a network fetch. The compose path
 // (getToolsForServerMode + the report-problem gate) stays real — that is what these tests exercise.
 vi.mock('../../src/utils/tools_loader.js', async (importOriginal) => {
     const actual = await importOriginal<typeof ToolsLoaderModule>();
-    return { ...actual, getActors: vi.fn() };
+    return { ...actual, getActorsFromInput: vi.fn() };
 });
 
 // Stub the widget disk scan so apps-mode widget resolution yields a deterministic registry whose
@@ -33,11 +33,11 @@ vi.mock('../../src/resources/widgets.js', async (importOriginal) => {
     return { ...actual, resolveAvailableWidgets: vi.fn() };
 });
 
-const getActorsMock = vi.mocked(getActors);
+const getActorsFromInputMock = vi.mocked(getActorsFromInput);
 const resolveAvailableWidgetsMock = vi.mocked(resolveAvailableWidgets);
 
 async function loadSource(server: ActorsMcpServer, actorTools: ToolEntry[], input: Input = { tools: [] }) {
-    getActorsMock.mockResolvedValue(actorTools);
+    getActorsFromInputMock.mockResolvedValue(actorTools);
     await server.loadToolsFromInput(input, {} as never);
 }
 
@@ -97,8 +97,8 @@ function resourceUris(result: Record<string, unknown> | undefined): string[] {
 
 describe('createStatelessServer() request context', () => {
     afterEach(() => {
-        getActorsMock.mockReset();
-        getActorsMock.mockResolvedValue([]);
+        getActorsFromInputMock.mockReset();
+        getActorsFromInputMock.mockResolvedValue([]);
         vi.restoreAllMocks();
     });
 

--- a/tests/unit/mcp.stateless.tool_call.test.ts
+++ b/tests/unit/mcp.stateless.tool_call.test.ts
@@ -18,7 +18,7 @@ import { TOOL_TYPE } from '../../src/types.js';
 import { compileSchema } from '../../src/utils/ajv.js';
 import { respondRaw } from '../../src/utils/mcp.js';
 import type * as ToolsLoaderModule from '../../src/utils/tools_loader.js';
-import { getActors } from '../../src/utils/tools_loader.js';
+import { getActorsFromInput } from '../../src/utils/tools_loader.js';
 import {
     getRequestHandler,
     makeArgsRecorderTool,
@@ -32,7 +32,7 @@ import {
 
 vi.mock('../../src/utils/tools_loader.js', async (importOriginal) => {
     const actual = await importOriginal<typeof ToolsLoaderModule>();
-    return { ...actual, getActors: vi.fn() };
+    return { ...actual, getActorsFromInput: vi.fn() };
 });
 
 // Capturing ApifyClient construction is how the request-origin tag is observed; it is a static
@@ -51,7 +51,7 @@ vi.mock('../../src/apify_client.js', async (importOriginal) => {
     };
 });
 
-const getActorsMock = vi.mocked(getActors);
+const getActorsFromInputMock = vi.mocked(getActorsFromInput);
 
 function makeActorTool(): ToolEntry {
     return {
@@ -136,7 +136,7 @@ function softFailsStartingWith(
 }
 
 async function loadSource(server: ActorsMcpServer, actorTools: ToolEntry[], input: Input = { tools: [] }) {
-    getActorsMock.mockResolvedValue(actorTools);
+    getActorsFromInputMock.mockResolvedValue(actorTools);
     await server.loadToolsFromInput(input, {} as never);
 }
 
@@ -191,8 +191,8 @@ describe('createStatelessServer() tools/call', () => {
     });
 
     afterEach(() => {
-        getActorsMock.mockReset();
-        getActorsMock.mockResolvedValue([]);
+        getActorsFromInputMock.mockReset();
+        getActorsFromInputMock.mockResolvedValue([]);
         vi.restoreAllMocks();
     });
 

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -21,10 +21,10 @@ import { textOf, type TextToolResult } from './helpers/tool_context.js';
 
 vi.mock('../../src/tools/actors/actor_tools_factory.js', async () => {
     const actual = await vi.importActual<Record<string, unknown>>('../../src/tools/actors/actor_tools_factory.js');
-    return { ...actual, getActorsAsTools: vi.fn() };
+    return { ...actual, fetchActorsAsTools: vi.fn() };
 });
 
-const { getActorsAsTools } = await import('../../src/tools/actors/actor_tools_factory.js');
+const { fetchActorsAsTools } = await import('../../src/tools/actors/actor_tools_factory.js');
 
 describe('call_actor_common', () => {
     describe('buildCallActorDescription', () => {
@@ -251,7 +251,7 @@ describe('call_actor_common', () => {
         const stubToolArgs = { apifyClient: {}, mcpSessionId: 'session-1' } as unknown as InternalToolArgs;
 
         beforeEach(() => {
-            vi.mocked(getActorsAsTools).mockReset();
+            vi.mocked(fetchActorsAsTools).mockReset();
         });
 
         function mockActorTool(ajvValidate: ((input: unknown) => boolean) & { errors?: unknown }): void {
@@ -263,11 +263,11 @@ describe('call_actor_common', () => {
                 inputSchema: INPUT_SCHEMA,
                 ajvValidate,
             } as unknown as ToolEntry;
-            vi.mocked(getActorsAsTools).mockResolvedValue({ tools: [tool], errors: [] });
+            vi.mocked(fetchActorsAsTools).mockResolvedValue({ tools: [tool], errors: [] });
         }
 
         it('returns a SOFT_FAIL/404 not-found error when the Actor is missing', async () => {
-            vi.mocked(getActorsAsTools).mockResolvedValue({ tools: [], errors: [] });
+            vi.mocked(fetchActorsAsTools).mockResolvedValue({ tools: [], errors: [] });
 
             const resolution = await resolveAndValidateActor({
                 actorName: 'apify/missing',

--- a/tests/unit/tools.call_actor_widget.response.test.ts
+++ b/tests/unit/tools.call_actor_widget.response.test.ts
@@ -20,11 +20,11 @@ vi.mock('../../src/tools/actors/actor_tools_factory.js', async () => {
     const actual = await vi.importActual<Record<string, unknown>>('../../src/tools/actors/actor_tools_factory.js');
     return {
         ...actual,
-        getActorsAsTools: vi.fn(),
+        fetchActorsAsTools: vi.fn(),
     };
 });
 
-const { getActorsAsTools } = await import('../../src/tools/actors/actor_tools_factory.js');
+const { fetchActorsAsTools } = await import('../../src/tools/actors/actor_tools_factory.js');
 
 const MOCK_ACTOR_TOOL: ToolEntry = {
     type: TOOL_TYPE.ACTOR,
@@ -57,8 +57,8 @@ describe('call-actor-widget response', () => {
     beforeEach(() => {
         vi.mocked(getActorMcpUrlCached).mockReset();
         vi.mocked(getActorMcpUrlCached).mockResolvedValue(false);
-        vi.mocked(getActorsAsTools).mockReset();
-        vi.mocked(getActorsAsTools).mockResolvedValue({ tools: [MOCK_ACTOR_TOOL], errors: [] });
+        vi.mocked(fetchActorsAsTools).mockReset();
+        vi.mocked(fetchActorsAsTools).mockResolvedValue({ tools: [MOCK_ACTOR_TOOL], errors: [] });
     });
 
     it('starts the run and returns runId + widget _meta on the response', async () => {

--- a/tests/unit/utils.tools_loader.retired_selectors.test.ts
+++ b/tests/unit/utils.tools_loader.retired_selectors.test.ts
@@ -6,29 +6,29 @@ import { HELPER_TOOLS } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/index.js';
 import type * as ToolsIndexModule from '../../src/tools/index.js';
 import { SERVER_MODE } from '../../src/types.js';
-import { getActors, getToolsForServerMode, toolNamesToInput } from '../../src/utils/tools_loader.js';
+import { getActorsFromInput, getToolsForServerMode, toolNamesToInput } from '../../src/utils/tools_loader.js';
 
 const RETIRED_SELECTORS = ['add-actor', 'experimental', 'preview'] as const;
 
 vi.mock('../../src/tools/index.js', async (importOriginal) => {
     const actual = await importOriginal<typeof ToolsIndexModule>();
-    return { ...actual, getActorsAsTools: vi.fn().mockResolvedValue({ tools: [], errors: [] }) };
+    return { ...actual, fetchActorsAsTools: vi.fn().mockResolvedValue({ tools: [], errors: [] }) };
 });
 
-const { getActorsAsTools } = await import('../../src/tools/index.js');
-const getActorsAsToolsMock = vi.mocked(getActorsAsTools);
+const { fetchActorsAsTools } = await import('../../src/tools/index.js');
+const fetchActorsAsToolsMock = vi.mocked(fetchActorsAsTools);
 const apifyClient = new ApifyClient({ token: 'test-token' });
 
 beforeEach(() => {
-    getActorsAsToolsMock.mockClear();
+    fetchActorsAsToolsMock.mockClear();
 });
 
-describe('getActors()', () => {
+describe('getActorsFromInput()', () => {
     it.for(RETIRED_SELECTORS)('does not fetch retired selector "%s"', async (selector) => {
-        const tools = await getActors({ tools: [selector] }, apifyClient);
+        const tools = await getActorsFromInput({ tools: [selector] }, apifyClient);
 
         expect(tools).toEqual([]);
-        expect(getActorsAsToolsMock).not.toHaveBeenCalled();
+        expect(fetchActorsAsToolsMock).not.toHaveBeenCalled();
     });
 });
 
@@ -68,7 +68,7 @@ describe('ActorsMcpServer.loadToolsByName()', () => {
 
         await server.loadToolsByName([selector], apifyClient);
 
-        expect(getActorsAsToolsMock).not.toHaveBeenCalled();
+        expect(fetchActorsAsToolsMock).not.toHaveBeenCalled();
         expect(server.listAllToolNames()).toEqual([]);
     });
 });


### PR DESCRIPTION
## Why

Closes #758.

The existing names blur two abstraction levels and use `get` for a helper that fetches data from the Apify API.

## What changed

- Renamed `getActorsAsTools()` to `fetchActorsAsTools()`.
- Renamed `getActors()` to `getActorsFromInput()`.
- Updated their exports, consumers, tests, mocks, and documentation.

## Notes for reviewers (human-written)

## Proof it works

- An exact-symbol repository search finds no remaining references to either previous name.
- `corepack pnpm run format`
- `corepack pnpm run type-check`
- `corepack pnpm run lint` (0 warnings and errors)
- `corepack pnpm run check:agents` (7 docs checked)
- `corepack pnpm run test:unit` (1,246 passed, 1 skipped)

Integration tests were not run because repository instructions reserve them for humans with an `APIFY_TOKEN`.
