### PR TITLE
fix: Declare widget csp/prefersBorder on the UI resource, not the tool

### DIFF
--- a/src/resources/resource_service.ts
+++ b/src/resources/resource_service.ts
@@ -23,7 +23,7 @@ import { RESOURCE_MIME_TYPE } from './widgets.js';
 // API reads can yield binary blob contents, not just text; the widget fields are optional add-ons.
 type ExtendedResourceContents = (TextResourceContents | BlobResourceContents) & {
     html?: string;
-    _meta?: AvailableWidget['meta'];
+    _meta?: AvailableWidget['resourceMeta'];
 };
 
 type ExtendedReadResourceResult = Omit<ReadResourceResult, 'contents'> & {
@@ -76,7 +76,7 @@ export function createResourceService(options: ResourceServiceOptions): Resource
                     name: widget.name,
                     description: widget.description,
                     mimeType: RESOURCE_MIME_TYPE,
-                    _meta: widget.meta,
+                    _meta: widget.resourceMeta,
                 });
             }
         }
@@ -142,7 +142,7 @@ export function createResourceService(options: ResourceServiceOptions): Resource
                     mimeType: RESOURCE_MIME_TYPE,
                     text: widgetHtml,
                     html: widgetHtml,
-                    _meta: widget.meta,
+                    _meta: widget.resourceMeta,
                 };
                 return {
                     contents: [widgetContent],

--- a/src/resources/widgets.ts
+++ b/src/resources/widgets.ts
@@ -40,16 +40,31 @@ const OPENAI_WIDGET_CSP = {
     resource_domains: RESOURCE_DOMAINS,
 } as const;
 
-const WIDGET_BASE_UI = {
-    visibility: ['model', 'app'] as const,
+// MCP Apps spec (SEP-1865): `csp`/`prefersBorder` are UI-resource metadata (`McpUiResourceMeta`) —
+// "hosts read it from the resources/read content item (with resources/list entry as fallback) and
+// ignore it here [on the tool]"; `McpUiToolMeta` types `csp`/`permissions` as `never` and carries
+// only `resourceUri`/`visibility`. Claude's host warns at runtime when they're mixed up
+// ("declares _meta.ui.csp/permissions, which is ignored"), so each surface gets only its own fields.
+const WIDGET_RESOURCE_UI = {
     prefersBorder: true,
     csp: WIDGET_CSP,
+} as const;
+
+const WIDGET_TOOL_UI = {
+    visibility: ['model', 'app'] as const,
 } as const;
 
 export const WIDGET_URIS = {
     SEARCH_ACTORS: 'ui://widget/search-actors.html',
     ACTOR_RUN: 'ui://widget/actor-run.html',
 } as const;
+
+/** Resource-level `_meta` (`resources/list` entry and `resources/read` content item). */
+type WidgetResourceMeta = NonNullable<Resource['_meta']> & {
+    'openai/widgetCSP'?: typeof OPENAI_WIDGET_CSP;
+    'openai/widgetDomain'?: string;
+    ui: typeof WIDGET_RESOURCE_UI;
+};
 
 type WidgetMeta = NonNullable<Resource['_meta']> & {
     // ChatGPT UX hints (does not affect MCP Jam renderer detection)
@@ -63,13 +78,20 @@ type WidgetMeta = NonNullable<Resource['_meta']> & {
     // 'openai/widgetPrefersBorder'?: boolean;
     'openai/widgetDomain'?: string;
     // MCP Apps standard metadata (SEP-1865)
-    ui: {
-        resourceUri: string;
-        visibility: readonly string[];
-        prefersBorder: boolean;
-        csp: typeof WIDGET_CSP;
-    };
+    ui: typeof WIDGET_TOOL_UI & { resourceUri: string };
+    // Legacy alias for `ui.resourceUri`; the ext-apps SDK's `registerAppTool` populates both
+    // "for compatibility with older hosts" and Claude Desktop's host reads it.
+    'ui/resourceUri': string;
 };
+
+/** Resource `_meta`: CSP and border preference, the fields hosts read off the UI resource. */
+function createWidgetResourceMeta(): WidgetResourceMeta {
+    return {
+        'openai/widgetCSP': OPENAI_WIDGET_CSP,
+        'openai/widgetDomain': WIDGET_DOMAIN,
+        ui: WIDGET_RESOURCE_UI,
+    };
+}
 
 /**
  * Creates widget metadata for tool definitions.
@@ -100,9 +122,10 @@ function createWidgetMeta(params: { resourceUri: string; invoking: string; invok
         // what ChatGPT public apps read — re-add them if ChatGPT public-app support regresses.
         // 'openai/widgetAccessible': true,
         'openai/widgetCSP': OPENAI_WIDGET_CSP,
-        // 'openai/widgetPrefersBorder': WIDGET_BASE_UI.prefersBorder,
+        // 'openai/widgetPrefersBorder': WIDGET_RESOURCE_UI.prefersBorder,
         'openai/widgetDomain': WIDGET_DOMAIN,
-        ui: { ...WIDGET_BASE_UI, resourceUri },
+        ui: { ...WIDGET_TOOL_UI, resourceUri },
+        'ui/resourceUri': resourceUri,
     };
 }
 
@@ -112,7 +135,10 @@ export type WidgetConfig = {
     description: NonNullable<Resource['description']>;
     jsFilename: string;
     title: NonNullable<Resource['title']>;
+    /** Tool-descriptor and tool-result `_meta`. */
     meta: WidgetMeta;
+    /** `resources/list` and `resources/read` `_meta`. */
+    resourceMeta: WidgetResourceMeta;
 };
 
 /**
@@ -130,6 +156,7 @@ export const WIDGET_REGISTRY: Record<string, WidgetConfig> = {
             invoking: 'Searching Apify Store...',
             invoked: 'Found Actors matching your criteria',
         }),
+        resourceMeta: createWidgetResourceMeta(),
     },
     [WIDGET_URIS.ACTOR_RUN]: {
         uri: WIDGET_URIS.ACTOR_RUN,
@@ -142,6 +169,7 @@ export const WIDGET_REGISTRY: Record<string, WidgetConfig> = {
             invoking: 'Running Apify Actor...',
             invoked: 'Actor run started',
         }),
+        resourceMeta: createWidgetResourceMeta(),
     },
 };
 

--- a/tests/unit/tools.call_actor_widget.response.test.ts
+++ b/tests/unit/tools.call_actor_widget.response.test.ts
@@ -111,7 +111,8 @@ describe('call-actor-widget response', () => {
 
         expect(_meta?.ui?.resourceUri).toBe(WIDGET_URIS.ACTOR_RUN);
         expect(_meta?.ui?.visibility).toEqual(['model', 'app']);
-        expect(_meta?.ui?.csp).toBeDefined();
+        // csp lives on the UI resource _meta, not the tool (SEP-1865: McpUiToolMeta types csp as never)
+        expect(_meta?.ui?.csp).toBeUndefined();
         expect(_meta?.['openai/widgetDescription']).toContain('apify/rag-web-browser');
     });
 
@@ -120,7 +121,8 @@ describe('call-actor-widget response', () => {
         const meta = tool._meta as { ui?: { resourceUri?: string; visibility?: readonly string[]; csp?: unknown } };
         expect(meta.ui?.resourceUri).toBe(WIDGET_URIS.ACTOR_RUN);
         expect(meta.ui?.visibility).toEqual(['model', 'app']);
-        expect(meta.ui?.csp).toBeDefined();
+        // csp lives on the UI resource _meta, not the tool (SEP-1865: McpUiToolMeta types csp as never)
+        expect(meta.ui?.csp).toBeUndefined();
     });
 
     it('declares a strict input schema that silently strips stray keys like async/previewOutput', () => {

--- a/tests/unit/tools.fetch_actor_details.widget.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.widget.response.test.ts
@@ -95,7 +95,8 @@ describe('fetch-actor-details-widget response', () => {
         // Response-level widget _meta.
         expect(_meta?.ui?.resourceUri).toBe(WIDGET_URIS.SEARCH_ACTORS);
         expect(_meta?.ui?.visibility).toEqual(['model', 'app']);
-        expect(_meta?.ui?.csp).toBeDefined();
+        // csp lives on the UI resource _meta, not the tool (SEP-1865: McpUiToolMeta types csp as never)
+        expect(_meta?.ui?.csp).toBeUndefined();
         expect(_meta?.['openai/widgetDescription']).toContain('apify/web-scraper');
     });
 
@@ -104,7 +105,8 @@ describe('fetch-actor-details-widget response', () => {
         const meta = tool._meta as { ui?: { resourceUri?: string; visibility?: readonly string[]; csp?: unknown } };
         expect(meta.ui?.resourceUri).toBe(WIDGET_URIS.SEARCH_ACTORS);
         expect(meta.ui?.visibility).toEqual(['model', 'app']);
-        expect(meta.ui?.csp).toBeDefined();
+        // csp lives on the UI resource _meta, not the tool (SEP-1865: McpUiToolMeta types csp as never)
+        expect(meta.ui?.csp).toBeUndefined();
     });
 
     it('declares a strict input schema and strips stray keys like `output` at validation time', () => {

--- a/tests/unit/tools.get_actor_run.widget.response.test.ts
+++ b/tests/unit/tools.get_actor_run.widget.response.test.ts
@@ -72,7 +72,8 @@ describe('get-actor-run-widget response', () => {
         // Response-level widget _meta.
         expect(_meta?.ui?.resourceUri).toBe(WIDGET_URIS.ACTOR_RUN);
         expect(_meta?.ui?.visibility).toEqual(['model', 'app']);
-        expect(_meta?.ui?.csp).toBeDefined();
+        // csp lives on the UI resource _meta, not the tool (SEP-1865: McpUiToolMeta types csp as never)
+        expect(_meta?.ui?.csp).toBeUndefined();
         expect(_meta?.['openai/widgetDescription']).toContain('apify/rag-web-browser');
         // Widget _meta also carries run usage metadata (buildUsageMeta), alongside widget-specific meta.
         expect(_meta?.['com.apify/ActorRun']).toEqual({
@@ -86,7 +87,8 @@ describe('get-actor-run-widget response', () => {
         const meta = tool._meta as { ui?: { resourceUri?: string; visibility?: readonly string[]; csp?: unknown } };
         expect(meta.ui?.resourceUri).toBe(WIDGET_URIS.ACTOR_RUN);
         expect(meta.ui?.visibility).toEqual(['model', 'app']);
-        expect(meta.ui?.csp).toBeDefined();
+        // csp lives on the UI resource _meta, not the tool (SEP-1865: McpUiToolMeta types csp as never)
+        expect(meta.ui?.csp).toBeUndefined();
     });
 
     it('declares a strict input schema accepting runId only', () => {

--- a/tests/unit/tools.search_actors.widget.response.test.ts
+++ b/tests/unit/tools.search_actors.widget.response.test.ts
@@ -70,7 +70,8 @@ describe('search-actors-widget response', () => {
 
         expect(_meta?.ui?.resourceUri).toBe(WIDGET_URIS.SEARCH_ACTORS);
         expect(_meta?.ui?.visibility).toEqual(['model', 'app']);
-        expect(_meta?.ui?.csp).toBeDefined();
+        // csp lives on the UI resource _meta, not the tool (SEP-1865: McpUiToolMeta types csp as never)
+        expect(_meta?.ui?.csp).toBeUndefined();
         expect(_meta?.['openai/widgetDescription']).toContain('1 actor');
     });
 
@@ -109,7 +110,8 @@ describe('search-actors-widget response', () => {
         const meta = tool._meta as { ui?: { resourceUri?: string; visibility?: readonly string[]; csp?: unknown } };
         expect(meta.ui?.resourceUri).toBe(WIDGET_URIS.SEARCH_ACTORS);
         expect(meta.ui?.visibility).toEqual(['model', 'app']);
-        expect(meta.ui?.csp).toBeDefined();
+        // csp lives on the UI resource _meta, not the tool (SEP-1865: McpUiToolMeta types csp as never)
+        expect(meta.ui?.csp).toBeUndefined();
     });
 
     it('declares a strict input schema and strips stray keys at validation time', () => {

--- a/tests/unit/utils.widgets.test.ts
+++ b/tests/unit/utils.widgets.test.ts
@@ -32,6 +32,19 @@ describe('Widget Utils', () => {
         });
     });
 
+    describe('WIDGET_REGISTRY metadata placement', () => {
+        // MCP Apps spec (SEP-1865): csp/prefersBorder belong to the UI resource's _meta.ui
+        // (McpUiResourceMeta); the tool's _meta.ui (McpUiToolMeta) carries only
+        // resourceUri/visibility and types csp/permissions as `never` — hosts ignore them there.
+        it.each(Object.entries(WIDGET_REGISTRY))('keeps %s ui fields on their own surface', (uri, config) => {
+            expect(config.meta.ui).toStrictEqual({ resourceUri: uri, visibility: ['model', 'app'] });
+            expect(config.resourceMeta.ui.csp).toBeDefined();
+            expect(config.resourceMeta.ui.prefersBorder).toBe(true);
+            expect(config.resourceMeta.ui).not.toHaveProperty('resourceUri');
+            expect(config.resourceMeta.ui).not.toHaveProperty('visibility');
+        });
+    });
+
     describe('resolveAvailableWidgets', () => {
         it('should correctly identify existing and missing widgets', async () => {
             const fs = await import('node:fs');


### PR DESCRIPTION
## Why

Closes #1188. Per MCP Apps spec (SEP-1865), `csp`/`prefersBorder` are UI-resource metadata (`McpUiResourceMeta`) — hosts read them from the `resources/read` content item (with the `resources/list` entry as fallback) — while the tool's `_meta.ui` (`McpUiToolMeta`) carries only `resourceUri`/`visibility` and types `csp`/`permissions` as `never`. Claude's host warns at runtime about our current placement and ignores the misplaced keys, so our declared CSP is dead weight on the wrong surface.

## What changed

Before: one `_meta.ui` blob (resourceUri, visibility, csp, prefersBorder) served on every surface — tool descriptor, tool result, resources/list, resources/read.

Now: `WidgetConfig` carries `meta` (tool/result: `resourceUri`, `visibility`, plus the legacy `ui/resourceUri` alias that the ext-apps SDK's `registerAppTool` populates for older hosts) and `resourceMeta` (list/read: `csp`, `prefersBorder`). `resource_service.ts` serves `resourceMeta` on both resource surfaces. Widget-meta tests pin the per-surface placement.

## Notes for reviewers (human-written)

## Proof it works

mcpc probe against the built stdio server in apps mode: `tools/list` shows widget tools with `_meta.ui = {visibility, resourceUri}` + `ui/resourceUri` and no `csp`; `resources/read ui://widget/search-actors.html` returns `_meta` with `openai/widgetCSP`, `openai/widgetDomain`, and `ui: {prefersBorder, csp}`. Widgets verified rendering in Claude Desktop and MCP Jam alongside #1187 during the ext-apps#696 investigation (this change was bisected there and is behavior-neutral for current hosts — they ignore the misplaced keys either way; this aligns us with the spec surface hosts actually read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)