### PR TITLE
feat: Validate Actor input against the platform before every run

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -15,6 +15,15 @@ export class SchemaTooLargeError extends Error {
     }
 }
 
+/**
+ * Thrown when Apify's `validate-input` endpoint confirms Actor input is invalid against its real
+ * schema. `statusCode` lets the existing HTTP-based classifiers treat it as a 4xx user error.
+ */
+export class ActorInputValidationError extends Error {
+    override readonly name = 'ActorInputValidationError';
+    readonly statusCode = 400;
+}
+
 export const ACTOR_LOAD_ERROR_KIND = {
     NOT_FOUND: 'not-found',
     LOAD_FAILED: 'load-failed',

--- a/src/mcp/tool_dispatch.ts
+++ b/src/mcp/tool_dispatch.ts
@@ -241,6 +241,7 @@ export async function dispatchToolCall(params: {
                 });
                 const executorResult = await actorExecutor.executeActorTool({
                     actorFullName: tool.actorFullName,
+                    actorId: tool.actorId,
                     input: toolArgs,
                     apifyClient,
                     callOptions: { memory: tool.memoryMbytes },

--- a/src/tools/actors/actor_executor.ts
+++ b/src/tools/actors/actor_executor.ts
@@ -3,6 +3,7 @@ import log from '@apify/log';
 import type { ActorExecutionParams, ActorExecutionResult, ActorExecutor } from '../../types.js';
 import { getConsoleLinkContext } from '../../utils/console_link.js';
 import { redactSkyfirePayId } from '../../utils/logging.js';
+import { validateActorInputRemotely } from '../../utils/validate_actor_input.js';
 import { buildGetActorRunResponse } from '../runs/get_actor_run.js';
 import { abortRunOnSignal, CALL_ACTOR_WAIT_SECS_DEFAULT, fetchActorRunData } from './actor_run_response.js';
 
@@ -36,6 +37,13 @@ export const actorExecutor: ActorExecutor = {
             });
             return null;
         }
+
+        await validateActorInputRemotely({
+            apifyClient,
+            actorId: params.actorId,
+            input: actorInput,
+            build: params.callOptions.build,
+        });
 
         const actorRun = await apifyClient.actor(actorFullName).start(actorInput, params.callOptions);
 

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -14,7 +14,7 @@ import {
     FAILURE_CATEGORY,
     HELPER_TOOLS,
 } from '../../const.js';
-import { ACTOR_LOAD_ERROR_KIND, ActorLoadError } from '../../errors.js';
+import { ACTOR_LOAD_ERROR_KIND, ActorInputValidationError, ActorLoadError } from '../../errors.js';
 import { connectMCPClient } from '../../mcp/client.js';
 import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC } from '../../mcp/const.js';
 import type { PaymentProvider } from '../../payments/types.js';
@@ -42,6 +42,7 @@ import {
 import { buildPermissionApprovalTexts } from '../../utils/payment_errors.js';
 import { classifyFailureCategory, extractAjvErrorDetails } from '../../utils/tool_status.js';
 import { extractActorId } from '../../utils/tools.js';
+import { validateActorInputRemotely } from '../../utils/validate_actor_input.js';
 import { actorNameToToolName, isActorBlockedUnderPaymentProvider } from '../actor_tool_naming.js';
 import { buildGetActorRunResponse } from '../runs/get_actor_run.js';
 import { actorRunOutputSchema } from '../structured_output_schemas.js';
@@ -410,8 +411,10 @@ export async function resolveAndValidateActor(params: {
     actorName: string;
     input: Record<string, unknown>;
     toolArgs: InternalToolArgs;
+    /** Build the run will use, so remote validation checks the same build's schema. */
+    build?: string;
 }): Promise<{ error: ToolResponse } | { actor: ToolEntry }> {
-    const { actorName, input, toolArgs } = params;
+    const { actorName, input, toolArgs, build } = params;
     const { apifyClient } = toolArgs;
 
     const { tools, errors } = await getActorsAsTools([actorName], apifyClient, {
@@ -487,6 +490,28 @@ export async function resolveAndValidateActor(params: {
                 detail: validationSummary.slice(0, 200) || 'input validation failed',
                 ajvErrorDetails: ajvDetails,
             }),
+        };
+    }
+
+    try {
+        await validateActorInputRemotely({ apifyClient, actorId: actorId ?? actorName, input, build });
+    } catch (error) {
+        if (!(error instanceof ActorInputValidationError)) throw error;
+
+        log.softFail('Actor input failed platform validation', {
+            actorName,
+            mcpSessionId: toolArgs.mcpSessionId,
+            failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+        });
+        return {
+            error: respondUserError(
+                [
+                    `Input validation failed for Actor '${actorName}'. Please ensure your input matches the Actor's input schema.`,
+                    `Input schema:\n${wrapJsonText(actor.inputSchema)}`,
+                    `Validation errors: ${error.message}`,
+                ],
+                { actorId, detail: error.message.slice(0, 200) },
+            ),
         };
     }
 
@@ -582,6 +607,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<Tool
             actorName: baseActorName,
             input: input as Record<string, unknown>,
             toolArgs,
+            build: callOptions?.build,
         });
         if ('error' in resolution) {
             return resolution.error;

--- a/src/tools/widgets/call_actor_widget.ts
+++ b/src/tools/widgets/call_actor_widget.ts
@@ -105,6 +105,7 @@ export const callActorWidget: ToolEntry = Object.freeze({
                 actorName: baseActorName,
                 input: input as Record<string, unknown>,
                 toolArgs,
+                build: callOptions?.build,
             });
             if ('error' in resolution) {
                 return resolution.error;

--- a/src/types.ts
+++ b/src/types.ts
@@ -456,6 +456,8 @@ export type ServerModeOption = SERVER_MODE | 'auto';
 export type ActorExecutionParams = {
     /** Full name of the Actor (e.g., "apify/rag-web-browser") */
     actorFullName: string;
+    /** Actor's platform ID, for remote input validation before starting the run. */
+    actorId: string;
     /** Input to pass to the Actor (payment fields already stripped) */
     input: Record<string, unknown>;
     /** Apify client (may include payment headers) */

--- a/src/utils/validate_actor_input.ts
+++ b/src/utils/validate_actor_input.ts
@@ -1,0 +1,59 @@
+import log from '@apify/log';
+
+import type { ApifyClient } from '../apify_client.js';
+import { getApifyAPIBaseUrl } from '../apify_client.js';
+import { ActorInputValidationError } from '../errors.js';
+import { logHttpError } from './logging.js';
+
+/** Bounds the extra round trip so a slow validate-input call never dominates call-actor's latency budget. */
+const VALIDATE_INPUT_TIMEOUT_MSEC = 5_000;
+
+const DEFAULT_INVALID_INPUT_MESSAGE = 'Input does not match the Actor input schema.';
+
+type ValidateInputErrorBody = { error?: { message?: string } };
+
+/**
+ * Validates input against the Actor's real schema via Apify's `validate-input` endpoint — the
+ * server's own AJV gate validates a derived/shortened copy that can miss real errors (#736, #1253).
+ *
+ * Fails open on anything but a clean 400: an unavailable best-effort check must never block a run
+ * that would otherwise have started; the Actor's own run-time validation is the real backstop.
+ *
+ * @throws {ActorInputValidationError} only on a confirmed-invalid verdict from the platform.
+ */
+export async function validateActorInputRemotely(params: {
+    apifyClient: ApifyClient;
+    actorId: string;
+    input: Record<string, unknown>;
+    build?: string;
+}): Promise<void> {
+    const { apifyClient, actorId, input, build } = params;
+
+    let response: { status: number; data: unknown };
+    try {
+        response = await apifyClient.httpClient.axios.request({
+            url: `${getApifyAPIBaseUrl()}/v2/actors/${encodeURIComponent(actorId)}/validate-input`,
+            method: 'POST',
+            params: build ? { build } : undefined,
+            data: input,
+            timeout: VALIDATE_INPUT_TIMEOUT_MSEC,
+            validateStatus: null,
+        });
+    } catch (err) {
+        logHttpError(err, 'validate-input request failed, proceeding without it', { actorId });
+        return;
+    }
+
+    if (response.status !== 400) {
+        if (response.status !== 200) {
+            log.debug('validate-input responded unexpectedly, proceeding without it', {
+                actorId,
+                status: response.status,
+            });
+        }
+        return;
+    }
+
+    const body = response.data as ValidateInputErrorBody;
+    throw new ActorInputValidationError(body?.error?.message || DEFAULT_INVALID_INPUT_MESSAGE);
+}

--- a/tests/unit/tools.actor_executor.test.ts
+++ b/tests/unit/tools.actor_executor.test.ts
@@ -1,5 +1,5 @@
 import type { ActorRun } from 'apify-client';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { actorExecutor } from '../../src/tools/actors/actor_executor.js';
 import type { ActorExecutionParams } from '../../src/types.js';
@@ -98,6 +98,7 @@ function buildParams(
         spies,
         params: {
             actorFullName: ACTOR_FULL_NAME,
+            actorId: 'actor-id-1',
             input,
             apifyClient: client,
             callOptions: {},
@@ -141,6 +142,37 @@ describe('actorExecutor', () => {
             await actorExecutor.executeActorTool(params);
 
             expect(spies.waitForFinishOpts).toEqual({ waitSecs: undefined });
+            expect(spies.startInput).toEqual({ query: 'foo' });
+        });
+    });
+
+    // Direct actor tools skip `resolveAndValidateActor` — the remote check is wired here separately.
+    describe('remote input validation', () => {
+        it('rejects before starting the run when the platform confirms invalid input', async () => {
+            const { params, spies } = buildParams({ query: 'foo' });
+            const request = vi.fn().mockResolvedValue({
+                status: 400,
+                data: { error: { type: 'invalid-input', message: 'query: must be a non-empty string' } },
+            });
+            params.apifyClient = {
+                ...params.apifyClient,
+                httpClient: { axios: { request } },
+            } as unknown as typeof params.apifyClient;
+
+            await expect(actorExecutor.executeActorTool(params)).rejects.toThrow('query: must be a non-empty string');
+            expect(spies.startInput).toBeUndefined();
+        });
+
+        it('starts the run as usual when the platform confirms valid input', async () => {
+            const { params, spies } = buildParams({ query: 'foo' });
+            const request = vi.fn().mockResolvedValue({ status: 200, data: { valid: true } });
+            params.apifyClient = {
+                ...params.apifyClient,
+                httpClient: { axios: { request } },
+            } as unknown as typeof params.apifyClient;
+
+            await actorExecutor.executeActorTool(params);
+
             expect(spies.startInput).toEqual({ query: 'foo' });
         });
     });

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -334,6 +334,53 @@ describe('call_actor_common', () => {
                 actorId: 'actor-id-rag',
             });
         });
+
+        function toolArgsWithRemoteValidation(request: (...args: unknown[]) => Promise<unknown>): InternalToolArgs {
+            return {
+                apifyClient: { httpClient: { axios: { request } } },
+                mcpSessionId: 'session-1',
+            } as unknown as InternalToolArgs;
+        }
+
+        it('returns the actor once local AJV and remote platform validation both pass', async () => {
+            mockActorTool((() => true) as never);
+            const request = vi.fn().mockResolvedValue({ status: 200, data: { valid: true } });
+
+            const resolution = await resolveAndValidateActor({
+                actorName: 'apify/rag-web-browser',
+                input: { query: 'x' },
+                toolArgs: toolArgsWithRemoteValidation(request),
+                build: 'beta',
+            });
+
+            expect('actor' in resolution).toBe(true);
+            expect(request).toHaveBeenCalledWith(expect.objectContaining({ params: { build: 'beta' } }));
+        });
+
+        it('rejects with the platform message when local AJV passes but remote validation fails', async () => {
+            mockActorTool((() => true) as never);
+            const request = vi.fn().mockResolvedValue({
+                status: 400,
+                data: { error: { type: 'invalid-input', message: 'query: must be a non-empty string' } },
+            });
+
+            const resolution = await resolveAndValidateActor({
+                actorName: 'apify/rag-web-browser',
+                input: { query: '' },
+                toolArgs: toolArgsWithRemoteValidation(request),
+            });
+
+            const { error } = resolution as { error: TextToolResult & { toolTelemetry?: Record<string, unknown> } };
+            expect(error.isError).toBe(true);
+            const allText = (error.content ?? []).map(textOf).join('\n');
+            expect(allText).toContain('query: must be a non-empty string');
+            expect(allText).toContain(JSON.stringify(INPUT_SCHEMA));
+            expect(error.toolTelemetry).toMatchObject({
+                toolStatus: TOOL_STATUS.SOFT_FAIL,
+                failureCategory: FAILURE_CATEGORY.INVALID_INPUT,
+                actorId: 'actor-id-rag',
+            });
+        });
     });
 
     describe('handleMcpToolCall()', () => {

--- a/tests/unit/utils.validate_actor_input.test.ts
+++ b/tests/unit/utils.validate_actor_input.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApifyClient } from '../../src/apify_client.js';
+import { validateActorInputRemotely } from '../../src/utils/validate_actor_input.js';
+
+function stubClient(request: (...args: unknown[]) => Promise<unknown>): ApifyClient {
+    return { httpClient: { axios: { request } } } as unknown as ApifyClient;
+}
+
+describe('validateActorInputRemotely()', () => {
+    it('resolves and sends the input/build to the platform when the input is valid', async () => {
+        const request = vi.fn().mockResolvedValue({ status: 200, data: { valid: true } });
+        const client = stubClient(request);
+
+        await expect(
+            validateActorInputRemotely({
+                apifyClient: client,
+                actorId: 'actor-1',
+                input: { query: 'x' },
+                build: 'beta',
+            }),
+        ).resolves.toBeUndefined();
+
+        expect(request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: expect.stringContaining('/v2/actors/actor-1/validate-input'),
+                method: 'POST',
+                data: { query: 'x' },
+                params: { build: 'beta' },
+            }),
+        );
+    });
+
+    it('throws ActorInputValidationError with the platform message on a clean 400', async () => {
+        const request = vi.fn().mockResolvedValue({
+            status: 400,
+            data: {
+                error: { type: 'invalid-input', message: 'categoryFilterWords: must be one of the allowed values' },
+            },
+        });
+        const client = stubClient(request);
+
+        await expect(
+            validateActorInputRemotely({ apifyClient: client, actorId: 'actor-1', input: {} }),
+        ).rejects.toThrow('categoryFilterWords: must be one of the allowed values');
+    });
+
+    it('falls back to a generic message when the 400 body carries none', async () => {
+        const request = vi.fn().mockResolvedValue({ status: 400, data: {} });
+        const client = stubClient(request);
+
+        await expect(
+            validateActorInputRemotely({ apifyClient: client, actorId: 'actor-1', input: {} }),
+        ).rejects.toThrow('Input does not match the Actor input schema.');
+    });
+
+    it('fails open (never throws ActorInputValidationError) on a network error, an unavailable client, or an unexpected status', async () => {
+        const cases = [
+            stubClient(vi.fn().mockRejectedValue(new Error('socket hang up'))),
+            {} as unknown as ApifyClient, // missing httpClient — matches incomplete stubs elsewhere in the test suite
+            stubClient(vi.fn().mockResolvedValue({ status: 500, data: {} })),
+        ];
+
+        for (const client of cases) {
+            await expect(
+                validateActorInputRemotely({ apifyClient: client, actorId: 'actor-1', input: {} }),
+            ).resolves.toBeUndefined();
+        }
+    });
+});


### PR DESCRIPTION
## What
Adds a remote check via Apify's `validate-input` endpoint right before an Actor run starts: `call-actor`/`call-actor-widget` (shared `resolveAndValidateActor`) and direct per-Actor tools (`actor_executor.ts`). Local AJV validation is unchanged and still runs first — this is an added second gate, not a replacement.

## Why
The server's AJV gate validates a derived/shortened schema copy, not the Actor's real one — enum truncation in particular lets it pass input the Actor would reject at runtime, after a billable run already started (#736). The remote check asks the platform directly. Fails open on anything but a clean 400 (network error, timeout, 5xx, unexpected shape): the Actor's own run-time validation is the real backstop, so an unavailable best-effort check must never block a run that would otherwise have started.

Closes #736.

## Testing
`pnpm run type-check/lint/format/check:agents` clean. `pnpm run test:unit`: 1290 passed, 1 skipped, zero regressions — covers the validator (200/400/fail-open), `resolveAndValidateActor`, and `actorExecutor`.

Also tested live end-to-end (built `dist/stdio.js`, real token, via mcpc): `apify/instagram-scraper`'s `directUrls` has a `pattern` the local AJV strips — `call-actor` with a non-matching URL was rejected before any run started with the platform's own message; a valid URL still started a run normally.