### PR TITLE
chore(mcp): Stop declaring tools.listChanged capability

### DIFF
--- a/res/integration_test_coverage_audit.md
+++ b/res/integration_test_coverage_audit.md
@@ -13,7 +13,7 @@ Audit of `tests/integration/suite.ts` against the MCP 2025-11-25 spec and the re
 `src/mcp/server.ts:146` advertises:
 
 ```
-tools: { listChanged: true }
+tools: {}
 tasks: { list, cancel, requests.tools.call }
 resources: {}
 prompts: {}
@@ -99,7 +99,7 @@ it('should expose serverInfo, instructions and capabilities on initialize', ...)
 //   const caps = client.getServerCapabilities();
 //   const instr = client.getInstructions();
 //   assert: name=SERVER_NAME, version matches package.json, instructions length>0,
-//           caps has tools.listChanged, tasks.{list,cancel,requests.tools.call},
+//           caps has tools, tasks.{list,cancel,requests.tools.call},
 //           resources, prompts, logging declared.
 
 it('should respond to ping', ...)

--- a/res/integration_test_coverage_audit.md
+++ b/res/integration_test_coverage_audit.md
@@ -47,14 +47,14 @@ Every advertised capability MUST have a working integration path.
 | `logging/setLevel` | `legacy_server.ts:222` | **Missing** (no integration test sets a level) |
 | `notifications/message` filtered by level | `setupLoggingProxy` `legacy_server.ts:208` | **Missing** — no test asserts filtering behaves |
 | `ping` | SDK default | **Missing** (cheap; one-liner per transport) |
-| Streamable HTTP `Mcp-Session-Id` round trip | `dev_server.ts:184` | Implicit (client SDK uses it) |
-| Streamable HTTP `DELETE /` terminate | `dev_server.ts:277` | Covered (`terminateSession`) |
-| Streamable HTTP `GET /` returns 405 | `dev_server.ts:271` | **Missing** — pure HTTP assertion, no MCP client |
-| Reusing transport across requests in one session | `dev_server.ts:187` | Implicit |
+| Streamable HTTP `Mcp-Session-Id` round trip | `dev_server.ts:283` (read), `:337` (`sessionIdGenerator`) | Implicit (client SDK uses it) |
+| Streamable HTTP `DELETE /` terminate | `dev_server.ts:412` | Covered (`terminateSession`) |
+| Streamable HTTP `GET /` opens the session SSE stream (404 on unknown session) | `dev_server.ts:392` | **Missing** — pure HTTP assertion, no MCP client |
+| Reusing transport across requests in one session | `dev_server.ts:287` | Implicit |
 | Two concurrent sessions are isolated (tools, tasks, log level) | per-session `mcpServers[]` map | **Missing** — no parallel client test |
 | 401/403 when `APIFY_TOKEN` missing | implicit (Apify API) | **Missing** at transport layer |
-| Bad request: POST without session, not initialize → 404 | `dev_server.ts:244` | **Missing** |
-| SSE legacy: GET /sse → POST /message round trip | `dev_server.ts:64`, `:137` | Implicit (suite runs over SSE) |
+| Bad request: POST without session, not initialize → 400; unknown session id → 404 | `dev_server.ts:352`, `:364` | **Missing** |
+| SSE legacy: GET /sse → POST /message round trip | routes removed — `dev_server.ts` serves only `/` | Not applicable |
 | Server `instructions` text returned in `initialize` | `legacy_server.ts:178` (`getServerInstructions` `server.ts:277`) | **Missing** |
 | `ActorRun` widget structuredContent | get-actor-run | Covered |
 | `_meta.usageTotalUsd / usageUsd` | call-actor | Covered |
@@ -76,7 +76,7 @@ Ranked by blast radius if broken:
 5. **Initialize round-trip** — no test asserts `serverInfo.name`, `serverInfo.version`, `instructions`, and the declared `capabilities` block. A bad bump of capability shape breaks every client without any test catching it.
 6. **Session isolation (streamable-http)** — `mcpServers[sessionId]` is a Map; `taskStore` is shared. If two clients open sessions in parallel, A's `loadToolsFromUrl(actors=X)` must not affect B (`actors=Y`), and A's `tasks/list` must not see B's tasks. Today nothing exercises this and a regression here corrupts hosted multi-tenant traffic.
 7. **`prompts/get` error paths** — the invalid-name and invalid-args branches behind `legacy_server.ts:262` are dead code as far as tests are concerned.
-8. **Streamable-HTTP HTTP-level assertions** — `GET /` → 405 and `POST /` without `Mcp-Session-Id` and not init → 404. These are explicit branches in `dev_server.ts:244,271`. Cheap to assert, currently absent.
+8. **Streamable-HTTP HTTP-level assertions** — `GET /` → session SSE stream, 404 on unknown session, and `POST /` without `Mcp-Session-Id` and not init → 400. These are explicit branches in `dev_server.ts:352,392`. Cheap to assert, currently absent.
 
 ## Out of scope (deliberately not adding)
 

--- a/res/integration_test_coverage_audit.md
+++ b/res/integration_test_coverage_audit.md
@@ -1,6 +1,6 @@
 # Integration test coverage audit
 
-Audit of `tests/integration/suite.ts` against the MCP 2025-11-25 spec and the request handlers actually wired in `src/mcp/server.ts` and `src/dev_server.ts`. Goal: identify protocol-level gaps that block confident deploys, without duplicating SDK or unit tests.
+Audit of `tests/integration/suite.ts` against the MCP 2025-11-25 spec and the request handlers actually wired in `src/mcp/legacy_server.ts` and `src/dev_server.ts`. Goal: identify protocol-level gaps that block confident deploys, without duplicating SDK or unit tests.
 
 ## Scope rule
 
@@ -10,7 +10,7 @@ Audit of `tests/integration/suite.ts` against the MCP 2025-11-25 spec and the re
 
 ## What we declare in `initialize`
 
-`src/mcp/server.ts:146` advertises:
+`src/mcp/legacy_server.ts:124` advertises:
 
 ```
 tools: {}
@@ -26,26 +26,26 @@ Every advertised capability MUST have a working integration path.
 
 | Capability / surface | Handler | Integration test |
 |---|---|---|
-| `initialize` → `serverInfo`, `instructions`, `capabilities`, `protocolVersion` | SDK + `setupCapabilityNegotiation` `server.ts:208` | **Missing** |
-| `tools/list` | `server.ts:619` | Covered (~30 cases) |
-| `tools/list` `_meta` (MCP Apps `ui.*`) | `server.ts:619` + `expectWidgetToolMeta` | Covered (uiMode openai) |
-| `tools/call` happy path | `server.ts:633` | Covered |
-| `tools/call` AJV validation error | `server.ts:633` | One case (`'must have required property input'`) |
-| `tools/call` unknown tool name → JSON-RPC error | `server.ts:633` | **Missing** |
+| `initialize` → `serverInfo`, `instructions`, `capabilities`, `protocolVersion` | SDK + `legacy_server.ts:171` (delegates to `applyInitialize` `server.ts:248`) | **Missing** |
+| `tools/list` | `legacy_server.ts:364` | Covered (~30 cases) |
+| `tools/list` `_meta` (MCP Apps `ui.*`) | `legacy_server.ts:364` + `expectWidgetToolMeta` | Covered (uiMode openai) |
+| `tools/call` happy path | `legacy_server.ts:378` | Covered |
+| `tools/call` AJV validation error | `legacy_server.ts:378` | One case (`'must have required property input'`) |
+| `tools/call` unknown tool name → JSON-RPC error | `legacy_server.ts:378` | **Missing** |
 | `tools/call` returning `isError: true` content | several | One case (`fetch-apify-docs` forbidden URL) |
 | `notifications/tools/list_changed` | No MCP tool mutates the tool list | Not applicable |
 | `notifications/cancelled` for `tools/call` | SDK abort wiring | Covered (streamable-http only) |
-| `notifications/progress` (`progressToken` on call) | `server.ts:637` + `createProgressTracker` | **Missing** — server emits, no test asserts client receives them |
-| `tasks/list` / `tasks/get` / `tasks/cancel` / `tasks/result` | `server.ts:524` | Covered (sync stream, list+get+result, cancel, statusMessage) |
-| `resources/list` | `server.ts:464` | **Missing in integration** (only unit) |
-| `resources/read` | `server.ts:468` | **Missing in integration** |
-| `resources/templates/list` | `server.ts:472` | **Missing in integration** |
-| `prompts/list` | `server.ts:484` | One case (count > 0) |
-| `prompts/get` happy path | `server.ts:491` | One case (`GetLatestNewsOnTopic`) |
-| `prompts/get` invalid name → InvalidParams | `server.ts:495` | **Missing** |
-| `prompts/get` invalid args (AJV) → InvalidParams | `server.ts:500` | **Missing** |
-| `logging/setLevel` | `server.ts:447` | **Missing** (no integration test sets a level) |
-| `notifications/message` filtered by level | `setupLoggingProxy` `server.ts:~430` | **Missing** — no test asserts filtering behaves |
+| `notifications/progress` (`progressToken` on call) | `legacy_server.ts:383` + `createProgressTracker` | **Missing** — server emits, no test asserts client receives them |
+| `tasks/list` / `tasks/get` / `tasks/cancel` / `tasks/result` | `legacy_server.ts:291` | Covered (sync stream, list+get+result, cancel, statusMessage) |
+| `resources/list` | `legacy_server.ts:235` | **Missing in integration** (only unit) |
+| `resources/read` | `legacy_server.ts:239` | **Missing in integration** |
+| `resources/templates/list` | `legacy_server.ts:250` | **Missing in integration** |
+| `prompts/list` | `legacy_server.ts:261` | One case (count > 0) |
+| `prompts/get` happy path | `legacy_server.ts:262` | One case (`GetLatestNewsOnTopic`) |
+| `prompts/get` invalid name → InvalidParams | `legacy_server.ts:262` | **Missing** |
+| `prompts/get` invalid args (AJV) → InvalidParams | `legacy_server.ts:262` | **Missing** |
+| `logging/setLevel` | `legacy_server.ts:222` | **Missing** (no integration test sets a level) |
+| `notifications/message` filtered by level | `setupLoggingProxy` `legacy_server.ts:208` | **Missing** — no test asserts filtering behaves |
 | `ping` | SDK default | **Missing** (cheap; one-liner per transport) |
 | Streamable HTTP `Mcp-Session-Id` round trip | `dev_server.ts:184` | Implicit (client SDK uses it) |
 | Streamable HTTP `DELETE /` terminate | `dev_server.ts:277` | Covered (`terminateSession`) |
@@ -55,12 +55,12 @@ Every advertised capability MUST have a working integration path.
 | 401/403 when `APIFY_TOKEN` missing | implicit (Apify API) | **Missing** at transport layer |
 | Bad request: POST without session, not initialize → 404 | `dev_server.ts:244` | **Missing** |
 | SSE legacy: GET /sse → POST /message round trip | `dev_server.ts:64`, `:137` | Implicit (suite runs over SSE) |
-| Server `instructions` text returned in `initialize` | `server.ts:168` (`getServerInstructions`) | **Missing** |
+| Server `instructions` text returned in `initialize` | `legacy_server.ts:178` (`getServerInstructions` `server.ts:277`) | **Missing** |
 | `ActorRun` widget structuredContent | get-actor-run | Covered |
 | `_meta.usageTotalUsd / usageUsd` | call-actor | Covered |
 | Actorized MCP proxy (server-as-tool) | `mcp/proxy.ts` | Covered (add + call) |
 | call-actor `actor:tool` syntax routing | `mcp/proxy.ts` | Covered |
-| `apifyToken` propagation via `_meta.apifyToken` | `server.ts:638` | **Missing** (only `Authorization` header path is tested) |
+| `apifyToken` propagation via `_meta.apifyToken` | `legacy_server.ts:384` | **Missing** (only `Authorization` header path is tested) |
 | Payment x402 / skyfire flag injection | covered | Covered (streamable-http only) |
 | OpenAI / `ui=true` / `ui=openai` mode wiring | covered | Covered |
 | Telemetry env-var precedence | covered | Covered |
@@ -75,7 +75,7 @@ Ranked by blast radius if broken:
 4. **`tools/call` unknown name** — should return JSON-RPC `MethodNotFound`/`InvalidParams`, not 500. Currently untested; an exception path change would slip through.
 5. **Initialize round-trip** — no test asserts `serverInfo.name`, `serverInfo.version`, `instructions`, and the declared `capabilities` block. A bad bump of capability shape breaks every client without any test catching it.
 6. **Session isolation (streamable-http)** — `mcpServers[sessionId]` is a Map; `taskStore` is shared. If two clients open sessions in parallel, A's `loadToolsFromUrl(actors=X)` must not affect B (`actors=Y`), and A's `tasks/list` must not see B's tasks. Today nothing exercises this and a regression here corrupts hosted multi-tenant traffic.
-7. **`prompts/get` error paths** — invalid name and invalid args branches in `server.ts:495`/`:500` are dead code as far as tests are concerned.
+7. **`prompts/get` error paths** — the invalid-name and invalid-args branches behind `legacy_server.ts:262` are dead code as far as tests are concerned.
 8. **Streamable-HTTP HTTP-level assertions** — `GET /` → 405 and `POST /` without `Mcp-Session-Id` and not init → 404. These are explicit branches in `dev_server.ts:244,271`. Cheap to assert, currently absent.
 
 ## Out of scope (deliberately not adding)

--- a/res/integration_test_coverage_plan.md
+++ b/res/integration_test_coverage_plan.md
@@ -13,7 +13,7 @@ PR title format follows Conventional Commits (≤70 chars). Branch `test/<slug>`
 **Scope**: Block A + Block E from the audit. Lock down what the server returns at `initialize` time and what the unhappy paths of `tools/call` and `prompts/get` look like.
 
 **Test cases (all in `tests/integration/suite.ts`):**
-1. `should expose serverInfo, instructions and declared capabilities on initialize` — assert `client.getServerVersion().name === SERVER_NAME`, version matches `package.json`, `getInstructions()` non-empty, `getServerCapabilities()` contains `tools.listChanged`, `tasks.{list,cancel,requests.tools.call}`, `resources`, `prompts`, `logging`.
+1. `should expose serverInfo, instructions and declared capabilities on initialize` — assert `client.getServerVersion().name === SERVER_NAME`, version matches `package.json`, `getInstructions()` non-empty, `getServerCapabilities()` contains `tools`, `tasks.{list,cancel,requests.tools.call}`, `resources`, `prompts`, `logging`.
 2. `should respond to ping` — `await client.ping()` does not throw.
 3. `should return JSON-RPC error for tools/call with unknown tool name` — expect rejection with code/message indicating not found.
 4. `should return InvalidParams for prompts/get with unknown name` — assert `error.code === ErrorCode.InvalidParams`.

--- a/res/integration_test_coverage_plan.md
+++ b/res/integration_test_coverage_plan.md
@@ -29,7 +29,7 @@ PR title format follows Conventional Commits (≤70 chars). Branch `test/<slug>`
 ## PR 2 — `test: Add resources/list, templates, and read end-to-end tests`
 
 **Branch**: `test/resources-end-to-end`
-**Scope**: Block B. Today only unit tests touch `resource_service`; nothing verifies the request handlers in `server.ts:464,468,472` are wired.
+**Scope**: Block B. Today only unit tests touch `resource_service`; nothing verifies the request handlers in `legacy_server.ts:235,239,250` are wired.
 
 **Test cases (all in `tests/integration/suite.ts`):**
 1. `should list resources via resources/list` — `await client.listResources()`; assert `Array.isArray(resources)`. Run a second client with `uiMode: 'openai'`; assert at least one resource URI starts with `ui://` (widget).
@@ -84,7 +84,7 @@ In `tests/integration/suite.ts` (gated `runIf(streamable-http)`):
 ## PR 5 — `test: Add _meta.apifyToken propagation tests` (optional / lower priority)
 
 **Branch**: `test/meta-apify-token-propagation`
-**Scope**: Block H. The hosted server relies on `_meta.apifyToken` arriving in `tools/call` params (`server.ts:638`). Currently no test exercises this path; only the bearer header / env-var paths are covered.
+**Scope**: Block H. The hosted server relies on `_meta.apifyToken` arriving in `tools/call` params (`legacy_server.ts:384`). Currently no test exercises this path; only the bearer header / env-var paths are covered.
 
 **Helper change** — `tests/helpers.ts`:
 - Add an `omitToken?: boolean` flag to `McpClientOptions`. When set: `createMcpStdioClient` does not put `APIFY_TOKEN` in the spawned env, and the streamable-http variant does not send the `Authorization` header. ~10 lines.

--- a/res/mcp_resources_analysis.md
+++ b/res/mcp_resources_analysis.md
@@ -7,7 +7,7 @@ The current MCP resources implementation is intentionally minimal and uses the l
 ## Current Architecture Overview
 
 ### MCP Server Structure
-- **ActorsMcpServer** (`src/mcp/server.ts`) wraps the low-level MCP `Server`.
+- **ActorsMcpServer** (`src/mcp/server.ts`) delegates v1 protocol work to **LegacyMcpServer** (`src/mcp/legacy_server.ts`), which wraps the low-level MCP `Server`.
 - Resources are declared in capabilities (empty object) to prevent failures in clients that expect resource support.
 - Resource handling is implemented via `setRequestHandler` for:
   - `ListResourcesRequestSchema`
@@ -35,7 +35,7 @@ No templates are currently provided. `ListResourceTemplatesRequestSchema` always
 - **Keep resource handling explicit**: Resource listing and reading must be handled via request handlers.
 - **No new resources in this phase**: Only existing resources are in scope (Skyfire usage guide and UI widgets).
 
-The `setupResourceHandlers` wiring lives in `src/mcp/server.ts` and delegates list/read to
+The `setupResourceHandlers` wiring lives in `src/mcp/legacy_server.ts:232` and delegates list/read to
 `src/resources/resource_service.ts`.
 
 ## Not implemented

--- a/res/mcp_task_reference.md
+++ b/res/mcp_task_reference.md
@@ -190,6 +190,7 @@ interface CallToolResult {
 - `resources` — widgets + readme only, no dynamic resources
 - `prompts` — 1 helper prompt (`latest-news-on-topic`)
 - `logging` — proxy with filtering
+- The block above is the legacy (2025-11-25) era; the 2026-07-28 stateless era declares only `tools`, `resources` and `prompts` — no `tasks`, no `logging`
 
 ## Related Issues
 

--- a/res/mcp_task_reference.md
+++ b/res/mcp_task_reference.md
@@ -177,7 +177,7 @@ interface CallToolResult {
 
 ```typescript
 {
-    tools: { listChanged: true },
+    tools: {},
     tasks: { list: {}, cancel: {}, requests: { tools: { call: {} } } },
     resources: {},
     prompts: {},
@@ -185,7 +185,7 @@ interface CallToolResult {
 }
 ```
 
-- `tools.listChanged` — retained in the advertised legacy capability; no MCP tool mutates the tool list
+- `tools` — declared with no sub-capabilities; no MCP tool mutates the tool list
 - `tasks` — full implementation (create, get, result, cancel, list)
 - `resources` — widgets + readme only, no dynamic resources
 - `prompts` — 1 helper prompt (`latest-news-on-topic`)

--- a/res/mcp_task_reference.md
+++ b/res/mcp_task_reference.md
@@ -71,7 +71,7 @@ interface TaskStore {
 
 ### How Our Server Implements Tasks
 
-**Location**: `src/mcp/server.ts` → `executeToolAndUpdateTask()`
+**Location**: `src/mcp/task_execution.ts` → `executeToolAndUpdateTask()`
 
 1. Tool call with `task` params → server creates task via `taskStore.createTask()`
 2. Returns `{ task }` immediately to client

--- a/res/tasks_cancel_abort_flow.md
+++ b/res/tasks_cancel_abort_flow.md
@@ -71,7 +71,7 @@ sequenceDiagram
     Server->>Store: post-run isTaskCancelled check<br/>(skip result storage only)
 ```
 
-The post-run `isTaskCancelled` check (`src/mcp/server.ts`, see `isTaskCancelled`) mitigated
+The post-run `isTaskCancelled` check (`src/mcp/task_execution.ts`, see `isTaskCancelled`) mitigated
 the *result-storage* half (we don't return data for a cancelled task) but did nothing about
 the *compute-consumption* half.
 
@@ -120,10 +120,11 @@ sequenceDiagram
 ```
 
 `cancelWatcher.signal` replaces `extra.signal` at the two places where the in-flight
-execution observes cancellation (`src/mcp/server.ts`):
+execution observes cancellation (`src/mcp/task_execution.ts:265` passes it to `dispatchToolCall` as
+`signal`, which `src/mcp/tool_dispatch.ts` threads on):
 
-- internal-tool branch — `taskExtra = { ...extra, signal: cancelWatcher.signal }`
-- direct-actor-tool branch — `abortSignal: cancelWatcher.signal`
+- internal-tool branch — `signal` in the `tool.call({ … })` args (`tool_dispatch.ts:105`)
+- direct-actor-tool branch — `abortSignal: signal` (`tool_dispatch.ts:248`)
 
 Both funnel into `waitForRunWithProgress`, whose `raceAbort` reacts to the signal and calls
 `onAbort` (`abortRunOnSignal`) → `apifyClient.run(runId).abort()`.
@@ -200,7 +201,7 @@ Two extra defenses live inside `createTaskCancellationWatcher`:
 | Path | Role |
 |---|---|
 | `src/mcp/utils.ts` — `createTaskCancellationWatcher` | The polling watcher. Bridges TaskStore status → AbortSignal. |
-| `src/mcp/server.ts` — `executeToolAndUpdateTask` | Constructs the watcher per task; threads `cancelWatcher.signal` into the internal-tool (`taskExtra`) and direct-actor-tool (`abortSignal`) branches; `cancelWatcher.dispose()` in `finally`; `isTaskCancelled` post-run check. |
+| `src/mcp/task_execution.ts` — `executeToolAndUpdateTask` | Constructs the watcher per task; passes `cancelWatcher.signal` to `dispatchToolCall`, which threads it into the internal-tool (`signal`) and direct-actor-tool (`abortSignal`) branches; `cancelWatcher.dispose()` in `finally`; `isTaskCancelled` post-run check. |
 | `src/tools/core/actor_run_response.ts` — `waitForRunWithProgress`, `raceAbort`, `abortRunOnSignal` | Races platform calls against the abort signal and aborts the run via `onAbort`. |
 | `tests/unit/mcp.utils.test.ts` | Unit tests for the watcher (happy path, parent abort, dispose, transient errors, no overlap). |
 | `tests/integration/suite.ts` | E2E test: cancel mid-run, assert the Apify run reaches ABORTED. |

--- a/src/mcp/legacy_server.ts
+++ b/src/mcp/legacy_server.ts
@@ -122,9 +122,7 @@ export class LegacyMcpServer {
 
         this.server = new Server(getServerInfo(), {
             capabilities: {
-                tools: {
-                    listChanged: true,
-                },
+                tools: {},
                 // Declare long-running task support
                 tasks: {
                     list: {},

--- a/src/mcp/stateless_server.ts
+++ b/src/mcp/stateless_server.ts
@@ -129,8 +129,8 @@ class StatelessMcpServer {
         this.host = host;
         this.server = new Server(getServerInfo(), {
             capabilities: {
-                // Deliberately no `tasks` (tasks/* → method-not-found), no `logging` (deprecated
-                // by SEP-2577), no `tools.listChanged` (a per-request instance can never push one).
+                // Deliberately no `tasks` (tasks/* → method-not-found), no `logging` (deprecated by SEP-2577), no
+                // `tools.listChanged` (never originated; `tool_dispatch.ts` only relays a proxied Actor-MCP server's).
                 // TODO: the SDK answers `subscriptions/listen` upstream of our handlers and opens a
                 // stream that can never emit; the dev server closes it per request, a long-lived
                 // host does not. Refusing the method outright is a follow-up.

--- a/src/server_card.ts
+++ b/src/server_card.ts
@@ -52,7 +52,7 @@ export function getServerCard(): ServerCard {
             endpoint: '/',
         },
         capabilities: {
-            tools: { listChanged: true },
+            tools: {},
         },
         authentication: {
             required: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -731,7 +731,7 @@ export type ServerCard = {
         endpoint: string;
     };
     capabilities: {
-        tools: { listChanged: boolean };
+        tools: Record<string, never>;
     };
     authentication: {
         required: boolean;

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -187,7 +187,7 @@ reach here and are **not** pinned by this harness — check them another way bef
 | `_meta.apifyToken` on `tools/call` | mcpc sends no custom `_meta` | `tests/integration/suite.ts` |
 | Concurrent session isolation | one session per config, opened and closed in sequence | verified manually; needs two live sessions |
 | HTTP wire level (`GET /` 405, `POST /` without session 404, `DELETE /`) | not MCP traffic | `actor.server_streamable.test.ts` |
-| `notifications/tools/list_changed` | the server no longer declares the capability | not applicable |
+| `notifications/tools/list_changed` | the server never originates one; it can only relay a proxied Actor-MCP server's | not applicable |
 
 The HTTP configs pin **per-session query-param resolution** (`?tools=`, `?ui=`, `?payment=`), not
 simultaneous isolation.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -186,7 +186,7 @@ reach here and are **not** pinned by this harness — check them another way bef
 | `notifications/message` filtering | `logging-set-level` round-trips, but delivered logs are invisible | `tests/integration/suite.ts` |
 | `_meta.apifyToken` on `tools/call` | mcpc sends no custom `_meta` | `tests/integration/suite.ts` |
 | Concurrent session isolation | one session per config, opened and closed in sequence | verified manually; needs two live sessions |
-| HTTP wire level (`GET /` 405, `POST /` without session 404, `DELETE /`) | not MCP traffic | `actor.server_streamable.test.ts` |
+| HTTP wire level (`GET /` SSE stream, `POST /` without session 400, `DELETE /`) | not MCP traffic | `actor.server_streamable.test.ts` |
 | `notifications/tools/list_changed` | the server never originates one; it can only relay a proxied Actor-MCP server's | not applicable |
 
 The HTTP configs pin **per-session query-param resolution** (`?tools=`, `?ui=`, `?payment=`), not

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -187,7 +187,7 @@ reach here and are **not** pinned by this harness — check them another way bef
 | `_meta.apifyToken` on `tools/call` | mcpc sends no custom `_meta` | `tests/integration/suite.ts` |
 | Concurrent session isolation | one session per config, opened and closed in sequence | verified manually; needs two live sessions |
 | HTTP wire level (`GET /` 405, `POST /` without session 404, `DELETE /`) | not MCP traffic | `actor.server_streamable.test.ts` |
-| `notifications/tools/list_changed` | no v1 tool mutates the list post-connect | not applicable |
+| `notifications/tools/list_changed` | the server no longer declares the capability | not applicable |
 
 The HTTP configs pin **per-session query-param resolution** (`?tools=`, `?ui=`, `?payment=`), not
 simultaneous isolation.

--- a/tests/unit/mcp.legacy.capabilities.test.ts
+++ b/tests/unit/mcp.legacy.capabilities.test.ts
@@ -5,9 +5,10 @@ import { getRequestHandler, withServer } from './helpers/mcp_server.js';
 
 /**
  * Pins what the legacy (2025-11-25) adapter advertises at `initialize`. `tools` carries no
- * sub-capabilities: nothing in this server sends `notifications/tools/list_changed`, so declaring
- * `listChanged` would commit to a notification that never arrives. Read through the `initialize`
- * handler because the SDK keeps `Server.getCapabilities()` private.
+ * sub-capabilities: this server never changes its own tool list, so it never originates
+ * `notifications/tools/list_changed` — `tool_dispatch.ts` only relays a proxied Actor-MCP server's,
+ * which reports that server's list, not ours. Read through the `initialize` handler because the SDK
+ * keeps `Server.getCapabilities()` private.
  */
 describe('LegacyMcpServer capabilities', () => {
     const ADVERTISED_CAPABILITIES = {

--- a/tests/unit/mcp.legacy.capabilities.test.ts
+++ b/tests/unit/mcp.legacy.capabilities.test.ts
@@ -1,0 +1,39 @@
+import type { InitializeRequest, InitializeResult } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it } from 'vitest';
+
+import { getRequestHandler, withServer } from './helpers/mcp_server.js';
+
+/**
+ * Pins what the legacy (2025-11-25) adapter advertises at `initialize`. `tools` carries no
+ * sub-capabilities: nothing in this server sends `notifications/tools/list_changed`, so declaring
+ * `listChanged` would commit to a notification that never arrives. Read through the `initialize`
+ * handler because the SDK keeps `Server.getCapabilities()` private.
+ */
+describe('LegacyMcpServer capabilities', () => {
+    const ADVERTISED_CAPABILITIES = {
+        tools: {},
+        tasks: { list: {}, cancel: {}, requests: { tools: { call: {} } } },
+        resources: {},
+        prompts: {},
+        logging: {},
+    };
+
+    it('advertises tools without listChanged, alongside tasks, resources, prompts and logging', async () => {
+        await withServer(async (server) => {
+            const request: InitializeRequest = {
+                method: 'initialize',
+                params: {
+                    protocolVersion: '2025-06-18',
+                    clientInfo: { name: 'test-client', version: '1.0.0' },
+                    capabilities: {},
+                },
+            };
+            const result = (await getRequestHandler(server, 'initialize')(
+                request as unknown as Record<string, unknown>,
+                {},
+            )) as unknown as InitializeResult;
+
+            expect(result.capabilities).toEqual(ADVERTISED_CAPABILITIES);
+        });
+    });
+});

--- a/tests/unit/server_card.test.ts
+++ b/tests/unit/server_card.test.ts
@@ -32,10 +32,10 @@ describe('getServerCard', () => {
         expect(card.transport.endpoint).toBe('/');
     });
 
-    it('should declare tools capability with listChanged', () => {
+    it('declares the tools capability with no sub-capabilities', () => {
         const card = getServerCard();
 
-        expect(card.capabilities.tools.listChanged).toBe(true);
+        expect(card.capabilities.tools).toEqual({});
     });
 
     it('should require authentication with bearer and oauth2 schemes', () => {


### PR DESCRIPTION
The server declares `tools.listChanged: true` but never sends `notifications/tools/list_changed`. 

Removed `listChanged: true` from the `tools` capability in `LegacyMcpServer` and `getServerCard()`. The `tools` capability is now declared as an empty object `{}`, matching the actual behavior: the server supports tool calls but does not mutate the tool list post-initialization.

## Proof it works

<img width="336" height="400" alt="image" src="https://github.com/user-attachments/assets/6912b880-4c32-46ad-aa54-70c783908acd"/>

Follow up issue: https://github.com/apify/apify-mcp-server/issues/1233

We should clean up the `/res` but that&#39;s a separate thing.

---

Closes apify/ai-team#233
Part of apify/ai-team#214

Internal counterpart: apify/apify-mcp-server-internal#727. It is red on purpose — its test asserts the new `{}` shape while internal still pins `@apify/actors-mcp-server@0.14.2`, which predates this fix. Merge order: this PR → beta version bump → #727.

Closes: https://github.com/apify/ai-team/issues/233

GitHub does not auto-close issues across repositories, so ai-team#233 needs closing by hand once both PRs land.
