### PR TITLE
feat: extend official Apify usernames beyond apify

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -182,6 +182,26 @@ export const DOCS_SNIPPET_HIGHLIGHT_TAG = '\uE000';
 
 export const ALLOWED_DOC_DOMAINS = ['https://docs.apify.com', 'https://crawlee.dev'] as const;
 
+/** Actor usernames treated as official Apify (drives `isOfficialApify` on the Actor card). */
+export const OFFICIAL_APIFY_USERNAMES: ReadonlySet<string> = new Set([
+    'agentify',
+    'apify',
+    'apifyatevents',
+    'clockworks',
+    'compass',
+    'e-commerce',
+    'h_reviews',
+    'hooli',
+    'junglee',
+    'lukaskrivka',
+    'maxcopell',
+    'misceres',
+    'streamers',
+    'tri_angle',
+    'vdrmota',
+    'voyager',
+]);
+
 export const APIFY_STORE_URL = 'https://apify.com';
 /** Apify Console origin (production). */
 export const CONSOLE_BASE_URL = 'https://console.apify.com';

--- a/src/utils/actor_card.ts
+++ b/src/utils/actor_card.ts
@@ -1,4 +1,4 @@
-import { APIFY_STORE_URL, MAX_INPUT_FIELDS_IN_ACTOR_CARD } from '../const.js';
+import { APIFY_STORE_URL, MAX_INPUT_FIELDS_IN_ACTOR_CARD, OFFICIAL_APIFY_USERNAMES } from '../const.js';
 import type { Actor, ActorCardOptions, ActorStoreInputSchema, ActorStoreList, StructuredActorCard } from '../types.js';
 import { buildConsoleActorUrl } from './console_link.js';
 import {
@@ -172,7 +172,7 @@ function extractActorData(actor: Actor | ActorStoreList, options: ActorCardOptio
     if (options.includeMetadata) {
         data.developer = {
             username: actor.username,
-            isOfficialApify: actor.username === 'apify',
+            isOfficialApify: OFFICIAL_APIFY_USERNAMES.has(actor.username),
             url: `${APIFY_STORE_URL}/${actor.username}`,
         };
         data.categories = formatCategories('categories' in actor ? actor.categories : undefined);


### PR DESCRIPTION
## What
Extends the Actor-card `isOfficialApify` check from a single hardcoded `username === 'apify'` comparison to a lookup against a new `OFFICIAL_APIFY_USERNAMES` set (`src/const.ts`), covering the additional in-house Store accounts: agentify, apifyatevents, clockworks, compass, e-commerce, h_reviews, hooli, junglee, lukaskrivka, maxcopell, misceres, streamers, tri_angle, vdrmota, voyager.

## Why
These usernames are Apify-operated Store accounts but were previously shown as third-party/community in Actor cards, since only `apify` matched.

## Testing
`pnpm run type-check/lint/test:unit/format/check:agents` all pass (1415 unit tests). E2E-verified live via mcpc against the built stdio server: `fetch-actor-details` on `clockworks/tiktok-scraper` and `compass/crawler-google-places` now returns `developer.isOfficialApify: true`; `search-actors` for non-listed usernames (e.g. `apidojo`, `scraping_solutions`) still returns `false`; `apify/rag-web-browser` unaffected (`true`, as before).