### PR TITLE
docs: Align README resources and prompts with runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Configure the Skyfire MCP server and the Apify MCP Server in your client. Add `p
 {
   "mcpServers": {
     "skyfire": {
-      "url": "https://mcp.skyfire.xyz/mcp",
+      "url": "https://api.skyfire.xyz/mcp/sse",
       "headers": {
         "skyfire-api-key": "<YOUR_SKYFIRE_API_KEY>"
       }

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Configure the Skyfire MCP server and the Apify MCP Server in your client. Add `p
 {
   "mcpServers": {
     "skyfire": {
-      "url": "https://api.skyfire.xyz/mcp/sse",
+      "url": "https://mcp.skyfire.xyz/mcp",
       "headers": {
         "skyfire-api-key": "<YOUR_SKYFIRE_API_KEY>"
       }
@@ -398,11 +398,11 @@ Existing URLs and commands using `?actors=...` or `--actors` continue to work un
 
 ### Prompts
 
-The server provides a set of predefined example prompts to help you get started interacting with Apify through MCP. For example, there is a `GetLatestNewsOnTopic` prompt that allows you to easily retrieve the latest news on a specific topic using the [RAG Web Browser](https://apify.com/apify/rag-web-browser) Actor.
+The server advertises the `prompts` capability, but no prompts are currently registered — `prompts/list` returns an empty list.
 
 ### Resources
 
-The server does not yet provide any resources.
+Your Apify data is not enumerated in `resources/list` — reads are on demand: pass any Apify API GET URL (`https://api.apify.com/v2/...`) to `resources/read` and the server injects the session's Apify token and returns the response body. `resources/templates/list` enumerates the common shapes — dataset items, key-value store records and keys, run metadata, run log — with their paging parameters. Responses inline up to 256 KB; anything larger returns a short notice with a download URL instead of the body. API reads require an Apify token, so a payment-only session (x402 or Skyfire) gets a JSON-RPC error for them.
 
 ## 💬 Usage examples
 


### PR DESCRIPTION
## Why

Two README claims disagreed with the runtime:

- It said the server provides no resources, while `initialize.instructions` documents the API read proxy, templates, the 256 KB cap and the payment-only restriction.
- It advertised a `GetLatestNewsOnTopic` prompt; `src/prompts/index.ts` is an empty array.

`Part of apify/apify-mcp-server-internal#688`.

## What changed

README only, two paragraphs. Resources now describes the on-demand read proxy, the templates list, the 256 KB inline cap with its download-URL fallback, and that API reads need an Apify token. Prompts now says the capability is advertised but nothing is registered.

It deliberately makes **no claim that `resources/list` is empty** — that would be false. `listResources()` serves `file://readme.md` when the payment provider has a usage guide (Skyfire's does), and widget resources in apps mode, which is auto-selected whenever the client negotiates MCP Apps UI support.

## Notes for reviewers (human-written)

<!-- left for the human author, per this template's instruction -->

## Proof it works

Every claim re-derived from source: `MAX_INLINE_BYTES` (`src/const.ts:19`), token injection and the no-token error (`src/resources/api_resources.ts:194-217`), `listResourceTemplates()`, the `prompts` capability in both server eras, and the empty `src/prompts/index.ts`.

Checks green and identical to baseline: `type-check`, `lint`, `test:unit` (91 files, 1268 passed), `check:agents`, `format:check`.

## Not in this PR

The stale Skyfire URL (`README.md:199`) is left alone. `docs.skyfire.xyz`, `mcp.skyfire.xyz` and `api.skyfire.xyz` are all unreachable from where this was prepared, so neither endpoint could be probed. Indirect evidence favours `https://mcp.skyfire.xyz/mcp`, but swapping one unverified URL for another in public docs isn't worth it — left for someone who can reach it.

Also pre-existing, filed separately: apify/apify-mcp-server#1241 (`get-actor-output` not retired, so saved URLs still 404) and apify/apify-mcp-server#1242 (`server_card.ts` omits the `prompts` capability).

---

AI-assisted, under human review, per [CONTRIBUTING.md](https://github.com/apify/apify-mcp-server/blob/master/CONTRIBUTING.md#ai-assisted-contributions). No model credited as co-author.
