### PR TITLE
fix: Preserve Actor input-schema validation keywords

### DIFF
--- a/src/tools/actor_input_schema.ts
+++ b/src/tools/actor_input_schema.ts
@@ -80,14 +80,15 @@ export function buildApifySpecificProperties(
 }
 
 /**
- * Filters schema properties to include only the necessary fields.
- * This is done to reduce the size of the input schema and to make it more readable.
+ * Filters schema properties to the fields MCP tools need: core shape, examples/defaults,
+ * and JSON Schema validation keywords. UI-only Actor hints (`editor`, `enumTitles`, …) are
+ * dropped to keep advertised schemas smaller.
  *
- * TODO(#675): This object literal unconditionally assigns every whitelisted key,
- * including `default: undefined`, on properties that didn't declare them upstream.
- * This creates phantom keys that broke `fixZodSchemaRequired()` via key-presence
- * checks (#637). The symptom is patched in `src/utils/ajv.ts` (value-check), but
- * this function should only emit keys whose upstream value is not `undefined`.
+ * Only emits keys whose upstream value is not `undefined` — assigning `default: undefined`
+ * (and similar) created phantom keys that broke `'default' in field` checks (#637 / #675).
+ *
+ * Validation keywords (`minimum`, `maximum`, `minLength`, …) are preserved so AJV compile
+ * and tools/list honor Actor-declared bounds instead of silently accepting out-of-range input.
  *
  * @param properties
  */
@@ -96,19 +97,48 @@ export function filterSchemaProperties(properties: { [key: string]: SchemaProper
 } {
     const filteredProperties: { [key: string]: SchemaProperties } = {};
     for (const [key, property] of Object.entries(properties)) {
-        filteredProperties[key] = {
-            title: property.title,
-            description: property.description,
-            enum: property.enum,
-            type: property.type,
-            default: property.default,
-            prefill: property.prefill,
-            properties: property.properties,
-            items: property.items,
-            required: property.required,
-        };
+        filteredProperties[key] = pickDefinedSchemaFields(property);
     }
     return filteredProperties;
+}
+
+/** Optional SchemaProperties keys that survive filtering when the upstream value is defined. */
+const OPTIONAL_SCHEMA_FIELD_KEYS = [
+    'enum',
+    'default',
+    'prefill',
+    'properties',
+    'items',
+    'required',
+    'examples',
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+    'minLength',
+    'maxLength',
+    'minItems',
+    'maxItems',
+    'uniqueItems',
+    'pattern',
+] as const satisfies readonly (keyof SchemaProperties)[];
+
+function pickDefinedSchemaFields(property: SchemaProperties): SchemaProperties {
+    const filtered: SchemaProperties = {
+        type: property.type,
+        title: property.title,
+        description: property.description,
+    };
+
+    for (const field of OPTIONAL_SCHEMA_FIELD_KEYS) {
+        const value = property[field];
+        if (value !== undefined) {
+            // Indexed assignment through a keyof union needs a narrow cast.
+            (filtered as Record<string, unknown>)[field] = value;
+        }
+    }
+
+    return filtered;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,20 @@ export type SchemaProperties = {
 
     properties?: Record<string, SchemaProperties>;
     required?: string[];
+
+    // JSON Schema validation keywords from Actor input schemas. Kept through
+    // filterSchemaProperties so AJV and tools/list honor Actor-declared bounds.
+    minimum?: number;
+    maximum?: number;
+    exclusiveMinimum?: number;
+    exclusiveMaximum?: number;
+    minLength?: number;
+    maxLength?: number;
+    minItems?: number;
+    maxItems?: number;
+    uniqueItems?: boolean;
+    // Advertised to clients; AJV drops `pattern` at compile time (ReDoS guard in ajv.ts).
+    pattern?: string;
 };
 
 export type ActorInputSchema = {

--- a/src/utils/ajv.ts
+++ b/src/utils/ajv.ts
@@ -21,7 +21,8 @@ ajv.removeKeyword('format');
  * breaks AJV compilation.
  *
  * Uses a value-check (`field.default !== undefined`) instead of key-presence (`'default' in field`)
- * because `filterSchemaProperties()` assigns phantom `default: undefined` on every property (#675).
+ * so a future regression that reintroduces phantom `default: undefined` keys cannot clear
+ * required fields again (#637). `filterSchemaProperties` no longer emits those phantoms.
  *
  * @see https://github.com/apify/apify-mcp-server/issues/637
  */

--- a/tests/unit/tools.utils.test.ts
+++ b/tests/unit/tools.utils.test.ts
@@ -8,6 +8,7 @@ import {
     decodeDotPropertyNames,
     encodeDotPropertyNames,
     filterAndShortenEnum,
+    filterSchemaProperties,
     fixedAjvCompile,
     inferArrayItemsTypeIfMissing,
     inferArrayItemType,
@@ -748,21 +749,14 @@ describe('transformActorInputSchemaProperties', () => {
         expect(result.proxy.properties?.useApifyProxy).toBeDefined();
         expect(result.sources.items).toBeDefined();
         expect(result.sources.items?.properties?.url).toBeDefined();
-        // 3. filterSchemaProperties: only allowed fields present
-        // NOTE: includes phantom `default: undefined` etc. from filterSchemaProperties (#675).
-        expect(Object.keys(result['foo-dot-bar'])).toEqual(
-            expect.arrayContaining([
-                'title',
-                'description',
-                'type',
-                'default',
-                'prefill',
-                'properties',
-                'items',
-                'required',
-                'enum',
-            ]),
-        );
+        // 3. filterSchemaProperties: only defined allowed fields (no phantom undefined keys)
+        expect(Object.keys(result['foo-dot-bar']).sort()).toEqual(['description', 'title', 'type']);
+        expect(result['foo-dot-bar']).not.toHaveProperty('default');
+        expect(result['foo-dot-bar']).not.toHaveProperty('prefill');
+        expect(result['foo-dot-bar']).not.toHaveProperty('enum');
+        // UI-only `editor` is stripped from proxy / sources after filtering
+        expect(result.proxy).not.toHaveProperty('editor');
+        expect(result.sources).not.toHaveProperty('editor');
         // 4. shortenProperties: longDesc is truncated, enumProp.enum is shortened
         expect(result.longDesc.description.length).toBeLessThanOrEqual(ACTOR_MAX_DESCRIPTION_LENGTH + 3);
         if (result.enumProp.enum) {
@@ -857,6 +851,125 @@ describe('transformActorInputSchemaProperties', () => {
         // Verify that other transformations were applied
         expect(result.placeIds.title).toBe('🗃 Place IDs');
         expect(result.placeIds.description).toBe(input.properties.placeIds.description);
+    });
+});
+
+describe('filterSchemaProperties()', () => {
+    it('preserves JSON Schema validation keywords and omits undefined optionals', () => {
+        const filtered = filterSchemaProperties({
+            maxResults: {
+                type: 'integer',
+                title: 'Max results',
+                description: 'Cap',
+                minimum: 1,
+                maximum: 100,
+                default: 10,
+            },
+            query: {
+                type: 'string',
+                title: 'Query',
+                description: 'Search',
+                minLength: 1,
+                maxLength: 200,
+                pattern: '^[a-z]+$',
+            },
+            tags: {
+                type: 'array',
+                title: 'Tags',
+                description: 'Tags',
+                minItems: 1,
+                maxItems: 5,
+                uniqueItems: true,
+                items: { type: 'string', title: 'Tag', description: 'One tag' },
+            },
+        });
+
+        expect(filtered.maxResults).toEqual({
+            type: 'integer',
+            title: 'Max results',
+            description: 'Cap',
+            minimum: 1,
+            maximum: 100,
+            default: 10,
+        });
+        expect(filtered.maxResults).not.toHaveProperty('prefill');
+        expect(filtered.query).toMatchObject({
+            minLength: 1,
+            maxLength: 200,
+            pattern: '^[a-z]+$',
+        });
+        expect(filtered.tags).toMatchObject({
+            minItems: 1,
+            maxItems: 5,
+            uniqueItems: true,
+        });
+        expect(filtered.tags).not.toHaveProperty('editor');
+    });
+
+    it('keeps exclusive bounds when declared', () => {
+        const filtered = filterSchemaProperties({
+            score: {
+                type: 'number',
+                title: 'Score',
+                description: '0–1 exclusive',
+                exclusiveMinimum: 0,
+                exclusiveMaximum: 1,
+            },
+        });
+        expect(filtered.score.exclusiveMinimum).toBe(0);
+        expect(filtered.score.exclusiveMaximum).toBe(1);
+    });
+});
+
+describe('transformActorInputSchemaProperties — validation keywords', () => {
+    it('survives the full transform pipeline and is enforced by AJV', () => {
+        const properties = transformActorInputSchemaProperties({
+            type: 'object',
+            properties: {
+                maxResults: {
+                    type: 'integer',
+                    title: 'Max results',
+                    description: 'Cap',
+                    minimum: 1,
+                    maximum: 10,
+                    default: 5,
+                },
+                name: {
+                    type: 'string',
+                    title: 'Name',
+                    description: 'Name',
+                    minLength: 2,
+                    maxLength: 8,
+                },
+                urls: {
+                    type: 'array',
+                    title: 'URLs',
+                    description: 'URL list',
+                    minItems: 1,
+                    maxItems: 3,
+                    items: { type: 'string', title: 'URL', description: 'One URL' },
+                },
+            },
+        });
+
+        expect(properties.maxResults.minimum).toBe(1);
+        expect(properties.maxResults.maximum).toBe(10);
+        expect(properties.name.minLength).toBe(2);
+        expect(properties.name.maxLength).toBe(8);
+        expect(properties.urls.minItems).toBe(1);
+        expect(properties.urls.maxItems).toBe(3);
+
+        const validate = fixedAjvCompile(ajv, {
+            type: 'object',
+            properties,
+            required: [],
+        });
+
+        expect(validate({ maxResults: 5, name: 'ab', urls: ['https://a'] })).toBe(true);
+        expect(validate({ maxResults: 11, name: 'ab', urls: ['https://a'] })).toBe(false);
+        expect(validate({ maxResults: 5, name: 'a', urls: ['https://a'] })).toBe(false);
+        expect(validate({ maxResults: 5, name: 'ab', urls: [] })).toBe(false);
+        expect(validate({ maxResults: 5, name: 'ab', urls: ['a', 'b', 'c', 'd'] })).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Summary
- Keep Actor-declared JSON Schema validation keywords (minimum, maximum, minLength, maxLength, minItems, maxItems, exclusive bounds, uniqueItems, pattern) through filterSchemaProperties.
- Only emit keys whose upstream value is defined — no more phantom default: undefined on every property.
- Extend SchemaProperties so the type matches what AJV and tools/list actually need.

## Why
filterSchemaProperties whitelisted only title/description/enum/type/default/prefill/properties/items/required. Real Actor schemas declare bounds (e.g. maxResults maximum: 100), but MCP-side AJV never saw them, so out-of-range inputs reached Apify runs and failed late. Agents also never saw those constraints in tools/list.

## Test plan
- [x] pnpm run type-check
- [x] pnpm run lint
- [x] pnpm run test:unit (new filter + AJV enforcement cases; updated transform assertions)
- [x] pnpm run format / pnpm run check:agents
- [x] Spot-check tools/list for an Actor with maximum/minLength and confirm bounds appear