### PR TITLE
feat(evals): Trace the agent conversation to Langfuse

### DIFF
--- a/evals/workflows/README.md
+++ b/evals/workflows/README.md
@@ -170,7 +170,7 @@ Separation allows independent optimization for speed vs evaluation quality.
 - `ConversationHistory` carries only what the judge and the scores read; tool results and metrics live on `ToolInvocation` and `ConversationMetrics`
 - MCP tool names are stripped of their `mcp__apify__` prefix, so the judge sees `search-actors` as before
 - Subagent messages (via the `Task` tool) are excluded, so the transcript reflects the main agent
-- Cached prompt tokens are counted into `total_tokens`; the API reports them separately and a cached run would otherwise look nearly free
+- Cached prompt tokens are counted into `total_tokens`; the API reports them separately and a cached run would otherwise look nearly free. The trace's generation splits them out (`input`, `cache_read_input_tokens`, `cache_creation_input_tokens`): the SDK reports usage for the whole run, so a multi-turn run re-reads the cached system prompt and tool definitions every turn and the total is mostly cache traffic
 
 **Location:** `sdk_conversation_adapter.ts`
 

--- a/evals/workflows/README.md
+++ b/evals/workflows/README.md
@@ -174,6 +174,27 @@ Separation allows independent optimization for speed vs evaluation quality.
 
 **Location:** `sdk_conversation_adapter.ts`
 
+### 9. The agent's conversation is traced by hand
+
+**Decision:** After each agent run, `langfuse_observations.ts` emits the item's span tree from the adapted SDK stream; `llm_client.ts` traces the judge call itself.
+
+```
+experiment-item-run     Langfuse SDK, holds the scores
+|- agent                the prompt in, the final answer out
+|  |- <agent model>     generation: the run's aggregate tokens and cost
+|  |- <tool name>       one span per tool call: arguments in, result out
+|- <judge model>        generation, emitted by llm_client.ts
+```
+
+**Why:**
+- The agent runs in the Claude Code subprocess, so nothing it does is instrumented for us. Left alone, an item's trace holds a single span and the conversation is invisible in the UI
+- Tokens and cost only roll up to the trace from a **generation**. The SDK reports usage once for the whole run, not per turn, so one generation spanning the run is the finest honest granularity
+- Tool spans are timed from when the SDK delivered the call and its result (`claude_agent.ts` stamps every message as it arrives). Without those stamps every span would collapse to the moment the tree is emitted, after the run
+
+**Trade-off:** the tree is emitted after the fact, so a crashed run leaves no spans, and the agent's individual model turns are not separate generations.
+
+**Location:** `langfuse_observations.ts`, `claude_agent.ts`, `llm_client.ts`
+
 ## System components
 
 ### Core files
@@ -182,7 +203,8 @@ Separation allows independent optimization for speed vs evaluation quality.
 - `config.ts` - Models, prompts, constants
 - `claude_agent.ts` - The agent under test: Claude Agent SDK options, MCP server registration, failure injection
 - `sdk_conversation_adapter.ts` - Folds the SDK message stream into `ConversationHistory`, tool spans, and metrics
-- `llm_client.ts` - OpenRouter wrapper (judge)
+- `llm_client.ts` - OpenRouter wrapper (judge), traced as a Langfuse generation
+- `langfuse_observations.ts` - Builds and emits the item's span tree (agent, usage, tool calls)
 - `workflow_judge.ts` - Judge evaluation
 - `langfuse_tracing.ts` - OpenTelemetry span processor init/shutdown
 - `langfuse_dataset.ts` - Test case schema, dataset item mapping and validation, dataset fetch
@@ -212,7 +234,7 @@ Results are recorded in Langfuse, not to a local file. Each run:
 
 - **Reads the dataset** `workflow-evals` (override with `--dataset`) and matches its active items against `--id`/`--category`. For a variant set of cases, clone the dataset in the UI and pass `--dataset`; a run stays recorded against the dataset it used.
 - **Runs an experiment** named `<git-branch>-<agent-model>-<timestamp>`, with metadata `{ agentModel, judgeModel, toolTimeout, mcpToolsOnly, agentSdkVersion }`. Running on dataset items is what makes it a Langfuse **dataset run**, whose URL the console prints.
-- **Traces** every item as one trace whose root output is the judge verdict plus the agent's narration, thinking, and tool names - not the tool payloads. Individual LLM and MCP tool calls are not instrumented: they happen inside the Claude Code subprocess.
+- **Traces** every item as one trace. Its root output is the judge verdict plus the agent's narration, thinking, and tool names; nested under it are an `agent` span (prompt in, final answer out), a generation carrying the run's tokens and cost, one span per MCP tool call (arguments in, result out, `ERROR` when the call failed), and a generation for the judge call. See design decision 9.
 - **Scores** each item: `workflow_judge` (`1` on a PASS verdict, comment = judge reason) is the strict gate, and `total_tokens` is the agent tokens billed, omitted when the provider reported no usage so an unmeasured run cannot look like a free one.
 - **Scores the run** with `pass_rate`: passing items over items requested, so runs stay comparable even when items were dropped.
 

--- a/evals/workflows/README.md
+++ b/evals/workflows/README.md
@@ -234,7 +234,7 @@ Results are recorded in Langfuse, not to a local file. Each run:
 
 - **Reads the dataset** `workflow-evals` (override with `--dataset`) and matches its active items against `--id`/`--category`. For a variant set of cases, clone the dataset in the UI and pass `--dataset`; a run stays recorded against the dataset it used.
 - **Runs an experiment** named `<git-branch>-<agent-model>-<timestamp>`, with metadata `{ agentModel, judgeModel, toolTimeout, mcpToolsOnly, agentSdkVersion }`. Running on dataset items is what makes it a Langfuse **dataset run**, whose URL the console prints.
-- **Traces** every item as one trace. Its root output is the judge verdict plus the agent's narration, thinking, and tool names; nested under it are an `agent` span (prompt in, final answer out), a generation carrying the run's tokens and cost, one span per MCP tool call (arguments in, result out, `ERROR` when the call failed), and a generation for the judge call. See design decision 9.
+- **Traces** every item as one trace. Its root output is the judge verdict plus the agent's narration, thinking, and tool names; nested under it are an `agent` span (prompt in, final answer out), a generation carrying the run's tokens and cost, one span per tool call (arguments in, result out, `ERROR` when the call failed), and a generation for the judge call. See design decision 9.
 - **Scores** each item: `workflow_judge` (`1` on a PASS verdict, comment = judge reason) is the strict gate, and `total_tokens` is the agent tokens billed, omitted when the provider reported no usage so an unmeasured run cannot look like a free one.
 - **Scores the run** with `pass_rate`: passing items over items requested, so runs stay comparable even when items were dropped.
 

--- a/evals/workflows/README.md
+++ b/evals/workflows/README.md
@@ -181,14 +181,15 @@ Separation allows independent optimization for speed vs evaluation quality.
 ```
 experiment-item-run     Langfuse SDK, holds the scores
 |- agent                the prompt in, the final answer out
-|  |- <agent model>     generation: the run's aggregate tokens and cost
+|  |- <agent model>     generation: the run's aggregate tokens and cost, windowed to the last turn
 |  |- <tool name>       one span per tool call: arguments in, result out
 |- <judge model>        generation, emitted by llm_client.ts
 ```
 
 **Why:**
 - The agent runs in the Claude Code subprocess, so nothing it does is instrumented for us. Left alone, an item's trace holds a single span and the conversation is invisible in the UI
-- Tokens and cost only roll up to the trace from a **generation**. The SDK reports usage once for the whole run, not per turn, so one generation spanning the run is the finest honest granularity
+- Tokens and cost only roll up to the trace from a **generation**. The SDK reports usage once for the whole run, not per turn, so the run's aggregate sits on a single generation
+- That generation is windowed to the final model turn, not the whole run. The UI orders siblings by start time, so a generation spanning the tool calls sorts ahead of them and reads as though the model answered before calling anything. Its `usageScope: run` metadata marks that the numbers still cover the whole run
 - Tool spans are timed from when the SDK delivered the call and its result (`claude_agent.ts` stamps every message as it arrives). Without those stamps every span would collapse to the moment the tree is emitted, after the run
 
 **Trade-off:** the tree is emitted after the fact, so a crashed run leaves no spans, and the agent's individual model turns are not separate generations.

--- a/evals/workflows/README.md
+++ b/evals/workflows/README.md
@@ -268,7 +268,7 @@ A test case is a dataset item: `input.query`, `expectedOutput`, and the rest in 
 **Optional:**
 - `maxTurns` - Override default (10)
 - `tools` - List of tools to enable for this test (e.g., `["actors", "docs", "apify/rag-web-browser"]`). If omitted, all default tools are enabled. Passed to MCP server as `--tools` argument.
-- `failTools` - Tool names the harness force-fails with a synthetic `INTERNAL_ERROR` result carrying the real `report-problem` nudge, instead of calling the server (e.g. `["call-actor"]`). Use it to deterministically throw a nudge-eligible error that the live server + API cannot reproduce on demand, e.g. to test that the agent proactively calls `report-problem` after a failure. Injected as a `PreToolUse` deny, the one hook that survives `bypassPermissions`. See `claude_agent.ts`.
+- `failTools` - Tool names the harness force-fails before they reach the server (e.g. `["call-actor"]`), with a message carrying the real `report-problem` nudge. Use it to deterministically produce a nudge-eligible failure that the live server + API cannot reproduce on demand, e.g. to test that the agent proactively calls `report-problem` after one. Injected as a `PreToolUse` deny, the one hook that survives `bypassPermissions`, so the agent sees a refused call rather than an `INTERNAL_ERROR` tool result. See `claude_agent.ts`.
 
 ## Key insights
 

--- a/evals/workflows/claude_agent.ts
+++ b/evals/workflows/claude_agent.ts
@@ -119,10 +119,14 @@ export async function runAgentConversation(options: AgentRunOptions): Promise<Ad
 
     try {
         const messages: SDKMessage[] = [];
+        // Arrival times, so the tool spans have real durations. The SDK stream carries no
+        // timestamps and the messages are only folded once the run is over.
+        const receivedAt: number[] = [];
         for await (const message of query({ prompt, options: sdkOptions })) {
             messages.push(message);
+            receivedAt.push(Date.now());
         }
-        return adaptSdkConversation(prompt, messages);
+        return adaptSdkConversation(prompt, messages, receivedAt);
     } finally {
         abortController.abort();
     }

--- a/evals/workflows/langfuse_experiment.ts
+++ b/evals/workflows/langfuse_experiment.ts
@@ -155,7 +155,9 @@ export function makeTask(options: WorkflowTaskOptions) {
             // The agent ran in a subprocess, so its conversation reaches Langfuse only if
             // we send it. Emitted before the judge call, so a failing judge still leaves
             // the conversation on the trace to debug. Guarded separately from the run
-            // itself: losing the trace costs debuggability, not the item's result.
+            // itself: losing the trace costs debuggability, not the item's result. Only
+            // catches building the spans - the export happens later, in the span
+            // processor's batch flush, and never reaches here.
             try {
                 emitObservations(
                     buildAgentObservations({

--- a/evals/workflows/langfuse_experiment.ts
+++ b/evals/workflows/langfuse_experiment.ts
@@ -154,17 +154,25 @@ export function makeTask(options: WorkflowTaskOptions) {
 
             // The agent ran in a subprocess, so its conversation reaches Langfuse only if
             // we send it. Emitted before the judge call, so a failing judge still leaves
-            // the conversation on the trace to debug.
-            emitObservations(
-                buildAgentObservations({
-                    prompt: item.input.query,
-                    model: agentModel,
-                    mcpToolsOnly,
-                    adapted,
-                    startedAt,
-                    endedAt: Date.now(),
-                }),
-            );
+            // the conversation on the trace to debug. Guarded separately from the run
+            // itself: losing the trace costs debuggability, not the item's result.
+            try {
+                emitObservations(
+                    buildAgentObservations({
+                        prompt: item.input.query,
+                        model: agentModel,
+                        mcpToolsOnly,
+                        adapted,
+                        startedAt,
+                        endedAt: Date.now(),
+                    }),
+                );
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error(
+                    `⚠️ Item "${item.id}": emitting the agent trace failed: ${error instanceof Error ? error.message : String(error)}`,
+                );
+            }
 
             const { conversation, transcript } = adapted;
             const judgeResult = await evaluateConversation(item.expectedOutput, conversation, llmClient, judgeModel);

--- a/evals/workflows/langfuse_experiment.ts
+++ b/evals/workflows/langfuse_experiment.ts
@@ -10,6 +10,7 @@ import type { Evaluation } from '@langfuse/client';
 
 import { runAgentConversation } from './claude_agent.js';
 import { parseWorkflowItem } from './langfuse_dataset.js';
+import { buildAgentObservations, emitObservations } from './langfuse_observations.js';
 import type { LlmClient } from './llm_client.js';
 import type { TranscriptEntry } from './sdk_conversation_adapter.js';
 import type { JudgeResult } from './workflow_judge.js';
@@ -138,7 +139,8 @@ export function makeTask(options: WorkflowTaskOptions) {
         const item = parseWorkflowItem(rawItem);
 
         try {
-            const { conversation, transcript } = await runAgentConversation({
+            const startedAt = Date.now();
+            const adapted = await runAgentConversation({
                 prompt: item.input.query,
                 model: agentModel,
                 apifyToken,
@@ -149,6 +151,21 @@ export function makeTask(options: WorkflowTaskOptions) {
                 mcpToolsOnly,
             });
 
+            // The agent ran in a subprocess, so its conversation reaches Langfuse only if
+            // we send it. Emitted before the judge call, so a failing judge still leaves
+            // the conversation on the trace to debug.
+            emitObservations(
+                buildAgentObservations({
+                    prompt: item.input.query,
+                    model: agentModel,
+                    mcpToolsOnly,
+                    adapted,
+                    startedAt,
+                    endedAt: Date.now(),
+                }),
+            );
+
+            const { conversation, transcript } = adapted;
             const judgeResult = await evaluateConversation(item.expectedOutput, conversation, llmClient, judgeModel);
 
             return {

--- a/evals/workflows/langfuse_experiment.ts
+++ b/evals/workflows/langfuse_experiment.ts
@@ -19,8 +19,9 @@ import { evaluateConversation } from './workflow_judge.js';
 /**
  * Output produced by the experiment task for a single dataset item.
  *
- * A summary, not the transcript: the SDK writes whatever the task returns to the item's
- * root span, so returning conversations would re-upload every tool payload.
+ * The SDK writes whatever the task returns to the item's root span, so this stays a
+ * summary: the transcript carries narration and tool names, never the tool payloads,
+ * which would otherwise be re-uploaded on top of the tool spans that already hold them.
  */
 export type WorkflowTaskOutput = {
     /** Item id, carried here because `ExperimentItemResult.item` is typed as a union without one. */

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -80,8 +80,13 @@ function toolNode(invocation: ToolInvocation): ObservationNode {
 
 /**
  * The generation that carries the run's cost. Langfuse rolls tokens and cost up from
- * generations only, and the SDK reports usage once for the whole run rather than per
- * turn, so one generation spanning the run is the finest honest granularity.
+ * generations only, and the SDK reports usage once for the whole run rather than per turn,
+ * so the run's aggregate sits on this one generation.
+ *
+ * Windowed to the final model turn, not the whole run: the UI orders siblings by start
+ * time, so a generation spanning the tool calls sorts ahead of them and reads as though
+ * the model answered before calling anything. `usageScope` marks that the numbers still
+ * cover the whole run.
  */
 function usageNode(params: AgentObservationParams): ObservationNode {
     const { metrics } = params.adapted;
@@ -104,9 +109,9 @@ function usageNode(params: AgentObservationParams): ObservationNode {
                   }
                 : {}),
             ...(metrics.totalCostUsd === undefined ? {} : { costDetails: { total: metrics.totalCostUsd } }),
-            metadata: { turns: metrics.turns },
+            metadata: { turns: metrics.turns, usageScope: 'run' },
         },
-        startTime: new Date(params.startedAt),
+        startTime: new Date(params.adapted.finalTurnStartedAt ?? params.startedAt),
         endTime: new Date(params.endedAt),
         children: [],
     };

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -95,6 +95,8 @@ function toolNode(invocation: ToolInvocation): ObservationNode {
 function usageNode(params: AgentObservationParams): ObservationNode {
     const { metrics } = params.adapted;
     const hasTokens = metrics.promptTokens !== undefined && metrics.completionTokens !== undefined;
+    const cacheRead = metrics.cacheReadTokens ?? 0;
+    const cacheCreation = metrics.cacheCreationTokens ?? 0;
 
     return {
         name: params.model,
@@ -105,8 +107,13 @@ function usageNode(params: AgentObservationParams): ObservationNode {
             output: finalResponseOf(params.adapted),
             ...(hasTokens
                 ? {
+                      // Broken out rather than one prompt-token number: a multi-turn run re-reads
+                      // the cached system prompt and tool definitions every turn, so the total is
+                      // mostly cache traffic and reads as a huge prompt when it is not shown apart.
                       usageDetails: {
-                          input: metrics.promptTokens!,
+                          input: metrics.promptTokens! - cacheRead - cacheCreation,
+                          ...(cacheRead === 0 ? {} : { cache_read_input_tokens: cacheRead }),
+                          ...(cacheCreation === 0 ? {} : { cache_creation_input_tokens: cacheCreation }),
                           output: metrics.completionTokens!,
                           total: metrics.promptTokens! + metrics.completionTokens!,
                       },

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -94,7 +94,8 @@ function toolNode(invocation: ToolInvocation): ObservationNode {
  */
 function usageNode(params: AgentObservationParams): ObservationNode {
     const { metrics } = params.adapted;
-    const hasTokens = metrics.promptTokens !== undefined && metrics.completionTokens !== undefined;
+    const { promptTokens, completionTokens } = metrics;
+    const hasTokens = promptTokens !== undefined && completionTokens !== undefined;
     const cacheRead = metrics.cacheReadTokens ?? 0;
     const cacheCreation = metrics.cacheCreationTokens ?? 0;
 
@@ -111,11 +112,11 @@ function usageNode(params: AgentObservationParams): ObservationNode {
                       // the cached system prompt and tool definitions every turn, so the total is
                       // mostly cache traffic and reads as a huge prompt when it is not shown apart.
                       usageDetails: {
-                          input: metrics.promptTokens! - cacheRead - cacheCreation,
+                          input: promptTokens - cacheRead - cacheCreation,
                           ...(cacheRead === 0 ? {} : { cache_read_input_tokens: cacheRead }),
                           ...(cacheCreation === 0 ? {} : { cache_creation_input_tokens: cacheCreation }),
-                          output: metrics.completionTokens!,
-                          total: metrics.promptTokens! + metrics.completionTokens!,
+                          output: completionTokens,
+                          total: promptTokens + completionTokens,
                       },
                   }
                 : {}),

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -176,9 +176,13 @@ export function emitObservations(node: ObservationNode, parentSpanContext?: Span
         observation = startObservation(node.name, node.attributes, { ...options, asType: 'tool' });
     }
 
-    for (const child of node.children) {
-        emitObservations(child, observation.otelSpan.spanContext());
+    // Ended in a finally: a child that throws while building its span would otherwise leave
+    // the parent open, and an unended span never reaches Langfuse.
+    try {
+        for (const child of node.children) {
+            emitObservations(child, observation.otelSpan.spanContext());
+        }
+    } finally {
+        observation.end(node.endTime);
     }
-
-    observation.end(node.endTime);
 }

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -60,20 +60,33 @@ function finalResponseOf(adapted: AdaptedConversation): string | undefined {
 }
 
 /**
+ * Above this the result is left off the span. Langfuse rejects oversized ingestion events,
+ * which would drop the whole span rather than just the payload - and a tool that returns
+ * megabytes is exactly the one worth seeing in the trace.
+ */
+const MAX_TOOL_OUTPUT_BYTES = 128_000;
+
+/**
  * One tool call: arguments in, result out, failures raised to ERROR so they stand out.
  * The error text is left to `output` alone: Langfuse renders `statusMessage` in its own box
  * above the output preview, so setting it shows the same message twice.
  */
 function toolNode(invocation: ToolInvocation): ObservationNode {
     const { result } = invocation;
+    const omitted = result.success && (result.resultBytes ?? 0) > MAX_TOOL_OUTPUT_BYTES;
+
+    let output;
+    if (!result.success) output = result.error;
+    else if (omitted) output = `[output omitted: ${result.resultBytes} bytes]`;
+    else output = result.result;
 
     return {
         name: invocation.name,
         asType: 'tool',
         attributes: {
             input: invocation.arguments,
-            output: result.success ? result.result : result.error,
-            metadata: { resultBytes: result.resultBytes },
+            output,
+            metadata: { resultBytes: result.resultBytes, ...(omitted ? { outputOmitted: true } : {}) },
             ...(result.success ? {} : { level: 'ERROR' }),
         },
         ...(invocation.startedAt === undefined ? {} : { startTime: new Date(invocation.startedAt) }),

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -59,7 +59,11 @@ function finalResponseOf(adapted: AdaptedConversation): string | undefined {
     return adapted.conversation.turns.at(-1)?.finalResponse;
 }
 
-/** One tool call: arguments in, result out, failures raised to ERROR so they stand out. */
+/**
+ * One tool call: arguments in, result out, failures raised to ERROR so they stand out.
+ * The error text is left to `output` alone: Langfuse renders `statusMessage` in its own box
+ * above the output preview, so setting it shows the same message twice.
+ */
 function toolNode(invocation: ToolInvocation): ObservationNode {
     const { result } = invocation;
 
@@ -70,7 +74,7 @@ function toolNode(invocation: ToolInvocation): ObservationNode {
             input: invocation.arguments,
             output: result.success ? result.result : result.error,
             metadata: { resultBytes: result.resultBytes },
-            ...(result.success ? {} : { level: 'ERROR', statusMessage: result.error }),
+            ...(result.success ? {} : { level: 'ERROR' }),
         },
         ...(invocation.startedAt === undefined ? {} : { startTime: new Date(invocation.startedAt) }),
         ...(invocation.endedAt === undefined ? {} : { endTime: new Date(invocation.endedAt) }),

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -115,7 +115,7 @@ function usageNode(params: AgentObservationParams): ObservationNode {
 /** Build the item's agent subtree. Pure: nothing is sent until emitObservations runs. */
 export function buildAgentObservations(params: AgentObservationParams): ObservationNode {
     const { adapted } = params;
-    const { conversation, metrics } = adapted;
+    const { metrics } = adapted;
 
     return {
         name: 'agent',
@@ -130,16 +130,11 @@ export function buildAgentObservations(params: AgentObservationParams): Observat
                 turns: metrics.turns,
                 toolCalls: adapted.toolInvocations.length,
                 resultBytes: metrics.resultBytes,
-                hitMaxTurns: conversation.hitMaxTurns,
+                hitMaxTurns: adapted.hitMaxTurns,
             },
-            // A run that never reached a final answer is not an error here: the judge still
-            // scores it. Flag it so it is findable in the UI.
-            ...(conversation.completed
-                ? {}
-                : {
-                      level: 'WARNING',
-                      statusMessage: conversation.hitMaxTurns ? 'hit the turn limit' : 'did not complete',
-                  }),
+            // A run that ran out of turns is not an error here: the judge still scores it.
+            // Flag it so it is findable in the UI.
+            ...(adapted.hitMaxTurns ? { level: 'WARNING', statusMessage: 'hit the turn limit' } : {}),
         },
         startTime: new Date(params.startedAt),
         endTime: new Date(params.endedAt),

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -89,8 +89,9 @@ function toolNode(invocation: ToolInvocation): ObservationNode {
  *
  * Windowed to the final model turn, not the whole run: the UI orders siblings by start
  * time, so a generation spanning the tool calls sorts ahead of them and reads as though
- * the model answered before calling anything. `usageScope` marks that the numbers still
- * cover the whole run.
+ * the model answered before calling anything. A run that ran out of turns ends on a
+ * tool-calling turn, so the window is held past the last tool result to keep the ordering.
+ * `usageScope` marks that the numbers still cover the whole run.
  */
 function usageNode(params: AgentObservationParams): ObservationNode {
     const { metrics } = params.adapted;
@@ -123,7 +124,12 @@ function usageNode(params: AgentObservationParams): ObservationNode {
             ...(metrics.totalCostUsd === undefined ? {} : { costDetails: { total: metrics.totalCostUsd } }),
             metadata: { turns: metrics.turns, usageScope: 'run' },
         },
-        startTime: new Date(params.adapted.finalTurnStartedAt ?? params.startedAt),
+        startTime: new Date(
+            Math.max(
+                params.adapted.finalTurnStartedAt ?? params.startedAt,
+                ...params.adapted.toolInvocations.map((invocation) => invocation.endedAt ?? 0),
+            ),
+        ),
         endTime: new Date(params.endedAt),
         children: [],
     };

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -64,7 +64,7 @@ function finalResponseOf(adapted: AdaptedConversation): string | undefined {
  * which would drop the whole span rather than just the payload - and a tool that returns
  * megabytes is exactly the one worth seeing in the trace.
  */
-const MAX_TOOL_OUTPUT_BYTES = 128_000;
+const MAX_TOOL_OUTPUT_BYTES = 512_000;
 
 /**
  * One tool call: arguments in, result out, failures raised to ERROR so they stand out.

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -1,0 +1,170 @@
+/**
+ * The per-item observation tree that Langfuse shows behind an experiment item.
+ *
+ * The agent runs inside the Claude Code subprocess, so none of its work is instrumented
+ * for us: without this module an item's trace holds exactly one span (the Langfuse SDK's
+ * own `experiment-item-run`) and the conversation is invisible in the UI. The tree is
+ * built from the adapted SDK stream once the run has finished, from the timestamps taken
+ * while that stream was consumed, so the spans carry real durations instead of collapsing
+ * at emit time.
+ *
+ * Shape per item:
+ *
+ *     experiment-item-run     Langfuse SDK, holds the scores
+ *     |- agent                the prompt in, the final answer out
+ *     |  |- <agent model>     generation: the run's aggregate tokens and cost
+ *     |  |- <tool name>       one span per tool call: arguments in, result out
+ *     |- <judge model>        generation, emitted by llm_client.ts
+ *
+ * Building the tree is kept separate from emitting it so the payload shaping is testable
+ * without an OpenTelemetry provider.
+ */
+
+import type { LangfuseObservationAttributes } from '@langfuse/tracing';
+import { startObservation } from '@langfuse/tracing';
+import type { SpanContext } from '@opentelemetry/api';
+
+import type { AdaptedConversation, ToolInvocation } from './sdk_conversation_adapter.js';
+
+/** Observation types this module emits. */
+type ObservationType = 'agent' | 'generation' | 'tool';
+
+/** A Langfuse observation to emit, with its children. */
+export type ObservationNode = {
+    name: string;
+    asType: ObservationType;
+    attributes: LangfuseObservationAttributes;
+    /** Omitted when the moment is unknown, which makes the span start (or end) at emit time. */
+    startTime?: Date;
+    endTime?: Date;
+    children: ObservationNode[];
+};
+
+export type AgentObservationParams = {
+    /** The user prompt for this test case. */
+    prompt: string;
+    /** Anthropic model ID the agent ran on. */
+    model: string;
+    /** Whether the run dropped Claude Code's built-in tools. */
+    mcpToolsOnly: boolean;
+    /** The folded SDK stream: conversation, tool invocations, metrics. */
+    adapted: AdaptedConversation;
+    /** Epoch ms around the agent run, measured by the caller. */
+    startedAt: number;
+    endedAt: number;
+};
+
+/** The answer the agent finished on, which the adapter parks on the last turn. */
+function finalResponseOf(adapted: AdaptedConversation): string | undefined {
+    return adapted.conversation.turns.at(-1)?.finalResponse;
+}
+
+/** One tool call: arguments in, result out, failures raised to ERROR so they stand out. */
+function toolNode(invocation: ToolInvocation): ObservationNode {
+    const { result } = invocation;
+
+    return {
+        name: invocation.name,
+        asType: 'tool',
+        attributes: {
+            input: invocation.arguments,
+            output: result.success ? result.result : result.error,
+            metadata: { resultBytes: result.resultBytes },
+            ...(result.success ? {} : { level: 'ERROR', statusMessage: result.error }),
+        },
+        ...(invocation.startedAt === undefined ? {} : { startTime: new Date(invocation.startedAt) }),
+        ...(invocation.endedAt === undefined ? {} : { endTime: new Date(invocation.endedAt) }),
+        children: [],
+    };
+}
+
+/**
+ * The generation that carries the run's cost. Langfuse rolls tokens and cost up from
+ * generations only, and the SDK reports usage once for the whole run rather than per
+ * turn, so one generation spanning the run is the finest honest granularity.
+ */
+function usageNode(params: AgentObservationParams): ObservationNode {
+    const { metrics } = params.adapted;
+    const hasTokens = metrics.promptTokens !== undefined && metrics.completionTokens !== undefined;
+
+    return {
+        name: params.model,
+        asType: 'generation',
+        attributes: {
+            model: params.model,
+            input: params.prompt,
+            output: finalResponseOf(params.adapted),
+            ...(hasTokens
+                ? {
+                      usageDetails: {
+                          input: metrics.promptTokens!,
+                          output: metrics.completionTokens!,
+                          total: metrics.promptTokens! + metrics.completionTokens!,
+                      },
+                  }
+                : {}),
+            ...(metrics.totalCostUsd === undefined ? {} : { costDetails: { total: metrics.totalCostUsd } }),
+            metadata: { turns: metrics.turns },
+        },
+        startTime: new Date(params.startedAt),
+        endTime: new Date(params.endedAt),
+        children: [],
+    };
+}
+
+/** Build the item's agent subtree. Pure: nothing is sent until emitObservations runs. */
+export function buildAgentObservations(params: AgentObservationParams): ObservationNode {
+    const { adapted } = params;
+    const { conversation, metrics } = adapted;
+
+    return {
+        name: 'agent',
+        asType: 'agent',
+        attributes: {
+            input: params.prompt,
+            output: finalResponseOf(adapted),
+            metadata: {
+                model: params.model,
+                mcpToolsOnly: params.mcpToolsOnly,
+                claudeCodeVersion: adapted.claudeCodeVersion,
+                turns: metrics.turns,
+                toolCalls: adapted.toolInvocations.length,
+                resultBytes: metrics.resultBytes,
+                hitMaxTurns: conversation.hitMaxTurns,
+            },
+            // A run that never reached a final answer is not an error here: the judge still
+            // scores it. Flag it so it is findable in the UI.
+            ...(conversation.completed
+                ? {}
+                : {
+                      level: 'WARNING',
+                      statusMessage: conversation.hitMaxTurns ? 'hit the turn limit' : 'did not complete',
+                  }),
+        },
+        startTime: new Date(params.startedAt),
+        endTime: new Date(params.endedAt),
+        children: [usageNode(params), ...adapted.toolInvocations.map(toolNode)],
+    };
+}
+
+/**
+ * Send a built tree. Each node attaches to the active span when no parent is passed, so
+ * calling this inside the experiment task nests the tree under that item's trace.
+ */
+export function emitObservations(node: ObservationNode, parentSpanContext?: SpanContext): void {
+    const options = { startTime: node.startTime, parentSpanContext };
+    // Switched rather than passed through: startObservation is overloaded per type and
+    // only a literal asType picks the matching overload.
+    const observation =
+        node.asType === 'agent'
+            ? startObservation(node.name, node.attributes, { ...options, asType: 'agent' })
+            : node.asType === 'generation'
+              ? startObservation(node.name, node.attributes, { ...options, asType: 'generation' })
+              : startObservation(node.name, node.attributes, { ...options, asType: 'tool' });
+
+    for (const child of node.children) {
+        emitObservations(child, observation.otelSpan.spanContext());
+    }
+
+    observation.end(node.endTime);
+}

--- a/evals/workflows/langfuse_observations.ts
+++ b/evals/workflows/langfuse_observations.ts
@@ -165,14 +165,16 @@ export function buildAgentObservations(params: AgentObservationParams): Observat
  */
 export function emitObservations(node: ObservationNode, parentSpanContext?: SpanContext): void {
     const options = { startTime: node.startTime, parentSpanContext };
-    // Switched rather than passed through: startObservation is overloaded per type and
+    // Branched rather than passed through: startObservation is overloaded per type and
     // only a literal asType picks the matching overload.
-    const observation =
-        node.asType === 'agent'
-            ? startObservation(node.name, node.attributes, { ...options, asType: 'agent' })
-            : node.asType === 'generation'
-              ? startObservation(node.name, node.attributes, { ...options, asType: 'generation' })
-              : startObservation(node.name, node.attributes, { ...options, asType: 'tool' });
+    let observation;
+    if (node.asType === 'agent') {
+        observation = startObservation(node.name, node.attributes, { ...options, asType: 'agent' });
+    } else if (node.asType === 'generation') {
+        observation = startObservation(node.name, node.attributes, { ...options, asType: 'generation' });
+    } else {
+        observation = startObservation(node.name, node.attributes, { ...options, asType: 'tool' });
+    }
 
     for (const child of node.children) {
         emitObservations(child, observation.otelSpan.spanContext());

--- a/evals/workflows/llm_client.ts
+++ b/evals/workflows/llm_client.ts
@@ -3,6 +3,7 @@
  * Phase 3: Added support for tool calling
  */
 
+import { startActiveObservation } from '@langfuse/tracing';
 import OpenAI from 'openai';
 // eslint-disable-next-line import/extensions
 import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
@@ -36,6 +37,9 @@ export type LlmResponse = {
     usage?: LlmUsage;
 };
 
+/** Low temperature for deterministic evaluation results. */
+const TEMPERATURE = 0.15;
+
 /**
  * LLM client for chat completions with optional tool support
  */
@@ -57,8 +61,42 @@ export class LlmClient {
      * Call LLM with messages and optional tools
      * Phase 3: Added tools parameter
      * Phase 4: Added responseFormat for structured outputs
+     *
+     * Traced as a Langfuse generation, nested under whichever observation is active at the
+     * call site: inside the experiment task that is the item's trace, so a judge call shows
+     * up with its prompt, verdict, tokens, and cost.
      */
     async callLlm(
+        messages: ChatCompletionMessageParam[],
+        model: string,
+        tools?: ChatCompletionTool[],
+        responseFormat?: ResponseFormatJSONSchema,
+    ): Promise<LlmResponse> {
+        return startActiveObservation(
+            model,
+            async (generation) => {
+                generation.update({ model, input: messages, modelParameters: { temperature: TEMPERATURE } });
+                const llmResponse = await this.sendRequest(messages, model, tools, responseFormat);
+                generation.update({
+                    output: llmResponse.toolCalls ?? llmResponse.content,
+                    ...(llmResponse.usage
+                        ? {
+                              usageDetails: {
+                                  input: llmResponse.usage.promptTokens,
+                                  output: llmResponse.usage.completionTokens,
+                                  total: llmResponse.usage.totalTokens,
+                              },
+                          }
+                        : {}),
+                });
+                return llmResponse;
+            },
+            { asType: 'generation' },
+        );
+    }
+
+    /** The request itself, untraced. */
+    private async sendRequest(
         messages: ChatCompletionMessageParam[],
         model: string,
         tools?: ChatCompletionTool[],
@@ -67,7 +105,7 @@ export class LlmClient {
         const response = await this.openai.chat.completions.create({
             model,
             messages,
-            temperature: 0.15, // Low temperature for deterministic evaluation results
+            temperature: TEMPERATURE,
             ...(tools && tools.length > 0 ? { tools } : {}),
             ...(responseFormat ? { response_format: responseFormat } : {}),
         });

--- a/evals/workflows/run_workflow_evals.ts
+++ b/evals/workflows/run_workflow_evals.ts
@@ -100,6 +100,14 @@ async function main() {
                 default: false,
             },
         })
+        // Langfuse batches items with `i += concurrency`, so 0 loops forever and NaN never
+        // starts, reporting every item as "never completed". Reject both up front.
+        .check((parsed) => {
+            if (!Number.isInteger(parsed.concurrency) || parsed.concurrency < 1) {
+                throw new Error(`--concurrency must be a positive integer, got "${parsed.concurrency}"`);
+            }
+            return true;
+        })
         .help().argv) as CliArgs;
 
     // Fail before any test runs, listing every missing variable at once.

--- a/evals/workflows/run_workflow_evals.ts
+++ b/evals/workflows/run_workflow_evals.ts
@@ -148,7 +148,7 @@ async function main() {
 
         initTracing();
 
-        // Traces every agent/judge call as a generation nested under the item's trace.
+        // Traces each judge call as a generation nested under the item's trace.
         const llmClient = new LlmClient();
 
         const agentSdkVersion = resolveAgentSdkVersion();

--- a/evals/workflows/sdk_conversation_adapter.ts
+++ b/evals/workflows/sdk_conversation_adapter.ts
@@ -36,6 +36,9 @@ export type ConversationMetrics = {
     turns: number;
     promptTokens?: number;
     completionTokens?: number;
+    /** The share of promptTokens the API billed as cache reads / cache writes. */
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
     totalCostUsd?: number;
     durationMs?: number;
 };
@@ -117,7 +120,9 @@ export function adaptSdkConversation(
     let finalTurnStartedAt: number | undefined;
 
     let numTurns: number | undefined;
-    let usage: { promptTokens: number; completionTokens: number } | undefined;
+    let usage:
+        | { promptTokens: number; completionTokens: number; cacheReadTokens: number; cacheCreationTokens: number }
+        | undefined;
     let totalCostUsd: number | undefined;
     let durationMs: number | undefined;
     let resultSubtype: string | undefined;
@@ -232,12 +237,13 @@ export function adaptSdkConversation(
             // Cache reads and writes are prompt tokens the API reports separately. Left out,
             // a cached run reports a handful of prompt tokens and the total_tokens score stops
             // reflecting what the tool output actually costs.
+            const cacheReadTokens = message.usage.cache_read_input_tokens ?? 0;
+            const cacheCreationTokens = message.usage.cache_creation_input_tokens ?? 0;
             usage = {
-                promptTokens:
-                    message.usage.input_tokens +
-                    (message.usage.cache_read_input_tokens ?? 0) +
-                    (message.usage.cache_creation_input_tokens ?? 0),
+                promptTokens: message.usage.input_tokens + cacheReadTokens + cacheCreationTokens,
                 completionTokens: message.usage.output_tokens,
+                cacheReadTokens,
+                cacheCreationTokens,
             };
             if (message.subtype === 'success') finalResultText = message.result.trim();
             else resultErrors = message.errors;
@@ -274,6 +280,8 @@ export function adaptSdkConversation(
         turns: numTurns ?? turns.length,
         promptTokens: usage?.promptTokens,
         completionTokens: usage?.completionTokens,
+        cacheReadTokens: usage?.cacheReadTokens,
+        cacheCreationTokens: usage?.cacheCreationTokens,
         totalCostUsd,
         durationMs,
     };

--- a/evals/workflows/sdk_conversation_adapter.ts
+++ b/evals/workflows/sdk_conversation_adapter.ts
@@ -155,7 +155,7 @@ export function adaptSdkConversation(
             turn.toolCalls.push(...toolCalls);
             // Match the old harness: only a text-only turn exposes a finalResponse to the judge.
             if (text && turn.toolCalls.length === 0) {
-                turn.finalResponse = text;
+                turn.finalResponse = turn.finalResponse ? `${turn.finalResponse}\n${text}` : text;
             } else if (turn.toolCalls.length > 0) {
                 delete turn.finalResponse;
             }

--- a/evals/workflows/sdk_conversation_adapter.ts
+++ b/evals/workflows/sdk_conversation_adapter.ts
@@ -44,6 +44,11 @@ export type AdaptedConversation = {
     conversation: ConversationHistory;
     toolInvocations: ToolInvocation[];
     metrics: ConversationMetrics;
+    /**
+     * Whether the run stopped on the turn limit instead of reaching a final answer. The
+     * only non-success outcome that gets this far: every other subtype throws below.
+     */
+    hitMaxTurns: boolean;
     /** Claude Code runtime version from the `init` message. */
     claudeCodeVersion?: string;
     /** Agent narration + thinking, for the item's trace. Not shown to the judge. */
@@ -251,5 +256,5 @@ export function adaptSdkConversation(
         durationMs,
     };
 
-    return { conversation, toolInvocations, metrics, claudeCodeVersion, transcript };
+    return { conversation, toolInvocations, metrics, hitMaxTurns, claudeCodeVersion, transcript };
 }

--- a/evals/workflows/sdk_conversation_adapter.ts
+++ b/evals/workflows/sdk_conversation_adapter.ts
@@ -49,6 +49,11 @@ export type AdaptedConversation = {
      * only non-success outcome that gets this far: every other subtype throws below.
      */
     hitMaxTurns: boolean;
+    /**
+     * Epoch ms the final model turn opened, when the caller timed the stream. The usage
+     * generation is windowed to it rather than to the whole run.
+     */
+    finalTurnStartedAt?: number;
     /** Claude Code runtime version from the `init` message. */
     claudeCodeVersion?: string;
     /** Agent narration + thinking, for the item's trace. Not shown to the judge. */
@@ -94,6 +99,7 @@ export function adaptSdkConversation(
     const pendingToolUses = new Map<string, PendingToolUse>();
     let totalResultBytes = 0;
     let claudeCodeVersion: string | undefined;
+    let finalTurnStartedAt: number | undefined;
 
     let numTurns: number | undefined;
     let usage: { promptTokens: number; completionTokens: number } | undefined;
@@ -155,6 +161,7 @@ export function adaptSdkConversation(
                 turns.push(turn);
                 entry = { role: 'assistant' };
                 transcript.push(entry);
+                finalTurnStartedAt = messageTime;
             }
 
             turn.toolCalls.push(...toolCalls);
@@ -256,5 +263,13 @@ export function adaptSdkConversation(
         durationMs,
     };
 
-    return { conversation, toolInvocations, metrics, hitMaxTurns, claudeCodeVersion, transcript };
+    return {
+        conversation,
+        toolInvocations,
+        metrics,
+        hitMaxTurns,
+        finalTurnStartedAt,
+        claudeCodeVersion,
+        transcript,
+    };
 }

--- a/evals/workflows/sdk_conversation_adapter.ts
+++ b/evals/workflows/sdk_conversation_adapter.ts
@@ -2,8 +2,9 @@
  * Folds the Claude Agent SDK's message stream into what the eval reads: the judge's
  * `ConversationHistory`, the tool invocations, the transcript, and the run metrics.
  *
- * The stream is an `init` system message, one `assistant` message per model turn, `user`
- * messages carrying tool results, and a final `result` message.
+ * The stream is an `init` system message, `assistant` messages (one frame per content
+ * block, sharing `message.id` within a model turn), `user` messages carrying tool
+ * results, and a final `result` message.
  */
 
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
@@ -96,6 +97,13 @@ export function adaptSdkConversation(
     let resultSubtype: string | undefined;
     let resultErrors: string[] = [];
     let finalResultText = '';
+    /**
+     * The CLI splits every assistant turn into one wire frame per content block, all
+     * sharing `message.id`, so consecutive frames with the same id fold into one turn.
+     * Without this, narration that accompanies a tool call becomes its own text-only turn
+     * and leaks to the judge as an AGENT: line, and turn counts inflate.
+     */
+    let openAssistantId: string | undefined;
 
     for (const [messageIndex, message] of messages.entries()) {
         const messageTime = receivedAt?.[messageIndex];
@@ -112,6 +120,10 @@ export function adaptSdkConversation(
 
         if (message.type === 'assistant') {
             const blocks = blocksOf(message.message.content);
+            const messageId = message.message.id;
+            const merging = messageId !== undefined && messageId === openAssistantId;
+            openAssistantId = messageId;
+
             const textParts: string[] = [];
             const thinkingParts: string[] = [];
             const toolCalls: { name: string; arguments: Record<string, unknown> }[] = [];
@@ -129,19 +141,30 @@ export function adaptSdkConversation(
             }
 
             const text = textParts.join('\n').trim();
-            const turn: ConversationTurn = { toolCalls };
-            // Match the old harness: only a text-only turn exposes a finalResponse to the judge.
-            if (toolCalls.length === 0 && text) {
-                turn.finalResponse = text;
-            }
-            turns.push(turn);
-
-            const entry: TranscriptEntry = { role: 'assistant' };
-            if (text) entry.text = text;
             const thinking = thinkingParts.join('\n').trim();
-            if (thinking) entry.thinking = thinking;
-            if (toolCalls.length > 0) entry.toolCalls = toolCalls.map((toolCall) => toolCall.name);
-            transcript.push(entry);
+
+            let turn = merging ? turns[turns.length - 1] : undefined;
+            let entry = merging ? transcript[transcript.length - 1] : undefined;
+            if (!turn || !entry) {
+                turn = { toolCalls: [] };
+                turns.push(turn);
+                entry = { role: 'assistant' };
+                transcript.push(entry);
+            }
+
+            turn.toolCalls.push(...toolCalls);
+            // Match the old harness: only a text-only turn exposes a finalResponse to the judge.
+            if (text && turn.toolCalls.length === 0) {
+                turn.finalResponse = text;
+            } else if (turn.toolCalls.length > 0) {
+                delete turn.finalResponse;
+            }
+
+            if (text) entry.text = entry.text ? `${entry.text}\n${text}` : text;
+            if (thinking) entry.thinking = entry.thinking ? `${entry.thinking}\n${thinking}` : thinking;
+            if (toolCalls.length > 0) {
+                entry.toolCalls = [...(entry.toolCalls ?? []), ...toolCalls.map((toolCall) => toolCall.name)];
+            }
             continue;
         }
 

--- a/evals/workflows/sdk_conversation_adapter.ts
+++ b/evals/workflows/sdk_conversation_adapter.ts
@@ -16,6 +16,9 @@ export type ToolInvocation = {
     name: string;
     arguments: unknown;
     result: McpToolResult;
+    /** Epoch ms the call and its result were streamed, when the caller timed the stream */
+    startedAt?: number;
+    endedAt?: number;
 };
 
 /** A compact record of agent narration + thinking, logged to the item's trace (never judged). */
@@ -66,9 +69,19 @@ function blocksOf(content: unknown): ContentBlock[] {
 type PendingToolUse = {
     name: string;
     arguments: unknown;
+    startedAt?: number;
 };
 
-export function adaptSdkConversation(userPrompt: string, messages: SDKMessage[]): AdaptedConversation {
+/**
+ * `receivedAt` holds the epoch ms each message arrived, one per entry in `messages`. The
+ * SDK stream carries no timestamps of its own, so this is the only way tool spans get a
+ * real duration instead of collapsing to the moment the tree is emitted.
+ */
+export function adaptSdkConversation(
+    userPrompt: string,
+    messages: SDKMessage[],
+    receivedAt?: readonly number[],
+): AdaptedConversation {
     const turns: ConversationTurn[] = [];
     const toolInvocations: ToolInvocation[] = [];
     const transcript: TranscriptEntry[] = [];
@@ -84,7 +97,9 @@ export function adaptSdkConversation(userPrompt: string, messages: SDKMessage[])
     let resultErrors: string[] = [];
     let finalResultText = '';
 
-    for (const message of messages) {
+    for (const [messageIndex, message] of messages.entries()) {
+        const messageTime = receivedAt?.[messageIndex];
+
         // Ignore subagent activity so the transcript reflects the main agent.
         if ((message.type === 'assistant' || message.type === 'user') && message.parent_tool_use_id !== null) {
             continue;
@@ -109,7 +124,7 @@ export function adaptSdkConversation(userPrompt: string, messages: SDKMessage[])
                 } else if (block.type === 'tool_use') {
                     const name = stripToolPrefix(block.name);
                     toolCalls.push({ name, arguments: (block.input ?? {}) as Record<string, unknown> });
-                    pendingToolUses.set(block.id, { name, arguments: block.input });
+                    pendingToolUses.set(block.id, { name, arguments: block.input, startedAt: messageTime });
                 }
             }
 
@@ -148,7 +163,13 @@ export function adaptSdkConversation(userPrompt: string, messages: SDKMessage[])
                     error: success ? undefined : serialized,
                     resultBytes,
                 };
-                toolInvocations.push({ name: pending.name, arguments: pending.arguments, result });
+                toolInvocations.push({
+                    name: pending.name,
+                    arguments: pending.arguments,
+                    result,
+                    ...(pending.startedAt === undefined ? {} : { startedAt: pending.startedAt }),
+                    ...(messageTime === undefined ? {} : { endedAt: messageTime }),
+                });
             }
             continue;
         }

--- a/evals/workflows/sdk_conversation_adapter.ts
+++ b/evals/workflows/sdk_conversation_adapter.ts
@@ -76,6 +76,21 @@ function blocksOf(content: unknown): ContentBlock[] {
     return Array.isArray(content) ? (content as ContentBlock[]) : [];
 }
 
+/**
+ * Error text as the model saw it. A failed result is usually a string or text blocks;
+ * `JSON.stringify` on those would quote and escape them, which is what Langfuse then shows
+ * as one `\n`-riddled line instead of a readable message.
+ */
+function errorTextOf(content: unknown): string {
+    if (typeof content === 'string') return content;
+
+    const texts = blocksOf(content)
+        .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+        .map((block) => block.text);
+
+    return texts.length > 0 ? texts.join('\n') : JSON.stringify(content ?? null, null, 4);
+}
+
 /** A tool_use awaiting its result, so the two can be paired. */
 type PendingToolUse = {
     name: string;
@@ -195,7 +210,7 @@ export function adaptSdkConversation(
                     toolName: pending.name,
                     success,
                     result: success ? block.content : undefined,
-                    error: success ? undefined : serialized,
+                    error: success ? undefined : errorTextOf(block.content),
                     resultBytes,
                 };
                 toolInvocations.push({

--- a/evals/workflows/workflow_judge.ts
+++ b/evals/workflows/workflow_judge.ts
@@ -123,10 +123,12 @@ export async function evaluateConversation(
     // Format conversation for judge
     const formattedConversation = formatConversationForJudge(conversation);
 
-    // Create judge prompt using reference field
-    const judgePrompt = JUDGE_PROMPT_TEMPLATE.replace('{{reference}}', reference).replace(
+    // Create judge prompt using reference field. Both values are substituted through a
+    // function so `$&`, `$'`, `` $` `` and `$$` (routine in Bash commands the agent runs)
+    // are inserted literally instead of being read as replacement patterns.
+    const judgePrompt = JUDGE_PROMPT_TEMPLATE.replace('{{reference}}', () => reference).replace(
         '{{conversation}}',
-        formattedConversation,
+        () => formattedConversation,
     );
 
     // Call judge LLM with structured output schema

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@langfuse/tracing": "5.9.1",
     "@modelcontextprotocol/client": "2.0.0",
     "@modelcontextprotocol/conformance": "0.2.0-alpha.9",
+    "@opentelemetry/api": "1.9.1",
     "@opentelemetry/sdk-node": "0.220.0",
     "@sentry/cli": "^3.2.0",
     "@types/express": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       '@modelcontextprotocol/conformance':
         specifier: 0.2.0-alpha.9
         version: 0.2.0-alpha.9
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
       '@opentelemetry/sdk-node':
         specifier: 0.220.0
         version: 0.220.0(@opentelemetry/api@1.9.1)

--- a/tests/unit/evals.langfuse_experiment.test.ts
+++ b/tests/unit/evals.langfuse_experiment.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
     buildRunSummary,
@@ -10,10 +10,25 @@ import {
 import type { LlmClient } from '../../evals/workflows/llm_client.js';
 
 // The task runs the Claude Agent SDK, which would otherwise spawn the real agent + server.
-vi.mock('../../evals/workflows/claude_agent.js', () => ({
-    runAgentConversation: async () => {
+const mocks = vi.hoisted(() => ({
+    runAgentConversation: vi.fn(async (): Promise<unknown> => {
         throw new Error('spawn ENOENT');
-    },
+    }),
+    emitObservations: vi.fn(),
+    evaluateConversation: vi.fn(async () => ({ verdict: 'PASS', reason: 'looks good', rawResponse: '' })),
+}));
+
+vi.mock('../../evals/workflows/claude_agent.js', () => ({
+    runAgentConversation: mocks.runAgentConversation,
+}));
+
+vi.mock('../../evals/workflows/langfuse_observations.js', () => ({
+    buildAgentObservations: () => ({}),
+    emitObservations: mocks.emitObservations,
+}));
+
+vi.mock('../../evals/workflows/workflow_judge.js', () => ({
+    evaluateConversation: mocks.evaluateConversation,
 }));
 
 function makeOutput(overrides: Partial<WorkflowTaskOutput> = {}): WorkflowTaskOutput {
@@ -55,8 +70,15 @@ describe('evaluators', () => {
 });
 
 describe('makeTask()', () => {
-    it('names the item in a harness error, which the SDK log line omits', async () => {
-        const task = makeTask({
+    const makeItem = () => ({
+        id: 'search-001',
+        input: { query: 'q' },
+        expectedOutput: 'r',
+        metadata: { category: 'search' },
+    });
+
+    const makeWorkflowTask = () =>
+        makeTask({
             llmClient: {} as LlmClient,
             apifyToken: 'token',
             agentModel: 'agent',
@@ -65,9 +87,30 @@ describe('makeTask()', () => {
             mcpToolsOnly: false,
         });
 
-        await expect(
-            task({ id: 'search-001', input: { query: 'q' }, expectedOutput: 'r', metadata: { category: 'search' } }),
-        ).rejects.toThrow('Item "search-001": spawn ENOENT');
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.runAgentConversation.mockRejectedValue(new Error('spawn ENOENT'));
+    });
+
+    it('names the item in a harness error, which the SDK log line omits', async () => {
+        await expect(makeWorkflowTask()(makeItem())).rejects.toThrow('Item "search-001": spawn ENOENT');
+    });
+
+    it('still scores the item when emitting the agent trace throws', async () => {
+        mocks.runAgentConversation.mockResolvedValue({
+            conversation: { turns: [], totalTokens: 1234 },
+            transcript: [],
+        });
+        mocks.emitObservations.mockImplementation(() => {
+            throw new Error('span export failed');
+        });
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        await expect(makeWorkflowTask()(makeItem())).resolves.toMatchObject({
+            id: 'search-001',
+            judgeResult: { verdict: 'PASS' },
+            totalTokens: 1234,
+        });
     });
 });
 

--- a/tests/unit/evals.langfuse_observations.test.ts
+++ b/tests/unit/evals.langfuse_observations.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { startObservation } from '@langfuse/tracing';
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { type AgentObservationParams, buildAgentObservations } from '../../evals/workflows/langfuse_observations.js';
+import {
+    type AgentObservationParams,
+    buildAgentObservations,
+    emitObservations,
+} from '../../evals/workflows/langfuse_observations.js';
 import type { AdaptedConversation } from '../../evals/workflows/sdk_conversation_adapter.js';
+
+vi.mock('@langfuse/tracing', () => ({ startObservation: vi.fn() }));
+
+const startObservationMock = startObservation as unknown as Mock;
 
 const START = Date.parse('2026-08-12T10:00:00.000Z');
 const END = START + 5_000;
@@ -179,5 +189,39 @@ describe('buildAgentObservations()', () => {
             level: 'WARNING',
             statusMessage: 'hit the turn limit',
         });
+    });
+});
+
+describe('emitObservations()', () => {
+    /** Records which spans were ended, in order, and lets a named span fail to start. */
+    function stubObservations(failingName?: string): string[] {
+        const ended: string[] = [];
+        startObservationMock.mockImplementation((name: string) => {
+            if (name === failingName) throw new Error('attribute serialization failed');
+            return {
+                otelSpan: { spanContext: () => ({ traceId: 't', spanId: name, traceFlags: 1 }) },
+                end: () => ended.push(name),
+            };
+        });
+        return ended;
+    }
+
+    beforeEach(() => {
+        startObservationMock.mockReset();
+    });
+
+    it('emits the agent span with its generation and tool children', () => {
+        const ended = stubObservations();
+
+        emitObservations(buildAgentObservations(makeParams()));
+
+        expect(ended).toEqual(['claude-haiku-4-5', 'search-actors', 'agent']);
+    });
+
+    it('ends the parent span even when a child fails to start, so no span is left dangling', () => {
+        const ended = stubObservations('search-actors');
+
+        expect(() => emitObservations(buildAgentObservations(makeParams()))).toThrow('attribute serialization failed');
+        expect(ended).toEqual(['claude-haiku-4-5', 'agent']);
     });
 });

--- a/tests/unit/evals.langfuse_observations.test.ts
+++ b/tests/unit/evals.langfuse_observations.test.ts
@@ -168,16 +168,16 @@ describe('buildAgentObservations()', () => {
                     result: {
                         toolName: 'get-dataset-items',
                         success: true,
-                        result: [{ text: 'x'.repeat(300_000) }],
-                        resultBytes: 300_000,
+                        result: [{ text: 'x'.repeat(600_000) }],
+                        resultBytes: 600_000,
                     },
                 },
             ],
         });
         const toolNode = buildAgentObservations(makeParams({ adapted })).children[1];
 
-        expect(toolNode.attributes.output).toBe('[output omitted: 300000 bytes]');
-        expect(toolNode.attributes.metadata).toMatchObject({ resultBytes: 300_000, outputOmitted: true });
+        expect(toolNode.attributes.output).toBe('[output omitted: 600000 bytes]');
+        expect(toolNode.attributes.metadata).toMatchObject({ resultBytes: 600_000, outputOmitted: true });
     });
 
     it('raises a failed tool call to ERROR, leaving the payload to the output alone', () => {

--- a/tests/unit/evals.langfuse_observations.test.ts
+++ b/tests/unit/evals.langfuse_observations.test.ts
@@ -32,7 +32,15 @@ function makeAdapted(overrides: Partial<AdaptedConversation> = {}): AdaptedConve
                 endedAt: START + 2_000,
             },
         ],
-        metrics: { resultBytes: 16, turns: 2, promptTokens: 100, completionTokens: 20, totalCostUsd: 0.01 },
+        metrics: {
+            resultBytes: 16,
+            turns: 2,
+            promptTokens: 100,
+            completionTokens: 20,
+            cacheReadTokens: 60,
+            cacheCreationTokens: 30,
+            totalCostUsd: 0.01,
+        },
         claudeCodeVersion: '2.0.0',
         transcript: [],
         ...overrides,
@@ -74,9 +82,24 @@ describe('buildAgentObservations()', () => {
         expect(usage).toMatchObject({ name: 'claude-haiku-4-5', asType: 'generation' });
         expect(usage.attributes).toMatchObject({
             model: 'claude-haiku-4-5',
-            usageDetails: { input: 100, output: 20, total: 120 },
+            usageDetails: {
+                input: 10,
+                cache_read_input_tokens: 60,
+                cache_creation_input_tokens: 30,
+                output: 20,
+                total: 120,
+            },
             costDetails: { total: 0.01 },
         });
+    });
+
+    it('reports the whole prompt as fresh input when the provider reported no caching', () => {
+        const adapted = makeAdapted({
+            metrics: { resultBytes: 16, turns: 2, promptTokens: 100, completionTokens: 20 },
+        });
+        const [usage] = buildAgentObservations(makeParams({ adapted })).children;
+
+        expect(usage.attributes.usageDetails).toEqual({ input: 100, output: 20, total: 120 });
     });
 
     it('windows the generation to the final model turn, so the tool spans sort before it', () => {

--- a/tests/unit/evals.langfuse_observations.test.ts
+++ b/tests/unit/evals.langfuse_observations.test.ts
@@ -113,8 +113,22 @@ describe('buildAgentObservations()', () => {
         expect(usage).toMatchObject({ startTime: new Date(START + 3_000), endTime: new Date(END) });
     });
 
-    it('falls back to the run start when the final turn was never stamped', () => {
-        const adapted = makeAdapted({ finalTurnStartedAt: undefined });
+    it('pushes the generation past the last tool result when the final turn called tools', () => {
+        // A run that hit the turn limit ends on a tool-calling turn, so the final turn opens
+        // before its own tool spans.
+        const adapted = makeAdapted({ hitMaxTurns: true, finalTurnStartedAt: START + 1_000 });
+        const [usage] = buildAgentObservations(makeParams({ adapted })).children;
+
+        expect(usage.startTime).toEqual(new Date(START + 2_000));
+    });
+
+    it('falls back to the run start when the stream was never timed', () => {
+        const adapted = makeAdapted({
+            finalTurnStartedAt: undefined,
+            toolInvocations: [
+                { name: 'search-actors', arguments: {}, result: { toolName: 'search-actors', success: true } },
+            ],
+        });
         const [usage] = buildAgentObservations(makeParams({ adapted })).children;
 
         expect(usage.startTime).toEqual(new Date(START));

--- a/tests/unit/evals.langfuse_observations.test.ts
+++ b/tests/unit/evals.langfuse_observations.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import { type AgentObservationParams, buildAgentObservations } from '../../evals/workflows/langfuse_observations.js';
+import type { AdaptedConversation } from '../../evals/workflows/sdk_conversation_adapter.js';
+
+const START = Date.parse('2026-08-12T10:00:00.000Z');
+const END = START + 5_000;
+
+function makeAdapted(overrides: Partial<AdaptedConversation> = {}): AdaptedConversation {
+    return {
+        conversation: {
+            userPrompt: 'find a maps scraper',
+            turns: [
+                { turnNumber: 1, toolCalls: [{ name: 'search-actors', arguments: {} }], toolResults: [] },
+                { turnNumber: 2, toolCalls: [], toolResults: [], finalResponse: 'Found 3 Actors.' },
+            ],
+            completed: true,
+            hitMaxTurns: false,
+            totalTurns: 2,
+            promptTokens: 100,
+            completionTokens: 20,
+            totalTokens: 120,
+        },
+        toolInvocations: [
+            {
+                name: 'search-actors',
+                arguments: { search: 'maps' },
+                result: { toolName: 'search-actors', success: true, result: [{ text: 'ok' }], resultBytes: 16 },
+                startedAt: START + 1_000,
+                endedAt: START + 2_000,
+            },
+        ],
+        metrics: { resultBytes: 16, turns: 2, promptTokens: 100, completionTokens: 20, totalCostUsd: 0.01 },
+        claudeCodeVersion: '2.0.0',
+        transcript: [],
+        ...overrides,
+    };
+}
+
+function makeParams(overrides: Partial<AgentObservationParams> = {}): AgentObservationParams {
+    return {
+        prompt: 'find a maps scraper',
+        model: 'claude-haiku-4-5',
+        mcpToolsOnly: false,
+        adapted: makeAdapted(),
+        startedAt: START,
+        endedAt: END,
+        ...overrides,
+    };
+}
+
+describe('buildAgentObservations()', () => {
+    it('spans the agent run with the prompt in and the final answer out', () => {
+        const agent = buildAgentObservations(makeParams());
+
+        expect(agent).toMatchObject({
+            name: 'agent',
+            asType: 'agent',
+            startTime: new Date(START),
+            endTime: new Date(END),
+        });
+        expect(agent.attributes).toMatchObject({
+            input: 'find a maps scraper',
+            output: 'Found 3 Actors.',
+            metadata: { model: 'claude-haiku-4-5', turns: 2, toolCalls: 1, claudeCodeVersion: '2.0.0' },
+        });
+    });
+
+    it('carries the run tokens and cost on a generation, which is what Langfuse rolls up', () => {
+        const [usage] = buildAgentObservations(makeParams()).children;
+
+        expect(usage).toMatchObject({ name: 'claude-haiku-4-5', asType: 'generation' });
+        expect(usage.attributes).toMatchObject({
+            model: 'claude-haiku-4-5',
+            usageDetails: { input: 100, output: 20, total: 120 },
+            costDetails: { total: 0.01 },
+        });
+    });
+
+    it('omits usage when the provider reported none, so an unmeasured run cannot read as free', () => {
+        const adapted = makeAdapted({ metrics: { resultBytes: 0, turns: 1 } });
+        const [usage] = buildAgentObservations(makeParams({ adapted })).children;
+
+        expect(usage.attributes.usageDetails).toBeUndefined();
+        expect(usage.attributes.costDetails).toBeUndefined();
+    });
+
+    it('gives each tool call its own span, timed from the stream', () => {
+        const toolNode = buildAgentObservations(makeParams()).children[1];
+
+        expect(toolNode).toMatchObject({
+            name: 'search-actors',
+            asType: 'tool',
+            startTime: new Date(START + 1_000),
+            endTime: new Date(START + 2_000),
+        });
+        expect(toolNode.attributes).toMatchObject({
+            input: { search: 'maps' },
+            output: [{ text: 'ok' }],
+            metadata: { resultBytes: 16 },
+        });
+        expect(toolNode.attributes.level).toBeUndefined();
+    });
+
+    it('raises a failed tool call to ERROR with the payload as the status', () => {
+        const adapted = makeAdapted({
+            toolInvocations: [
+                {
+                    name: 'call-actor',
+                    arguments: {},
+                    result: { toolName: 'call-actor', success: false, error: 'internal error' },
+                },
+            ],
+        });
+        const toolNode = buildAgentObservations(makeParams({ adapted })).children[1];
+
+        expect(toolNode.attributes).toMatchObject({
+            level: 'ERROR',
+            statusMessage: 'internal error',
+            output: 'internal error',
+        });
+    });
+
+    it('leaves the span times open when the stream was not timed', () => {
+        const adapted = makeAdapted({
+            toolInvocations: [
+                {
+                    name: 'search-actors',
+                    arguments: {},
+                    result: { toolName: 'search-actors', success: true },
+                },
+            ],
+        });
+        const toolNode = buildAgentObservations(makeParams({ adapted })).children[1];
+
+        expect(toolNode.startTime).toBeUndefined();
+        expect(toolNode.endTime).toBeUndefined();
+    });
+
+    it('flags a run that hit the turn limit as a warning', () => {
+        const adapted = makeAdapted();
+        adapted.conversation.completed = false;
+        adapted.conversation.hitMaxTurns = true;
+
+        expect(buildAgentObservations(makeParams({ adapted })).attributes).toMatchObject({
+            level: 'WARNING',
+            statusMessage: 'hit the turn limit',
+        });
+    });
+});

--- a/tests/unit/evals.langfuse_observations.test.ts
+++ b/tests/unit/evals.langfuse_observations.test.ts
@@ -22,6 +22,7 @@ function makeAdapted(overrides: Partial<AdaptedConversation> = {}): AdaptedConve
             totalTokens: 120,
         },
         hitMaxTurns: false,
+        finalTurnStartedAt: START + 3_000,
         toolInvocations: [
             {
                 name: 'search-actors',
@@ -76,6 +77,19 @@ describe('buildAgentObservations()', () => {
             usageDetails: { input: 100, output: 20, total: 120 },
             costDetails: { total: 0.01 },
         });
+    });
+
+    it('windows the generation to the final model turn, so the tool spans sort before it', () => {
+        const [usage] = buildAgentObservations(makeParams()).children;
+
+        expect(usage).toMatchObject({ startTime: new Date(START + 3_000), endTime: new Date(END) });
+    });
+
+    it('falls back to the run start when the final turn was never stamped', () => {
+        const adapted = makeAdapted({ finalTurnStartedAt: undefined });
+        const [usage] = buildAgentObservations(makeParams({ adapted })).children;
+
+        expect(usage.startTime).toEqual(new Date(START));
     });
 
     it('omits usage when the provider reported none, so an unmeasured run cannot read as free', () => {

--- a/tests/unit/evals.langfuse_observations.test.ts
+++ b/tests/unit/evals.langfuse_observations.test.ts
@@ -11,14 +11,9 @@ function makeAdapted(overrides: Partial<AdaptedConversation> = {}): AdaptedConve
         conversation: {
             userPrompt: 'find a maps scraper',
             turns: [
-                { turnNumber: 1, toolCalls: [{ name: 'search-actors', arguments: {} }], toolResults: [] },
-                { turnNumber: 2, toolCalls: [], toolResults: [], finalResponse: 'Found 3 Actors.' },
+                { toolCalls: [{ name: 'search-actors', arguments: {} }] },
+                { toolCalls: [], finalResponse: 'Found 3 Actors.' },
             ],
-            completed: true,
-            hitMaxTurns: false,
-            totalTurns: 2,
-            promptTokens: 100,
-            completionTokens: 20,
             totalTokens: 120,
         },
         hitMaxTurns: false,

--- a/tests/unit/evals.langfuse_observations.test.ts
+++ b/tests/unit/evals.langfuse_observations.test.ts
@@ -159,6 +159,27 @@ describe('buildAgentObservations()', () => {
         expect(toolNode.attributes.level).toBeUndefined();
     });
 
+    it('drops an oversized tool result, which Langfuse would reject whole', () => {
+        const adapted = makeAdapted({
+            toolInvocations: [
+                {
+                    name: 'get-dataset-items',
+                    arguments: {},
+                    result: {
+                        toolName: 'get-dataset-items',
+                        success: true,
+                        result: [{ text: 'x'.repeat(300_000) }],
+                        resultBytes: 300_000,
+                    },
+                },
+            ],
+        });
+        const toolNode = buildAgentObservations(makeParams({ adapted })).children[1];
+
+        expect(toolNode.attributes.output).toBe('[output omitted: 300000 bytes]');
+        expect(toolNode.attributes.metadata).toMatchObject({ resultBytes: 300_000, outputOmitted: true });
+    });
+
     it('raises a failed tool call to ERROR, leaving the payload to the output alone', () => {
         const adapted = makeAdapted({
             toolInvocations: [

--- a/tests/unit/evals.langfuse_observations.test.ts
+++ b/tests/unit/evals.langfuse_observations.test.ts
@@ -117,7 +117,7 @@ describe('buildAgentObservations()', () => {
         expect(toolNode.attributes.level).toBeUndefined();
     });
 
-    it('raises a failed tool call to ERROR with the payload as the status', () => {
+    it('raises a failed tool call to ERROR, leaving the payload to the output alone', () => {
         const adapted = makeAdapted({
             toolInvocations: [
                 {
@@ -131,9 +131,10 @@ describe('buildAgentObservations()', () => {
 
         expect(toolNode.attributes).toMatchObject({
             level: 'ERROR',
-            statusMessage: 'internal error',
             output: 'internal error',
         });
+        // The UI already renders output; a copy in statusMessage only repeats it.
+        expect(toolNode.attributes.statusMessage).toBeUndefined();
     });
 
     it('leaves the span times open when the stream was not timed', () => {

--- a/tests/unit/evals.langfuse_observations.test.ts
+++ b/tests/unit/evals.langfuse_observations.test.ts
@@ -21,6 +21,7 @@ function makeAdapted(overrides: Partial<AdaptedConversation> = {}): AdaptedConve
             completionTokens: 20,
             totalTokens: 120,
         },
+        hitMaxTurns: false,
         toolInvocations: [
             {
                 name: 'search-actors',
@@ -139,8 +140,7 @@ describe('buildAgentObservations()', () => {
 
     it('flags a run that hit the turn limit as a warning', () => {
         const adapted = makeAdapted();
-        adapted.conversation.completed = false;
-        adapted.conversation.hitMaxTurns = true;
+        adapted.hitMaxTurns = true;
 
         expect(buildAgentObservations(makeParams({ adapted })).attributes).toMatchObject({
             level: 'WARNING',

--- a/tests/unit/evals.sdk_conversation_adapter.test.ts
+++ b/tests/unit/evals.sdk_conversation_adapter.test.ts
@@ -222,13 +222,12 @@ describe('adaptSdkConversation()', () => {
 
         expect(conversation.turns).toHaveLength(2);
         expect(conversation.turns[0]).toMatchObject({
-            turnNumber: 1,
             toolCalls: [{ name: 'search-actors', arguments: { search: 'maps' } }],
         });
         // Narration accompanying a tool call never reaches the judge.
         expect(conversation.turns[0].finalResponse).toBeUndefined();
-        expect(conversation.turns[0].toolResults).toHaveLength(1);
-        expect(conversation.turns[1]).toMatchObject({ turnNumber: 2, finalResponse: 'Found 3 Actors.' });
+        expect(toolInvocations).toHaveLength(1);
+        expect(conversation.turns[1]).toMatchObject({ finalResponse: 'Found 3 Actors.' });
         // The tool span still starts when its own frame arrived, not when the turn opened.
         expect(toolInvocations[0]).toMatchObject({ startedAt: 20, endedAt: 50 });
         expect(transcript).toEqual([

--- a/tests/unit/evals.sdk_conversation_adapter.test.ts
+++ b/tests/unit/evals.sdk_conversation_adapter.test.ts
@@ -4,8 +4,12 @@ import { describe, expect, it } from 'vitest';
 import { adaptSdkConversation } from '../../evals/workflows/sdk_conversation_adapter.js';
 
 /** An assistant message as the SDK streams it; only the fields the adapter reads. */
-function assistantMessage(content: unknown[], parentToolUseId: string | null = null): SDKMessage {
-    return { type: 'assistant', message: { content }, parent_tool_use_id: parentToolUseId } as unknown as SDKMessage;
+function assistantMessage(content: unknown[], parentToolUseId: string | null = null, id?: string): SDKMessage {
+    return {
+        type: 'assistant',
+        message: { id, content },
+        parent_tool_use_id: parentToolUseId,
+    } as unknown as SDKMessage;
 }
 
 /** A user message carrying tool results. */
@@ -132,6 +136,47 @@ describe('adaptSdkConversation()', () => {
                 }),
             ]),
         ).toThrow(/error_during_execution.*API error: 529 overloaded/s);
+    });
+
+    it('merges the frames the CLI splits one API turn into', () => {
+        // The CLI serializes one content block per wire frame, all sharing message.id.
+        const { conversation, transcript, toolInvocations } = adaptSdkConversation(
+            'find a maps scraper',
+            [
+                assistantMessage([{ type: 'thinking', thinking: 'which tool?' }], null, 'msg-1'),
+                assistantMessage([{ type: 'text', text: 'I found the scraper, calling it now' }], null, 'msg-1'),
+                assistantMessage(
+                    [{ type: 'tool_use', id: 'tool-1', name: 'mcp__apify__search-actors', input: { search: 'maps' } }],
+                    null,
+                    'msg-1',
+                ),
+                toolResultMessage([{ type: 'tool_result', tool_use_id: 'tool-1', content: [{ text: 'ok' }] }]),
+                assistantMessage([{ type: 'text', text: 'Found 3 Actors.' }], null, 'msg-2'),
+                resultMessage(),
+            ],
+            [10, 15, 20, 50, 55, 60],
+        );
+
+        expect(conversation.turns).toHaveLength(2);
+        expect(conversation.turns[0]).toMatchObject({
+            turnNumber: 1,
+            toolCalls: [{ name: 'search-actors', arguments: { search: 'maps' } }],
+        });
+        // Narration accompanying a tool call never reaches the judge.
+        expect(conversation.turns[0].finalResponse).toBeUndefined();
+        expect(conversation.turns[0].toolResults).toHaveLength(1);
+        expect(conversation.turns[1]).toMatchObject({ turnNumber: 2, finalResponse: 'Found 3 Actors.' });
+        // The tool span still starts when its own frame arrived, not when the turn opened.
+        expect(toolInvocations[0]).toMatchObject({ startedAt: 20, endedAt: 50 });
+        expect(transcript).toEqual([
+            {
+                role: 'assistant',
+                text: 'I found the scraper, calling it now',
+                thinking: 'which tool?',
+                toolCalls: ['search-actors'],
+            },
+            { role: 'assistant', text: 'Found 3 Actors.' },
+        ]);
     });
 
     it('records narration, thinking, and tool names in the transcript', () => {

--- a/tests/unit/evals.sdk_conversation_adapter.test.ts
+++ b/tests/unit/evals.sdk_conversation_adapter.test.ts
@@ -125,6 +125,36 @@ describe('adaptSdkConversation()', () => {
         expect(conversation.turns.at(-1)?.finalResponse).toBeUndefined();
     });
 
+    it('stamps when the final model turn opened, so the generation can be windowed to it', () => {
+        const { finalTurnStartedAt } = adaptSdkConversation(
+            'find a maps scraper',
+            [
+                assistantMessage(
+                    [{ type: 'tool_use', id: 'tool-1', name: 'mcp__apify__search-actors', input: {} }],
+                    null,
+                    'msg-1',
+                ),
+                toolResultMessage([{ type: 'tool_result', tool_use_id: 'tool-1', content: [{ text: 'ok' }] }]),
+                assistantMessage([{ type: 'thinking', thinking: 'that is the one' }], null, 'msg-2'),
+                assistantMessage([{ type: 'text', text: 'Found 3 Actors.' }], null, 'msg-2'),
+                resultMessage(),
+            ],
+            [10, 20, 30, 35, 40],
+        );
+
+        // The first frame of the last turn, not the frame the answer text arrived in.
+        expect(finalTurnStartedAt).toBe(30);
+    });
+
+    it('leaves the final turn unstamped when the caller did not time the stream', () => {
+        const { finalTurnStartedAt } = adaptSdkConversation('hi', [
+            assistantMessage([{ type: 'text', text: 'done' }]),
+            resultMessage({ num_turns: 1 }),
+        ]);
+
+        expect(finalTurnStartedAt).toBeUndefined();
+    });
+
     it('throws on a run the SDK aborted, so it is not judged as a failing eval', () => {
         expect(() =>
             adaptSdkConversation('hi', [

--- a/tests/unit/evals.sdk_conversation_adapter.test.ts
+++ b/tests/unit/evals.sdk_conversation_adapter.test.ts
@@ -68,6 +68,20 @@ describe('adaptSdkConversation()', () => {
         expect(metrics.resultBytes).toBe(Buffer.byteLength(JSON.stringify([{ text: 'ok' }]), 'utf8'));
     });
 
+    it('times each invocation from when its call and result were streamed', () => {
+        // One per message in toolCallStream: init, assistant, tool result, result.
+        const { toolInvocations } = adaptSdkConversation('find a maps scraper', toolCallStream, [10, 20, 50, 60]);
+
+        expect(toolInvocations[0]).toMatchObject({ startedAt: 20, endedAt: 50 });
+    });
+
+    it('leaves invocations untimed when the caller did not time the stream', () => {
+        const { toolInvocations } = adaptSdkConversation('find a maps scraper', toolCallStream);
+
+        expect(toolInvocations[0].startedAt).toBeUndefined();
+        expect(toolInvocations[0].endedAt).toBeUndefined();
+    });
+
     it('marks an errored tool result as failed and keeps the payload as the error', () => {
         const { toolInvocations } = adaptSdkConversation('find a maps scraper', [
             assistantMessage([{ type: 'tool_use', id: 'tool-1', name: 'mcp__apify__search-actors', input: {} }]),

--- a/tests/unit/evals.sdk_conversation_adapter.test.ts
+++ b/tests/unit/evals.sdk_conversation_adapter.test.ts
@@ -95,7 +95,40 @@ describe('adaptSdkConversation()', () => {
             resultMessage(),
         ]);
 
-        expect(toolInvocations[0].result).toMatchObject({ success: false, error: '"internal error"' });
+        expect(toolInvocations[0].result).toMatchObject({ success: false, error: 'internal error' });
+    });
+
+    it('keeps an errored text block readable instead of JSON-escaping it', () => {
+        const { toolInvocations } = adaptSdkConversation('call the browser', [
+            assistantMessage([{ type: 'tool_use', id: 'tool-1', name: 'mcp__apify__call-actor', input: {} }]),
+            toolResultMessage([
+                {
+                    type: 'tool_result',
+                    tool_use_id: 'tool-1',
+                    content: [
+                        { type: 'text', text: "Input validation failed.\nErrors: must have required property 'query'" },
+                    ],
+                    is_error: true,
+                },
+            ]),
+            resultMessage(),
+        ]);
+
+        expect(toolInvocations[0].result.error).toBe(
+            "Input validation failed.\nErrors: must have required property 'query'",
+        );
+    });
+
+    it('falls back to pretty JSON for an error payload that is not text', () => {
+        const { toolInvocations } = adaptSdkConversation('call the browser', [
+            assistantMessage([{ type: 'tool_use', id: 'tool-1', name: 'mcp__apify__call-actor', input: {} }]),
+            toolResultMessage([
+                { type: 'tool_result', tool_use_id: 'tool-1', content: { code: 'invalid-input' }, is_error: true },
+            ]),
+            resultMessage(),
+        ]);
+
+        expect(toolInvocations[0].result.error).toBe('{\n    "code": "invalid-input"\n}');
     });
 
     it('counts cached prompt tokens, which the API reports separately', () => {

--- a/tests/unit/evals.sdk_conversation_adapter.test.ts
+++ b/tests/unit/evals.sdk_conversation_adapter.test.ts
@@ -179,6 +179,17 @@ describe('adaptSdkConversation()', () => {
         ]);
     });
 
+    it('keeps every text block of a merged turn as the final response', () => {
+        const { conversation } = adaptSdkConversation('hi', [
+            assistantMessage([{ type: 'text', text: 'Part A' }], null, 'msg-1'),
+            assistantMessage([{ type: 'text', text: 'Part B' }], null, 'msg-1'),
+            resultMessage({ result: 'Part A\nPart B', num_turns: 1 }),
+        ]);
+
+        expect(conversation.turns).toHaveLength(1);
+        expect(conversation.turns[0].finalResponse).toBe('Part A\nPart B');
+    });
+
     it('records narration, thinking, and tool names in the transcript', () => {
         const { transcript } = adaptSdkConversation('hi', [
             assistantMessage([

--- a/tests/unit/evals.workflow_judge.test.ts
+++ b/tests/unit/evals.workflow_judge.test.ts
@@ -11,6 +11,18 @@ function makeJudgeClient(content: string): LlmClient {
     } as unknown as LlmClient;
 }
 
+/** LLM client that records the prompt it was asked to judge. */
+function makePromptCapturingClient(): { client: LlmClient; prompt: () => string } {
+    let captured = '';
+    const client = {
+        callLlm: async (messages: { content: string }[]) => {
+            captured = messages[0].content;
+            return { content: '{"verdict":"PASS","reason":"ok"}' };
+        },
+    } as unknown as LlmClient;
+    return { client, prompt: () => captured };
+}
+
 const reference = 'the agent should search';
 
 const conversation: ConversationHistory = {
@@ -27,6 +39,21 @@ describe('evaluateConversation()', () => {
         );
 
         expect(result.verdict).toBe('PASS');
+    });
+
+    it('inserts $-patterns literally instead of letting them rewrite the prompt', async () => {
+        // `$'`, `$&`, `` $` `` and `$$` are replacement patterns for String.replace; a Bash
+        // command like $'\n' in the transcript must not splice the template around itself.
+        const { client, prompt } = makePromptCapturingClient();
+        await evaluateConversation(
+            'expected $& output $$',
+            { ...conversation, userPrompt: "run $'\\n' $` here" },
+            client,
+        );
+
+        expect(prompt()).toContain("run $'\\n' $` here");
+        expect(prompt()).toContain('expected $& output $$');
+        expect(prompt()).not.toContain('{{conversation}}');
     });
 
     it('rejects a verdict that is neither PASS nor FAIL', async () => {


### PR DESCRIPTION
Stacked on #1238. Second of two: #1238 makes the agent under test the real Claude Code harness, this one puts its conversation on the Langfuse trace.

## What

- `langfuse_observations.ts` builds the tree from the adapted SDK stream and emits it.
- Tool spans are timed from when the SDK delivered the call and its result.
- `llm_client.ts` wraps each call in a generation, which is what puts the judge call, its verdict, and its tokens on the trace.
- A failed tool call is raised to `ERROR` level with the payload as the status, and a run that never reached a final answer is flagged `WARNING`, so both are findable in the UI.
- The tree is emitted before the judge call, so a failing judge still leaves the conversation on the trace to debug. A crashed agent run leaves no spans.
- Adds `@opentelemetry/api`, the peer dependency of `@langfuse/tracing`, for the `SpanContext` type.

## Verification

- `--id search-google-maps`: 1/1 passed, the five observations land with the right nesting, and `GET /api/public/v2/metrics` reports 71.5k tokens and $0.039 on the agent generation plus 798 tokens on the judge one.
- `type-check`, `lint`, `test:unit` (1289 pass / 1 skip), `format`, `check:agents` all green.
