### PR TITLE
test: Add eval coverage for get-actor-run

### DIFF
--- a/evals/workflows/test_cases.json
+++ b/evals/workflows/test_cases.json
@@ -151,6 +151,14 @@
       "maxTurns": 20
     },
     {
+      "id": "storage-actor-run-status-seeded",
+      "category": "storage",
+      "query": "Run the apify/rag-web-browser Actor on the URL https://docs.apify.com/ with maxResults set to 1, waiting up to 45 seconds for it to finish. Then look up that specific run by its run ID to confirm its status, and retrieve its dataset items. Tell me the run status and the title of the scraped page.",
+      "reference": "The agent must call call-actor for apify/rag-web-browser, then call get-actor-run with the runId from that call, and call get-dataset-items with the datasetId from that run. PASS only if get-actor-run was called with a runId argument, get-dataset-items was called with a datasetId argument, and the final answer states the run status and a page title.",
+      "tools": ["actors", "get-actor-run", "get-dataset-items"],
+      "maxTurns": 14
+    },
+    {
       "id": "storage-run-list-recent",
       "category": "storage",
       "query": "List my 10 most recent Actor runs, newest first. For each run report its run ID, the Actor it ran, and its status.",


### PR DESCRIPTION
[Refs #29461](https://github.com/apify/apify-core/issues/29461)

### Why

get-actor-run (look up a specific Actor run by runId) has no eval coverage. Every other storage-category test exercises a different tool — get-actor-run-list for listing runs, or one of the dataset/KV tools (get-dataset-items, get-dataset, get-dataset-schema, get-key-value-store-keys, get-key-value-store-record) for storage retrieval. None of them call the single-run lookup path, so a regression in get-actor-run itself would go unnoticed.

### What

Add storage-actor-run-status-seeded to evals/workflows/test_cases.json: runs apify/rag-web-browser (the same deterministic seed Actor the other *-seeded tests already use, for speed/cost/determinism), then requires the agent to call get-actor-run with the resulting runId and get-dataset-items with the resulting datasetId, reporting the run status and the scraped page title.

### Test plan

```
pnpm run build
pnpm exec tsx evals/workflows/run_workflow_evals.ts \
  --test-cases-path "$(pwd)/evals/workflows/test_cases.json" \
  --id storage-actor-run-status-seeded --verbose

```
(needs APIFY_TOKEN / OPENROUTER_API_KEY)


<!-- A PR that is hard to review is not ready for review. One concern per PR, clean diff (no debug logs, formatting noise, commented-out code). -->

<!-- AI agents: fill in Why, What changed, and Proof it works. Leave "Notes for reviewers" empty — it belongs to the human author. No file lists, no restating the diff, no praising the change. -->

<!-- Human author: an AI draft is a draft, not a description. Before requesting review: (1) self-review your own diff in the GitHub UI, (2) check every claim below against the diff and cut what you wouldn't say yourself, (3) write "Notes for reviewers" in your own words. -->

> **Outside contributors:** maintainers implement unassigned issues. Unless this is a documentation fix or a maintainer asked you to write it, close this and [open an issue](https://github.com/apify/apify-mcp-server/issues) instead. A reproduction is more useful than a patch. See [Before you write code](https://github.com/apify/apify-mcp-server/blob/master/CONTRIBUTING.md#before-you-write-code). Using AI? [Disclose it and show proof](https://github.com/apify/apify-mcp-server/blob/master/CONTRIBUTING.md#ai-assisted-contributions).

## Notes for reviewers (human-written)
<!-- Your own words — two sentences beat none. Where should review look hardest? What are you unsure about? If AI wrote parts you don't fully follow, say which — the reviewer must not be the first human to read them. Any impact on apify-mcp-server-internal (internals.js exports, _meta, structuredContent, clientInfo, ?ui=/?payment=)? -->

## Proof it works
<!-- Not "unit tests pass" — CI shows that. An end-to-end MCP probe (mcpc transcript), a screenshot, or a link to an Actor run on the Apify platform. "Works on my machine" / "the AI said it works" is not proof. -->
