### PR TITLE
refactor: Remove the write-only serverId field on ActorMcpTool

### DIFF
--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -67,9 +67,9 @@ Two MCP protocol revisions are served, each by its own adapter:
   proxied Actor-MCP tools: `proxy.ts` `getProxyMCPServerToolName`). Never widen the
   cap — downstream clients depend on it.
 - **Proxy server IDs are keyed by URL, not Actor ID.** `getMCPServerID(url)` is
-  `sha256(url)` sliced to `SERVER_ID_LENGTH`. One Actor can expose both an SSE and a
-  streamable endpoint; keying by URL keeps those distinct. Keying by Actor ID would
-  collapse them and cross transports.
+  `sha256(url)` sliced to `SERVER_ID_LENGTH`, and its only consumer is the MCP SDK client
+  name (`client.ts`). One Actor can expose both an SSE and a streamable endpoint; keying by
+  URL keeps those distinct. Keying by Actor ID would collapse them and cross transports.
 - **Transport negotiation is streamable-first, SSE-fallback** (`client.ts`): try
   streamable HTTP, fall back to SSE on a protocol failure — but a connection
   **timeout** returns `null` with no SSE fallback (a timeout means unreachable, not

--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -67,9 +67,10 @@ Two MCP protocol revisions are served, each by its own adapter:
   proxied Actor-MCP tools: `proxy.ts` `getProxyMCPServerToolName`). Never widen the
   cap — downstream clients depend on it.
 - **Proxy server IDs are keyed by URL, not Actor ID.** `getMCPServerID(url)` is
-  `sha256(url)` sliced to `SERVER_ID_LENGTH`, and its only consumer is the MCP SDK client
-  name (`client.ts`). One Actor can expose both an SSE and a streamable endpoint; keying by
-  URL keeps those distinct. Keying by Actor ID would collapse them and cross transports.
+  `sha256(url)` sliced to `SERVER_ID_LENGTH`; consumers are tool-name prefixing
+  (`getProxyMCPServerToolName`, same file) and the MCP SDK client name (`client.ts`).
+  One Actor can expose both an SSE and a streamable endpoint; keying by URL keeps
+  those distinct. Keying by Actor ID would collapse them and cross transports.
 - **Transport negotiation is streamable-first, SSE-fallback** (`client.ts`): try
   streamable HTTP, fall back to SSE on a protocol failure — but a connection
   **timeout** returns `null` with no SSE fallback (a timeout means unreachable, not

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -43,7 +43,6 @@ export async function getMCPServerTools(actorID: string, client: Client, serverU
         (tool): ActorMcpTool => ({
             type: TOOL_TYPE.ACTOR_MCP,
             actorId: actorID,
-            serverId: getMCPServerID(serverUrl),
             serverUrl,
             originToolName: tool.name,
             name: getProxyMCPServerToolName(serverUrl, tool.name),

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,11 +208,6 @@ export type ActorMcpTool = ToolBase & {
     originToolName: string;
     /** ID of the Actorized MCP server - for example, apify/actors-mcp-server */
     actorId: string;
-    /**
-     * ID of the Actorized MCP server the tool is associated with.
-     * serverId is generated unique ID based on the serverUrl.
-     */
-    serverId: string;
     /** Connection URL of the Actorized MCP server */
     serverUrl: string;
 };

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -171,7 +171,6 @@ function makeActorMcpTool(): ToolEntry {
         ajvValidate: compileSchema({ type: 'object', properties: {} }),
         originToolName: 'origin-tool',
         actorId: 'test/actor',
-        serverId: 'server-id',
         serverUrl: 'https://example.invalid/mcp',
         execution: { taskSupport: 'optional' },
     } as ToolEntry;

--- a/tests/unit/mcp.stateless.tool_call.test.ts
+++ b/tests/unit/mcp.stateless.tool_call.test.ts
@@ -74,7 +74,6 @@ function makeActorMcpTool(): ToolEntry {
         ajvValidate: compileSchema({ type: 'object', properties: {} }),
         originToolName: 'origin-tool',
         actorId: 'test/actor',
-        serverId: 'server-id',
         serverUrl: 'https://example.invalid/mcp',
     } as ToolEntry;
 }


### PR DESCRIPTION
The `serverId` was written on every proxied tool and read nowhere — not in `src/`, not in `apify-mcp-server-internal`. Dispatch routes on `originToolName` + `serverUrl`, so it carried no behavior, and it cost a `sha256` per proxied tool at list time for no consumer.

### Conflicts with #1279 — read before merging

Whichever merges second needs to reconcile:
- if **#1279 first** → rebase this branch, and drop the `serverId` half of that sentence;
- if **this first** → #1279's `AGENTS.md` hunk and its `proxy.ts` object literal both need updating.

Merging #1279 first is the simpler order, since this PR is the smaller rebase.