### PR TITLE
chore: Add format:check to the shepherd oracle

### DIFF
--- a/.shepherd/config.json
+++ b/.shepherd/config.json
@@ -16,7 +16,8 @@
       "pnpm run type-check",
       "pnpm run lint",
       "pnpm run test:unit",
-      "pnpm run check:agents"
+      "pnpm run check:agents",
+      "pnpm run format:check"
     ]
   },
   "limits": { "inner_iterations": 3, "final_review_rounds": 2 },


### PR DESCRIPTION
Shepherd :)

Added `pnpm run format:check` to `oracle.commands`. Not `format` — that rewrites files, and an oracle must be non-mutating. `format:check` is `oxfmt --check`.
