### PR TITLE
fix: Wire getApifyToken/getApifyApiBaseUrl through CaseCtx

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -177,6 +177,15 @@ Integration tests run against two purpose-built Actors defined in [apify/mcp-ser
 
 ### Test organization across repos
 
+**Why `CaseCtx` couples the two repos.** MCP contract tests (protocol, tools, prompts,
+resources) have one correct behavior regardless of who's hosting the server, so they
+live here once and internal imports them — no second copy to keep in sync. Internal
+keeps only what's genuinely deployment-specific: databases, rate limiting, auth,
+multi-node coordination. `CaseCtx` is the seam that makes sharing possible without
+merging the two codebases — it's a non-standard cross-repo dependency injection
+(each side supplies its own client/environment for the same case logic), accepted
+deliberately for this trade-off.
+
 This package is also used by the hosted server in `apify-mcp-server-internal`. Every integration case is a `Case` object (`{ name, isDeploymentTest, run, ... }`) defined in `tests/test_kit/cases/*.cases.ts` — published behind the package's `./test-kit` export (`vitest` optional peerDependency). This repo's own `suite.ts` runs every case via `registerCases(name, allGroupCases, ctx)`; internal imports the same case arrays via `@apify/actors-mcp-server/test-kit` and calls `registerCases(name, allCases, { ...ctx, isDeploymentTestOnly: true })` against its own live staging/prod deploy — cases with `isDeploymentTest: false` register as `it.skip` there, so nothing needs re-registering by hand.
 
 Cases that share expensive setup (one seeded Actor run, say) do it via `ctx.getFixture(fixture)` (`Fixture<T> = { key, setup(ctx) }`) instead of a vitest `beforeAll` — `setup` runs at most once per `registerCases` call (once per transport dimension), memoized by `fixture.key`, no matter how many or few of the cases sharing it actually run (e.g. under `isDeploymentTestOnly`). This is what lets `storage.cases.ts`'s 13 cases built on one seeded run stay ordinary, individually eligible-for-`isDeploymentTest` `Case` objects instead of a separate non-flattenable group. See `tests/test_kit/register.ts` and `storage.cases.ts`'s `normalModeRunFixture`.

--- a/src/apify_client.ts
+++ b/src/apify_client.ts
@@ -53,7 +53,8 @@ export class ApifyClient extends _ApifyClient {
         super({
             // token null case is handled, we can assert type here
             ...(clientOptions as ApifyClientOptions),
-            baseUrl: getApifyAPIBaseUrl(),
+            // Explicit baseUrl wins over env default.
+            baseUrl: clientOptions.baseUrl ?? getApifyAPIBaseUrl(),
             userAgentSuffix: USER_AGENT_ORIGIN,
             requestInterceptors: [(config) => ({ ...config, headers: { ...config.headers, ...staticHeaders } })],
         });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,17 +1,12 @@
-import type { Client as StatelessClient } from '@modelcontextprotocol/client';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { expect } from 'vitest';
 
-import { createMcpStatelessClient, createMcpStreamableClient, type SuiteClientOptions } from './test_kit/index.js';
+import type { SuiteClientOptions } from './test_kit/index.js';
 import { checkToken, resolveToken } from './test_kit/mcp_client.js';
 
-export { createMcpStatelessClient, createMcpStreamableClient };
-export type McpClientOptions = SuiteClientOptions;
-export type McpSuiteClient = Client | StatelessClient;
-
 /** stdio client for this repo's dist/stdio.js. Honors the shared `options.token` contract. */
-export async function createMcpStdioClient(options?: McpClientOptions): Promise<Client> {
+export async function createMcpStdioClient(options?: SuiteClientOptions): Promise<Client> {
     checkToken(options);
     const { actors, tools, useEnv, telemetry, serverMode, payment } = options || {};
     const args = ['dist/stdio.js'];

--- a/tests/integration/actor.server_stateless.test.ts
+++ b/tests/integration/actor.server_stateless.test.ts
@@ -5,7 +5,7 @@ import type { Express } from 'express';
 import log from '@apify/log';
 
 import { createExpressApp } from '../../src/dev_server.js';
-import { createMcpStatelessClient } from '../helpers.js';
+import { createMcpStatelessClient } from '../test_kit/index.js';
 import { createIntegrationTestsSuite } from './suite.js';
 import { getAvailablePort } from './utils/port.js';
 

--- a/tests/integration/actor.server_streamable.test.ts
+++ b/tests/integration/actor.server_streamable.test.ts
@@ -5,7 +5,7 @@ import type { Express } from 'express';
 import log from '@apify/log';
 
 import { createExpressApp } from '../../src/dev_server.js';
-import { createMcpStreamableClient } from '../helpers.js';
+import { createMcpStreamableClient } from '../test_kit/index.js';
 import { createIntegrationTestsSuite } from './suite.js';
 import { getAvailablePort } from './utils/port.js';
 

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe } from 'vitest';
 
-import type { McpClientOptions, McpSuiteClient } from '../helpers.js';
+import { ApifyClient } from '../../src/apify_client.js';
 import {
     actorsCases,
     appsCases,
@@ -11,12 +11,13 @@ import {
     tasksCases,
     toolsCases,
 } from '../test_kit/index.js';
-import type { CaseCtx, Transport } from '../test_kit/types.js';
+import type { SuiteClientOptions } from '../test_kit/index.js';
+import type { CaseCtx, SuiteClient, Transport } from '../test_kit/types.js';
 
 export type IntegrationTestsSuiteOptions = {
     suiteName: string;
     transport: Transport;
-    createClientFn: (options?: McpClientOptions) => Promise<McpSuiteClient>;
+    createClientFn: (options?: SuiteClientOptions) => Promise<SuiteClient>;
     beforeAllFn?: () => Promise<void>;
     afterAllFn?: () => Promise<void>;
     beforeEachFn?: () => Promise<void>;
@@ -42,6 +43,11 @@ export function createIntegrationTestsSuite(options: IntegrationTestsSuiteOption
             const ctx: Omit<CaseCtx, 'getFixture'> = {
                 createClientFn: createClientFn as CaseCtx['createClientFn'],
                 transport: options.transport,
+                createApifyClient: () =>
+                    new ApifyClient({
+                        token: process.env.APIFY_TOKEN as string,
+                        baseUrl: process.env.APIFY_API_BASE_URL,
+                    }),
             };
 
             registerCases('registration', registrationCases, ctx);

--- a/tests/test_kit/cases/actors.cases.ts
+++ b/tests/test_kit/cases/actors.cases.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest';
 
-import { actorNameToToolName, ApifyClient, getCategoryTools } from '@apify/actors-mcp-server/internals.js';
+import { actorNameToToolName, getCategoryTools } from '@apify/actors-mcp-server/internals.js';
 import { HELPER_TOOLS, MAX_LIMIT_WITH_INPUT_SCHEMA } from '@apify/actors-mcp-server/internals/test-kit.js';
 
 import {
@@ -934,8 +934,8 @@ export const actorsCases: Case[] = [
     {
         name: 'should return Actor details both for full Actor name and ID',
         isDeploymentTest: false,
-        run: withClient(undefined, async (client) => {
-            const apifyClient = new ApifyClient({ token: process.env.APIFY_TOKEN as string });
+        run: withClient(undefined, async (client, ctx) => {
+            const apifyClient = ctx.createApifyClient();
             const actor = await apifyClient.actor(ACTOR_NORMAL_MODE).get();
             expect(actor).toBeDefined();
             const actorId = actor!.id as string;
@@ -949,7 +949,10 @@ export const actorsCases: Case[] = [
             expect(contentByName[0].text).toContain(ACTOR_NORMAL_MODE);
 
             // Fetch by Actor ID only
-            const resultById = await client.callTool({ name: 'fetch-actor-details', arguments: { actor: actorId } });
+            const resultById = await client.callTool({
+                name: 'fetch-actor-details',
+                arguments: { actor: actorId },
+            });
             const contentById = resultById.content as { text: string }[];
             expect(contentById[0].text).toContain(ACTOR_NORMAL_MODE);
         }),

--- a/tests/test_kit/cases/payments.cases.ts
+++ b/tests/test_kit/cases/payments.cases.ts
@@ -1,15 +1,11 @@
+import type { Client as ClientV1 } from '@modelcontextprotocol/sdk/client/index.js';
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { expect } from 'vitest';
 
 import { HELPER_TOOLS, SKYFIRE_ENABLED_TOOLS } from '@apify/actors-mcp-server/internals/test-kit.js';
 
-import { ACTOR_EXAMPLE_MCP_SERVER, ACTOR_NORMAL_MODE, asLegacyClient } from '../helpers.js';
-import type { Case, CaseCtx } from '../types.js';
-
-// Payment modes need HTTP headers — never stdio.
-function skipOnStdio(ctx: CaseCtx): boolean {
-    return ctx.transport === 'stdio';
-}
+import { ACTOR_EXAMPLE_MCP_SERVER, ACTOR_NORMAL_MODE, skipOnStdio } from '../helpers.js';
+import type { Case } from '../types.js';
 
 /** Skyfire and x402 payment modes. */
 export const paymentsCases: Case[] = [
@@ -184,7 +180,7 @@ export const paymentsCases: Case[] = [
         run: async (ctx) => {
             const client = await ctx.createClientFn({ payment: 'x402' });
             try {
-                const stream = asLegacyClient(client).experimental.tasks.callToolStream(
+                const stream = (client as ClientV1).experimental.tasks.callToolStream(
                     { name: 'call-actor', arguments: { actor: ACTOR_EXAMPLE_MCP_SERVER, input: {} } },
                     CallToolResultSchema,
                     { task: { ttl: 60000 } },

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -19,13 +19,10 @@ import {
     RETIRED_SELECTORS,
     servedDefaultTools,
     servedDefaultToolNames,
+    skipUnlessStdio,
     withClient,
 } from '../helpers.js';
-import type { Case, CaseCtx } from '../types.js';
-
-function skipUnlessStdio(ctx: CaseCtx): boolean {
-    return ctx.transport !== 'stdio';
-}
+import type { Case } from '../types.js';
 
 const TWO_TEST_ACTORS = ['apify/python-example', 'apify/rag-web-browser'];
 const SINGLE_NORMAL_MODE_ACTOR = [ACTOR_NORMAL_MODE];

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -136,12 +136,22 @@ export const registrationCases: Case[] = [
     {
         name: 'should return tool with execution field when listing tools with apify/normal-mode-test-actor',
         isDeploymentTest: false,
-        run: withClient({ tools: SINGLE_NORMAL_MODE_ACTOR }, async (client) => {
+        run: withClient({ tools: SINGLE_NORMAL_MODE_ACTOR }, async (client, ctx) => {
             const tools = await client.listTools();
 
             // Find the tool for apify/normal-mode-test-actor
             const normalModeTool = tools.tools.find((tool) => tool.name === actorNameToToolName(ACTOR_NORMAL_MODE));
             expect(normalModeTool).toBeDefined();
+
+            // Verify the tool contains the execution field (as returned by getToolPublicFieldOnly).
+            // The 2026-07-28 codec strips `execution` as deleted vocabulary (no tasks capability there).
+            if (ctx.transport !== '2026-07-28') {
+                expect(normalModeTool).toHaveProperty('execution');
+                expect(normalModeTool?.execution).toBeDefined();
+            } else {
+                expect(normalModeTool).not.toHaveProperty('execution');
+            }
+
             expect(normalModeTool).toHaveProperty('name');
             expect(normalModeTool).toHaveProperty('description');
             expect(normalModeTool).toHaveProperty('inputSchema');

--- a/tests/test_kit/cases/tasks.cases.ts
+++ b/tests/test_kit/cases/tasks.cases.ts
@@ -2,7 +2,7 @@ import type { Client as ClientV1 } from '@modelcontextprotocol/sdk/client/index.
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { expect } from 'vitest';
 
-import { actorNameToToolName, ApifyClient } from '@apify/actors-mcp-server/internals.js';
+import { actorNameToToolName } from '@apify/actors-mcp-server/internals.js';
 import { HELPER_TOOLS } from '@apify/actors-mcp-server/internals/test-kit.js';
 
 import {
@@ -30,7 +30,7 @@ export const tasksCases: Case[] = [
             // Load the Actor at connection time — add-actor's dynamic add is gone (PR 0).
             const client = (await ctx.createClientFn({ actors: [ACTOR_NORMAL_MODE] })) as ClientV1;
             try {
-                const api = new ApifyClient({ token: process.env.APIFY_TOKEN as string });
+                const api = ctx.createApifyClient();
                 const controller = new AbortController();
                 const { onprogress, runIdPromise } = captureRunIdFromProgress();
                 const requestPromise = client
@@ -67,7 +67,7 @@ export const tasksCases: Case[] = [
         run: async (ctx) => {
             const client = (await ctx.createClientFn({ tools: ['actors'] })) as ClientV1;
             try {
-                const api = new ApifyClient({ token: process.env.APIFY_TOKEN as string });
+                const api = ctx.createApifyClient();
                 const controller = new AbortController();
                 const { onprogress, runIdPromise } = captureRunIdFromProgress();
                 const requestPromise = client
@@ -229,7 +229,7 @@ export const tasksCases: Case[] = [
         run: async (ctx) => {
             const client = (await ctx.createClientFn({ tools: [ACTOR_NORMAL_MODE] })) as ClientV1;
             try {
-                const api = new ApifyClient({ token: process.env.APIFY_TOKEN as string });
+                const api = ctx.createApifyClient();
                 const { onprogress, runIdPromise } = captureRunIdFromProgress();
 
                 const stream = client.experimental.tasks.callToolStream(

--- a/tests/test_kit/cases/tools.cases.ts
+++ b/tests/test_kit/cases/tools.cases.ts
@@ -1,3 +1,4 @@
+import type { Client as ClientV1 } from '@modelcontextprotocol/sdk/client/index.js';
 import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { expect } from 'vitest';
 
@@ -5,17 +6,13 @@ import { CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG, HELPER_TOOLS } from '@apify/actor
 
 import {
     ACTOR_EXAMPLE_MCP_SERVER,
-    asLegacyClient,
     buildExampleMcpServerAddToolContent,
     getToolNames,
+    skipUnlessLegacyHttp,
     validateStructuredOutputForTool,
     withClient,
 } from '../helpers.js';
-import type { Case, CaseCtx } from '../types.js';
-
-function skipUnlessLegacyHttp(ctx: CaseCtx): boolean {
-    return ctx.transport !== '2025-11-25';
-}
+import type { Case } from '../types.js';
 
 /** Protocol/tool behavior: prompts, docs, report-problem, schemas, MCP passthrough. */
 export const toolsCases: Case[] = [
@@ -180,7 +177,7 @@ export const toolsCases: Case[] = [
         run: withClient(undefined, async (client) => {
             await client.listTools();
             await expect(
-                (asLegacyClient(client).transport as StreamableHTTPClientTransport).terminateSession(),
+                ((client as ClientV1).transport as StreamableHTTPClientTransport).terminateSession(),
             ).resolves.toBeUndefined();
         }),
     },

--- a/tests/test_kit/helpers.ts
+++ b/tests/test_kit/helpers.ts
@@ -19,11 +19,13 @@ import {
     toolCategoriesEnabledByDefault,
 } from '@apify/actors-mcp-server/internals/test-kit.js';
 
-import type { CaseCtx, SuiteClient } from './types.js';
+import type { CaseCtx, SuiteClient, Transport } from './types.js';
 
 // Live fixtures from apify/mcp-server-test-actor (see DEVELOPMENT.md).
 export const ACTOR_NORMAL_MODE = 'apify/normal-mode-test-actor';
 export const ACTOR_EXAMPLE_MCP_SERVER = 'apify/example-mcp-server';
+
+const STDIO_TRANSPORT: Transport = 'stdio';
 
 export const RETIRED_SELECTORS = ['add-actor', 'experimental', 'preview'] as const;
 export const AUTO_INJECTED_TOOL_NAMES = AUTO_INJECTED_TOOLS.map((t) => t.name);
@@ -57,9 +59,19 @@ export function withClient(
     };
 }
 
-/** Cast to v1 SDK client (legacy dimensions only). */
-export function asLegacyClient(client: SuiteClient): ClientV1 {
-    return client as ClientV1;
+/** Skip unless transport is legacy streamable HTTP (`2025-11-25`). */
+export function skipUnlessLegacyHttp(ctx: CaseCtx): boolean {
+    return ctx.transport !== '2025-11-25';
+}
+
+/** Skip on stdio. */
+export function skipOnStdio(ctx: CaseCtx): boolean {
+    return ctx.transport === STDIO_TRANSPORT;
+}
+
+/** Skip on every transport except stdio. */
+export function skipUnlessStdio(ctx: CaseCtx): boolean {
+    return ctx.transport !== STDIO_TRANSPORT;
 }
 
 export function getToolNames(tools: { tools: { name: string }[] }): string[] {
@@ -134,6 +146,7 @@ export function expectWidgetToolMeta(tools: { tools: { name: string; _meta?: Rec
         HELPER_TOOLS.STORE_SEARCH_WIDGET,
         HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET,
         HELPER_TOOLS.ACTOR_CALL_WIDGET,
+        HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET,
     ];
     for (const toolName of toolNames) {
         const tool = tools.tools.find((t) => t.name === toolName);

--- a/tests/test_kit/index.ts
+++ b/tests/test_kit/index.ts
@@ -6,7 +6,13 @@ export { createMcpStatelessClient, createMcpStreamableClient } from './mcp_clien
 export type { SuiteClientOptions } from './mcp_client.js';
 export { registerCases } from './register.js';
 export type { Case, CaseCtx, Fixture, SuiteClient, Transport } from './types.js';
-export { withClient } from './helpers.js';
+export {
+    expectNormalModeTestStructuredContent,
+    expectToolNamesToContain,
+    expectWidgetToolMeta,
+    getToolNames,
+    withClient,
+} from './helpers.js';
 
 export { actorsCases } from './cases/actors.cases.js';
 export { appsCases } from './cases/apps.cases.js';

--- a/tests/test_kit/types.ts
+++ b/tests/test_kit/types.ts
@@ -1,6 +1,8 @@
 import type { Client as ClientV2 } from '@modelcontextprotocol/client';
 import type { Client as ClientV1 } from '@modelcontextprotocol/sdk/client/index.js';
 
+import type { ApifyClient } from '@apify/actors-mcp-server/internals.js';
+
 import type { SuiteClientOptions } from './mcp_client.js';
 
 /** v1 or v2 MCP SDK client. */
@@ -21,6 +23,12 @@ export interface CaseCtx {
     isDeploymentTestOnly?: boolean;
     /** Memoized fixture setup — once per `registerCases` call, keyed by `fixture.key`. */
     getFixture: <T>(fixture: Fixture<T>) => Promise<T>;
+    /**
+     * Direct `ApifyClient` for verification calls (not the MCP client's own token).
+     * Each repo supplies its own token/baseUrl — never exposed separately so staging/local
+     * tokens can't silently hit `api.apify.com`.
+     */
+    createApifyClient: () => ApifyClient;
 }
 
 /** Value shared across cases via `ctx.getFixture`. */

--- a/tests/unit/apify_client.test.ts
+++ b/tests/unit/apify_client.test.ts
@@ -1,7 +1,4 @@
-/**
- * Tests for the extended ApifyClient options — request origin forwarding as a static header
- * on outbound Apify API requests.
- */
+/** ApifyClient: request-origin header + baseUrl override. */
 import { describe, expect, it, vi } from 'vitest';
 
 import { ApifyClient, REQUEST_ORIGIN } from '../../src/apify_client.js';
@@ -19,6 +16,7 @@ vi.mock('apify-client', () => ({
 type RequestConfig = { headers: Record<string, string> };
 type CapturedClientOptions = {
     requestInterceptors: ((config: RequestConfig) => RequestConfig)[];
+    baseUrl: string;
 };
 
 /** Builds a client and runs its request interceptor to get the headers sent with every request. */
@@ -27,6 +25,13 @@ function buildStaticHeaders(options: ConstructorParameters<typeof ApifyClient>[0
     void new ApifyClient(options);
     const passed = capturedOptions[0] as CapturedClientOptions;
     return passed.requestInterceptors[0]({ headers: {} }).headers;
+}
+
+/** baseUrl passed to the underlying apify-client. */
+function buildBaseUrl(options: ConstructorParameters<typeof ApifyClient>[0]): string {
+    capturedOptions.length = 0;
+    void new ApifyClient(options);
+    return (capturedOptions[0] as CapturedClientOptions).baseUrl;
 }
 
 describe('ApifyClient', () => {
@@ -47,5 +52,18 @@ describe('ApifyClient', () => {
         });
         expect(headers['skyfire-pay-id']).toBe('jwt-token-123');
         expect(headers['X-Apify-Request-Origin']).toBe('APIFY_AI');
+    });
+
+    it('explicit baseUrl wins over env default', () => {
+        const original = process.env.APIFY_API_BASE_URL;
+        process.env.APIFY_API_BASE_URL = 'https://api.apify.com';
+        try {
+            expect(buildBaseUrl({ token: 'test-token', baseUrl: 'http://localhost:3333' })).toBe(
+                'http://localhost:3333',
+            );
+        } finally {
+            if (original === undefined) delete process.env.APIFY_API_BASE_URL;
+            else process.env.APIFY_API_BASE_URL = original;
+        }
     });
 });


### PR DESCRIPTION
Closes #776

**Cross-repo:** ships with apify-mcp-server-internal PR chain [#709](https://github.com/apify/apify-mcp-server-internal/pull/709) → [#724](https://github.com/apify/apify-mcp-server-internal/pull/724) → [#725](https://github.com/apify/apify-mcp-server-internal/pull/725) — merge this chain first, internal depends on it.

**Chain:** [PR1: Case-model architecture](https://github.com/apify/apify-mcp-server/pull/1202) → **PR2 (this)**.

## What

Two real bugs in the direct-`ApifyClient` polling path (`waitForRunAborted`,
run-status checks), found once internal ran these cases against its own dev
platform instead of production.

## Why

- **Token**: 4 call sites read `process.env.APIFY_TOKEN` directly instead of
  the case's own token — silently unauthenticated under internal, 180s hang
  instead of a clear failure.
- **BaseUrl**: same call sites had no environment override, always resolving
  to production. First fix attempt was a no-op — `ApifyClient`'s wrapper
  discarded any caller-supplied `baseUrl`; fixed in the same commit.

Both are required on `CaseCtx`, not defaulted — a missing wire-up is a
compile error, not a silent wrong-environment call. Superseded below by
`createApifyClient`.

## Review follow-ups (rebased from #1202, all addressed)

- **createApifyClient**: collapsed the two always-together getters
  (`getApifyToken`/`getApifyApiBaseUrl`) into one `ctx.createApifyClient()`
  factory — keeps token+baseUrl together, stops exposing the raw token to
  case code. `DEVELOPMENT.md` documents why `CaseCtx` couples the two repos
  at all (MCP contract tests live here once; internal keeps only
  deployment-specific concerns).
- **Renames + dead field**: rebased onto #1202's `isDeploymentTest` rename;
  found and fixed a real regression mid-rebase (this branch's own
  `createApifyClient` commit had silently dropped `CaseCtx.hasTasksSupport`)
  before removing it again cleanly once confirmed dead.
- **stdio coverage regressions**: rebased onto #1202's two stdio-coverage
  fixes, one conflict resolved keeping both sides.
- **Real npm-install packaging bug**: rebased onto #1202's `internals.js`
  routing fix — this branch's own `createApifyClient()` call sites needed
  the same self-reference-import treatment; one extra leftover
  (`tests/test_kit/types.ts`'s relative `src/apify_client.js` import,
  introduced by this branch's own commit after #1202's fix landed) found and
  fixed in the same rebase.
- **8 code-review nits**: rebased onto #1202's fixes; also converted this
  branch's own `withClient(...)(ctx)` nested-invocation call site
  (`ctx.createApifyClient()` in `actors.cases.ts`) to the new direct
  `(client, ctx)` form.
- **execution-field assertion**: `registration.cases.ts`'s "execution field"
  case lost its transport-conditional check when `hasTasksSupport` was
  removed — the `2026-07-28` codec strips the field entirely, every other
  transport must still expose it. Restored the same branch, now keyed
  directly off `ctx.transport` instead of the removed field.

## Testing

`type-check`, `lint`, `format`, unit suite green after every rebase,
including live CI (Integration tests job).

## AI disclosure

Written with AI assistance (Poisson/Claude); reviewed and directed throughout.
