### PR TITLE
docs: Link internal release manual in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,8 @@ There are two release tracks:
 1. **The npm package `@apify/actors-mcp-server`** (this repo) — documented below.
 2. **The hosted server at [mcp.apify.com](https://mcp.apify.com)** — lives in the hosted-server repo (`apify/apify-mcp-server-internal`); see its `RELEASE.md`. A package release here automatically opens a dependency-bump PR there, which starts that track.
 
+Apify employees: [How to release the Apify MCP server](https://app.notion.com/p/apify/How-to-release-the-Apify-MCP-server-3b3f39950a22802fabafea844105e85d) (Notion, internal) walks through both tracks end to end.
+
 Versioning is [SemVer](https://semver.org/). Conventional Commits drive automatic bumps (`feat:` → minor, `fix:` → patch, `!` → major).
 
 ## Release the npm package


### PR DESCRIPTION
## Why

Releases have been a recurring source of friction, so the team wrote a step-by-step manual in Notion covering both repos end to end. Nothing in this repo pointed at it.

## What changed

One line in `RELEASE.md`, under the two-track intro, linking the Notion manual.

Labeled "Apify employees" / "internal" because this repo is public and the page is not reachable from outside — same convention the file already uses for `apify/apify-mcp-server-internal`. The rest of the file is unchanged: the Notion page already links back here for the package-track detail, so the two cross-reference rather than duplicate.

## Notes for reviewers (human-written)

<!-- fill in -->

## Proof it works

- Fetched the target URL before linking it: it resolves, and the page title matches the link text ("How to release the Apify MCP server").
- `pnpm run check:agents` → `AGENTS.md link check passed (7 docs)`.

---

AI disclosure: drafted with Claude Code (Opus 5) — it verified the URL resolved, wrote the `RELEASE.md` line and this description. Docs-only change; no code touched.
