### PR TITLE
fix: Normalize judge verdict casing instead of erroring the item

### DIFF
--- a/evals/workflows/workflow_judge.ts
+++ b/evals/workflows/workflow_judge.ts
@@ -5,6 +5,7 @@
 
 // eslint-disable-next-line import/extensions
 import type { ResponseFormatJSONSchema } from 'openai/resources/shared';
+import { z } from 'zod';
 
 import { JUDGE_PROMPT_TEMPLATE, MODELS } from './config.js';
 import type { LlmClient } from './llm_client.js';
@@ -83,22 +84,26 @@ function formatConversationForJudge(conversation: ConversationHistory): string {
 }
 
 /**
+ * Judge output as it comes back over the wire. JUDGE_RESPONSE_SCHEMA asks for a strict
+ * schema, but that is only honoured by some OpenRouter providers, so normalize the
+ * casing the judge actually reached a verdict in rather than discard the item.
+ * Structure only: an unrecognized verdict stays an error, never a guess.
+ */
+const JudgeResponseValidator = z.object({
+    verdict: z
+        .string()
+        .trim()
+        .toUpperCase()
+        .pipe(z.enum(['PASS', 'FAIL'])),
+    reason: z.string().min(1),
+});
+
+/**
  * Parse structured JSON response from judge
  */
 function parseJudgeResponse(response: string): { verdict: 'PASS' | 'FAIL'; reason: string } {
     try {
-        const parsed = JSON.parse(response) as { verdict: 'PASS' | 'FAIL'; reason: string };
-
-        // Validate the structure (should be guaranteed by schema, but double-check)
-        if (!parsed.verdict || (parsed.verdict !== 'PASS' && parsed.verdict !== 'FAIL')) {
-            throw new Error(`Invalid verdict: ${parsed.verdict}`);
-        }
-
-        if (!parsed.reason || typeof parsed.reason !== 'string') {
-            throw new Error(`Invalid reason: ${parsed.reason}`);
-        }
-
-        return parsed;
+        return JudgeResponseValidator.parse(JSON.parse(response));
     } catch (error) {
         throw new Error(
             `Failed to parse judge JSON response: ${error instanceof Error ? error.message : String(error)}\n` +

--- a/tests/unit/evals.workflow_judge.test.ts
+++ b/tests/unit/evals.workflow_judge.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LlmClient } from '../../evals/workflows/llm_client.js';
+import type { WorkflowTestCase } from '../../evals/workflows/test_cases_loader.js';
+import type { ConversationHistory } from '../../evals/workflows/types.js';
+import { evaluateConversation } from '../../evals/workflows/workflow_judge.js';
+
+/** LLM client that returns one fixed judge response. */
+function makeJudgeClient(content: string): LlmClient {
+    return {
+        callLlm: async () => ({ content }),
+    } as unknown as LlmClient;
+}
+
+const testCase: WorkflowTestCase = {
+    id: 'test-1',
+    category: 'search',
+    query: 'find an actor',
+    reference: 'the agent should search',
+};
+
+const conversation: ConversationHistory = {
+    userPrompt: 'find an actor',
+    turns: [{ turnNumber: 1, toolCalls: [], toolResults: [], finalResponse: 'done' }],
+    completed: true,
+    hitMaxTurns: false,
+    totalTurns: 1,
+};
+
+describe('evaluateConversation()', () => {
+    it('normalizes a lowercase verdict instead of erroring the item', async () => {
+        const result = await evaluateConversation(
+            testCase,
+            conversation,
+            makeJudgeClient('{"verdict":"pass","reason":"the agent searched"}'),
+        );
+
+        expect(result.verdict).toBe('PASS');
+    });
+
+    it('rejects a verdict that is neither PASS nor FAIL', async () => {
+        await expect(
+            evaluateConversation(testCase, conversation, makeJudgeClient('{"verdict":"maybe","reason":"unclear"}')),
+        ).rejects.toThrow();
+    });
+
+    it('keeps the verdict when the judge returns an unknown extra key', async () => {
+        const result = await evaluateConversation(
+            testCase,
+            conversation,
+            makeJudgeClient('{"verdict":"PASS","reason":"the agent searched","confidence":0.9}'),
+        );
+
+        expect(result.verdict).toBe('PASS');
+    });
+});


### PR DESCRIPTION
Stack 3/5, splitting up #1205. Base: master (#1219 and #1221 have landed).

## Why

The judge requests a strict JSON schema (`JUDGE_RESPONSE_SCHEMA`, `strict: true`), but OpenRouter honours that only on some provider routes. When it is dropped, the judge still reaches a verdict - it just comes back as `"pass"` instead of `"PASS"`.

## What changed

`parseJudgeResponse` now validates with Zod, mirroring `WorkflowTestCaseValidator` in the loader:

## Scope

Casing and whitespace only, because that is the failure that was actually observed. Deliberately not handled: verdicts nested under a wrapper key, alternative key names, and prose-only responses. Those stay hard errors, and the thrown message still prints the raw response so the next occurrence identifies itself.

## Proof it works

Test added first, failing on the old code with the real defect:

Passes after the fix. Three cases cover it: lowercase normalizes to `PASS`, `"maybe"` still rejects, an unknown extra key keeps the verdict. Full gate passes.

workflow eval still run fine.

---
Written with Claude Code: it interviewed me on the design, wrote the test and fix, and ran the verification gate.