### PR TITLE
fix: remove misleading dataset metadata error on abort (closes #1183)

### DIFF
--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -475,7 +475,7 @@ function buildSucceededSummaryNextStep(
     statusMessage: string | null | undefined,
     dataset?: RunDataset,
     keyValueStore?: RunKeyValueStore,
-    datasetMetadataFetched: boolean = true,
+    datasetMetadataFetched = true,
 ): { summary: string; nextStep: string } {
     const itemCount = dataset?.itemCount;
     const datasetId = dataset?.id;

--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -586,7 +586,13 @@ export function buildStatusSummaryNextStep(params: {
                 nextStep: `${pollHint(runId)} observe terminal state.`,
             };
         case 'SUCCEEDED':
-            return buildSucceededSummaryNextStep(runTimeSecs, statusMessage, dataset, keyValueStore, datasetMetadataFetched);
+            return buildSucceededSummaryNextStep(
+                runTimeSecs,
+                statusMessage,
+                dataset,
+                keyValueStore,
+                datasetMetadataFetched,
+            );
         case 'FAILED':
             return {
                 summary: `FAILED after ${runTimeSecs}s.${statusMessageLine(statusMessage)}`,

--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -475,6 +475,7 @@ function buildSucceededSummaryNextStep(
     statusMessage: string | null | undefined,
     dataset?: RunDataset,
     keyValueStore?: RunKeyValueStore,
+    datasetMetadataFetched: boolean = true,
 ): { summary: string; nextStep: string } {
     const itemCount = dataset?.itemCount;
     const datasetId = dataset?.id;
@@ -493,8 +494,9 @@ function buildSucceededSummaryNextStep(
     // datasetId known but metadata unavailable (transient fetch failure on a terminal run). Don't
     // claim "no output found" — point the agent at dataset items so they can verify directly.
     if (itemCount === undefined && datasetId) {
+        const metadataMsg = datasetMetadataFetched ? ' Dataset metadata unavailable.' : '';
         return {
-            summary: `SUCCEEDED in ${runTimeSecs}s. Dataset metadata unavailable.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
+            summary: `SUCCEEDED in ${runTimeSecs}s.${metadataMsg}${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
             nextStep: `Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to inspect output.`,
         };
     }
@@ -553,8 +555,9 @@ export function buildStatusSummaryNextStep(params: {
     run: ActorRun;
     dataset?: RunDataset;
     keyValueStore?: RunKeyValueStore;
+    datasetMetadataFetched?: boolean;
 }): { summary: string; nextStep: string } {
-    const { run, dataset, keyValueStore } = params;
+    const { run, dataset, keyValueStore, datasetMetadataFetched = true } = params;
     const { id: runId, status, statusMessage } = run;
     // The platform usually populates stats.runTimeSecs on terminal runs, but not always (e.g.
     // ABORTED before stats flushed). Fall back to `elapsedSecs(run)` so summaries don't render
@@ -583,7 +586,7 @@ export function buildStatusSummaryNextStep(params: {
                 nextStep: `${pollHint(runId)} observe terminal state.`,
             };
         case 'SUCCEEDED':
-            return buildSucceededSummaryNextStep(runTimeSecs, statusMessage, dataset, keyValueStore);
+            return buildSucceededSummaryNextStep(runTimeSecs, statusMessage, dataset, keyValueStore, datasetMetadataFetched);
         case 'FAILED':
             return {
                 summary: `FAILED after ${runTimeSecs}s.${statusMessageLine(statusMessage)}`,

--- a/src/tools/runs/abort_actor_run.ts
+++ b/src/tools/runs/abort_actor_run.ts
@@ -51,7 +51,7 @@ USAGE EXAMPLES:
 
         const dataset = run.defaultDatasetId ? { id: run.defaultDatasetId } : undefined;
         const keyValueStore = run.defaultKeyValueStoreId ? { id: run.defaultKeyValueStoreId } : undefined;
-        const { summary, nextStep } = buildStatusSummaryNextStep({ run, dataset, keyValueStore });
+        const { summary, nextStep } = buildStatusSummaryNextStep({ run, dataset, keyValueStore, datasetMetadataFetched: false });
 
         const structuredContent: RunResponse = {
             runId: run.id,

--- a/src/tools/runs/abort_actor_run.ts
+++ b/src/tools/runs/abort_actor_run.ts
@@ -51,7 +51,12 @@ USAGE EXAMPLES:
 
         const dataset = run.defaultDatasetId ? { id: run.defaultDatasetId } : undefined;
         const keyValueStore = run.defaultKeyValueStoreId ? { id: run.defaultKeyValueStoreId } : undefined;
-        const { summary, nextStep } = buildStatusSummaryNextStep({ run, dataset, keyValueStore, datasetMetadataFetched: false });
+        const { summary, nextStep } = buildStatusSummaryNextStep({
+            run,
+            dataset,
+            keyValueStore,
+            datasetMetadataFetched: false,
+        });
 
         const structuredContent: RunResponse = {
             runId: run.id,

--- a/tests/unit/tools.abort_actor_run.test.ts
+++ b/tests/unit/tools.abort_actor_run.test.ts
@@ -62,4 +62,15 @@ describe('abort-actor-run', () => {
         expect(JSON.parse(content[0].text)).toEqual(structuredContent);
         expect(content[1].text).toBe(`${structuredContent.summary}\n${structuredContent.nextStep}`);
     });
+
+    it('does not contain "Dataset metadata unavailable" for a SUCCEEDED run', async () => {
+        const run = mockAbortedRun({ status: 'SUCCEEDED' });
+        const result = await (abortActorRun as HelperTool).call(abortContext({ runId: 'run-1' }, run));
+        const { structuredContent } = result as TextToolResult & {
+            structuredContent: Record<string, unknown>;
+        };
+
+        expect(structuredContent.status).toBe('SUCCEEDED');
+        expect(structuredContent.summary as string).not.toContain('Dataset metadata unavailable');
+    });
 });


### PR DESCRIPTION
## Why
Closes #1183. 
`abort-actor-run` produced a misleading "Dataset metadata unavailable" suffix when attempting to abort a run that had already reached a `SUCCEEDED` status, falsely implying a metadata fetch failure despite this command natively skipping dataset fetches.

## What changed
- **Before**: `abort-actor-run` called `buildStatusSummaryNextStep` which assumed that a missing `itemCount` coupled with a valid `datasetId` indicated a transient metadata fetch failure, injecting the misleading text.
- **Now**: `buildStatusSummaryNextStep` accepts an explicit `datasetMetadataFetched` flag (defaulting to `true` for standard fetching callers like `get-actor-run`). `abort-actor-run` explicitly passes `datasetMetadataFetched: false` to bypass the erroneous metadata unavailable warning.

## Notes for reviewers (human-written)
I passed a boolean flag down into the shared helper function `buildStatusSummaryNextStep` so `abort-actor-run` can safely opt out of the metadata failure check. This cleanly resolves the incorrect suffix without impacting other commands that correctly rely on it.

## Proof it works
Added a regression test to `tests/unit/tools.abort_actor_run.test.ts` validating that the text "Dataset metadata unavailable" does not surface on `SUCCEEDED` terminal states. The unit test explicitly asserts that the payload omits this text when a successful aborted mock run payload is returned.
