### PR TITLE
fix: Stop reporting a cancelled Actor-MCP call as a failure

### DIFF
--- a/src/mcp/tool_dispatch.ts
+++ b/src/mcp/tool_dispatch.ts
@@ -27,7 +27,8 @@ import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC } from './const.js';
  * Both the sync `CallToolRequestSchema` handler and `executeToolAndUpdateTask` call this after their
  * own pre-dispatch validation and keep their own try/catch + buildToolCallErrorResult around it.
  * INTERNAL and ACTOR execution errors propagate to the caller's catch; the ACTOR_MCP case keeps its
- * own inner catch and returns a soft-fail result instead of throwing.
+ * own inner catch and returns a soft-fail result instead of throwing — except on abort, which
+ * returns an empty result like ACTOR.
  *
  * `extractToolTelemetry` (via `applyToolTelemetry`) runs once here, in the INTERNAL and ACTOR
  * cases, and strips `toolTelemetry` in place, so callers must not re-strip. ACTOR_MCP sets
@@ -123,10 +124,10 @@ export async function dispatchToolCall(params: {
 
         case TOOL_TYPE.ACTOR_MCP: {
             // This case never throws: connect/exec failures resolve to a soft-fail `result`
-            // (isError body) below instead. As a task, that means the outer completeTask
-            // stores it via the 'completed' path (isError body) — deliberately matching sync's
-            // own soft-fail semantics, unlike ACTOR/INTERNAL, whose thrown errors land in the
-            // task caller's 'failed' path.
+            // (isError body) below instead, and an abort resolves to an empty one. As a task, that
+            // means the outer completeTask stores it via the 'completed' path (isError body) —
+            // deliberately matching sync's own soft-fail semantics, unlike ACTOR/INTERNAL, whose
+            // thrown errors land in the task caller's 'failed' path.
             let client: Client | null = null;
             try {
                 client = await connectMCPClient(tool.serverUrl, apifyToken, mcpSessionId);
@@ -203,6 +204,11 @@ export async function dispatchToolCall(params: {
                     // Yield a macrotask first: the SDK sends notifications/cancelled fire-and-forget on
                     // the transport's AbortController, which the finally's close() would abort.
                     await new Promise((resolve) => setImmediate(resolve));
+                    // Same as the ACTOR branch below: a cancelled request gets no response, and a
+                    // cancel is not a failure — so no error body, no failure_* fields, no error log.
+                    toolStatus = TOOL_STATUS.ABORTED;
+                    result = {};
+                    break;
                 }
                 ({ toolStatus, callDiagnostics } = buildExecutionDiagnostics({
                     error,

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -733,6 +733,48 @@ describe('ACTOR_MCP remote-McpError containment (sync tools/call catch)', () => 
         });
     });
 
+    it('reports a cancelled Actor-MCP call as ABORTED with no result body and no failure log', async () => {
+        // A cancel is not an execution failure. Falling through to buildExecutionDiagnostics/logHttpError
+        // files it as INTERNAL_ERROR and logs it — at error level when the abort lands during connect,
+        // where the SDK throws a bare DOMException that no logHttpError branch matches.
+        const trackSpy = vi.spyOn(telemetry, 'trackToolCall').mockImplementation(() => {});
+        const logSpy = vi.spyOn(logging, 'logHttpError').mockImplementation(() => {});
+        await withServer(
+            async (server) => {
+                silenceLogs();
+                const controller = new AbortController();
+                const callTool = vi.fn().mockImplementation(async () => {
+                    controller.abort();
+                    throw new McpError(ErrorCode.RequestTimeout, 'Request cancelled');
+                });
+                vi.spyOn(mcpClient, 'connectMCPClient').mockResolvedValue({
+                    callTool,
+                    close: vi.fn().mockResolvedValue(undefined),
+                    setNotificationHandler: vi.fn(),
+                } as unknown as Client);
+
+                server.upsertTools([makeActorMcpTool()]);
+                const handler = getRequestHandler(server, 'tools/call');
+                const result = await handler(
+                    {
+                        method: 'tools/call',
+                        params: { name: 'test-actor-mcp-tool', arguments: {}, _meta: { mcpSessionId: 's1' } },
+                    },
+                    { signal: controller.signal, sendNotification: vi.fn() },
+                );
+
+                // An empty `result` surfaces as `{ content: [] }` — CallToolResultSchema defaults `content`.
+                expect(result).toEqual({ content: [] });
+                expect(logSpy).not.toHaveBeenCalled();
+            },
+            { token: undefined, telemetry: { enabled: true }, allowUnauthMode: true },
+        );
+        expect(trackSpy.mock.calls).toHaveLength(1);
+        // ABORTED already held before this guard existed (buildExecutionDiagnostics derives it from
+        // `isAborted`); pinned here so the status can't regress alongside the body and log.
+        expect(trackSpy.mock.calls[0][2].tool_status).toBe(TOOL_STATUS.ABORTED);
+    });
+
     it('re-throws an escaped McpError as a JSON-RPC error, not an isError tool result', async () => {
         // Escaped McpErrors must remain JSON-RPC errors, including 402-coded errors.
         await withServer(async (server) => {


### PR DESCRIPTION
## Why

Cancelling an Actor-MCP tool call is reported as a failure. Probed against a local MCP server: an error result body and `failure_category: INTERNAL_ERROR`, plus a failure log. (`tool_status` was already `ABORTED` — `buildExecutionDiagnostics` derives it from `isAborted` — so the status was never the problem.)

An abort mid-call throws `McpError(-32001)`, which is in `SOFT_MCP_ERROR_CODES`, so `log.softFail`. An abort that lands while `connectMCPClient` is in flight is worse: `connectMCPClient` itself never throws on abort, but the subsequent `client.callTool` calls `signal.throwIfAborted()` and raises a bare `DOMException` (`AbortError`, `code: 20`) that no `logHttpError` branch matches — 20 is outside 100–600 and −32768..−32000, and "This operation was aborted" fits neither transient pattern — so it reaches the final `log.error`. Alert level, on a user pressing cancel.

Reachable since #1185 started passing the abort signal into `client.callTool()`. In `@apify/actors-mcp-server 0.14.2-beta.2`; `latest` is still `0.14.1`.

## What changed

Before: an aborted `ACTOR_MCP` call fell through the generic catch to `buildExecutionDiagnostics` and `logHttpError`.

Now: it returns `result = {}` and breaks, matching the `ACTOR` branch. `tool_status` stays `ABORTED`; the error body, the `failure_*` fields and the log go away.

Also updated two comments in the same file that described the catch as always producing a soft-fail `isError` body.

## Notes for reviewers

The one decision here is logging nothing on a cancel. That matches the `ACTOR` branch, but if you'd rather a cancellation left a debug trace, that's a one-line change.

Known trade-off: the guard keys on `signal.aborted`, not on the error being abort-caused. So a genuine remote failure that races with a cancel is now dropped with no log, where before it was misfiled as `INTERNAL_ERROR` but at least logged. Keying on the signal is the existing convention here (`handleMcpToolCall` and `buildExecutionDiagnostics` both do it), so I left it alone — say the word if you'd rather narrow it to abort-shaped errors.

Telemetry shifts: `failure_category` and `failure_detail` are no longer emitted for these. Anything grouping cancelled Actor-MCP calls under `INTERNAL_ERROR` will see that bucket empty out — intended, but worth telling whoever owns those charts. There is no cancel/abort value in `FAILURE_CATEGORY`, and the three `ABORTED` sites in `task_execution.ts` already emit actor fields only, so unset is the existing convention.

Task mode is unaffected: the cancel-watcher signal only aborts after the store shows the task cancelled, so `skipIfTaskCancelled` short-circuits before the `{}` could be stored.

No `apify-mcp-server-internal` surface touched — no `internals.js` exports, `_meta`, `structuredContent`, or `?ui=`/`?payment=` parsing.

## Proof it works

Probe against a real SDK `Server` with a hanging tool, cancelled mid-call:

```
before:  toolStatus=ABORTED  errorBody=true   failure_category=INTERNAL_ERROR
after:   toolStatus=ABORTED  errorBody=false  failure_category=<unset>
```

New unit test asserts the aborted result carries no error body and that `logHttpError` is not called; both assertions fail independently when the guard is removed. Local gates: `type-check`, `lint`, `format`, `check:agents`, 1268 unit tests.

Found and fixed with Claude Code while reviewing #1185; a second model did an adversarial pass over the diff and description, which is where the title correction and the stale comments came from.
