### PR TITLE
fix: get-actor-log errors when run is not found

### DIFF
--- a/src/tools/runs/get_actor_run_log.ts
+++ b/src/tools/runs/get_actor_run_log.ts
@@ -4,7 +4,7 @@ import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { respondOk } from '../../utils/mcp.js';
+import { respondOk, respondUserError } from '../../utils/mcp.js';
 import { getActorRunLogToolOutputSchema } from '../structured_output_schemas.js';
 
 const GetRunLogArgs = z.object({
@@ -47,7 +47,14 @@ USAGE EXAMPLES:
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient: client } = toolArgs;
         const parsed = GetRunLogArgs.parse(args);
-        const v = (await client.run(parsed.runId).log().get()) ?? '';
+        let v = await client.run(parsed.runId).log().get();
+        if (v === undefined) {
+            const run = await client.run(parsed.runId).get();
+            if (!run) {
+                return respondUserError(`Run with ID '${parsed.runId}' not found.`);
+            }
+            v = '';
+        }
         // Logs from the API end with a newline; drop it so the tail slice counts only content lines.
         const lines = v.replace(/\n$/, '').split('\n');
         const text = lines.slice(-parsed.lines).join('\n');

--- a/tests/unit/tools.get_actor_run_log.test.ts
+++ b/tests/unit/tools.get_actor_run_log.test.ts
@@ -11,8 +11,9 @@ import {
 } from './helpers/tool_context.js';
 
 const getMock = vi.fn();
+const getRunMock = vi.fn();
 
-const stubClient = { run: () => ({ log: () => ({ get: getMock }) }) } as unknown as InternalToolArgs['apifyClient'];
+const stubClient = { run: () => ({ log: () => ({ get: getMock }), get: getRunMock }) } as unknown as InternalToolArgs['apifyClient'];
 
 const numberedLog = (count: number) => Array.from({ length: count }, (_, i) => `line ${i + 1}`).join('\n');
 
@@ -106,11 +107,22 @@ describe('get-actor-log', () => {
 
     it('returns conforming structuredContent for an empty log', async () => {
         getMock.mockResolvedValue(undefined);
+        getRunMock.mockResolvedValue({ id: 'run-1' });
 
         const result = await callTool({ runId: 'run-1', lines: 10 });
 
         expect(result.content[0].text).toBe('');
         expect(result.structuredContent).toEqual({ log: '' });
         expectSchemaConformingStructuredContent(result, getActorRunLogToolOutputSchema);
+    });
+
+    it('returns an error when the run is not found', async () => {
+        getMock.mockResolvedValue(undefined);
+        getRunMock.mockResolvedValue(undefined);
+
+        const result = await callTool({ runId: 'run-nonexistent', lines: 10 });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Run with ID 'run-nonexistent' not found.");
     });
 });


### PR DESCRIPTION
## Why
Closes #1193.
`get-actor-log` was returning success with an empty log for non-existent runs, whereas it should fail with a clear "not found" error, just like `get-actor-run` does.

## What changed
Before: `get-actor-log` coalesced the `undefined` return value from `apifyClient.run(id).log().get()` to an empty string, yielding a false success.
Now: When the log fetch returns `undefined`, the tool actively attempts to fetch the run. If the run does not exist, it throws a standard `respondUserError("Run with ID '{runId}' not found.")`.

## Notes for reviewers (human-written)
The main decision here was to implement a fallback fetch `client.run(id).get()` when the log is not found (i.e. when `log().get()` returns `undefined`). This adds one additional API call only in the specific failure case where a run or its log doesn't exist, which shouldn't impact the latency of successful log fetches. There is no impact on `apify-mcp-server-internal`.

## Proof it works
Added regression tests confirming the error is thrown. 
Probing via MCP now correctly yields the expected error response:
```json
{
  "content": [
    {
      "type": "text",
      "text": "Failed to get Actor run '1': Run with ID '1' not found.\nPlease verify the run ID and ensure that the run exists."
    }
  ],
  "isError": true
}
```
