### PR TITLE
fix: remove gameable Runs succeeded stat from actor search/details

### DIFF
--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -116,7 +116,6 @@ export const statsSchema = {
     properties: {
         totalUsers: { type: 'number', description: 'Total users' },
         monthlyUsers: { type: 'number', description: 'Monthly active users' },
-        successRate: { type: 'number', description: 'Success rate percentage' },
         bookmarks: { type: 'number', description: 'Number of bookmarks' },
     },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -641,7 +641,6 @@ export type StructuredActorCard = {
     stats?: {
         totalUsers: number;
         monthlyUsers: number;
-        successRate?: number;
         bookmarks?: number;
     };
     rating?: {

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -97,7 +97,6 @@ type ExtractedActorData = {
     stats?: {
         totalUsers: number;
         monthlyUsers: number;
-        successRate?: number;
         bookmarks?: number;
     };
     rating?: {
@@ -143,17 +142,6 @@ function extractActorData(actor: Actor | ActorStoreList, options: ActorCardOptio
                 totalUsers: stats.totalUsers,
                 monthlyUsers: stats.totalUsers30Days,
             };
-        }
-
-        if ('publicActorRunStats30Days' in stats && stats.publicActorRunStats30Days) {
-            const runStats = stats.publicActorRunStats30Days as {
-                SUCCEEDED: number;
-                TOTAL: number;
-            };
-            if (runStats.TOTAL > 0) {
-                data.stats ??= { totalUsers: 0, monthlyUsers: 0 };
-                data.stats.successRate = Number(((runStats.SUCCEEDED / runStats.TOTAL) * 100).toFixed(1));
-            }
         }
 
         const bookmarkCount =
@@ -230,9 +218,6 @@ export function formatActorToActorCard(
         const statsParts = [
             `${data.stats.totalUsers.toLocaleString()} total users, ${data.stats.monthlyUsers.toLocaleString()} monthly users`,
         ];
-        if (data.stats.successRate !== undefined) {
-            statsParts.push(`Runs succeeded: ${data.stats.successRate}%`);
-        }
         if (data.stats.bookmarks) {
             statsParts.push(`${data.stats.bookmarks} bookmarks`);
         }

--- a/src/web/src/utils/mock-actor-details.ts
+++ b/src/web/src/utils/mock-actor-details.ts
@@ -91,7 +91,6 @@ export const MOCK_ACTOR_DETAILS_RESPONSE = {
             stats: {
                 totalUsers: 734,
                 monthlyUsers: 113,
-                successRate: 100,
                 bookmarks: 5,
             },
             modifiedAt: '2026-01-23T08:11:16.995Z',

--- a/tests/unit/utils.actor_card.test.ts
+++ b/tests/unit/utils.actor_card.test.ts
@@ -202,19 +202,6 @@ describe('formatActorToActorCard', () => {
             expect(result).not.toContain('- **Pricing');
         });
 
-        it('should include success rate in stats', () => {
-            const result = formatActorToActorCard(mockActor, {
-                includeDescription: false,
-                includeStats: true,
-                includePricing: false,
-                includeRating: false,
-                includeMetadata: false,
-            });
-
-            // Success rate: 68663/69395 = 98.9%
-            expect(result).toContain('Runs succeeded: 98.9%');
-        });
-
         it('should include bookmark count from Actor.stats', () => {
             const result = formatActorToActorCard(mockActor, {
                 includeDescription: false,
@@ -453,7 +440,6 @@ describe('formatActorToStructuredCard', () => {
             expect(result.stats).toBeDefined();
             expect(result.stats?.totalUsers).toBe(8594);
             expect(result.stats?.monthlyUsers).toBe(904);
-            expect(result.stats?.successRate).toBe(98.9);
         });
 
         it('should include bookmarks from Actor.stats', () => {


### PR DESCRIPTION
Adresses https://apify.slack.com/archives/C04URRT3934/p1785403187603329

## What
Removes the per-Actor \"Runs succeeded\" success-rate stat from `search-actors` and `fetch-actor-details` (markdown card, structured output, and JSON schema), plus the now-stale dev-harness mock fixture and test assertions.

## Why
Reported in Slack: this metric is gamed by developers and was already pulled from public Actor pages on apify.com. MCP/API/CLI should mirror that. This PR covers the MCP surface only, per team decision — API/CLI and a follow-up \"show verified creators\" feature (blocked on apify-core exposing that field publicly) are tracked separately.

## Testing
`pnpm run type-check`, `pnpm run lint`, `pnpm run test:unit` (89 files, 1245 passed / 1 skipped), `pnpm run format` (no diff), `pnpm run check:agents` — all clean. Confirmed via grep that `successRate`/\"Runs succeeded\" has zero remaining references in `src/` and `tests/`, and that the widget/apps-mode path never carried this field (nothing to change there). Independently re-verified by a fresh subagent (PASS).