### PR TITLE
feat: Return task input verbatim and align task tools with the API

### DIFF
--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -353,7 +353,9 @@ export const reportProblemToolOutputSchema = {
 };
 
 /**
- * Schema shared by every Actor task tool. Input values are omitted on purpose (they may hold secrets) `inputFields` lists the field names that `publicConfig.inputSchemaFields` can use.
+ * Schema shared by every Actor task tool. `input` mirrors the API task object verbatim; input
+ * fields the Actor's schema declares as secret arrive as `ENCRYPTED_VALUE:` placeholders. The
+ * keys are the field names that `publicConfig.inputSchemaFields` can use.
  */
 export const actorTaskOutputSchema = {
     type: 'object' as const,
@@ -378,13 +380,14 @@ export const actorTaskOutputSchema = {
                 datasetView: { type: ['string', 'null'] },
             },
         },
-        inputFields: {
-            type: 'array',
-            items: { type: 'string' },
-            description: "Field names of the task's input; values are not returned",
+        input: {
+            type: ['object', 'array', 'null'],
+            description:
+                'The stored task input, as the API returns it. Fields the Actor declares as secret are ' +
+                'encrypted placeholders, never plaintext.',
         },
     },
-    required: ['taskId', 'actorId', 'name', 'title', 'description', 'publishedAt', 'publicConfig', 'inputFields'],
+    required: ['taskId', 'actorId', 'name', 'title', 'description', 'publishedAt', 'publicConfig', 'input'],
 };
 
 /**

--- a/src/tools/tasks/create_actor_task.ts
+++ b/src/tools/tasks/create_actor_task.ts
@@ -40,9 +40,10 @@ const createActorTaskArgs = z.object({
 });
 
 function buildDescription({ hasTool }: ToolDescriptionContext): string {
-    return `Create a saved Actor task — a named, reusable configuration of an Actor that stores its
-input and run options such as the build, memory, and timeout. Tasks are useful for repeated or scheduled
-jobs, because the user does not have to configure the Actor again for every run.
+    return `Create a saved Actor task: a reusable configuration of a single Actor, adapted for a specific
+use case. A task stores the Actor input and run options such as the build, memory, and timeout, and can be
+run repeatedly from Apify Console, Schedules, or the API, so the user does not have to configure the Actor
+again for every run.
 
 Creating a task does not make it public. The public display configuration (\`publicConfig\`) can be set \
 here${hasTool(HELPER_TOOLS.ACTOR_TASK_UPDATE) ? ` or later with ${HELPER_TOOLS.ACTOR_TASK_UPDATE}` : ''}; either \
@@ -50,6 +51,11 @@ way the task stays private until it is published${hasTool(HELPER_TOOLS.ACTOR_TAS
 
 USAGE:
 - Use when the user wants to save an Actor configuration for repeated use.
+- When the user's intent is clear, pick sensible values for unspecified input fields from the Actor's input schema, state the choices, and proceed instead of asking.${
+        hasTool(HELPER_TOOLS.STORE_SEARCH)
+            ? `\n- When the user names the Actor loosely (e.g. "the troubleshooter Actor from jane.doe"), resolve it with ${HELPER_TOOLS.STORE_SEARCH} instead of asking for the exact ID or guessing one.`
+            : ''
+    }
 
 USAGE EXAMPLES:
 - user_input: Save this instagram-scraper config as a task called daily-posts`;
@@ -97,7 +103,9 @@ export const createActorTask: ToolEntry = Object.freeze({
         } satisfies TaskCreateData);
 
         const result = taskResult(task);
-        const summary = `Created task "${result.name}" (ID: ${result.taskId}) for Actor ${result.actorId}.`;
+        const summary =
+            `Created task "${result.name}" (ID: ${result.taskId}) for Actor ${result.actorId}. ` +
+            `The task is private until published with ${HELPER_TOOLS.ACTOR_TASK_PUBLISH}.`;
         return respondOk([JSON.stringify(result), summary], { structuredContent: result });
     },
 } as const);

--- a/src/tools/tasks/get_actor_task.ts
+++ b/src/tools/tasks/get_actor_task.ts
@@ -18,8 +18,8 @@ const getActorTaskArgs = z.object({
 });
 
 function buildDescription({ hasTool }: ToolDescriptionContext): string {
-    return `Get a saved Actor task — the Actor it runs, its name, title, description, and run options.
-Input values are not returned (they may contain secrets), only the input field names.
+    return `Get a saved Actor task: the Actor it runs, its name, title, description, stored input, and run options.
+Input fields the Actor declares as secret are returned as encrypted placeholders, never in plaintext.
 Also reports whether the task is published on a public landing page, and its display configuration if so.
 ${hasTool(HELPER_TOOLS.ACTOR_TASK_UPDATE) ? `Use ${HELPER_TOOLS.ACTOR_TASK_UPDATE} to change the task.\n` : ''}
 USAGE:
@@ -62,7 +62,7 @@ export const getActorTask: ToolEntry = Object.freeze({
         const result = taskResult(task);
         const summary = `Task "${result.name}" (ID: ${result.taskId}) runs Actor ${result.actorId}${
             result.publishedAt ? '; published' : ''
-        }.`;
+        }. The stored input is in the result; secret fields are encrypted placeholders.`;
         return respondOk([JSON.stringify(result), summary], { structuredContent: result });
     },
 } as const);

--- a/src/tools/tasks/publish_actor_task.ts
+++ b/src/tools/tasks/publish_actor_task.ts
@@ -24,8 +24,9 @@ in the Actor's Examples tab and can be discovered by users, search engines, and 
 users understand and try the Actor and can increase its runs. Publish only tasks that represent a useful,
 reliable, and specific use case. Not every saved task needs to be public.
 
-The task's Actor must be public and the task must have its public display configuration set up -
-at least \`publicConfig.inputSchemaFields\` and \`publicConfig.datasetView\`. If publishing fails, \
+The task's Actor must be public and the task must have its public display configuration set up:
+at least \`publicConfig.inputSchemaFields\`, \`publicConfig.datasetView\`, and \`publicConfig.seoDescription\`. \
+If publishing fails, \
 follow the API reason${hasTool(HELPER_TOOLS.ACTOR_TASK_UPDATE) ? `; update these fields with ${HELPER_TOOLS.ACTOR_TASK_UPDATE} only when the reason identifies them` : ''}.
 At most 50 tasks can be published per Actor.
 Publishing an already published task has no effect.
@@ -64,7 +65,10 @@ export const publishActorTask: ToolEntry = Object.freeze({
         const task = await setTaskPublication(client, parsed.taskId, true);
 
         const result = taskResult(task);
-        const summary = `Task "${task.name}" (ID: ${task.id}) is published. The link to the public page is available in Apify Console, on the task's Publication tab.`;
+        const summary =
+            `Task "${task.name}" (ID: ${task.id}) is published; publishedAt in the result is the publication time. ` +
+            `The link to the public page is available in Apify Console, on the task's Publication tab. ` +
+            `To re-check the publication state later, use ${HELPER_TOOLS.ACTOR_TASK_GET}.`;
         return respondOk([JSON.stringify(result), summary], { structuredContent: result });
     },
 } as const);

--- a/src/tools/tasks/task_helpers.ts
+++ b/src/tools/tasks/task_helpers.ts
@@ -61,8 +61,16 @@ export const taskNameSchema = z
 
 /** Writable public display configuration, shared by the create and update tools. */
 export const publicConfigSchema = z.object({
-    seoTitle: z.string().optional().describe('Title shown on the public landing page and in search results.'),
-    seoDescription: z.string().optional().describe('Description shown on the public landing page.'),
+    seoTitle: z
+        .string()
+        .max(60)
+        .optional()
+        .describe('Title shown on the public landing page and in search results. At most 60 characters.'),
+    seoDescription: z
+        .string()
+        .max(160)
+        .optional()
+        .describe('Description shown on the public landing page. At most 160 characters.'),
     inputSchemaFields: z
         .array(z.string())
         .optional()
@@ -80,8 +88,10 @@ export const publicConfigSchema = z.object({
 
 /**
  * The task subset returned by every task tool: identity, publication state, and the display
- * config. Input *values* are deliberately omitted — they may hold secrets — but the field names
- * are included because `publicConfig.inputSchemaFields` must reference them.
+ * config. `input` is returned verbatim, as the API, CLI, and apify-client return it — input
+ * fields the Actor's schema declares as secret arrive as `ENCRYPTED_VALUE:` placeholders,
+ * never plaintext, so no extra redaction happens here. Its keys are what
+ * `publicConfig.inputSchemaFields` can reference.
  */
 export function taskResult(task: Task) {
     const publicConfig = task.publicConfig
@@ -103,7 +113,7 @@ export function taskResult(task: Task) {
         // returns a string; the declared output schema promises a string either way.
         publishedAt: toIsoString(task.publicConfig?.publishedAt) ?? null,
         publicConfig,
-        inputFields: task.input && !Array.isArray(task.input) ? Object.keys(task.input) : [],
+        input: task.input ?? null,
     };
 }
 

--- a/src/tools/tasks/update_actor_task.ts
+++ b/src/tools/tasks/update_actor_task.ts
@@ -46,9 +46,10 @@ function buildDescription({ hasTool }: ToolDescriptionContext): string {
         hasTool(name),
     );
     return `Update a saved Actor task: its input, run options, or the public display configuration (\`publicConfig\`) of its landing page.
-This does not publish or unpublish the task${publicationTools.length ? ` — use ${publicationTools.join(' and ')} for that` : ''}.
-To publish a task, \`publicConfig.inputSchemaFields\` (at least one field name from the task input) and
-\`publicConfig.datasetView\` must be set here first. Updating \`publicConfig\` requires write access to the task's Actor.
+This does not publish or unpublish the task${publicationTools.length ? `; use ${publicationTools.join(' and ')} for that` : ''}.
+To publish a task, \`publicConfig.inputSchemaFields\` (at least one field name from the task input),
+\`publicConfig.datasetView\`, and \`publicConfig.seoDescription\` must be set here first. Updating \`publicConfig\`
+requires write access to the task's Actor.
 
 USAGE:
 - Use to change a task's input or run options.
@@ -118,7 +119,7 @@ export const updateActorTask: ToolEntry = Object.freeze({
         const task = await client.task(resolvedTaskId).update(update);
 
         const result = taskResult(task);
-        const summary = `Updated task "${result.name}" (ID: ${result.taskId}).`;
+        const summary = `Updated task "${result.name}" (ID: ${result.taskId}). The returned input reflects the update.`;
         return respondOk([JSON.stringify(result), summary], { structuredContent: result });
     },
 } as const);

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -1,4 +1,5 @@
 import type { CallToolResult, ContentBlock } from '@modelcontextprotocol/sdk/types.js';
+import { ApifyApiError } from 'apify-client';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
 import type { AjvErrorDetails, ApifyRequestParams, FailureCategory, ToolTelemetryContext } from '../types.js';
@@ -283,7 +284,12 @@ export function getHttpErrorHint(status: number | undefined): string | undefined
 
 /** User-facing error text for tool execution failures with HTTP-aware hints. */
 export function getToolCallErrorUserText(toolName: string, error: unknown): string {
-    const msg = error instanceof Error ? error.message : String(error);
+    let msg = error instanceof Error ? error.message : String(error);
+    // The Apify API's machine-readable error type (e.g. "actor-task-name-not-unique"), so
+    // callers can branch on the exact error instead of parsing the message.
+    if (error instanceof ApifyApiError && error.type) {
+        msg = `${msg} (API error type: ${error.type})`;
+    }
     if (isActorRunLimitError(error)) {
         return `Error calling tool "${toolName}": ${msg}. ${ACTOR_RUN_LIMIT_MESSAGE}`;
     }

--- a/tests/unit/tools.actor_task_crud.test.ts
+++ b/tests/unit/tools.actor_task_crud.test.ts
@@ -15,7 +15,7 @@ import {
 type StructuredResult = TextToolResult & { structuredContent: Record<string, unknown> };
 
 describe('get-actor-task', () => {
-    it('returns the task subset with input field names but no input values', async () => {
+    it('returns the task subset including the stored input', async () => {
         const { apifyClient, calls } = mockTaskApiClient(mockTask());
         const result = (await (getActorTask as HelperTool).call(
             stubToolCallContext({ taskId: 'task-1' }, apifyClient),
@@ -28,16 +28,16 @@ describe('get-actor-task', () => {
             actorId: 'actor-id-1',
             name: 'my-task',
             publishedAt: '2026-08-01T10:00:00.000Z',
-            inputFields: ['query', 'apiKey'],
+            input: { query: 'cats', apiKey: 'secret-input-value' },
         });
         expect(result.structuredContent.publicConfig).toEqual({
             seoTitle: 'Seo title',
             datasetView: 'overview',
         });
 
-        // Input values and internal fields must NOT leak.
+        // Internal fields must NOT leak. Input values are returned by contract (the platform
+        // encrypts fields declared as secret before they ever reach the client).
         const dump = JSON.stringify(result);
-        expect(dump).not.toContain('secret-input-value');
         expect(dump).not.toContain('user-secret');
     });
 

--- a/tests/unit/tools.publish_actor_task.test.ts
+++ b/tests/unit/tools.publish_actor_task.test.ts
@@ -33,9 +33,9 @@ describe('publish-actor-task', () => {
         expect(JSON.parse(result.content[0].text)).toEqual(result.structuredContent);
         expect(result.content[1].text).toContain('my-task');
 
-        // Task input and internal fields must NOT leak.
+        // Internal fields must NOT leak. Input values are returned by contract (the platform
+        // encrypts fields declared as secret before they ever reach the client).
         const dump = JSON.stringify(result);
-        expect(dump).not.toContain('secret-input-value');
         expect(dump).not.toContain('user-secret');
     });
 


### PR DESCRIPTION
Task tools now return the stored task `input` verbatim, under the same key the API, CLI, and apify-client use. Everything in this PR came out of the task-tool workflow evals (#1294): agents could not answer "what input is my task configured with?", could not verify their own updates, and hallucinated values from the field-name list.

Not obvious from the code:

- **Returning the input is safe.** The platform encrypts input fields declared `isSecret: true` server-side on save. Verified empirically: a task created via the raw API with a plaintext secret returns `ENCRYPTED_VALUE:...` from both `GET actor-task` and `GET actor-task/input`; the plaintext never comes back. Non-secret values are already returned by every other Apify surface.
- **`seoDescription` is required to publish**, which no docs state — discovered via API probing after eval agents got stuck. Descriptions now list the full requirements, and the schema declares the SEO length limits (60/160) the API enforces.
- **Contract change:** the task tools' `structuredContent` replaces `inputFields` (names only) with `input`. 
- Tool errors append the machine-readable API error type, e.g. `(API error type: actor-task-name-not-unique)`.
