### PR TITLE
fix: Keep cross-tool references out of task tool summaries

### DIFF
--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -51,7 +51,22 @@ does not exist. Any other cross-tool reference must be gated per session: define
 `buildDescription(ctx)` on the entry (see `ToolDescriptionContext` in `../types.ts`), wrap the
 reference in `ctx.hasTool(...)`, and set `description` to the `ALL_TOOLS_PRESENT` render. Rendering
 happens once, at the tools/list boundary (`getToolPublicFieldOnly` in `../utils/tools.ts`). Enforced
-by `tests/unit/tools.mode_contract.test.ts`.
+by `tests/unit/tools.mode_contract.test.ts`, which scans `description` only.
+
+Input-schema field text (`.describe()` on a Zod field) reaches `tools/list` verbatim — nothing
+renders it per session — so never name a tool there; put the guidance in `buildDescription` behind
+`hasTool`. `actors/actor_tools_factory.ts`'s `waitSecs` is the one exception: an Actor tool always
+auto-injects the `get-actor-run` it names.
+
+Result text (`summary` / `nextStep` in `content[1]`) has no `hasTool`, but it does have a per-session
+gate: `InternalToolArgs.loadedToolNames` (see `suggestTool` in `storage/storage_helpers.ts`). Name a
+tool there only through that gate, or when it is the calling tool itself (the "call it again with the
+next offset" pagination hint); otherwise leave the cross-tool guidance to the gated description.
+An `AUTO_INJECTED_TOOLS` member is no exception — the injection is conditional on `call-actor`, an
+Actor tool, or `get-actor-run` being loaded, so a session that loaded only `abort-actor-run` gets
+none of them. The task tools name no tool, enforced by `tests/unit/tools.actor_task_crud.test.ts`;
+result text elsewhere predates the gate, and `suggestTool` is the pattern to fix it with. Grep
+`HELPER_TOOLS` outside `buildDescription` for the current set rather than trusting a list here.
 
 ## Related, owned elsewhere (don't restate)
 

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -352,11 +352,7 @@ export const reportProblemToolOutputSchema = {
     required: ['reported'],
 };
 
-/**
- * Schema shared by every Actor task tool. `input` mirrors the API task object verbatim; input
- * fields the Actor's schema declares as secret arrive as `ENCRYPTED_VALUE:` placeholders. The
- * keys are the field names that `publicConfig.inputSchemaFields` can use.
- */
+/** Schema shared by every Actor task tool. */
 export const actorTaskOutputSchema = {
     type: 'object' as const,
     properties: {
@@ -383,8 +379,8 @@ export const actorTaskOutputSchema = {
         input: {
             type: ['object', 'array', 'null'],
             description:
-                'The stored task input, as the API returns it. Fields the Actor declares as secret are ' +
-                'encrypted placeholders, never plaintext.',
+                'The stored task input, as the API returns it; fields the Actor declares as secret are ' +
+                'encrypted placeholders, never plaintext. Its keys are what `publicConfig.inputSchemaFields` can use.',
         },
     },
     required: ['taskId', 'actorId', 'name', 'title', 'description', 'publishedAt', 'publicConfig', 'input'],

--- a/src/tools/tasks/create_actor_task.ts
+++ b/src/tools/tasks/create_actor_task.ts
@@ -21,12 +21,7 @@ const createActorTaskArgs = z.object({
         .describe(
             'Name of the task, unique within the account: 3-63 characters, letters, digits and dashes only (e.g. "my-task"). Generated from the Actor name when omitted.',
         ),
-    input: z
-        .looseObject({})
-        .optional()
-        .describe(
-            `The input JSON the task runs the Actor with. Use ${HELPER_TOOLS.ACTOR_GET_DETAILS} to get the Actor's input schema first.`,
-        ),
+    input: z.looseObject({}).optional().describe('The input JSON the task runs the Actor with.'),
     title: z.string().optional().describe('Human-readable title of the task.'),
     description: z.string().optional().describe('Short description of what the task does.'),
     build: z.string().optional().describe('Actor build tag or number to run, e.g. "latest".'),
@@ -54,6 +49,10 @@ USAGE:
 - When the user's intent is clear, pick sensible values for unspecified input fields from the Actor's input schema, state the choices, and proceed instead of asking.${
         hasTool(HELPER_TOOLS.STORE_SEARCH)
             ? `\n- When the user names the Actor loosely (e.g. "the troubleshooter Actor from jane.doe"), resolve it with ${HELPER_TOOLS.STORE_SEARCH} instead of asking for the exact ID or guessing one.`
+            : ''
+    }${
+        hasTool(HELPER_TOOLS.ACTOR_GET_DETAILS)
+            ? `\n- Once you have the exact Actor ID, read its input schema with ${HELPER_TOOLS.ACTOR_GET_DETAILS} before setting \`input\`.`
             : ''
     }
 
@@ -103,9 +102,7 @@ export const createActorTask: ToolEntry = Object.freeze({
         } satisfies TaskCreateData);
 
         const result = taskResult(task);
-        const summary =
-            `Created task "${result.name}" (ID: ${result.taskId}) for Actor ${result.actorId}. ` +
-            `The task is private until published with ${HELPER_TOOLS.ACTOR_TASK_PUBLISH}.`;
+        const summary = `Created task "${result.name}" (ID: ${result.taskId}) for Actor ${result.actorId}.`;
         return respondOk([JSON.stringify(result), summary], { structuredContent: result });
     },
 } as const);

--- a/src/tools/tasks/get_actor_task.ts
+++ b/src/tools/tasks/get_actor_task.ts
@@ -62,7 +62,7 @@ export const getActorTask: ToolEntry = Object.freeze({
         const result = taskResult(task);
         const summary = `Task "${result.name}" (ID: ${result.taskId}) runs Actor ${result.actorId}${
             result.publishedAt ? '; published' : ''
-        }. The stored input is in the result; secret fields are encrypted placeholders.`;
+        }.`;
         return respondOk([JSON.stringify(result), summary], { structuredContent: result });
     },
 } as const);

--- a/src/tools/tasks/publish_actor_task.ts
+++ b/src/tools/tasks/publish_actor_task.ts
@@ -66,10 +66,8 @@ export const publishActorTask: ToolEntry = Object.freeze({
         const result = taskResult(task);
         // publishedAt is the server's confirmation that the page is live: without saying so, an agent
         // asked to "confirm it is live" either claims it unverified or makes a redundant lookup.
-        const summary =
-            `Task "${task.name}" (ID: ${task.id}) is published; publishedAt in the result is the ` +
-            `confirmed publication time. ` +
-            `The link to the public page is available in Apify Console, on the task's Publication tab.`;
+        const summary = `Task "${task.name}" (ID: ${task.id}) is published; publishedAt in the result is the \
+confirmed publication time. The link to the public page is available in Apify Console, on the task's Publication tab.`;
         return respondOk([JSON.stringify(result), summary], { structuredContent: result });
     },
 } as const);

--- a/src/tools/tasks/publish_actor_task.ts
+++ b/src/tools/tasks/publish_actor_task.ts
@@ -26,8 +26,7 @@ reliable, and specific use case. Not every saved task needs to be public.
 
 The task's Actor must be public and the task must have its public display configuration set up:
 at least \`publicConfig.inputSchemaFields\`, \`publicConfig.datasetView\`, and \`publicConfig.seoDescription\`. \
-If publishing fails, \
-follow the API reason${hasTool(HELPER_TOOLS.ACTOR_TASK_UPDATE) ? `; update these fields with ${HELPER_TOOLS.ACTOR_TASK_UPDATE} only when the reason identifies them` : ''}.
+If publishing fails, follow the API reason${hasTool(HELPER_TOOLS.ACTOR_TASK_UPDATE) ? `; update these fields with ${HELPER_TOOLS.ACTOR_TASK_UPDATE} only when the reason identifies them` : ''}.
 At most 50 tasks can be published per Actor.
 Publishing an already published task has no effect.
 Requires write access to both the task and its Actor.
@@ -65,10 +64,12 @@ export const publishActorTask: ToolEntry = Object.freeze({
         const task = await setTaskPublication(client, parsed.taskId, true);
 
         const result = taskResult(task);
+        // publishedAt is the server's confirmation that the page is live: without saying so, an agent
+        // asked to "confirm it is live" either claims it unverified or makes a redundant lookup.
         const summary =
-            `Task "${task.name}" (ID: ${task.id}) is published; publishedAt in the result is the publication time. ` +
-            `The link to the public page is available in Apify Console, on the task's Publication tab. ` +
-            `To re-check the publication state later, use ${HELPER_TOOLS.ACTOR_TASK_GET}.`;
+            `Task "${task.name}" (ID: ${task.id}) is published; publishedAt in the result is the ` +
+            `confirmed publication time. ` +
+            `The link to the public page is available in Apify Console, on the task's Publication tab.`;
         return respondOk([JSON.stringify(result), summary], { structuredContent: result });
     },
 } as const);

--- a/src/tools/tasks/task_helpers.ts
+++ b/src/tools/tasks/task_helpers.ts
@@ -59,7 +59,12 @@ export const taskNameSchema = z
         'Task name may contain only letters, digits and dashes, and cannot start or end with a dash',
     );
 
-/** Writable public display configuration, shared by the create and update tools. */
+/**
+ * Writable public display configuration, shared by the create and update tools.
+ *
+ * The SEO length caps mirror the API's own, which it enforces on every `publicConfig` write and not
+ * just at publish time, so rejecting here costs the user nothing.
+ */
 export const publicConfigSchema = z.object({
     seoTitle: z
         .string()
@@ -70,7 +75,7 @@ export const publicConfigSchema = z.object({
         .string()
         .max(160)
         .optional()
-        .describe('Description shown on the public landing page. At most 160 characters.'),
+        .describe('Description shown on the public landing page. Required to publish. At most 160 characters.'),
     inputSchemaFields: z
         .array(z.string())
         .optional()
@@ -87,11 +92,9 @@ export const publicConfigSchema = z.object({
 });
 
 /**
- * The task subset returned by every task tool: identity, publication state, and the display
- * config. `input` is returned verbatim, as the API, CLI, and apify-client return it — input
- * fields the Actor's schema declares as secret arrive as `ENCRYPTED_VALUE:` placeholders,
- * never plaintext, so no extra redaction happens here. Its keys are what
- * `publicConfig.inputSchemaFields` can reference.
+ * The task subset returned by every task tool: identity, publication state, display config, and the
+ * input verbatim — secret fields arrive from the API as `ENCRYPTED_VALUE:` placeholders, so nothing
+ * is redacted here.
  */
 export function taskResult(task: Task) {
     const publicConfig = task.publicConfig

--- a/src/tools/tasks/update_actor_task.ts
+++ b/src/tools/tasks/update_actor_task.ts
@@ -119,7 +119,7 @@ export const updateActorTask: ToolEntry = Object.freeze({
         const task = await client.task(resolvedTaskId).update(update);
 
         const result = taskResult(task);
-        const summary = `Updated task "${result.name}" (ID: ${result.taskId}). The returned input reflects the update.`;
+        const summary = `Updated task "${result.name}" (ID: ${result.taskId}).`;
         return respondOk([JSON.stringify(result), summary], { structuredContent: result });
     },
 } as const);

--- a/src/utils/apify_errors.ts
+++ b/src/utils/apify_errors.ts
@@ -7,9 +7,14 @@ import {
     APIFY_ERROR_TYPE_MEMORY_LIMIT_EXCEEDED,
 } from '../const.js';
 
-// Predicates that classify an error received from the Apify API by its `type`. Kept in one leaf
+// Helpers that read or classify an error received from the Apify API by its `type`. Kept in one leaf
 // module (imports only const + apify-client) so logging, telemetry, payments, and the tool layer
 // can share them without import cycles.
+
+/** The API's machine-readable error type (e.g. `actor-task-name-not-unique`), if the error carries one. */
+export function getApifyErrorType(error: unknown): string | undefined {
+    return error instanceof ApifyApiError ? error.type : undefined;
+}
 
 /** True when an Actor requires full-permission approval the user has not granted. */
 export function isPermissionApprovalError(error: unknown): error is ApifyApiError {

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -1,9 +1,13 @@
 import type { CallToolResult, ContentBlock } from '@modelcontextprotocol/sdk/types.js';
-import { ApifyApiError } from 'apify-client';
 
 import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
 import type { AjvErrorDetails, ApifyRequestParams, FailureCategory, ToolTelemetryContext } from '../types.js';
-import { ACTOR_RUN_LIMIT_MESSAGE, isActorRunLimitError, isCannotPublishTaskError } from './apify_errors.js';
+import {
+    ACTOR_RUN_LIMIT_MESSAGE,
+    getApifyErrorType,
+    isActorRunLimitError,
+    isCannotPublishTaskError,
+} from './apify_errors.js';
 import { wrapJsonText } from './encode_text.js';
 import { getHttpStatusCode } from './logging.js';
 import { classifyFailureCategory, getToolStatusFromError } from './tool_status.js';
@@ -285,10 +289,11 @@ export function getHttpErrorHint(status: number | undefined): string | undefined
 /** User-facing error text for tool execution failures with HTTP-aware hints. */
 export function getToolCallErrorUserText(toolName: string, error: unknown): string {
     let msg = error instanceof Error ? error.message : String(error);
-    // The Apify API's machine-readable error type (e.g. "actor-task-name-not-unique"), so
-    // callers can branch on the exact error instead of parsing the message.
-    if (error instanceof ApifyApiError && error.type) {
-        msg = `${msg} (API error type: ${error.type})`;
+    // The model only sees the message, so name the API's error type (e.g.
+    // "actor-task-name-not-unique") to let it report the exact failure.
+    const apiErrorType = getApifyErrorType(error);
+    if (apiErrorType) {
+        msg = `${msg} (API error type: ${apiErrorType})`;
     }
     if (isActorRunLimitError(error)) {
         return `Error calling tool "${toolName}": ${msg}. ${ACTOR_RUN_LIMIT_MESSAGE}`;

--- a/tests/unit/tools.actor_task_crud.test.ts
+++ b/tests/unit/tools.actor_task_crud.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { HELPER_TOOLS } from '../../src/const.js';
+import { getCategoryTools } from '../../src/tools/index.js';
 import { actorTaskOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import { createActorTask } from '../../src/tools/tasks/create_actor_task.js';
 import { getActorTask } from '../../src/tools/tasks/get_actor_task.js';
@@ -282,5 +284,29 @@ describe('update-actor-task', () => {
 
         expect(result.content[0].text).toContain('not found');
         expect(calls).toEqual([{ fn: 'get', taskId: '~nope' }]);
+    });
+});
+
+// Cross-tool guidance belongs in buildDescription, where hasTool omits tools this session was not
+// served. A summary can only gate on `loadedToolNames`, so the task tools name no tool at all.
+describe('task tool summaries', () => {
+    const argsByTool: Record<string, Record<string, unknown>> = {
+        [HELPER_TOOLS.ACTOR_TASK_GET]: { taskId: 'task-1' },
+        [HELPER_TOOLS.ACTOR_TASK_CREATE]: { actorId: 'actor-id-1', name: 'my-task' },
+        [HELPER_TOOLS.ACTOR_TASK_UPDATE]: { taskId: 'task-1', title: 'Renamed' },
+        [HELPER_TOOLS.ACTOR_TASK_PUBLISH]: { taskId: 'task-1' },
+        [HELPER_TOOLS.ACTOR_TASK_UNPUBLISH]: { taskId: 'task-1' },
+    };
+    // Driven off the registry so a task tool added later is covered; it needs an `argsByTool` entry.
+    const taskTools = getCategoryTools('default').tasks.map((tool) => [tool.name, tool as HelperTool] as const);
+
+    it.each(taskTools)('%s names no tool, leaving cross-tool guidance to the description', async (name, tool) => {
+        expect(argsByTool[name], `add an \`argsByTool\` entry for ${name}`).toBeDefined();
+        const { apifyClient } = mockTaskApiClient(mockTask());
+        const result = (await tool.call(stubToolCallContext(argsByTool[name], apifyClient))) as TextToolResult;
+
+        for (const toolName of Object.values(HELPER_TOOLS)) {
+            expect(result.content[1].text).not.toContain(toolName);
+        }
     });
 });

--- a/tests/unit/utils.mcp.test.ts
+++ b/tests/unit/utils.mcp.test.ts
@@ -257,6 +257,28 @@ describe('getToolCallErrorUserText()', () => {
         expect(text).toContain('check APIFY_TOKEN');
         expect(text).not.toContain('—');
     });
+
+    it('names the API error type so the model can report the exact failure', () => {
+        const error = new ApifyApiError(
+            {
+                data: { error: { type: 'actor-task-name-not-unique', message: 'Task name is not unique' } },
+                status: 400,
+            } as never,
+            1,
+        );
+        const text = getToolCallErrorUserText('create-actor-task', error);
+        expect(text).toContain('Task name is not unique');
+        expect(text).toContain('API error type: actor-task-name-not-unique');
+    });
+
+    // Only an `ApifyApiError` carries an API error type. A plain Error with a `type` field is not
+    // one (node-fetch sets `type: 'system'`), so the suffix must stay off.
+    it('omits the API error type for an error that is not an ApifyApiError', () => {
+        const error = Object.assign(new Error('Request failed'), { type: 'system' });
+        const text = getToolCallErrorUserText('create-actor-task', error);
+        expect(text).toContain('Request failed');
+        expect(text).not.toContain('API error type');
+    });
 });
 
 describe('computeToolResponseBytes()', () => {


### PR DESCRIPTION
Follow-up to #1293, split out of the eval-suites branch.

📄 **[Reviewer walkthrough](https://claude.ai/code/artifact/599bc39a-cd89-4df6-840a-ac46346c0ce6)** — longer visual version with the full evidence.

## Problem

So a session started with `?tools=create-actor-task` got an input schema telling the model to call `fetch-actor-details`, which was never served. Task summaries had the same bug: `create-actor-task` named `publish-actor-task`, `publish-actor-task` named `get-actor-task`, both unconditionally.

## Fix

Deleted, not re-gated: each summary reference was already stated in a `hasTool`-gated description, so summaries now say only what the call did. The `.describe()` guidance moved into `buildDescription`. `src/tools/AGENTS.md` documented only the description surface — that silence let the bug be written — so it now covers all three.

Two removals turned out not to be redundant. Both were caught only by running the task evals (agent model `claude-haiku-4-5`; errors suite 3/3, proper suite 7/7 after fixing):

- The `fetch-actor-details` bullet must come *after* name resolution ("Once you have the exact Actor ID…") — placed first, the agent guessed an Actor slug instead of searching.
- The publish summary's `publishedAt` sentence is load-bearing: without it, an agent asked to "confirm it is live" claimed confirmation it never obtained. Restored; it names no tool.

## Also here, separately reviewable

- `ApifyApiError.type` read moved to `apify_errors.ts`, the module that owns error-type classification. Behaviour-identical; drops the `apify-client` value import from `utils/mcp.ts`. Adds the coverage the `(API error type: …)` suffix never had — the `task-create-collision` eval depends on `actor-task-name-not-unique` reaching the model.
- SEO caps `.max(60)` / `.max(160)` verified against the live API: 61/161 rejected with `cannot-publish-actor-task`, and it validates on **every** `publicConfig` write — so rejecting client-side costs the user nothing.

Same bug in other tool families is filed, not fixed here: #1296 (storage tools), #1297 (`AUTO_INJECTED_TOOLS`).