### PR TITLE
docs: Fix canary release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,9 +524,9 @@ Example: `https://mcp.apify.com?tools=search-actors`.
 Apify MCP is split across two repositories: this repository for core MCP logic and the private `apify-mcp-server-internal` for the hosted server.
 Changes must be synchronized between both.
 
-To create a canary release, add the `beta` tag to your PR branch.
+To create a canary release, add the `beta` label to your pull request.
 This publishes the package to [pkg.pr.new](https://pkg.pr.new/) for staging and testing before merging.
-See [the workflow file](.github/workflows/pre_release.yaml) for details.
+See [the workflow file](.github/workflows/on_pull_request_label.yaml) for details.
 
 ## 🐋 Docker Hub integration
 The Apify MCP Server is also available on [Docker Hub](https://hub.docker.com/mcp/server/apify-mcp-server/overview), registered via the [mcp-registry](https://github.com/docker/mcp-registry) repository. The entry in `servers/apify-mcp-server/server.yaml` should be deployed automatically by the Docker Hub MCP registry (deployment frequency is unknown). **Before making major changes to the `stdio` server version, test it locally to ensure the Docker build passes.** To test, change the `source.branch` to your PR branch and run `task build -- apify-mcp-server`. For more details, see [CONTRIBUTING.md](https://github.com/docker/mcp-registry/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## What changed

- Changed `beta` from a branch tag to a pull request label.
- Linked the current pull request label workflow.

## Why

The README links to a workflow that no longer exists, while the active workflow triggers on the `beta` label.

## Verification

- Confirmed `.github/workflows/on_pull_request_label.yaml` exists.
- Confirmed the workflow checks for the `beta` pull request label.
- Ran `git diff --check`.

## Risk

Documentation only.

## AI assistance

Codex helped identify the stale link and draft this documentation update. I verified the behavior against the current workflow.
