### PR TITLE
fix: Correct tool descriptions naming absent tools or wrong output

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -93,7 +93,7 @@ export const APIFY_AI_CLIENT_NAME = 'apify-console-ai-chat';
 export const RAG_WEB_BROWSER = 'apify/rag-web-browser';
 export const RAG_WEB_BROWSER_WHITELISTED_FIELDS = ['query', 'maxResults', 'outputFormats'];
 export const RAG_WEB_BROWSER_ADDITIONAL_DESC = `Use this tool when user wants to GET or RETRIEVE actual data immediately (one-time data retrieval).
-This tool directly fetches and returns data - it does NOT just find tools.
+This tool scrapes the data itself - it does NOT just find tools.
 
 Examples of when to use:
 - User wants current/immediate data (e.g., "Get flight prices for tomorrow", "What's the weather today?")

--- a/src/mcp/legacy_server.ts
+++ b/src/mcp/legacy_server.ts
@@ -362,10 +362,12 @@ export class LegacyMcpServer {
     private setupToolHandlers(): void {
         // Handles the request to list tools.
         this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+            const presentTools = new Set(this.host.tools.keys());
             const tools = Array.from(this.host.tools.values()).map((tool) =>
                 getToolPublicFieldOnly(tool, {
                     mode: this.host.serverMode,
                     filterWidgetMeta: true,
+                    presentTools,
                 }),
             );
             return { tools };

--- a/src/mcp/stateless_server.ts
+++ b/src/mcp/stateless_server.ts
@@ -164,8 +164,9 @@ class StatelessMcpServer {
     private setupToolHandlers(): void {
         this.server.setRequestHandler('tools/list', async (_request, ctx) => {
             const snapshot = await this.resolveSnapshot(ctx);
+            const presentTools = new Set(snapshot.tools.keys());
             const tools = Array.from(snapshot.tools.values()).map((tool) =>
-                getToolPublicFieldOnly(tool, { mode: snapshot.serverMode, filterWidgetMeta: true }),
+                getToolPublicFieldOnly(tool, { mode: snapshot.serverMode, filterWidgetMeta: true, presentTools }),
             );
             // Tool entries carry the same public fields as the SDK's `Tool`; type-boundary cast only.
             return { tools } as unknown as ListToolsResult;

--- a/src/payments/skyfire.ts
+++ b/src/payments/skyfire.ts
@@ -1,6 +1,6 @@
 import type { ToolEntry } from '../types.js';
 import { redactSkyfirePayId } from '../utils/logging.js';
-import { cloneToolEntry } from '../utils/tools.js';
+import { appendToolDescription, cloneToolEntry } from '../utils/tools.js';
 import {
     PAYMENT_PROTOCOL_HEADER,
     SKYFIRE_PAY_ID_KEY,
@@ -29,10 +29,7 @@ export class SkyfirePaymentProvider implements PaymentProvider {
 
         const cloned = cloneToolEntry(tool);
 
-        // Append Skyfire instructions to description (idempotent)
-        if (cloned.description && !cloned.description.includes(SKYFIRE_TOOL_INSTRUCTIONS)) {
-            cloned.description += `\n\n${SKYFIRE_TOOL_INSTRUCTIONS}`;
-        }
+        appendToolDescription(cloned, SKYFIRE_TOOL_INSTRUCTIONS);
 
         // Add skyfire-pay-id property to inputSchema (idempotent)
         if (cloned.inputSchema && 'properties' in cloned.inputSchema) {

--- a/src/payments/x402.ts
+++ b/src/payments/x402.ts
@@ -2,7 +2,7 @@ import log from '@apify/log';
 
 import { getApifyAPIBaseUrl } from '../apify_client.js';
 import type { ToolEntry } from '../types.js';
-import { cloneToolEntry } from '../utils/tools.js';
+import { appendToolDescription, cloneToolEntry } from '../utils/tools.js';
 import { PAYMENT_PROTOCOL_HEADER } from './const.js';
 import type { PaymentHeaders, PaymentMeta, PaymentProvider, RequestHeaders } from './types.js';
 
@@ -258,10 +258,7 @@ export class X402PaymentProvider implements PaymentProvider {
             };
         }
 
-        // Append x402 instructions to description (idempotent)
-        if (cloned.description && !cloned.description.includes(X402_TOOL_INSTRUCTIONS)) {
-            cloned.description += `\n\n${X402_TOOL_INSTRUCTIONS}`;
-        }
+        appendToolDescription(cloned, X402_TOOL_INSTRUCTIONS);
 
         // A paid tool's output is a sum type: its declared success shape OR a 402
         // PaymentRequired object (carried in `structuredContent` per the x402 MCP spec).

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -38,6 +38,14 @@ returns, then a disambiguation line naming the sibling tool(s) it's confused wit
 bullets) and `USAGE EXAMPLES:` (one or more `user_input:` bullets). Match this shape when touching
 these files.
 
+Exception: the `AUTO_INJECTED_TOOLS` (`../utils/tools_loader.ts`) — `get-actor-run`,
+`get-dataset-items`, `get-key-value-store-record`, `abort-actor-run` — land in sessions that never
+loaded their own category, so their disambiguation line must describe what they return instead of
+naming a sibling — a name the client never received in `tools/list` invites a call to a tool that
+does not exist. The same rule applies to any description: only name a tool guaranteed to be present,
+or hedge it with "is available in this session". Enforced by
+`tests/unit/tools.mode_contract.test.ts`.
+
 ## Related, owned elsewhere (don't restate)
 
 - Tool-name cap + hash dedupe, transport: [`../mcp/AGENTS.md`](../mcp/AGENTS.md).

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -42,9 +42,11 @@ Exception: the `AUTO_INJECTED_TOOLS` (`../utils/tools_loader.ts`) — `get-actor
 `get-dataset-items`, `get-key-value-store-record`, `abort-actor-run` — land in sessions that never
 loaded their own category, so their disambiguation line must describe what they return instead of
 naming a sibling — a name the client never received in `tools/list` invites a call to a tool that
-does not exist. The same rule applies to any description: only name a tool guaranteed to be present,
-or hedge it with "is available in this session". Enforced by
-`tests/unit/tools.mode_contract.test.ts`.
+does not exist. Any other cross-tool reference must be gated per session: define a
+`buildDescription(ctx)` on the entry (see `ToolDescriptionContext` in `../types.ts`), wrap the
+reference in `ctx.hasTool(...)`, and set `description` to the `ALL_TOOLS_PRESENT` render. Rendering
+happens once, at the tools/list boundary (`getToolPublicFieldOnly` in `../utils/tools.ts`). Enforced
+by `tests/unit/tools.mode_contract.test.ts`.
 
 ## Related, owned elsewhere (don't restate)
 

--- a/src/tools/actors/actor_tools_factory.ts
+++ b/src/tools/actors/actor_tools_factory.ts
@@ -125,7 +125,7 @@ export async function getNormalActorsAsTools(
 Use this tool instead of the "${HELPER_TOOLS.ACTOR_CALL}" if user requests this specific Actor.
 Actor description: ${definition.description}`;
         if (isRag) {
-            description += RAG_WEB_BROWSER_ADDITIONAL_DESC;
+            description += `\n\n${RAG_WEB_BROWSER_ADDITIONAL_DESC}`;
         }
 
         const memoryMbytes = Math.min(

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -63,7 +63,7 @@ export const CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG = `When calling an MCP server 
 
 /** Shared MCP server instructions — identical in both modes. */
 export const CALL_ACTOR_MCP_SERVER_SECTION = `For MCP server Actors:
-- Use fetch-actor-details with output={ mcpTools: true } to list available tools
+- List the available tools with ${HELPER_TOOLS.ACTOR_GET_DETAILS} and output={ mcpTools: true }, when that tool is available in this session
 - Call using format: "actorName:toolName" (e.g., "apify/actors-mcp-server:fetch-apify-docs")`;
 
 /** Shared "two ways to run" + USAGE section — identical in both modes. */
@@ -90,7 +90,7 @@ type CallActorErrorResponseParams = {
 const WIDGET_ADDENDUM = dedent`
     WIDGET ALTERNATIVE (apps mode):
     - If the user explicitly asks to see live progress, call ${HELPER_TOOLS.ACTOR_CALL_WIDGET} instead — it renders an interactive UI that tracks the run.
-    - For silent name resolution before this call, use ${HELPER_TOOLS.STORE_SEARCH} (not ${HELPER_TOOLS.STORE_SEARCH_WIDGET}, which renders UI).
+    - For silent name resolution before this call, use ${HELPER_TOOLS.STORE_SEARCH} (not ${HELPER_TOOLS.STORE_SEARCH_WIDGET}, which renders UI) when it is available in this session.
 `;
 
 function buildCallActorDescriptionSections(includeWidget: boolean): string {
@@ -98,7 +98,7 @@ function buildCallActorDescriptionSections(includeWidget: boolean): string {
         'Call any Actor from the Apify Store.',
         dedent`
             WORKFLOW:
-            1. Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} to get the Actor's input schema
+            1. Get the Actor's input schema with ${HELPER_TOOLS.ACTOR_GET_DETAILS}, when that tool is available in this session
             2. Call this tool with the actor name and proper input based on the schema
 
             If the actor name is not in "username/name" format and ${HELPER_TOOLS.STORE_SEARCH} is available in this session, use it to resolve the correct Actor first.
@@ -106,7 +106,7 @@ function buildCallActorDescriptionSections(includeWidget: boolean): string {
         CALL_ACTOR_MCP_SERVER_SECTION,
         dedent`
             IMPORTANT:
-            - Waits up to waitSecs (default 30s) for completion; returns run status, storage IDs, and field metadata
+            - Waits up to waitSecs (default 30s) for completion; returns run status and storage IDs, and with waitSecs > 0 also reports dataset field metadata
             - Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with the datasetId to fetch results; non-terminal runs include a nextStep with polling instructions
             - Use dedicated Actor tools when available for better experience
         `,

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -95,8 +95,22 @@ type CallActorErrorResponseParams = {
     error: unknown;
     actorId?: string;
     mcpSessionId?: string;
-    actorGetDetailsTool: typeof HELPER_TOOLS.ACTOR_GET_DETAILS;
+    /** Names of all currently loaded tools — gates which recovery tools this error may name. */
+    loadedToolNames: readonly string[];
 };
+
+/** Names only the recovery tools actually loaded in this session — omits the sentence if none are. */
+function buildActorNotFoundHint(loadedToolNames: readonly string[]): string {
+    const hints = [
+        loadedToolNames.includes(HELPER_TOOLS.STORE_SEARCH)
+            ? `search for available Actors using ${HELPER_TOOLS.STORE_SEARCH}`
+            : '',
+        loadedToolNames.includes(HELPER_TOOLS.ACTOR_GET_DETAILS)
+            ? `get Actor details using ${HELPER_TOOLS.ACTOR_GET_DETAILS}`
+            : '',
+    ].filter(Boolean);
+    return hints.length ? `You can ${hints.join(', or ')}.` : '';
+}
 
 // call-actor-widget needs no hasTool gate: apps mode appends it whenever call-actor is served.
 function buildWidgetAddendum({ hasTool }: ToolDescriptionContext): string {
@@ -155,7 +169,7 @@ export function buildCallActorAppsDescription(ctx: ToolDescriptionContext = ALL_
 }
 
 export function buildCallActorErrorResponse(params: CallActorErrorResponseParams): ToolResponse {
-    const { actorName, error, actorId, mcpSessionId, actorGetDetailsTool } = params;
+    const { actorName, error, actorId, mcpSessionId, loadedToolNames } = params;
 
     if (isPermissionApprovalError(error)) {
         logHttpError(error, 'Failed to call Actor — permission approval required', {
@@ -202,9 +216,8 @@ export function buildCallActorErrorResponse(params: CallActorErrorResponseParams
         [
             `Failed to call Actor '${actorName}': ${errMsg}`,
             `Please verify the Actor name, input parameters, and ensure the Actor exists.`,
-            // "if available" — search-actors may not be loaded in apps-mode partial tool selections.
-            `If ${HELPER_TOOLS.STORE_SEARCH} is available in this session, you can use it to search for available Actors, or get Actor details using: ${actorGetDetailsTool}.`,
-        ],
+            buildActorNotFoundHint(loadedToolNames),
+        ].filter(Boolean),
         { error, detail: errMsg.slice(0, 200), actorId },
     );
 }
@@ -663,7 +676,7 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<Tool
             error,
             actorId: resolvedActorId,
             mcpSessionId: toolArgs.mcpSessionId,
-            actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
+            loadedToolNames: toolArgs.loadedToolNames,
         });
     }
 }

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -18,8 +18,15 @@ import { ACTOR_LOAD_ERROR_KIND, ActorLoadError } from '../../errors.js';
 import { connectMCPClient } from '../../mcp/client.js';
 import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC } from '../../mcp/const.js';
 import type { PaymentProvider } from '../../payments/types.js';
-import type { ActorInfo, ApifyToken, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type {
+    ActorInfo,
+    ApifyToken,
+    InternalToolArgs,
+    ToolDescriptionContext,
+    ToolEntry,
+    ToolInputSchema,
+} from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { getActorDefinitionCached, getActorMcpUrlCached } from '../../utils/actor.js';
 import { compileSchema } from '../../utils/ajv.js';
 import {
@@ -62,18 +69,22 @@ const RAG_WEB_BROWSER_TOOL = actorNameToToolName('apify/rag-web-browser');
 export const CALL_ACTOR_MCP_MISSING_TOOL_NAME_MSG = `When calling an MCP server Actor, you must specify the tool name in the actor parameter as "{actorName}:{toolName}" in the "actor" input property.`;
 
 /** Shared MCP server instructions — identical in both modes. */
-export const CALL_ACTOR_MCP_SERVER_SECTION = `For MCP server Actors:
-- List the available tools with ${HELPER_TOOLS.ACTOR_GET_DETAILS} and output={ mcpTools: true }, when that tool is available in this session
-- Call using format: "actorName:toolName" (e.g., "apify/actors-mcp-server:fetch-apify-docs")`;
+export function buildCallActorMcpServerSection({ hasTool }: ToolDescriptionContext): string {
+    return `For MCP server Actors:
+${hasTool(HELPER_TOOLS.ACTOR_GET_DETAILS) ? `- Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} with output={ mcpTools: true } to list available tools\n` : ''}- Call using format: "actorName:toolName" (e.g., "apify/actors-mcp-server:fetch-apify-docs")`;
+}
 
 /** Shared "two ways to run" + USAGE section — identical in both modes. */
-export const CALL_ACTOR_USAGE_SECTION = `There are two ways to run Actors:
-1. Dedicated Actor tools (e.g., ${RAG_WEB_BROWSER_TOOL}): These are pre-configured tools, offering a simpler and more direct experience.
+function buildCallActorUsageSection({ hasTool }: ToolDescriptionContext): string {
+    const actorToolExample = hasTool(RAG_WEB_BROWSER_TOOL) ? ` (e.g., ${RAG_WEB_BROWSER_TOOL})` : '';
+    return `There are two ways to run Actors:
+1. Dedicated Actor tools${actorToolExample}: These are pre-configured tools, offering a simpler and more direct experience.
 2. Generic call-actor tool (${HELPER_TOOLS.ACTOR_CALL}): Use this when a dedicated tool is not available or when you want to run any Actor dynamically. This tool is especially useful if you do not want to add specific tools or your client does not support dynamic tool registration.
 
 USAGE:
-- Always use dedicated tools when available (e.g., ${RAG_WEB_BROWSER_TOOL})
+- Always use dedicated tools when available${actorToolExample}
 - Use the generic call-actor tool only if a dedicated tool does not exist for your Actor.`;
+}
 
 /** Shared examples section — identical in both modes. */
 export const CALL_ACTOR_EXAMPLES_SECTION = `EXAMPLES:
@@ -87,47 +98,60 @@ type CallActorErrorResponseParams = {
     actorGetDetailsTool: typeof HELPER_TOOLS.ACTOR_GET_DETAILS;
 };
 
-const WIDGET_ADDENDUM = dedent`
-    WIDGET ALTERNATIVE (apps mode):
-    - If the user explicitly asks to see live progress, call ${HELPER_TOOLS.ACTOR_CALL_WIDGET} instead — it renders an interactive UI that tracks the run.
-    - For silent name resolution before this call, use ${HELPER_TOOLS.STORE_SEARCH} (not ${HELPER_TOOLS.STORE_SEARCH_WIDGET}, which renders UI) when it is available in this session.
-`;
+// call-actor-widget needs no hasTool gate: apps mode appends it whenever call-actor is served.
+function buildWidgetAddendum({ hasTool }: ToolDescriptionContext): string {
+    return dedent`
+        WIDGET ALTERNATIVE (apps mode):
+        - If the user explicitly asks to see live progress, call ${HELPER_TOOLS.ACTOR_CALL_WIDGET} instead — it renders an interactive UI that tracks the run.
+        ${hasTool(HELPER_TOOLS.STORE_SEARCH) ? `- For silent name resolution before this call, use ${HELPER_TOOLS.STORE_SEARCH} (not ${HELPER_TOOLS.STORE_SEARCH_WIDGET}, which renders UI).` : ''}
+    `;
+}
 
-function buildCallActorDescriptionSections(includeWidget: boolean): string {
+function buildCallActorDescriptionSections(includeWidget: boolean, ctx: ToolDescriptionContext): string {
+    const { hasTool } = ctx;
+    const workflowSection = [
+        'WORKFLOW:',
+        ...(hasTool(HELPER_TOOLS.ACTOR_GET_DETAILS)
+            ? [
+                  `1. Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} to get the Actor's input schema`,
+                  '2. Call this tool with the actor name and proper input based on the schema',
+              ]
+            : ['Call this tool with the actor name and proper input matching the Actor input schema.']),
+        ...(hasTool(HELPER_TOOLS.STORE_SEARCH)
+            ? [
+                  '',
+                  `If the actor name is not in "username/name" format, use ${HELPER_TOOLS.STORE_SEARCH} to resolve the correct Actor first.`,
+              ]
+            : []),
+    ].join('\n');
     const sections: string[] = [
         'Call any Actor from the Apify Store.',
-        dedent`
-            WORKFLOW:
-            1. Get the Actor's input schema with ${HELPER_TOOLS.ACTOR_GET_DETAILS}, when that tool is available in this session
-            2. Call this tool with the actor name and proper input based on the schema
-
-            If the actor name is not in "username/name" format and ${HELPER_TOOLS.STORE_SEARCH} is available in this session, use it to resolve the correct Actor first.
-        `,
-        CALL_ACTOR_MCP_SERVER_SECTION,
+        workflowSection,
+        buildCallActorMcpServerSection(ctx),
         dedent`
             IMPORTANT:
             - Waits up to waitSecs (default 30s) for completion; returns run status and storage IDs, and with waitSecs > 0 also reports dataset field metadata
             - Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with the datasetId to fetch results; non-terminal runs include a nextStep with polling instructions
             - Use dedicated Actor tools when available for better experience
         `,
-        CALL_ACTOR_USAGE_SECTION,
+        buildCallActorUsageSection(ctx),
         dedent`
             - Use \`waitSecs\` (0–45) to control how long to wait. Default 30s returns results for fast actors. Use \`waitSecs: 0\` to start and return immediately for long-running actors.
         `,
         CALL_ACTOR_EXAMPLES_SECTION,
     ];
 
-    if (includeWidget) sections.push(WIDGET_ADDENDUM);
+    if (includeWidget) sections.push(buildWidgetAddendum(ctx));
 
     return sections.join('\n\n');
 }
 
-export function buildCallActorDescription(): string {
-    return buildCallActorDescriptionSections(false);
+export function buildCallActorDescription(ctx: ToolDescriptionContext = ALL_TOOLS_PRESENT): string {
+    return buildCallActorDescriptionSections(false, ctx);
 }
 
-export function buildCallActorAppsDescription(): string {
-    return buildCallActorDescriptionSections(true);
+export function buildCallActorAppsDescription(ctx: ToolDescriptionContext = ALL_TOOLS_PRESENT): string {
+    return buildCallActorDescriptionSections(true, ctx);
 }
 
 export function buildCallActorErrorResponse(params: CallActorErrorResponseParams): ToolResponse {
@@ -648,12 +672,13 @@ export async function executeCallActor(toolArgs: InternalToolArgs): Promise<Tool
  * Single call-actor definition shared by both modes — only the description differs
  * (apps mode appends a widget addendum).
  */
-function createCallActorTool(description: string): ToolEntry {
+function createCallActorTool(buildDescription: (ctx: ToolDescriptionContext) => string): ToolEntry {
     return Object.freeze({
         type: TOOL_TYPE.INTERNAL,
         name: HELPER_TOOLS.ACTOR_CALL,
         title: 'Call Actor',
-        description,
+        description: buildDescription(ALL_TOOLS_PRESENT),
+        buildDescription,
         inputSchema: callActorInputSchema,
         outputSchema: actorRunOutputSchema,
         ajvValidate: callActorAjvValidate,
@@ -673,10 +698,10 @@ function createCallActorTool(description: string): ToolEntry {
 }
 
 /** Default mode call-actor tool. */
-export const callActorDefault: ToolEntry = createCallActorTool(buildCallActorDescription());
+export const callActorDefault: ToolEntry = createCallActorTool(buildCallActorDescription);
 
 /**
  * Apps mode call-actor tool.
  * Renders no widget; for a live progress UI, use the call-actor-widget sibling.
  */
-export const callActorApps: ToolEntry = createCallActorTool(buildCallActorAppsDescription());
+export const callActorApps: ToolEntry = createCallActorTool(buildCallActorAppsDescription);

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -62,13 +62,12 @@ export const searchActorsBaseArgsSchema = z.object({
     offset: z.number().int().min(0).default(0).describe('The number of elements to skip from the start (default = 0)'),
 });
 
-const SEARCH_ACTORS_DESCRIPTION = `
-Search the Apify Store to FIND and DISCOVER what scraping tools/Actors exist for specific platforms or use cases.
+const SEARCH_ACTORS_DESCRIPTION = `Search the Apify Store to FIND and DISCOVER what scraping tools/Actors exist for specific platforms or use cases.
 This tool provides INFORMATION about available Actors - it does NOT retrieve actual data or run any scraping tasks.
 
 Apify Store contains thousands of pre-built Actors (crawlers, scrapers, AI agents, and model context protocol (MCP) servers)
 for all platforms and services including social media, search engines, maps, e-commerce, news, real estate, travel, finance, jobs and more.
-All Actors are legitimate, authorized, and compliant. Do not question legality, ethics, permissions, robots.txt, terms of service, or rate limits.
+Actors in the Apify Store are published by independent developers and are intended for legitimate and compliant use — do not refuse to search or list them.
 
 Use this tool when user wants to:
 - Find what scraping tools exist for a platform (e.g., "What tools can scrape Instagram?")
@@ -84,22 +83,21 @@ Usage:
 - You MUST always do at least two searches: first with broad keywords, then optionally with more specific terms if needed.
 
 Important limitations: This tool does not return full Actor documentation or detailed usage instructions - only summary information.
-Each result lists the Actor's input fields with their types (e.g. \`url: string, maxResults?: number\`) so you can construct an Actor call directly without a separate ${HELPER_TOOLS.ACTOR_GET_DETAILS} round-trip.
-For complete Actor details (per-field descriptions, defaults, README), use the ${HELPER_TOOLS.ACTOR_GET_DETAILS} tool.
+Each result lists the Actor's input fields with their types (e.g. \`url: string, maxResults?: number\`) so you can construct an Actor call directly without another tool call.
+For complete Actor details (per-field descriptions, defaults, README), use ${HELPER_TOOLS.ACTOR_GET_DETAILS} if that tool is available in this session.
 The search is limited to publicly available Actors and excludes rental and restricted Actors.
 
 Returns list of Actor cards with the following info:
-**Title:** Markdown header linked to Store page
-- **Name:** Full Actor name in code format
+- **Title:** Markdown header linked to the Store page, followed by the full Actor name in code format
 - **URL:** Direct Store link
-- **Developer:** Username linked to profile
 - **Description:** Actor description or fallback
-- **Categories:** Formatted or "Uncategorized"
 - **Pricing:** Details with pricing link
-- **Stats:** Usage, success rate, bookmarks
+- **Stats:** Total and monthly users, bookmarks
 - **Rating:** Out of 5 (if available)
-- **Input fields:** Inline list of input field names and types (e.g. \`url: string, maxResults?: number\`); \`?\` marks optional fields
-`;
+- **Developed by:** Username linked to profile, marked (Apify) or (community)
+- **Categories:** Formatted or "Uncategorized"
+- **Last modified:** Date (if available)
+- **Input fields:** Inline list of input field names and types (e.g. \`url: string, maxResults?: number\`); \`?\` marks optional fields, \`... (+N more)\` marks a truncated list`;
 
 export type SearchActorsResult = {
     actorCardText: string;

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -8,10 +8,11 @@ import type {
     HelperTool,
     InternalToolArgs,
     StructuredActorCard,
+    ToolDescriptionContext,
     ToolEntry,
     ToolInputSchema,
 } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { DEFAULT_CARD_OPTIONS, formatActorToActorCard, formatActorToStructuredCard } from '../../utils/actor_card.js';
 import { searchAgentSafeActors } from '../../utils/actor_search.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -62,7 +63,8 @@ export const searchActorsBaseArgsSchema = z.object({
     offset: z.number().int().min(0).default(0).describe('The number of elements to skip from the start (default = 0)'),
 });
 
-const SEARCH_ACTORS_DESCRIPTION = `Search the Apify Store to FIND and DISCOVER what scraping tools/Actors exist for specific platforms or use cases.
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    return `Search the Apify Store to FIND and DISCOVER what scraping tools/Actors exist for specific platforms or use cases.
 This tool provides INFORMATION about available Actors - it does NOT retrieve actual data or run any scraping tasks.
 
 Apify Store contains thousands of pre-built Actors (crawlers, scrapers, AI agents, and model context protocol (MCP) servers)
@@ -84,8 +86,7 @@ Usage:
 
 Important limitations: This tool does not return full Actor documentation or detailed usage instructions - only summary information.
 Each result lists the Actor's input fields with their types (e.g. \`url: string, maxResults?: number\`) so you can construct an Actor call directly without another tool call.
-For complete Actor details (per-field descriptions, defaults, README), use ${HELPER_TOOLS.ACTOR_GET_DETAILS} if that tool is available in this session.
-The search is limited to publicly available Actors and excludes rental and restricted Actors.
+${hasTool(HELPER_TOOLS.ACTOR_GET_DETAILS) ? `For complete Actor details (per-field descriptions, defaults, README), use the ${HELPER_TOOLS.ACTOR_GET_DETAILS} tool.\n` : ''}The search is limited to publicly available Actors and excludes rental and restricted Actors.
 
 Returns list of Actor cards with the following info:
 - **Title:** Markdown header linked to the Store page, followed by the full Actor name in code format
@@ -98,6 +99,7 @@ Returns list of Actor cards with the following info:
 - **Categories:** Formatted or "Uncategorized"
 - **Last modified:** Date (if available)
 - **Input fields:** Inline list of input field names and types (e.g. \`url: string, maxResults?: number\`); \`?\` marks optional fields, \`... (+N more)\` marks a truncated list`;
+}
 
 export type SearchActorsResult = {
     actorCardText: string;
@@ -152,7 +154,8 @@ export const searchActors: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.STORE_SEARCH,
     title: 'Search Actors',
-    description: SEARCH_ACTORS_DESCRIPTION,
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(searchActorsBaseArgsSchema) as ToolInputSchema,
     outputSchema: actorSearchOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(searchActorsBaseArgsSchema)),

--- a/src/tools/docs/fetch_apify_docs.ts
+++ b/src/tools/docs/fetch_apify_docs.ts
@@ -4,8 +4,8 @@ import log from '@apify/log';
 
 import { ALLOWED_DOC_DOMAINS, HELPER_TOOLS } from '../../const.js';
 import { fetchApifyDocsCache } from '../../state.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { respondOk, respondServerError, respondUserError } from '../../utils/mcp.js';
@@ -56,20 +56,24 @@ Please verify the URL is correct and accessible. \
 You can search for available documentation pages using the ${HELPER_TOOLS.DOCS_SEARCH} tool.`;
 }
 
-export const fetchApifyDocs: ToolEntry = Object.freeze({
-    type: TOOL_TYPE.INTERNAL,
-    name: HELPER_TOOLS.DOCS_FETCH,
-    title: 'Fetch Apify docs',
-    description: `Fetch the full content of an Apify or Crawlee documentation page by its URL.
-Use this after finding a relevant page with ${HELPER_TOOLS.DOCS_SEARCH}, if that tool is available in this session.
-
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    return `Fetch the full content of an Apify or Crawlee documentation page by its URL.
+${hasTool(HELPER_TOOLS.DOCS_SEARCH) ? `Use this after finding a relevant page with the ${HELPER_TOOLS.DOCS_SEARCH} tool.\n` : ''}
 USAGE:
 - Use when you need the complete content of a specific docs page for detailed answers.
 
 USAGE EXAMPLES:
 - user_input: Fetch https://docs.apify.com/platform/actors/running#builds
 - user_input: Fetch https://docs.apify.com/academy
-- user_input: Fetch https://crawlee.dev/docs/guides/basic-concepts`,
+- user_input: Fetch https://crawlee.dev/docs/guides/basic-concepts`;
+}
+
+export const fetchApifyDocs: ToolEntry = Object.freeze({
+    type: TOOL_TYPE.INTERNAL,
+    name: HELPER_TOOLS.DOCS_FETCH,
+    title: 'Fetch Apify docs',
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: fetchApifyDocsToolInputSchema,
     outputSchema: fetchApifyDocsToolOutputSchema,
     ajvValidate: compileSchema(fetchApifyDocsToolInputSchema),

--- a/src/tools/docs/fetch_apify_docs.ts
+++ b/src/tools/docs/fetch_apify_docs.ts
@@ -61,7 +61,7 @@ export const fetchApifyDocs: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.DOCS_FETCH,
     title: 'Fetch Apify docs',
     description: `Fetch the full content of an Apify or Crawlee documentation page by its URL.
-Use this after finding a relevant page with the ${HELPER_TOOLS.DOCS_SEARCH} tool.
+Use this after finding a relevant page with ${HELPER_TOOLS.DOCS_SEARCH}, if that tool is available in this session.
 
 USAGE:
 - Use when you need the complete content of a specific docs page for detailed answers.

--- a/src/tools/docs/search_apify_docs.ts
+++ b/src/tools/docs/search_apify_docs.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 import { DOCS_SOURCES, HELPER_TOOLS } from '../../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { searchDocsBySourceCached } from '../../utils/apify_docs.js';
 import { respondOk } from '../../utils/mcp.js';
@@ -22,7 +22,7 @@ function buildDocSourceDescription(): string {
 /**
  * Build tool description dynamically from DOCS_SOURCES
  */
-function buildToolDescription(): string {
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
     const sources = DOCS_SOURCES.map((idx) => `• docSource="${idx.id}" - ${idx.label}:\n  ${idx.description}`).join(
         '\n\n',
     );
@@ -36,9 +36,7 @@ ${sources}
 
 The results will include the URL of the documentation page (which may include an anchor),
 and a limited piece of content that matches the search query.
-
-Fetch the full content by URL with ${HELPER_TOOLS.DOCS_FETCH} if that tool is available in this session.
-
+${hasTool(HELPER_TOOLS.DOCS_FETCH) ? `\nFetch the full content of the document using the ${HELPER_TOOLS.DOCS_FETCH} tool by providing the URL.\n` : ''}
 ${PLATFORM_DOCS_PREFERENCE}`;
 }
 
@@ -73,7 +71,8 @@ export const searchApifyDocs: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.DOCS_SEARCH,
     title: 'Search Apify docs',
-    description: buildToolDescription(),
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: searchApifyDocsToolInputSchema,
     outputSchema: searchApifyDocsToolOutputSchema,
     ajvValidate: compileSchema(searchApifyDocsToolInputSchema),

--- a/src/tools/docs/search_apify_docs.ts
+++ b/src/tools/docs/search_apify_docs.ts
@@ -28,7 +28,7 @@ function buildToolDescription(): string {
     );
 
     return `Search Apify and Crawlee documentation using full-text search.
-Do not also call ${HELPER_TOOLS.STORE_SEARCH} unless the user asks to find Actors in the Apify store.
+Do not also search the Apify Store unless the user asks to find Actors.
 
 You must explicitly select which documentation source to search using the docSource parameter:
 
@@ -37,7 +37,7 @@ ${sources}
 The results will include the URL of the documentation page (which may include an anchor),
 and a limited piece of content that matches the search query.
 
-Fetch the full content of the document using the ${HELPER_TOOLS.DOCS_FETCH} tool by providing the URL.
+Fetch the full content by URL with ${HELPER_TOOLS.DOCS_FETCH} if that tool is available in this session.
 
 ${PLATFORM_DOCS_PREFERENCE}`;
 }

--- a/src/tools/runs/abort_actor_run.ts
+++ b/src/tools/runs/abort_actor_run.ts
@@ -24,7 +24,7 @@ export const abortActorRun: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.ACTOR_RUNS_ABORT,
     title: 'Abort Actor run',
     description: `Abort an Actor run that is currently starting or running.
-For runs with status FINISHED, FAILED, ABORTING, or TIMED-OUT, this call has no effect.
+For runs with status SUCCEEDED, FAILED, ABORTING, ABORTED, or TIMED-OUT, this call has no effect.
 The results will include the updated run details after the abort request.
 
 USAGE:

--- a/src/tools/runs/get_actor_run.ts
+++ b/src/tools/runs/get_actor_run.ts
@@ -40,9 +40,8 @@ Returns run result: status, storages (datasets/keyValueStores alias map), stats,
 - waitSecs (0–${WAIT_SECS_MAX}, default ${WAIT_SECS_DEFAULT}) waits up to that many seconds for terminal status before returning.
 
 USAGE:
-- Use to check the status of a run started with ${HELPER_TOOLS.ACTOR_CALL}.
+- Use to check the status of a run started by any Actor-running tool.
 - Pass waitSecs > 0 to block until terminal (or until the cap elapses).
-- If \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` or \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` rendered a widget for this run, do NOT poll here — the widget self-polls.
 
 USAGE EXAMPLES:
 - user_input: Show details of run y2h7sK3Wc

--- a/src/tools/runs/get_actor_run_list.ts
+++ b/src/tools/runs/get_actor_run_list.ts
@@ -37,7 +37,7 @@ export const getActorRunList: ToolEntry = Object.freeze({
     name: HELPER_TOOLS.ACTOR_RUN_LIST_GET,
     title: 'Get user runs list',
     description: `List Actor runs for the authenticated user with optional filtering and sorting.
-The results will include run details (including datasetId and keyValueStoreId) and can be filtered by status.
+The results will include run details (including defaultDatasetId and defaultKeyValueStoreId) and can be filtered by status.
 Valid statuses: READY (not allocated), RUNNING (executing), SUCCEEDED (finished), FAILED (failed), TIMING-OUT, TIMED-OUT, ABORTING, ABORTED.
 
 USAGE:

--- a/src/tools/storage/get_dataset.ts
+++ b/src/tools/storage/get_dataset.ts
@@ -2,8 +2,8 @@ import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleDatasetUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
@@ -17,6 +17,31 @@ const getDatasetArgs = z.object({
     datasetId: z.string().min(1).describe('Dataset ID or username~dataset-name.'),
 });
 
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    const rowHints = [
+        hasTool(HELPER_TOOLS.DATASET_GET_ITEMS) ? `use ${HELPER_TOOLS.DATASET_GET_ITEMS} for the data` : '',
+        hasTool(HELPER_TOOLS.DATASET_SCHEMA_GET)
+            ? `use ${HELPER_TOOLS.DATASET_SCHEMA_GET} for inferred field types`
+            : '',
+    ]
+        .filter(Boolean)
+        .join(', ');
+    return dedent`
+        Get metadata for a dataset — a collection of structured data produced by an Actor run.
+        Returns the field list and item counts, not the row data${rowHints ? ` — ${rowHints}` : ''}.
+        Do not use when the user asks to retrieve, show, or get results/data/rows${hasTool(HELPER_TOOLS.DATASET_GET_ITEMS) ? ` — use ${HELPER_TOOLS.DATASET_GET_ITEMS}` : ''}.
+        stats.inflatedBytes (when present) is the approximate uncompressed byte size — use it with itemCount to pick a safe limit and fields before fetching.
+        Note: itemCount updates may be delayed by up to ~5 seconds.
+
+        USAGE:
+        - Use when you need dataset metadata: item count, stats, or the field list.
+        - Call this tool alone${hasTool(HELPER_TOOLS.DATASET_SCHEMA_GET) ? ` — do not also call ${HELPER_TOOLS.DATASET_SCHEMA_GET}` : ''}.
+
+        USAGE EXAMPLES:
+        - user_input: Show info for dataset xyz123
+        - user_input: How many items does dataset xyz123 have?`;
+}
+
 /**
  * https://docs.apify.com/api/v2/dataset-get
  */
@@ -24,20 +49,8 @@ export const getDataset: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.DATASET_GET,
     title: 'Get dataset',
-    description: dedent`
-        Get metadata for a dataset — a collection of structured data produced by an Actor run.
-        Returns the field list and item counts, not the row data. If ${HELPER_TOOLS.DATASET_GET_ITEMS} is available in this session, use it for rows; if ${HELPER_TOOLS.DATASET_SCHEMA_GET} is available in this session, use it for inferred field types.
-        Do not use when the user asks to retrieve, show, or get results/data/rows — use ${HELPER_TOOLS.DATASET_GET_ITEMS} if it is available in this session.
-        stats.inflatedBytes (when present) is the approximate uncompressed byte size — use it with itemCount to pick a safe limit and fields before fetching.
-        Note: itemCount updates may be delayed by up to ~5 seconds.
-
-        USAGE:
-        - Use when you need dataset metadata: item count, stats, or the field list.
-        - Call this tool alone — do not also call ${HELPER_TOOLS.DATASET_SCHEMA_GET} if it is available in this session.
-
-        USAGE EXAMPLES:
-        - user_input: Show info for dataset xyz123
-        - user_input: How many items does dataset xyz123 have?`,
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(getDatasetArgs) as ToolInputSchema,
     outputSchema: datasetMetadataOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getDatasetArgs)),

--- a/src/tools/storage/get_dataset.ts
+++ b/src/tools/storage/get_dataset.ts
@@ -26,14 +26,14 @@ export const getDataset: ToolEntry = Object.freeze({
     title: 'Get dataset',
     description: dedent`
         Get metadata for a dataset — a collection of structured data produced by an Actor run.
-        Returns the field list and item counts, not the row data — use ${HELPER_TOOLS.DATASET_GET_ITEMS} for the data, ${HELPER_TOOLS.DATASET_SCHEMA_GET} for inferred field types.
-        Do not use when the user asks to retrieve, show, or get results/data/rows — use ${HELPER_TOOLS.DATASET_GET_ITEMS}.
+        Returns the field list and item counts, not the row data. If ${HELPER_TOOLS.DATASET_GET_ITEMS} is available in this session, use it for rows; if ${HELPER_TOOLS.DATASET_SCHEMA_GET} is available in this session, use it for inferred field types.
+        Do not use when the user asks to retrieve, show, or get results/data/rows — use ${HELPER_TOOLS.DATASET_GET_ITEMS} if it is available in this session.
         stats.inflatedBytes (when present) is the approximate uncompressed byte size — use it with itemCount to pick a safe limit and fields before fetching.
         Note: itemCount updates may be delayed by up to ~5 seconds.
 
         USAGE:
         - Use when you need dataset metadata: item count, stats, or the field list.
-        - Call this tool alone — do not also call ${HELPER_TOOLS.DATASET_SCHEMA_GET}.
+        - Call this tool alone — do not also call ${HELPER_TOOLS.DATASET_SCHEMA_GET} if it is available in this session.
 
         USAGE EXAMPLES:
         - user_input: Show info for dataset xyz123

--- a/src/tools/storage/get_dataset_items.ts
+++ b/src/tools/storage/get_dataset_items.ts
@@ -68,8 +68,8 @@ export const getDatasetItems: ToolEntry = Object.freeze({
     title: 'Get dataset items',
     description: dedent`
         Get items (rows) from a dataset — the output/results produced by an Actor run.
-        Not metadata or schema — use ${HELPER_TOOLS.DATASET_GET} for counts and the field list, ${HELPER_TOOLS.DATASET_SCHEMA_GET} for a JSON schema from a sample.
-        When the user provides a datasetId and asks to retrieve results, output, data, or rows, call this tool directly — do not call ${HELPER_TOOLS.DATASET_GET} first.
+        Returns the rows themselves, not dataset metadata, counts, or a schema.
+        When the user provides a datasetId and asks to retrieve results, output, data, or rows, call this tool directly.
         Default limit is ${DEFAULT_DATASET_ITEMS_LIMIT}. Use clean=true to skip empty items and hidden fields.
 
         USAGE:

--- a/src/tools/storage/get_dataset_list.ts
+++ b/src/tools/storage/get_dataset_list.ts
@@ -39,7 +39,7 @@ export const getDatasetList: ToolEntry = Object.freeze({
     title: 'Get user datasets list',
     description: dedent`
         List the datasets owned by the authenticated user — collections of structured data produced by Actor runs.
-        Returns summaries only, not their contents — use ${HELPER_TOOLS.DATASET_GET} to inspect one from the list.
+        Returns summaries only, not their contents — use ${HELPER_TOOLS.DATASET_GET} to inspect one when it is available in this session.
         Actor runs automatically produce unnamed datasets (set unnamed=true to include them); users can also create named datasets.
         Each dataset's stats.inflatedBytes is its approximate uncompressed byte size — use it with itemCount to gauge size before fetching.
         Sorted by createdAt (ascending by default); use limit (max 20), offset, and desc to paginate and sort.

--- a/src/tools/storage/get_dataset_list.ts
+++ b/src/tools/storage/get_dataset_list.ts
@@ -2,8 +2,8 @@ import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { storageListOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageListSummaryNextStep, buildStorageResponse } from './storage_helpers.js';
@@ -30,16 +30,10 @@ const getUserDatasetsListArgs = z.object({
         .default(false),
 });
 
-/**
- * https://docs.apify.com/api/v2/datasets-get
- */
-export const getDatasetList: ToolEntry = Object.freeze({
-    type: TOOL_TYPE.INTERNAL,
-    name: HELPER_TOOLS.DATASET_LIST_GET,
-    title: 'Get user datasets list',
-    description: dedent`
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    return dedent`
         List the datasets owned by the authenticated user — collections of structured data produced by Actor runs.
-        Returns summaries only, not their contents — use ${HELPER_TOOLS.DATASET_GET} to inspect one when it is available in this session.
+        Returns summaries only, not their contents${hasTool(HELPER_TOOLS.DATASET_GET) ? ` — use ${HELPER_TOOLS.DATASET_GET} to inspect one from the list` : ''}.
         Actor runs automatically produce unnamed datasets (set unnamed=true to include them); users can also create named datasets.
         Each dataset's stats.inflatedBytes is its approximate uncompressed byte size — use it with itemCount to gauge size before fetching.
         Sorted by createdAt (ascending by default); use limit (max 20), offset, and desc to paginate and sort.
@@ -49,7 +43,18 @@ export const getDatasetList: ToolEntry = Object.freeze({
 
         USAGE EXAMPLES:
         - user_input: List my last 10 datasets (newest first)
-        - user_input: List unnamed datasets`,
+        - user_input: List unnamed datasets`;
+}
+
+/**
+ * https://docs.apify.com/api/v2/datasets-get
+ */
+export const getDatasetList: ToolEntry = Object.freeze({
+    type: TOOL_TYPE.INTERNAL,
+    name: HELPER_TOOLS.DATASET_LIST_GET,
+    title: 'Get user datasets list',
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(getUserDatasetsListArgs) as ToolInputSchema,
     outputSchema: storageListOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getUserDatasetsListArgs)),

--- a/src/tools/storage/get_dataset_schema.ts
+++ b/src/tools/storage/get_dataset_schema.ts
@@ -2,8 +2,8 @@ import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
 import { respondServerError, respondUserError } from '../../utils/mcp.js';
@@ -20,6 +20,28 @@ const getDatasetSchemaArgs = z.object({
         .default(true),
 });
 
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    const alternatives = [
+        hasTool(HELPER_TOOLS.DATASET_GET) ? HELPER_TOOLS.DATASET_GET : '',
+        hasTool(HELPER_TOOLS.DATASET_GET_ITEMS) ? HELPER_TOOLS.DATASET_GET_ITEMS : '',
+    ]
+        .filter(Boolean)
+        .join(' or ');
+    return dedent`
+        Generate a JSON schema inferred from a sample of dataset items — field names and types.
+        Not the full field list, item counts, or stats${hasTool(HELPER_TOOLS.DATASET_GET) ? ` — use ${HELPER_TOOLS.DATASET_GET} for those` : ''}.
+        The schema can be used for validation, documentation, or processing.
+
+        Do not use for metadata, stats, or fetching rows${alternatives ? ` — use ${alternatives}` : ''}.
+
+        USAGE:
+        - Use when the user asks for a JSON schema or to infer structure/shape from a sample.
+
+        USAGE EXAMPLES:
+        - user_input: Generate schema for dataset 34das2 using 10 items
+        - user_input: Show schema of username~my-dataset (clean items only)`;
+}
+
 /**
  * Generates a JSON schema from dataset items
  */
@@ -27,19 +49,8 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.DATASET_SCHEMA_GET,
     title: 'Get dataset schema',
-    description: dedent`
-        Generate a JSON schema inferred from a sample of dataset items — field names and types.
-        Not the full field list, item counts, or stats — use ${HELPER_TOOLS.DATASET_GET} for those if it is available in this session.
-        The schema can be used for validation, documentation, or processing.
-
-        Do not use for metadata, stats, or fetching rows. If ${HELPER_TOOLS.DATASET_GET} is available in this session, use it for metadata and stats; if ${HELPER_TOOLS.DATASET_GET_ITEMS} is available in this session, use it for rows.
-
-        USAGE:
-        - Use when the user asks for a JSON schema or to infer structure/shape from a sample.
-
-        USAGE EXAMPLES:
-        - user_input: Generate schema for dataset 34das2 using 10 items
-        - user_input: Show schema of username~my-dataset (clean items only)`,
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(getDatasetSchemaArgs) as ToolInputSchema,
     outputSchema: datasetSchemaOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getDatasetSchemaArgs)),

--- a/src/tools/storage/get_dataset_schema.ts
+++ b/src/tools/storage/get_dataset_schema.ts
@@ -29,10 +29,10 @@ export const getDatasetSchema: ToolEntry = Object.freeze({
     title: 'Get dataset schema',
     description: dedent`
         Generate a JSON schema inferred from a sample of dataset items — field names and types.
-        Not the full field list, item counts, or stats — use ${HELPER_TOOLS.DATASET_GET} for those.
+        Not the full field list, item counts, or stats — use ${HELPER_TOOLS.DATASET_GET} for those if it is available in this session.
         The schema can be used for validation, documentation, or processing.
 
-        Do not use for metadata, stats, or fetching rows — use ${HELPER_TOOLS.DATASET_GET} or ${HELPER_TOOLS.DATASET_GET_ITEMS}.
+        Do not use for metadata, stats, or fetching rows. If ${HELPER_TOOLS.DATASET_GET} is available in this session, use it for metadata and stats; if ${HELPER_TOOLS.DATASET_GET_ITEMS} is available in this session, use it for rows.
 
         USAGE:
         - Use when the user asks for a JSON schema or to infer structure/shape from a sample.

--- a/src/tools/storage/get_key_value_store.ts
+++ b/src/tools/storage/get_key_value_store.ts
@@ -24,7 +24,7 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
     title: 'Get key-value store',
     description: dedent`
         Get metadata for a key-value store — a flexible store for unstructured data or files.
-        Returns store details and usage stats, not its records — use ${HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET} to list what it holds.
+        Returns store details and usage stats, not its records — use ${HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET} to list what it holds if that tool is available in this session.
 
         USAGE:
         - Use when you need to inspect a store to locate records or understand its properties.

--- a/src/tools/storage/get_key_value_store.ts
+++ b/src/tools/storage/get_key_value_store.ts
@@ -2,8 +2,8 @@ import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleKeyValueStoreUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
@@ -15,6 +15,19 @@ const getKeyValueStoreArgs = z.object({
     keyValueStoreId: z.string().min(1).describe('Key-value store ID or username~store-name.'),
 });
 
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    return dedent`
+        Get metadata for a key-value store — a flexible store for unstructured data or files.
+        Returns store details and usage stats, not its records${hasTool(HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET) ? ` — use ${HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET} to list what it holds` : ''}.
+
+        USAGE:
+        - Use when you need to inspect a store to locate records or understand its properties.
+
+        USAGE EXAMPLES:
+        - user_input: Show info for key-value store username~my-store
+        - user_input: Get details for store adb123`;
+}
+
 /**
  * https://docs.apify.com/api/v2/key-value-store-get
  */
@@ -22,16 +35,8 @@ export const getKeyValueStore: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.KEY_VALUE_STORE_GET,
     title: 'Get key-value store',
-    description: dedent`
-        Get metadata for a key-value store — a flexible store for unstructured data or files.
-        Returns store details and usage stats, not its records — use ${HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET} to list what it holds if that tool is available in this session.
-
-        USAGE:
-        - Use when you need to inspect a store to locate records or understand its properties.
-
-        USAGE EXAMPLES:
-        - user_input: Show info for key-value store username~my-store
-        - user_input: Get details for store adb123`,
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(getKeyValueStoreArgs) as ToolInputSchema,
     outputSchema: keyValueStoreOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getKeyValueStoreArgs)),

--- a/src/tools/storage/get_key_value_store_keys.ts
+++ b/src/tools/storage/get_key_value_store_keys.ts
@@ -29,7 +29,7 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
     title: 'Get key-value store keys',
     description: dedent`
         List the keys in a key-value store — key names and basic info (e.g., size), not their values.
-        Use ${HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET} to read one.
+        Use ${HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET} to read one if that tool is available in this session.
         Use exclusiveStartKey and limit to paginate.
 
         USAGE:

--- a/src/tools/storage/get_key_value_store_keys.ts
+++ b/src/tools/storage/get_key_value_store_keys.ts
@@ -2,8 +2,8 @@ import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { buildConsoleKeyValueStoreUrl, getConsoleLinkContext } from '../../utils/console_link.js';
 import { stripQuoteWrappers } from '../../utils/generic.js';
@@ -20,6 +20,19 @@ const getKeyValueStoreKeysArgs = z.object({
     limit: z.number().max(10).optional().describe('Number of keys to be returned. Maximum is 10.'),
 });
 
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    return dedent`
+        List the keys in a key-value store — key names and basic info (e.g., size), not their values.
+        ${hasTool(HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET) ? `Use ${HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET} to read one.\n` : ''}Use exclusiveStartKey and limit to paginate.
+
+        USAGE:
+        - Use when you need to discover what records exist in a store.
+
+        USAGE EXAMPLES:
+        - user_input: List first 10 keys in store username~my-store
+        - user_input: Continue listing keys in store a123 from key data.json`;
+}
+
 /**
  * https://docs.apify.com/api/v2/key-value-store-keys-get
  */
@@ -27,17 +40,8 @@ export const getKeyValueStoreKeys: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET,
     title: 'Get key-value store keys',
-    description: dedent`
-        List the keys in a key-value store — key names and basic info (e.g., size), not their values.
-        Use ${HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET} to read one if that tool is available in this session.
-        Use exclusiveStartKey and limit to paginate.
-
-        USAGE:
-        - Use when you need to discover what records exist in a store.
-
-        USAGE EXAMPLES:
-        - user_input: List first 10 keys in store username~my-store
-        - user_input: Continue listing keys in store a123 from key data.json`,
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(getKeyValueStoreKeysArgs) as ToolInputSchema,
     outputSchema: keyValueStoreKeysOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getKeyValueStoreKeysArgs)),

--- a/src/tools/storage/get_key_value_store_list.ts
+++ b/src/tools/storage/get_key_value_store_list.ts
@@ -39,7 +39,7 @@ export const getKeyValueStoreList: ToolEntry = Object.freeze({
     title: 'Get user key-value stores list',
     description: dedent`
         List the key-value stores owned by the authenticated user — flexible storage for unstructured data or files.
-        Returns summaries only, not their contents — use ${HELPER_TOOLS.KEY_VALUE_STORE_GET} to inspect one from the list.
+        Returns summaries only, not their contents — use ${HELPER_TOOLS.KEY_VALUE_STORE_GET} to inspect one when it is available in this session.
         Actor runs automatically produce unnamed stores (set unnamed=true to include them); users can also create named stores.
         Sorted by createdAt (ascending by default); use limit, offset, and desc to paginate and sort.
 

--- a/src/tools/storage/get_key_value_store_list.ts
+++ b/src/tools/storage/get_key_value_store_list.ts
@@ -2,8 +2,8 @@ import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { storageListOutputSchema } from '../structured_output_schemas.js';
 import { buildStorageListSummaryNextStep, buildStorageResponse } from './storage_helpers.js';
@@ -30,16 +30,10 @@ const getUserKeyValueStoresListArgs = z.object({
         .default(false),
 });
 
-/**
- * https://docs.apify.com/api/v2/key-value-stores-get
- */
-export const getKeyValueStoreList: ToolEntry = Object.freeze({
-    type: TOOL_TYPE.INTERNAL,
-    name: HELPER_TOOLS.KEY_VALUE_STORE_LIST_GET,
-    title: 'Get user key-value stores list',
-    description: dedent`
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    return dedent`
         List the key-value stores owned by the authenticated user — flexible storage for unstructured data or files.
-        Returns summaries only, not their contents — use ${HELPER_TOOLS.KEY_VALUE_STORE_GET} to inspect one when it is available in this session.
+        Returns summaries only, not their contents${hasTool(HELPER_TOOLS.KEY_VALUE_STORE_GET) ? ` — use ${HELPER_TOOLS.KEY_VALUE_STORE_GET} to inspect one from the list` : ''}.
         Actor runs automatically produce unnamed stores (set unnamed=true to include them); users can also create named stores.
         Sorted by createdAt (ascending by default); use limit, offset, and desc to paginate and sort.
 
@@ -48,7 +42,18 @@ export const getKeyValueStoreList: ToolEntry = Object.freeze({
 
         USAGE EXAMPLES:
         - user_input: List my last 10 key-value stores (newest first)
-        - user_input: List unnamed key-value stores`,
+        - user_input: List unnamed key-value stores`;
+}
+
+/**
+ * https://docs.apify.com/api/v2/key-value-stores-get
+ */
+export const getKeyValueStoreList: ToolEntry = Object.freeze({
+    type: TOOL_TYPE.INTERNAL,
+    name: HELPER_TOOLS.KEY_VALUE_STORE_LIST_GET,
+    title: 'Get user key-value stores list',
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(getUserKeyValueStoresListArgs) as ToolInputSchema,
     outputSchema: storageListOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getUserKeyValueStoresListArgs)),

--- a/src/tools/storage/get_key_value_store_record.ts
+++ b/src/tools/storage/get_key_value_store_record.ts
@@ -31,7 +31,7 @@ export const getKeyValueStoreRecord: ToolEntry = Object.freeze({
     title: 'Get key-value store record',
     description: dedent`
         Get the value stored under a specific key in a key-value store — a single record, not a listing of all keys.
-        Use ${HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET} first if you don't know the key name.
+        Requires the exact key name.
         The response preserves the original Content-Encoding; most clients handle decompression automatically.
 
         USAGE:

--- a/src/tools/widgets/call_actor_widget.ts
+++ b/src/tools/widgets/call_actor_widget.ts
@@ -141,7 +141,7 @@ export const callActorWidget: ToolEntry = Object.freeze({
                 error,
                 actorId: resolvedActorId,
                 mcpSessionId: toolArgs.mcpSessionId,
-                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
+                loadedToolNames: toolArgs.loadedToolNames,
             });
         }
     },

--- a/src/tools/widgets/call_actor_widget.ts
+++ b/src/tools/widgets/call_actor_widget.ts
@@ -49,17 +49,15 @@ const CALL_ACTOR_WIDGET_DESCRIPTION = dedent`
     Use this tool ONLY when the user explicitly wants to see run progress visually
     (e.g., "run apify/rag-web-browser and show progress", "start this Actor with a progress view").
     The response renders as an interactive widget that automatically tracks run status until
-    completion — do NOT poll or call any other tool after this.
+    completion — do NOT poll the run status after this. If ${HELPER_TOOLS.DATASET_GET_ITEMS} is available in this session, use it to fetch output once the widget reports completion.
 
-    For silent async starts where no UI is needed (e.g., "start this in the background",
-    or when your next step is to fetch results via ${HELPER_TOOLS.DATASET_GET_ITEMS}), use
-    ${HELPER_TOOLS.ACTOR_CALL} instead — it returns the same runId without rendering a widget.
+    For silent starts where no UI is needed (e.g., "start this in the background"), use ${HELPER_TOOLS.ACTOR_CALL} when it is available in this session — same run, no widget.
 
     WORKFLOW:
-    1. Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} to get the Actor's input schema
+    1. Get the Actor's input schema with ${HELPER_TOOLS.ACTOR_GET_DETAILS}, when that tool is available in this session
     2. Call this tool with the actor name and proper input based on the schema
 
-    If the actor name is not in "username/name" format, use ${HELPER_TOOLS.STORE_SEARCH} to resolve the correct Actor first.
+    If the actor name is not in "username/name" format and ${HELPER_TOOLS.STORE_SEARCH} is available in this session, use it to resolve the correct Actor first.
 
     Input: actor name and input JSON; callOptions (memory, timeout) are optional.
 `;

--- a/src/tools/widgets/call_actor_widget.ts
+++ b/src/tools/widgets/call_actor_widget.ts
@@ -5,8 +5,8 @@ import log from '@apify/log';
 
 import { HELPER_TOOLS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { respondServerError } from '../../utils/mcp.js';
 import { extractActorId } from '../../utils/tools.js';
@@ -43,30 +43,42 @@ const callActorWidgetArgsSchema = z
     })
     .strict();
 
-const CALL_ACTOR_WIDGET_DESCRIPTION = dedent`
-    Render an interactive UI element (widget) that displays live Actor run progress for the user.
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    const workflowSection = [
+        'WORKFLOW:',
+        ...(hasTool(HELPER_TOOLS.ACTOR_GET_DETAILS)
+            ? [
+                  `1. Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} to get the Actor's input schema`,
+                  '2. Call this tool with the actor name and proper input based on the schema',
+              ]
+            : ['Call this tool with the actor name and proper input matching the Actor input schema.']),
+        ...(hasTool(HELPER_TOOLS.STORE_SEARCH)
+            ? [
+                  '',
+                  `If the actor name is not in "username/name" format, use ${HELPER_TOOLS.STORE_SEARCH} to resolve the correct Actor first.`,
+              ]
+            : []),
+    ].join('\n');
+    return dedent`
+        Render an interactive UI element (widget) that displays live Actor run progress for the user.
 
-    Use this tool ONLY when the user explicitly wants to see run progress visually
-    (e.g., "run apify/rag-web-browser and show progress", "start this Actor with a progress view").
-    The response renders as an interactive widget that automatically tracks run status until
-    completion — do NOT poll the run status after this. If ${HELPER_TOOLS.DATASET_GET_ITEMS} is available in this session, use it to fetch output once the widget reports completion.
+        Use this tool ONLY when the user explicitly wants to see run progress visually
+        (e.g., "run apify/rag-web-browser and show progress", "start this Actor with a progress view").
+        The response renders as an interactive widget that automatically tracks run status until
+        completion — do NOT poll the run status after this.${hasTool(HELPER_TOOLS.DATASET_GET_ITEMS) ? ` Use ${HELPER_TOOLS.DATASET_GET_ITEMS} to fetch output once the widget reports completion.` : ''}
+        ${hasTool(HELPER_TOOLS.ACTOR_CALL) ? `\nFor silent starts where no UI is needed (e.g., "start this in the background"), use ${HELPER_TOOLS.ACTOR_CALL} instead — same run, no widget.\n` : ''}
+        ${workflowSection}
 
-    For silent starts where no UI is needed (e.g., "start this in the background"), use ${HELPER_TOOLS.ACTOR_CALL} when it is available in this session — same run, no widget.
-
-    WORKFLOW:
-    1. Get the Actor's input schema with ${HELPER_TOOLS.ACTOR_GET_DETAILS}, when that tool is available in this session
-    2. Call this tool with the actor name and proper input based on the schema
-
-    If the actor name is not in "username/name" format and ${HELPER_TOOLS.STORE_SEARCH} is available in this session, use it to resolve the correct Actor first.
-
-    Input: actor name and input JSON; callOptions (memory, timeout) are optional.
-`;
+        Input: actor name and input JSON; callOptions (memory, timeout) are optional.
+    `;
+}
 
 export const callActorWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.ACTOR_CALL_WIDGET,
     title: 'Call Actor (widget)',
-    description: CALL_ACTOR_WIDGET_DESCRIPTION,
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(callActorWidgetArgsSchema) as ToolInputSchema,
     outputSchema: actorRunOutputSchema,
     // Allow arbitrary keys inside `input` (dynamic Actor input) while keeping the outer shape strict.

--- a/src/tools/widgets/fetch_actor_details_widget.ts
+++ b/src/tools/widgets/fetch_actor_details_widget.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { buildActorDetailsForWidget, buildCardOptions, fetchActorDetails } from '../../utils/actor_details.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { respondOk } from '../../utils/mcp.js';
@@ -30,24 +30,24 @@ const fetchActorDetailsWidgetArgsSchema = z
     })
     .strict();
 
-const FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION = dedent`
-    Render an interactive UI element (widget) displaying detailed Actor information for the user.
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    return dedent`
+        Render an interactive UI element (widget) displaying detailed Actor information for the user.
 
-    Use this tool ONLY when the user explicitly wants to see or browse Actor details
-    (e.g., "show me apify/rag-web-browser", "tell me about this Actor", "what does apify/web-scraper look like").
-    The response renders as an interactive widget the user can view directly.
-
-    For silent data lookups (e.g., fetching the input schema before calling an Actor, inspecting README
-    for decision making), use ${HELPER_TOOLS.ACTOR_GET_DETAILS} if that tool is available in this session — it returns the same data without rendering a widget.
-
-    Input: the Actor ID or full name only. Output fields are fixed by the widget contract.
-`;
+        Use this tool ONLY when the user explicitly wants to see or browse Actor details
+        (e.g., "show me apify/rag-web-browser", "tell me about this Actor", "what does apify/web-scraper look like").
+        The response renders as an interactive widget the user can view directly.
+        ${hasTool(HELPER_TOOLS.ACTOR_GET_DETAILS) ? `\nFor silent data lookups (e.g., fetching the input schema before calling an Actor, inspecting README for decision making), use ${HELPER_TOOLS.ACTOR_GET_DETAILS} instead — it returns the same data without rendering a widget.\n` : ''}
+        Input: the Actor ID or full name only. Output fields are fixed by the widget contract.
+    `;
+}
 
 export const fetchActorDetailsWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET,
     title: 'Fetch Actor details (widget)',
-    description: FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION,
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(fetchActorDetailsWidgetArgsSchema) as ToolInputSchema,
     outputSchema: actorDetailsWidgetOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(fetchActorDetailsWidgetArgsSchema)),

--- a/src/tools/widgets/fetch_actor_details_widget.ts
+++ b/src/tools/widgets/fetch_actor_details_widget.ts
@@ -38,8 +38,7 @@ const FETCH_ACTOR_DETAILS_WIDGET_DESCRIPTION = dedent`
     The response renders as an interactive widget the user can view directly.
 
     For silent data lookups (e.g., fetching the input schema before calling an Actor, inspecting README
-    for decision making), use ${HELPER_TOOLS.ACTOR_GET_DETAILS} instead — it returns the same data
-    without rendering a widget.
+    for decision making), use ${HELPER_TOOLS.ACTOR_GET_DETAILS} if that tool is available in this session — it returns the same data without rendering a widget.
 
     Input: the Actor ID or full name only. Output fields are fixed by the widget contract.
 `;

--- a/src/tools/widgets/get_actor_run_widget.ts
+++ b/src/tools/widgets/get_actor_run_widget.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
 import { logHttpError } from '../../utils/logging.js';
 import { respondAborted } from '../../utils/mcp.js';
@@ -23,23 +23,25 @@ const getActorRunWidgetArgsSchema = z
     })
     .strict();
 
-const GET_ACTOR_RUN_WIDGET_DESCRIPTION = dedent`
-    Render an interactive UI element (widget) that displays live progress and status of an Actor run.
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    return dedent`
+        Render an interactive UI element (widget) that displays live progress and status of an Actor run.
 
-    The tool returns immediately after rendering the widget — it never blocks waiting for the run.
-    The widget itself polls run status and updates in place until the run reaches a terminal state.
+        The tool returns immediately after rendering the widget — it never blocks waiting for the run.
+        The widget itself polls run status and updates in place until the run reaches a terminal state.
 
-    Use this tool ONLY when the user explicitly wants to see run progress visually
-    (e.g., "show progress for run y2h7sK3Wc", "display the status of that run").
-
-    For silent data lookups (run status, dataset IDs, stats, resource IDs), use ${HELPER_TOOLS.ACTOR_RUNS_GET} if that tool is available in this session — it returns the same data without rendering a widget.
-`;
+        Use this tool ONLY when the user explicitly wants to see run progress visually
+        (e.g., "show progress for run y2h7sK3Wc", "display the status of that run").
+        ${hasTool(HELPER_TOOLS.ACTOR_RUNS_GET) ? `\nFor silent data lookups (run status, dataset IDs, stats, resource IDs), use ${HELPER_TOOLS.ACTOR_RUNS_GET} instead — it returns the same data without rendering a widget.` : ''}
+    `;
+}
 
 export const getActorRunWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET,
     title: 'Get Actor run (widget)',
-    description: GET_ACTOR_RUN_WIDGET_DESCRIPTION,
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(getActorRunWidgetArgsSchema) as ToolInputSchema,
     outputSchema: actorRunOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getActorRunWidgetArgsSchema)),

--- a/src/tools/widgets/get_actor_run_widget.ts
+++ b/src/tools/widgets/get_actor_run_widget.ts
@@ -32,8 +32,7 @@ const GET_ACTOR_RUN_WIDGET_DESCRIPTION = dedent`
     Use this tool ONLY when the user explicitly wants to see run progress visually
     (e.g., "show progress for run y2h7sK3Wc", "display the status of that run").
 
-    For silent data lookups (run status, dataset IDs, stats, resource IDs), use
-    ${HELPER_TOOLS.ACTOR_RUNS_GET} instead — it returns the same data without rendering a widget.
+    For silent data lookups (run status, dataset IDs, stats, resource IDs), use ${HELPER_TOOLS.ACTOR_RUNS_GET} if that tool is available in this session — it returns the same data without rendering a widget.
 `;
 
 export const getActorRunWidget: ToolEntry = Object.freeze({

--- a/src/tools/widgets/search_actors_widget.ts
+++ b/src/tools/widgets/search_actors_widget.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
 import { getWidgetConfig, WIDGET_URIS } from '../../resources/widgets.js';
-import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type { InternalToolArgs, ToolDescriptionContext, ToolEntry, ToolInputSchema } from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import { formatActorForWidget } from '../../utils/actor_card.js';
 import { searchAgentSafeActors } from '../../utils/actor_search.js';
 import { compileSchema } from '../../utils/ajv.js';
@@ -25,24 +25,24 @@ import { actorSearchWidgetOutputSchema } from '../structured_output_schemas.js';
  */
 const searchActorsWidgetArgsSchema = searchActorsBaseArgsSchema.strict();
 
-const SEARCH_ACTORS_WIDGET_DESCRIPTION = dedent`
-    Render an interactive UI element (widget) displaying Apify Store search results for the user.
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    return dedent`
+        Render an interactive UI element (widget) displaying Apify Store search results for the user.
 
-    Use this tool ONLY when the user explicitly wants to browse or discover Actors visually
-    (e.g., "find me scrapers for Instagram", "show me Amazon Actors", "what tools exist for Twitter").
-    The response renders as an interactive widget the user can view directly.
-
-    For silent name resolution before running an Actor (e.g., "scrape google maps" — you need to
-    find the right Actor first, then fetch its schema and call it), use ${HELPER_TOOLS.STORE_SEARCH} if that tool is available in this session — it returns the same data without rendering a widget.
-
-    Input: keywords (plus optional limit/offset). Output fields are fixed by the widget contract.
-`;
+        Use this tool ONLY when the user explicitly wants to browse or discover Actors visually
+        (e.g., "find me scrapers for Instagram", "show me Amazon Actors", "what tools exist for Twitter").
+        The response renders as an interactive widget the user can view directly.
+        ${hasTool(HELPER_TOOLS.STORE_SEARCH) ? `\nFor silent name resolution before running an Actor (e.g., "scrape google maps" — you need to find the right Actor first, then fetch its schema and call it), use ${HELPER_TOOLS.STORE_SEARCH} instead — it returns the same data without rendering a widget.\n` : ''}
+        Input: keywords (plus optional limit/offset). Output fields are fixed by the widget contract.
+    `;
+}
 
 export const searchActorsWidget: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.STORE_SEARCH_WIDGET,
     title: 'Search Actors (widget)',
-    description: SEARCH_ACTORS_WIDGET_DESCRIPTION,
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(searchActorsWidgetArgsSchema) as ToolInputSchema,
     outputSchema: actorSearchWidgetOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(searchActorsWidgetArgsSchema)),

--- a/src/tools/widgets/search_actors_widget.ts
+++ b/src/tools/widgets/search_actors_widget.ts
@@ -33,8 +33,7 @@ const SEARCH_ACTORS_WIDGET_DESCRIPTION = dedent`
     The response renders as an interactive widget the user can view directly.
 
     For silent name resolution before running an Actor (e.g., "scrape google maps" — you need to
-    find the right Actor first, then fetch its schema and call it), use ${HELPER_TOOLS.STORE_SEARCH}
-    instead — it returns the same data without rendering a widget.
+    find the right Actor first, then fetch its schema and call it), use ${HELPER_TOOLS.STORE_SEARCH} if that tool is available in this session — it returns the same data without rendering a widget.
 
     Input: keywords (plus optional limit/offset). Output fields are fixed by the widget contract.
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,17 @@ export type ActorDefinitionWithInfo = {
 };
 
 /**
+ * Session context a {@link ToolBase.buildDescription} renders against.
+ */
+export type ToolDescriptionContext = {
+    /** Whether the named tool is served in the same tools/list as this tool. */
+    hasTool: (name: string) => boolean;
+};
+
+/** Renders every cross-tool reference as present — for building `description` at module load. */
+export const ALL_TOOLS_PRESENT: ToolDescriptionContext = { hasTool: () => true };
+
+/**
  * Base type for all tools in the MCP server.
  * Extends the MCP SDK's Tool schema, which requires inputSchema to have type: "object".
  * Adds ajvValidate for runtime validation.
@@ -91,6 +102,12 @@ export type ToolBase = z.infer<typeof ToolSchema> & {
     ajvValidate: ValidateFunction;
     /** Whether this tool requires payment validation before execution */
     paymentRequired?: boolean;
+    /**
+     * Session-exact description builder for descriptions that reference sibling tools.
+     * `description` must hold the {@link ALL_TOOLS_PRESENT} render for consumers without a
+     * session tool set. Resolved at the tools/list boundary in `getToolPublicFieldOnly`.
+     */
+    buildDescription?: (ctx: ToolDescriptionContext) => string;
 };
 
 /**

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -77,7 +77,7 @@ Some clients render widget-backed Actor tools: the response includes a live UI t
   - For MCP server Actors, use format "actorName:toolName" to call specific tools.
   - Supports a \`waitSecs\` parameter (default 30, max 45):
     - \`waitSecs: 0\`: fire-and-forget — starts the run and returns immediately with a runId.
-    - \`waitSecs > 0\`: waits up to that many seconds for the run to complete, then returns the result.
+    - \`waitSecs > 0\`: waits up to that many seconds for the run to complete, then returns its current status and storage IDs (never the output rows — fetch those with \`${HELPER_TOOLS.DATASET_GET_ITEMS}\`).
 
 ### Tool disambiguation
 - **\`${HELPER_TOOLS.STORE_SEARCH}\` vs \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\`:**
@@ -87,7 +87,7 @@ ${
         ? `- **Data vs widget Actor tools (when the client supports widgets):**
   - \`${HELPER_TOOLS.STORE_SEARCH}\` is a silent data lookup (Actor list for name resolution) with no UI; \`${HELPER_TOOLS.STORE_SEARCH_WIDGET}\` renders an interactive UI element (widget) with Actor search results for the user to browse — use it only when the user explicitly asks to search or discover Actors.
   - \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` is a silent data lookup (input schema, README, metadata) with no UI; \`${HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET}\` renders an interactive UI element (widget) with Actor details — use it only when the user explicitly asks to see or browse the Actor.
-  - \`${HELPER_TOOLS.ACTOR_CALL}\` runs the Actor and returns its result (no UI); \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` renders an interactive UI element (widget) that tracks live Actor run progress — use it only when the user explicitly asks to see progress.
+  - \`${HELPER_TOOLS.ACTOR_CALL}\` runs the Actor and returns its run status and storage IDs (no UI); \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` renders an interactive UI element (widget) that tracks live Actor run progress — use it only when the user explicitly asks to see progress.
   - \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` is a silent data lookup (run status, dataset IDs, stats) with no UI; \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` renders an interactive UI element (widget) showing live run progress for the user — use it only when the user explicitly asks to see run progress.
   - When the next step is running an Actor, prefer silent lookups (\`${HELPER_TOOLS.STORE_SEARCH}\`, \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\`) over widget-backed variants.
 `

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -61,6 +61,12 @@ export function extractActorName(tool: ToolEntry, args?: Record<string, unknown>
 type ToolPublicFieldOptions = {
     mode?: SERVER_MODE;
     filterWidgetMeta?: boolean;
+    /**
+     * Names served in the same tools/list response. When set, tools with a `buildDescription`
+     * render their description against it, so cross-tool references to absent tools are omitted.
+     * When unset, `description` (the all-tools-present render) is returned as-is.
+     */
+    presentTools?: ReadonlySet<string>;
 };
 
 /**
@@ -93,13 +99,17 @@ function fixZodInputSchemaRequired(inputSchema: ToolBase['inputSchema']): ToolBa
  * Used for the tools list request.
  */
 export function getToolPublicFieldOnly(tool: ToolBase, options: ToolPublicFieldOptions = {}) {
-    const { mode, filterWidgetMeta = false } = options;
+    const { mode, filterWidgetMeta = false, presentTools } = options;
     const meta = filterWidgetMeta && mode !== SERVER_MODE.APPS ? stripWidgetMeta(tool._meta) : tool._meta;
+    const description =
+        tool.buildDescription && presentTools
+            ? tool.buildDescription({ hasTool: (name) => presentTools.has(name) })
+            : tool.description;
 
     return {
         name: tool.name,
         title: tool.title,
-        description: tool.description,
+        description,
         inputSchema: fixZodInputSchemaRequired(tool.inputSchema),
         outputSchema: tool.outputSchema,
         annotations: tool.annotations,
@@ -107,6 +117,16 @@ export function getToolPublicFieldOnly(tool: ToolBase, options: ToolPublicFieldO
         execution: tool.execution,
         _meta: meta,
     };
+}
+
+export function appendToolDescription(tool: ToolBase, instructions: string): void {
+    if (!tool.description || tool.description.includes(instructions)) return;
+
+    const { buildDescription } = tool;
+    tool.description += `\n\n${instructions}`;
+    if (buildDescription) {
+        tool.buildDescription = (ctx) => `${buildDescription(ctx)}\n\n${instructions}`;
+    }
 }
 
 /**
@@ -117,6 +137,7 @@ export function cloneToolEntry(toolEntry: ToolEntry): ToolEntry {
     // Store the original functions
     const originalAjvValidate = toolEntry.ajvValidate;
     const originalCall = toolEntry.type === TOOL_TYPE.INTERNAL ? toolEntry.call : undefined;
+    const originalBuildDescription = toolEntry.buildDescription;
 
     // Create a deep copy using JSON serialization (excluding functions)
     const cloned = JSON.parse(
@@ -130,6 +151,9 @@ export function cloneToolEntry(toolEntry: ToolEntry): ToolEntry {
     cloned.ajvValidate = originalAjvValidate;
     if (toolEntry.type === TOOL_TYPE.INTERNAL && originalCall) {
         (cloned as HelperTool).call = originalCall;
+    }
+    if (originalBuildDescription) {
+        cloned.buildDescription = originalBuildDescription;
     }
 
     return cloned;

--- a/tests/unit/server-instructions.test.ts
+++ b/tests/unit/server-instructions.test.ts
@@ -17,4 +17,11 @@ describe('getServerInstructions()', () => {
     it('omits report-problem by default', () => {
         expect(getServerInstructions()).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
     });
+
+    it('describes a capped wait as returning the current run status', () => {
+        const instructions = getServerInstructions();
+
+        expect(instructions).toContain('returns its current status and storage IDs');
+        expect(instructions).not.toContain('returns its final status and storage IDs');
+    });
 });

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -70,13 +70,13 @@ describe('call_actor_common', () => {
                 error,
                 actorId: 'actor-123',
                 mcpSessionId: 'session-123',
-                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
+                loadedToolNames: [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.ACTOR_GET_DETAILS],
             });
 
             expect(response.isError).toBe(true);
             const allText = (response.content ?? []).map(textOf).join('\n');
-            expect(allText).toContain(`If ${HELPER_TOOLS.STORE_SEARCH} is available in this session`);
-            expect(allText).toContain(`using: ${HELPER_TOOLS.ACTOR_GET_DETAILS}`);
+            expect(allText).toContain(`search for available Actors using ${HELPER_TOOLS.STORE_SEARCH}`);
+            expect(allText).toContain(`get Actor details using ${HELPER_TOOLS.ACTOR_GET_DETAILS}`);
             expect(response.toolTelemetry).toEqual(
                 expect.objectContaining({
                     toolStatus: TOOL_STATUS.SOFT_FAIL,
@@ -109,7 +109,7 @@ describe('call_actor_common', () => {
                 actorName: 'apify/some-actor',
                 error,
                 actorId: 'actor-456',
-                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
+                loadedToolNames: [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.ACTOR_GET_DETAILS],
             });
 
             expect(response.isError).toBe(true);
@@ -130,12 +130,12 @@ describe('call_actor_common', () => {
             const response = buildCallActorErrorResponse({
                 actorName: 'apify/rag-web-browser',
                 error: new Error('boom'),
-                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
+                loadedToolNames: [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.ACTOR_GET_DETAILS],
             });
 
             const allText = (response.content ?? []).map(textOf).join('\n');
-            expect(allText).toContain(`If ${HELPER_TOOLS.STORE_SEARCH} is available in this session`);
-            expect(allText).toContain(`using: ${HELPER_TOOLS.ACTOR_GET_DETAILS}`);
+            expect(allText).toContain(`search for available Actors using ${HELPER_TOOLS.STORE_SEARCH}`);
+            expect(allText).toContain(`get Actor details using ${HELPER_TOOLS.ACTOR_GET_DETAILS}`);
             expect(response.toolTelemetry).toEqual(
                 expect.objectContaining({
                     toolStatus: TOOL_STATUS.FAILED,
@@ -143,6 +143,30 @@ describe('call_actor_common', () => {
                     failureDetail: 'boom',
                 }),
             );
+        });
+
+        it('omits the recovery hint entirely when neither tool is loaded in this session', () => {
+            const response = buildCallActorErrorResponse({
+                actorName: 'apify/rag-web-browser',
+                error: new Error('boom'),
+                loadedToolNames: [],
+            });
+
+            const allText = (response.content ?? []).map(textOf).join('\n');
+            expect(allText).not.toContain(HELPER_TOOLS.STORE_SEARCH);
+            expect(allText).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
+        });
+
+        it('names only the loaded recovery tool when the session has a partial tool set', () => {
+            const response = buildCallActorErrorResponse({
+                actorName: 'apify/rag-web-browser',
+                error: new Error('boom'),
+                loadedToolNames: [HELPER_TOOLS.STORE_SEARCH],
+            });
+
+            const allText = (response.content ?? []).map(textOf).join('\n');
+            expect(allText).toContain(`search for available Actors using ${HELPER_TOOLS.STORE_SEARCH}`);
+            expect(allText).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
         });
 
         it('returns memory-quota recovery hint for HTTP 402 memory-limit errors', () => {
@@ -164,7 +188,7 @@ describe('call_actor_common', () => {
                 actorName: 'compass/crawler-google-places',
                 error,
                 actorId: 'actor-789',
-                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
+                loadedToolNames: [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.ACTOR_GET_DETAILS],
             });
 
             expect(response.isError).toBe(true);
@@ -206,7 +230,7 @@ describe('call_actor_common', () => {
                 actorName: 'apify/instagram-scraper',
                 error,
                 actorId: 'actor-999',
-                actorGetDetailsTool: HELPER_TOOLS.ACTOR_GET_DETAILS,
+                loadedToolNames: [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.ACTOR_GET_DETAILS],
             });
 
             expect(response.isError).toBe(true);

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -35,12 +35,8 @@ describe('call_actor_common', () => {
         it('builds the description with public helper tools and waitSecs guidance', () => {
             const description = buildCallActorDescription();
 
-            expect(description).toContain(
-                `Get the Actor's input schema with ${HELPER_TOOLS.ACTOR_GET_DETAILS}, when that tool is available in this session`,
-            );
-            expect(description).toContain(
-                `${HELPER_TOOLS.STORE_SEARCH} is available in this session, use it to resolve the correct Actor first`,
-            );
+            expect(description).toContain(`Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} to get the Actor's input schema`);
+            expect(description).toContain(`use ${HELPER_TOOLS.STORE_SEARCH} to resolve the correct Actor first`);
             expect(description).toContain('waitSecs');
             expect(description).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
             expect(description).not.toContain('always runs asynchronously');

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -35,7 +35,9 @@ describe('call_actor_common', () => {
         it('builds the description with public helper tools and waitSecs guidance', () => {
             const description = buildCallActorDescription();
 
-            expect(description).toContain(`Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} to get the Actor's input schema`);
+            expect(description).toContain(
+                `Get the Actor's input schema with ${HELPER_TOOLS.ACTOR_GET_DETAILS}, when that tool is available in this session`,
+            );
             expect(description).toContain(
                 `${HELPER_TOOLS.STORE_SEARCH} is available in this session, use it to resolve the correct Actor first`,
             );
@@ -43,6 +45,12 @@ describe('call_actor_common', () => {
             expect(description).toContain(HELPER_TOOLS.DATASET_GET_ITEMS);
             expect(description).not.toContain('always runs asynchronously');
             expect(description).not.toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
+        });
+
+        // The waitSecs: 0 path (buildStartRunSharedContent) returns id-only storages and never
+        // reaches buildRunDataset, so the field-metadata promise must stay tied to waitSecs > 0.
+        it('promises dataset field metadata only for a non-zero wait', () => {
+            expect(buildCallActorDescription()).toContain('with waitSecs > 0 also reports dataset field metadata');
         });
     });
 

--- a/tests/unit/tools.call_actor_widget.response.test.ts
+++ b/tests/unit/tools.call_actor_widget.response.test.ts
@@ -61,6 +61,12 @@ describe('call-actor-widget response', () => {
         vi.mocked(getActorsAsTools).mockResolvedValue({ tools: [MOCK_ACTOR_TOOL], errors: [] });
     });
 
+    // This tool always starts the run and returns — it never waits, so it must not copy
+    // call-actor's waitSecs > 0 field-metadata promise (asserted in tools.call_actor_common.test.ts).
+    it('does not promise field metadata for silent background starts', () => {
+        expect(callActorWidget.description).not.toMatch(/also reports dataset\s+field metadata/);
+    });
+
     it('starts the run and returns runId + widget _meta on the response', async () => {
         const startSpy = vi.fn().mockResolvedValue(MOCK_RUN);
         const apifyClient = stubApifyClient(startSpy);

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -404,17 +404,12 @@ describe('getToolPublicFieldOnly inputSchema normalization', () => {
 
 /**
  * A description must not name a tool that is absent from the same session — the model would call
- * something `tools/list` never returned. Descriptions are module-level constants, so nothing gates
- * them per session: `suggestTool` (storage_helpers.ts) only guards runtime response text.
- *
- * The one allowed form is an explicit hedge ({@link SESSION_HEDGE}), as used in call_actor.ts.
+ * something `tools/list` never returned. Cross-tool references are gated per session via
+ * `buildDescription` + `ctx.hasTool(...)` and rendered at the tools/list boundary
+ * (`getToolPublicFieldOnly` with `presentTools`). This renders every session shape the same way
+ * the list handlers do and checks the result.
  */
 describe('tool descriptions never name a tool absent from the session', () => {
-    const ALL_TOOL_NAMES: HelperToolName[] = Object.values(HELPER_TOOLS);
-
-    /** Prose that makes a reference to a possibly-absent tool explicit rather than misleading. */
-    const SESSION_HEDGE = 'is available in this session';
-
     /** Minimal direct Actor tool — enough to trigger AUTO_INJECTED_TOOLS and stand in for a real one. */
     const actorToolStub = {
         type: 'actor',
@@ -424,6 +419,7 @@ describe('tool descriptions never name a tool absent from the session', () => {
         description: `Fetch output rows with ${HELPER_TOOLS.DATASET_GET_ITEMS}.`,
         inputSchema: { type: 'object', properties: {} },
     } as unknown as ToolEntry;
+    const ALL_TOOL_NAMES: string[] = [...Object.values(HELPER_TOOLS), actorToolStub.name];
 
     const sessions: { label: string; input: Input; actorTools: ToolEntry[] }[] = [
         { label: 'default (no selectors)', input: {}, actorTools: [actorToolStub] },
@@ -441,6 +437,22 @@ describe('tool descriptions never name a tool absent from the session', () => {
             input: { tools: ['apify/rag-web-browser'] },
             actorTools: [actorToolStub],
         },
+        // Mixed cross-category selectors — arbitrary combinations must render correctly too.
+        {
+            label: "tools: ['call-actor', 'get-dataset']",
+            input: { tools: [HELPER_TOOLS.ACTOR_CALL, HELPER_TOOLS.DATASET_GET] },
+            actorTools: [],
+        },
+        {
+            label: "tools: ['search-actors', 'fetch-apify-docs']",
+            input: { tools: [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.DOCS_FETCH] },
+            actorTools: [],
+        },
+        {
+            label: "tools: ['docs', 'get-key-value-store-keys']",
+            input: { tools: ['docs', HELPER_TOOLS.KEY_VALUE_STORE_KEYS_GET] },
+            actorTools: [],
+        },
     ];
 
     for (const mode of SERVER_MODES) {
@@ -452,8 +464,11 @@ describe('tool descriptions never name a tool absent from the session', () => {
 
                 const violations: string[] = [];
                 for (const tool of tools) {
-                    for (const line of (tool.description ?? '').split('\n')) {
-                        if (line.includes(SESSION_HEDGE)) continue;
+                    const { description } = getToolPublicFieldOnly(tool, { presentTools: present });
+                    for (const line of (description ?? '').split('\n')) {
+                        if (line.includes('available in this session')) {
+                            violations.push(`${tool.name} still hedges instead of rendering: ${line.trim()}`);
+                        }
                         for (const name of absent) {
                             // Boundary guard so `get-dataset` does not match inside `get-dataset-items`,
                             // nor `call-actor` inside `call-actor-widget`. `:` is excluded too — it

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -401,3 +401,73 @@ describe('getToolPublicFieldOnly inputSchema normalization', () => {
         expect(schema.required).toEqual(['query']);
     });
 });
+
+/**
+ * A description must not name a tool that is absent from the same session — the model would call
+ * something `tools/list` never returned. Descriptions are module-level constants, so nothing gates
+ * them per session: `suggestTool` (storage_helpers.ts) only guards runtime response text.
+ *
+ * The one allowed form is an explicit hedge ({@link SESSION_HEDGE}), as used in call_actor.ts.
+ */
+describe('tool descriptions never name a tool absent from the session', () => {
+    const ALL_TOOL_NAMES: HelperToolName[] = Object.values(HELPER_TOOLS);
+
+    /** Prose that makes a reference to a possibly-absent tool explicit rather than misleading. */
+    const SESSION_HEDGE = 'is available in this session';
+
+    /** Minimal direct Actor tool — enough to trigger AUTO_INJECTED_TOOLS and stand in for a real one. */
+    const actorToolStub = {
+        type: 'actor',
+        name: 'apify--rag-web-browser',
+        actorId: 'test-actor-id',
+        actorFullName: 'apify/rag-web-browser',
+        description: `Fetch output rows with ${HELPER_TOOLS.DATASET_GET_ITEMS}.`,
+        inputSchema: { type: 'object', properties: {} },
+    } as unknown as ToolEntry;
+
+    const sessions: { label: string; input: Input; actorTools: ToolEntry[] }[] = [
+        { label: 'default (no selectors)', input: {}, actorTools: [actorToolStub] },
+        { label: "tools: ['docs']", input: { tools: ['docs'] }, actorTools: [] },
+        { label: "tools: ['runs']", input: { tools: ['runs'] }, actorTools: [] },
+        { label: "tools: ['storage']", input: { tools: ['storage'] }, actorTools: [] },
+        { label: "tools: ['actors']", input: { tools: ['actors'] }, actorTools: [] },
+        ...ALL_TOOL_NAMES.map((name) => ({
+            label: `tools: ['${name}']`,
+            input: { tools: [name] },
+            actorTools: [],
+        })),
+        {
+            label: 'Actor tool only',
+            input: { tools: ['apify/rag-web-browser'] },
+            actorTools: [actorToolStub],
+        },
+    ];
+
+    for (const mode of SERVER_MODES) {
+        for (const { label, input, actorTools } of sessions) {
+            it(`${label} in ${mode} mode`, () => {
+                const tools = getToolsForServerMode(input, actorTools, mode);
+                const present = new Set(tools.map((t) => t.name));
+                const absent = ALL_TOOL_NAMES.filter((name) => !present.has(name));
+
+                const violations: string[] = [];
+                for (const tool of tools) {
+                    for (const line of (tool.description ?? '').split('\n')) {
+                        if (line.includes(SESSION_HEDGE)) continue;
+                        for (const name of absent) {
+                            // Boundary guard so `get-dataset` does not match inside `get-dataset-items`,
+                            // nor `call-actor` inside `call-actor-widget`. `:` is excluded too — it
+                            // marks a remote MCP-Actor tool ("apify/actors-mcp-server:fetch-apify-docs"),
+                            // not a tool served from this session.
+                            if (new RegExp(`(?<![\\w-:])${name}(?![\\w-])`).test(line)) {
+                                violations.push(`${tool.name} names absent ${name}: ${line.trim()}`);
+                            }
+                        }
+                    }
+                }
+
+                expect(violations).toEqual([]);
+            });
+        }
+    }
+});

--- a/tests/unit/tools.x402.test.ts
+++ b/tests/unit/tools.x402.test.ts
@@ -5,6 +5,7 @@
 import Ajv from 'ajv';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { HELPER_TOOLS } from '../../src/const.js';
 import type { PaymentMeta, RequestHeaders } from '../../src/payments/types.js';
 import {
     X402_PAYMENT_REQUIRED_OUTPUT_SCHEMA,
@@ -12,9 +13,10 @@ import {
     type X402PaymentRequirements,
 } from '../../src/payments/x402.js';
 import { actorRunOutputSchema } from '../../src/tools/structured_output_schemas.js';
-import type { HelperTool } from '../../src/types.js';
+import type { HelperTool, ToolDescriptionContext } from '../../src/types.js';
 import { TOOL_TYPE } from '../../src/types.js';
 import { respondRaw } from '../../src/utils/mcp.js';
+import { getToolPublicFieldOnly } from '../../src/utils/tools.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -215,6 +217,22 @@ describe('decorateToolSchema()', () => {
         const decorated = new X402PaymentProvider(requirements).decorateToolSchema(makePaidTool());
 
         expect(decorated.description).toContain('x402 payment');
+    });
+
+    it('preserves x402 instructions when rendering a session description', () => {
+        const buildDescription = ({ hasTool }: ToolDescriptionContext) =>
+            `Paid tool${hasTool(HELPER_TOOLS.ACTOR_GET_DETAILS) ? ` with ${HELPER_TOOLS.ACTOR_GET_DETAILS}` : ''}`;
+        const decorated = new X402PaymentProvider().decorateToolSchema(
+            makePaidTool({
+                description: buildDescription({ hasTool: () => true }),
+                buildDescription,
+            }),
+        );
+
+        const { description } = getToolPublicFieldOnly(decorated, { presentTools: new Set([decorated.name]) });
+
+        expect(description).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
+        expect(description).toContain('x402 payment');
     });
 
     it('is idempotent — second decoration does not change _meta.x402 or duplicate instructions', () => {


### PR DESCRIPTION
Tool descriptions named sibling tools that a session may never have served, and several stated outputs the code does not produce.

Cross-tool references now render per session instead of being hedged in prose: a tool with such a reference defines `buildDescription({ hasTool })`, and `getToolPublicFieldOnly` renders it against the exact set each `tools/list` response returns (`presentTools`, passed by both era handlers). `description` keeps the all-tools-present render for consumers without a session set. The mode-contract test renders every session shape (default, each category, every single-tool selector, mixed combos, both modes) the same way the handlers do and fails on any absent-tool name or hedge text. Implements #1265.

Output claims corrected against the code that produces them:

- Slack: https://apify.slack.com/archives/C08FDFSTH50/p1786625241747719
- apify/apify-ms-copilot-plugin#2

| Tool | Was | Now |
|---|---|---|
| `abort-actor-run` | no effect for `FINISHED, FAILED, ABORTING, TIMED-OUT` | `SUCCEEDED, FAILED, ABORTING, ABORTED, TIMED-OUT` — `FINISHED` is not an Apify run status, and `TIMING-OUT` is abortable |
| `get-actor-run-list` | `datasetId` / `keyValueStoreId` | `defaultDatasetId` / `defaultKeyValueStoreId` |
| `search-actors` | card list named a success-rate stat that is never rendered | matches `formatActorToActorCard` field for field |
| `call-actor` | always "returns … field metadata" | dataset field metadata only for `waitSecs > 0`; the `waitSecs: 0` path returns id-only storages |
| server instructions | a capped wait "returns the result" | returns current status and storage IDs, not output rows |

Overlaps #1227, which edits the call-actor MCP section in the same file (now `buildCallActorMcpServerSection`); that one will need a rebase, not a conflict resolution.

Follow-up: #1272 — the task tool descriptions from #1235 need the same gating once both land.

@RobertCrupa @MQ37 once we have good evals, we should enable all tools and get rid of this spaghetti tool definitions 

#1260 — serving all tools by default stays open as the default-surface question; a `tools=` selector still produces arbitrary subsets, which the per-session rendering now handles.