### PR TITLE
docs: Add test to the allowed commit-type list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ TypeScript, ES modules. Runs in two modes: **stdio** (local CLI clients, `stdio.
 
 ## Git: branch names, commits, PR titles
 
-Conventional Commits for all three. Branch: `type/short-desc` (e.g. `fix/connection-timeout`). Commit/PR title: `type: Description` (e.g. `fix: Handle connection errors`). Types: `feat`, `fix`, `chore`, `refactor`, `docs`. Append `!` for breaking changes. PR title ≤70 chars.
+Conventional Commits for all three. Branch: `type/short-desc` (e.g. `fix/connection-timeout`). Commit/PR title: `type: Description` (e.g. `fix: Handle connection errors`). Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`. Append `!` for breaking changes. PR title ≤70 chars.
 
 Use `git mv` (not `mv` + `rm`) when renaming files so git records a rename rather than delete+create.
 


### PR DESCRIPTION
Adds `test` to the conventional-commit type list in the root `AGENTS.md` (which `CLAUDE.md` symlinks to).

The list said `feat`, `fix`, `chore`, `refactor`, `docs` — omitting `test`, which the project already accepts:

Closes #1281
