### PR TITLE
feat: Add apify/web-fetch as a default Actor tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For example, it can:
 - Use [Google Search Results Scraper](https://apify.com/apify/google-search-scraper) to scrape Google Search Engine Results Pages (SERPs).
 - Use [Instagram Scraper](https://apify.com/apify/instagram-scraper) to scrape Instagram posts, profiles, places, photos, and comments.
 - Use [RAG Web Browser](https://apify.com/apify/rag-web-browser) to search the web, scrape the top N URLs, and return their content.
+- Use [Web Fetch](https://apify.com/apify/web-fetch) to fetch any URL and return its content as Markdown, plain text, HTML, or links — with JavaScript rendering and anti-bot protection.
 
 **Video tutorial: Integrate 8,000+ Apify Actors and Agents with Claude**
 
@@ -218,7 +219,7 @@ Since Apify Store is large and growing rapidly, the MCP server provides a way to
 ### Actors
 
 Any [Apify Actor](https://apify.com/store) can be used as a tool.
-By default, the server is pre-configured with one Actor, `apify/rag-web-browser`, and several helper tools.
+By default, the server is pre-configured with two Actors, `apify/rag-web-browser` and `apify/web-fetch`, and several helper tools.
 The MCP server loads an Actor's input schema and creates a corresponding MCP tool.
 This allows the AI agent to know exactly what arguments to pass to the Actor and what to expect in return.
 
@@ -268,6 +269,7 @@ Legend for the **Enabled by default** column:
 | `search-apify-docs` | docs | Search the Apify documentation for relevant pages. | ✅ |
 | `fetch-apify-docs` | docs | Fetch the full content of an Apify documentation page by its URL. | ✅ |
 | [`apify--rag-web-browser`](https://apify.com/apify/rag-web-browser) | Actor (see [tool configuration](#tools-configuration)) | An Actor tool to browse the web. | ✅ |
+| [`apify--web-fetch`](https://apify.com/apify/web-fetch) | Actor (see [tool configuration](#tools-configuration)) | An Actor tool to fetch a URL and return its content. | ✅ |
 | `report-problem` | dev | Report a problem with an Apify tool or Actor to the Apify team. | ✅¹ |
 | `get-actor-run-list` | runs | Get a list of an Actor's runs, filterable by status. |  |
 | `get-actor-log` | runs | Retrieve the logs for a specific Actor run. |  |
@@ -306,6 +308,7 @@ When no query parameters are provided, the MCP server loads the following `tools
 - `actors`
 - `docs`
 - `apify/rag-web-browser`
+- `apify/web-fetch`
 
 If the tools parameter is specified, only the listed tools or categories will be enabled – no default tools will be included.
 
@@ -320,7 +323,7 @@ If the tools parameter is specified, only the listed tools or categories will be
 The hosted server can be configured using query parameters in the URL. For example, to load the default tools, use:
 
 ```
-https://mcp.apify.com?tools=actors,docs,apify/rag-web-browser
+https://mcp.apify.com?tools=actors,docs,apify/rag-web-browser,apify/web-fetch
 ```
 
 
@@ -395,7 +398,7 @@ The v2 configuration preserves backward compatibility with v1 usage. Notes:
   - Internally they are merged into `tools` selectors.
   - Examples: `?actors=apify/rag-web-browser` ≡ `?tools=apify/rag-web-browser`; `--actors apify/rag-web-browser` ≡ `--tools apify/rag-web-browser`.
 - `enableAddingActors` (URL), `enable-adding-actors` (CLI), and the legacy `enableActorAutoLoading` alias have been removed. To call Actors dynamically, use `tools=call-actor` (included by default via the `actors` category). Any lingering raw value is ignored.
-- Defaults remain compatible: when no `tools` are specified, the server loads `actors`, `docs`, and `apify/rag-web-browser`.
+- Defaults remain compatible: when no `tools` are specified, the server loads `actors`, `docs`, `apify/rag-web-browser`, and `apify/web-fetch`.
   - If any `tools` are specified, the defaults are not added (same as v1 intent for explicit selection).
 - `call-actor` is now included by default via the `actors` category (additive change). To exclude it, specify an explicit `tools` list without `actors`.
 - `tools=add-actor`, `tools=experimental`, and `tools=preview` are retired: they are ignored and load no tools. Use `tools=call-actor` (or the default `actors` category) instead.
@@ -524,9 +527,9 @@ Example: `https://mcp.apify.com?tools=search-actors`.
 Apify MCP is split across two repositories: this repository for core MCP logic and the private `apify-mcp-server-internal` for the hosted server.
 Changes must be synchronized between both.
 
-To create a canary release, add the `beta` label to your pull request.
+To create a canary release, add the `beta` tag to your PR branch.
 This publishes the package to [pkg.pr.new](https://pkg.pr.new/) for staging and testing before merging.
-See [the workflow file](.github/workflows/on_pull_request_label.yaml) for details.
+See [the workflow file](.github/workflows/pre_release.yaml) for details.
 
 ## 🐋 Docker Hub integration
 The Apify MCP Server is also available on [Docker Hub](https://hub.docker.com/mcp/server/apify-mcp-server/overview), registered via the [mcp-registry](https://github.com/docker/mcp-registry) repository. The entry in `servers/apify-mcp-server/server.yaml` should be deployed automatically by the Docker Hub MCP registry (deployment frequency is unknown). **Before making major changes to the `stdio` server version, test it locally to ensure the Docker build passes.** To test, change the `source.branch` to your PR branch and run `task build -- apify-mcp-server`. For more details, see [CONTRIBUTING.md](https://github.com/docker/mcp-registry/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ This setup exposes only the specified Actor (`apify/my-actor`) as a tool. No oth
 The CLI can be configured using command-line flags. For example, to load the same tools as in the hosted server configuration, use:
 
 ```bash
-npx @apify/actors-mcp-server --tools actors,docs,apify/rag-web-browser
+npx @apify/actors-mcp-server --tools actors,docs,apify/rag-web-browser,apify/web-fetch
 ```
 
 The minimal configuration is similar to the hosted server configuration:
@@ -527,9 +527,9 @@ Example: `https://mcp.apify.com?tools=search-actors`.
 Apify MCP is split across two repositories: this repository for core MCP logic and the private `apify-mcp-server-internal` for the hosted server.
 Changes must be synchronized between both.
 
-To create a canary release, add the `beta` tag to your PR branch.
+To create a canary release, add the `beta` label to your pull request.
 This publishes the package to [pkg.pr.new](https://pkg.pr.new/) for staging and testing before merging.
-See [the workflow file](.github/workflows/pre_release.yaml) for details.
+See [the workflow file](.github/workflows/on_pull_request_label.yaml) for details.
 
 ## 🐋 Docker Hub integration
 The Apify MCP Server is also available on [Docker Hub](https://hub.docker.com/mcp/server/apify-mcp-server/overview), registered via the [mcp-registry](https://github.com/docker/mcp-registry) repository. The entry in `servers/apify-mcp-server/server.yaml` should be deployed automatically by the Docker Hub MCP registry (deployment frequency is unknown). **Before making major changes to the `stdio` server version, test it locally to ensure the Docker build passes.** To test, change the `source.branch` to your PR branch and run `task build -- apify-mcp-server`. For more details, see [CONTRIBUTING.md](https://github.com/docker/mcp-registry/blob/main/CONTRIBUTING.md).

--- a/manifest.json
+++ b/manifest.json
@@ -75,7 +75,7 @@
       "title": "Enabled tools",
       "description": "Comma-separated list of tool categories or Actors, e.g. \"actors,docs,apify/rag-web-browser\". For details, see https://mcp.apify.com",
       "required": false,
-      "default": "actors,docs,apify/rag-web-browser"
+      "default": "actors,docs,apify/rag-web-browser,apify/web-fetch"
     }
   },
   "compatibility": {

--- a/src/const.ts
+++ b/src/const.ts
@@ -105,10 +105,39 @@ Examples of when to use:
 - User needs to fetch specific content now (e.g., "Fetch news articles from CNN", "Get product info from Amazon")
 - User has time indicators like "today", "current", "latest", "recent", "now"
 
-This is for general web scraping and immediate data needs. For repeated/scheduled scraping of specific platforms (e-commerce, social media), consider suggesting a specialized Actor from the Store for better performance and reliability.`;
+This is for general web scraping and immediate data needs. For repeated/scheduled scraping of specific platforms (e-commerce, social media), consider suggesting a specialized Actor from the Store for better performance and reliability.
+When the user provides one specific URL and wants that page's full or verbatim content, prefer the dedicated apify/web-fetch tool when it is available - this tool is for searching and scraping by query.
+If a scraped page comes back blocked or empty (e.g. the crawl reports a 403 or the page text is missing), do not give up: retry that URL with the apify/web-fetch tool when it is available - its anti-bot fetching gets through blocks this tool cannot.`;
+
+export const WEB_FETCH = 'apify/web-fetch';
+/**
+ * Appended to the `apify/web-fetch` Actor tool description. Client-agnostic on purpose:
+ * no references to any specific client or its built-in tools, so the same text works
+ * for every MCP client. Tune only based on eval results (`web-fetch-evals` dataset).
+ */
+export const WEB_FETCH_ADDITIONAL_DESC = `Use this tool to fetch a specific http(s) URL and return its complete content (one URL per call; http and https only).
+It renders JavaScript and bypasses anti-bot protection, so it also retrieves pages where a plain HTTP fetch gets blocked, fails with an error such as 403 or 429, or returns incomplete content.
+The page comes back verbatim - full content, no summarization - as Markdown, plain text, HTML, the raw response body, or the list of links on the page.
+
+Examples of when to use:
+- User provides a URL and wants its content, its data or links, or an answer that requires reading that page
+- A previous attempt to fetch a page was blocked, returned an error or CAPTCHA, or came back incomplete because the page needs JavaScript rendering
+- Verbatim page content is needed, e.g. for quoting, extraction, or archiving
+
+This tool does not search the web - it needs a URL. To find pages by query, use a web search tool instead.
+If the exact URL cannot be fetched (e.g. a non-http(s) scheme), say so rather than silently substituting a different URL.`;
+
+/**
+ * Appended to the `url` parameter description of the `apify/web-fetch` tool. Lives on the
+ * parameter because that is what an agent reads while writing the argument: eval agents
+ * (web-fetch-evals-errors, unsupported-protocol case) silently rewrote ftp:// URLs to
+ * https:// instead of telling the user the scheme is unsupported.
+ */
+export const WEB_FETCH_URL_SCHEME_NOTE =
+    ' http(s) URLs only - for any other scheme (e.g. ftp:), tell the user this tool cannot fetch it rather than substituting a different URL.';
 
 export const defaults = {
-    actors: [RAG_WEB_BROWSER],
+    actors: [RAG_WEB_BROWSER, WEB_FETCH],
 };
 
 /** API rejects `includeInputSchema=true` above this; mirrors apify-core `MAX_LIMIT_WITH_INPUT_SCHEMA`. */

--- a/src/const.ts
+++ b/src/const.ts
@@ -134,7 +134,7 @@ If the exact URL cannot be fetched (e.g. a non-http(s) scheme), say so rather th
  * https:// instead of telling the user the scheme is unsupported.
  */
 export const WEB_FETCH_URL_SCHEME_NOTE =
-    ' http(s) URLs only - for any other scheme (e.g. ftp:), tell the user this tool cannot fetch it rather than substituting a different URL.';
+    'http(s) URLs only - for any other scheme (e.g. ftp:), tell the user this tool cannot fetch it rather than substituting a different URL.';
 
 export const defaults = {
     actors: [RAG_WEB_BROWSER, WEB_FETCH],

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -92,10 +92,10 @@ const argv = yargs(hideBin(process.argv))
     })
     .options('tools', {
         type: 'string',
-        describe: `Comma-separated list of tools to enable. Can be either a tool category, a specific tool, or an Apify Actor. For example: --tools actors,docs,apify/rag-web-browser. Can also be set via TOOLS environment variable.
+        describe: `Comma-separated list of tools to enable. Can be either a tool category, a specific tool, or an Apify Actor. For example: --tools actors,docs,apify/rag-web-browser,apify/web-fetch. Can also be set via TOOLS environment variable.
 
 For more details visit https://mcp.apify.com`,
-        example: 'actors,docs,apify/rag-web-browser',
+        example: 'actors,docs,apify/rag-web-browser,apify/web-fetch',
     })
     .option('telemetry-enabled', {
         type: 'boolean',

--- a/src/tools/actor_input_schema.ts
+++ b/src/tools/actor_input_schema.ts
@@ -1,7 +1,13 @@
 import type { ValidateFunction } from 'ajv';
 import type Ajv from 'ajv';
 
-import { ACTOR_ENUM_MAX_LENGTH, ACTOR_MAX_DESCRIPTION_LENGTH, RAG_WEB_BROWSER_WHITELISTED_FIELDS } from '../const.js';
+import {
+    ACTOR_ENUM_MAX_LENGTH,
+    ACTOR_MAX_DESCRIPTION_LENGTH,
+    RAG_WEB_BROWSER_WHITELISTED_FIELDS,
+    WEB_FETCH,
+    WEB_FETCH_URL_SCHEME_NOTE,
+} from '../const.js';
 import { SchemaTooLargeError } from '../errors.js';
 import type { ActorInputSchema, SchemaProperties } from '../types.js';
 import {
@@ -197,6 +203,10 @@ export function buildActorInputSchema(actorFullName: string, input: ActorInputSc
     let finalSchema = working;
     if (isRag) {
         finalSchema = pruneSchemaPropertiesByWhitelist(finalSchema, RAG_WEB_BROWSER_WHITELISTED_FIELDS);
+    }
+
+    if (actorFullName === WEB_FETCH && finalSchema.properties.url) {
+        finalSchema.properties.url.description += ` ${WEB_FETCH_URL_SCHEME_NOTE}`;
     }
 
     finalSchema.$id = getToolSchemaID(actorFullName);

--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -439,16 +439,20 @@ type KvSummary =
 /**
  * `buildRunKeyValueStore` omits `keyCount` on truncation; surface that as "at least N keys"
  * instead of silently substituting `keys.length`.
+ *
+ * The INPUT record (every run's own input echoed back by the platform) never counts: it is
+ * not run output, and advertising it steers agents into get-key-value-store-record detours
+ * when the real output sits in the dataset. `structuredContent.keys` still carries it.
  */
 function summarizeKv(keyValueStore?: RunKeyValueStore): KvSummary {
     const kvId = keyValueStore?.id;
     const keys = keyValueStore?.keys ?? [];
-    if (!kvId || keys.length === 0) {
+    const outputKeys = keys.filter((key) => key !== 'INPUT');
+    if (!kvId || outputKeys.length === 0) {
         return { hasKv: false, summarySuffix: '' };
     }
-    const reportedKeyCount = keyValueStore.keyCount;
-    const kvTruncated = reportedKeyCount === undefined && keys.length === KV_KEYS_LIMIT;
-    const n = reportedKeyCount ?? keys.length;
+    const kvTruncated = keyValueStore.keyCount === undefined && keys.length === KV_KEYS_LIMIT;
+    const n = outputKeys.length;
     const keyCountLabel = kvTruncated ? `at least ${KV_KEYS_LIMIT} keys` : `${n} ${n === 1 ? 'key' : 'keys'}`;
     return { hasKv: true, kvId, keys, keyCountLabel, summarySuffix: ` Key-value store has ${keyCountLabel}.` };
 }
@@ -499,12 +503,14 @@ function buildSucceededSummaryNextStep(
         };
     }
 
-    // Metadata can report itemCount === 0 briefly after SUCCEEDED (eventual consistency). Surface the
-    // same fetch-first guidance as TIMED-OUT with an empty partial dataset — never imply "re-run only".
+    // Metadata can report itemCount === 0 after SUCCEEDED even past the lag-fallback probe window
+    // (eventual consistency). The zero is unverified, so the summary must not state "no items" as a
+    // conclusion — agents quote the summary and give up on it (observed in web-fetch evals: a run
+    // with an item was reported as blocked). The nextStep is the only place a conclusion may form.
     if (itemCount === 0 && datasetId) {
         return {
-            summary: `SUCCEEDED in ${runTimeSecs}s. No dataset items found.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
-            nextStep: `Use ${HELPER_TOOLS.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) to verify output (metadata reports 0 items).${fieldsProjectionHint(dataset?.fields)}`,
+            summary: `SUCCEEDED in ${runTimeSecs}s. Dataset item count reads 0 - counts can lag right after a run finishes.${statusMessageLine(statusMessage)}${kv.summarySuffix}`,
+            nextStep: `Fetch ${HELPER_TOOLS.DATASET_GET_ITEMS} with datasetId=${datasetId} and limit (for example ${DEFAULT_DATASET_ITEMS_LIMIT}) before concluding the run produced no output.${fieldsProjectionHint(dataset?.fields)}`,
         };
     }
 

--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -453,7 +453,10 @@ function summarizeKv(keyValueStore?: RunKeyValueStore): KvSummary {
     }
     const kvTruncated = keyValueStore.keyCount === undefined && keys.length === KV_KEYS_LIMIT;
     const n = outputKeys.length;
-    const keyCountLabel = kvTruncated ? `at least ${KV_KEYS_LIMIT} keys` : `${n} ${n === 1 ? 'key' : 'keys'}`;
+    // On truncation the fetched window itself may still hold INPUT; the output-key floor is
+    // one lower than KV_KEYS_LIMIT whenever it does, or the label overstates by one.
+    const truncatedFloor = KV_KEYS_LIMIT - (keys.length - outputKeys.length);
+    const keyCountLabel = kvTruncated ? `at least ${truncatedFloor} keys` : `${n} ${n === 1 ? 'key' : 'keys'}`;
     return { hasKv: true, kvId, keys, keyCountLabel, summarySuffix: ` Key-value store has ${keyCountLabel}.` };
 }
 

--- a/src/tools/actors/actor_tools_factory.ts
+++ b/src/tools/actors/actor_tools_factory.ts
@@ -10,7 +10,6 @@ import {
     RAG_WEB_BROWSER_ADDITIONAL_DESC,
     WEB_FETCH,
     WEB_FETCH_ADDITIONAL_DESC,
-    WEB_FETCH_URL_SCHEME_NOTE,
 } from '../../const.js';
 import { ActorLoadError } from '../../errors.js';
 import { getActorMCPServerPath, getActorMCPServerURL } from '../../mcp/actors.js';
@@ -123,15 +122,6 @@ export async function getNormalActorsAsTools(
             ...(inputSchemaWithWaitSecs.properties ?? {}),
             waitSecs: WAIT_SECS_INPUT_PROPERTY,
         };
-
-        // Scheme note on the parameter itself: that is what an agent reads while writing the
-        // url argument, where a tool-description tail gets skimmed past.
-        if (definition.actorFullName === WEB_FETCH) {
-            const urlProperty = inputSchemaWithWaitSecs.properties.url as { description?: string } | undefined;
-            if (urlProperty?.description) {
-                urlProperty.description += WEB_FETCH_URL_SCHEME_NOTE;
-            }
-        }
 
         let description = `This tool calls the Actor "${definition.actorFullName}" and retrieves its output results.
 Use this tool instead of the "${HELPER_TOOLS.ACTOR_CALL}" if user requests this specific Actor.

--- a/src/tools/actors/actor_tools_factory.ts
+++ b/src/tools/actors/actor_tools_factory.ts
@@ -8,6 +8,9 @@ import {
     HELPER_TOOLS,
     RAG_WEB_BROWSER,
     RAG_WEB_BROWSER_ADDITIONAL_DESC,
+    WEB_FETCH,
+    WEB_FETCH_ADDITIONAL_DESC,
+    WEB_FETCH_URL_SCHEME_NOTE,
 } from '../../const.js';
 import { ActorLoadError } from '../../errors.js';
 import { getActorMCPServerPath, getActorMCPServerURL } from '../../mcp/actors.js';
@@ -121,11 +124,22 @@ export async function getNormalActorsAsTools(
             waitSecs: WAIT_SECS_INPUT_PROPERTY,
         };
 
+        // Scheme note on the parameter itself: that is what an agent reads while writing the
+        // url argument, where a tool-description tail gets skimmed past.
+        if (definition.actorFullName === WEB_FETCH) {
+            const urlProperty = inputSchemaWithWaitSecs.properties.url as { description?: string } | undefined;
+            if (urlProperty?.description) {
+                urlProperty.description += WEB_FETCH_URL_SCHEME_NOTE;
+            }
+        }
+
         let description = `This tool calls the Actor "${definition.actorFullName}" and retrieves its output results.
 Use this tool instead of the "${HELPER_TOOLS.ACTOR_CALL}" if user requests this specific Actor.
 Actor description: ${definition.description}`;
         if (isRag) {
             description += `\n\n${RAG_WEB_BROWSER_ADDITIONAL_DESC}`;
+        } else if (definition.actorFullName === WEB_FETCH) {
+            description += `\n\n${WEB_FETCH_ADDITIONAL_DESC}`;
         }
 
         const memoryMbytes = Math.min(

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { getApifyAPIBaseUrl } from '../../apify_client.js';
-import { HELPER_TOOLS, RAG_WEB_BROWSER } from '../../const.js';
+import { HELPER_TOOLS, RAG_WEB_BROWSER, WEB_FETCH } from '../../const.js';
 import { SERVER_MODE } from '../../types.js';
 
 /**
@@ -101,6 +101,8 @@ ${
         : ''
 }- **\`${HELPER_TOOLS.STORE_SEARCH}\` vs ${RAG_WEB_BROWSER}:**
   \`${HELPER_TOOLS.STORE_SEARCH}\` finds robust and reliable Actors for specific websites; ${RAG_WEB_BROWSER} is a general and versatile web scraping tool.
+- **${WEB_FETCH} vs ${RAG_WEB_BROWSER}:**
+  ${WEB_FETCH} fetches one specific URL and returns its full content verbatim; ${RAG_WEB_BROWSER} searches the web by query and returns content from the top results.
 - **Dedicated Actor tools (e.g. ${RAG_WEB_BROWSER}) vs \`${HELPER_TOOLS.ACTOR_CALL}\`:**
   Prefer dedicated tools when available; use \`${HELPER_TOOLS.ACTOR_CALL}\` only when no specialized tool exists in the Apify store.
 ${

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -33,16 +33,19 @@ const DOCS_RUNS_STORAGE_CATEGORIES = ['docs', 'runs', 'storage'] as ToolCategory
 export const registrationCases: Case[] = [
     {
         // telemetry off so default tool set is deterministic across environments.
-        name: 'should match spec default: actors,docs,apify/rag-web-browser when no params provided (telemetry off)',
+        name: 'should match spec default: actors,docs,apify/rag-web-browser,apify/web-fetch when no params provided (telemetry off)',
         isDeploymentTest: true,
         run: withClient({ telemetry: { enabled: false } }, async (client) => {
             const tools = await client.listTools();
             const names = getToolNames(tools);
 
-            // Equivalent to tools=actors,docs,apify/rag-web-browser (no widgets outside apps).
+            // Equivalent to tools=actors,docs,apify/rag-web-browser,apify/web-fetch (no widgets outside apps).
             const expectedActorsTools = ['fetch-actor-details', 'search-actors', 'call-actor'];
             const expectedDocsTools = ['search-apify-docs', 'fetch-apify-docs'];
-            const expectedActors = [actorNameToToolName('apify/rag-web-browser')];
+            const expectedActors = [
+                actorNameToToolName('apify/rag-web-browser'),
+                actorNameToToolName('apify/web-fetch'),
+            ];
 
             const expectedTotal = expectedActorsTools.concat(expectedDocsTools, expectedActors);
             expect(names).toHaveLength(expectedTotal.length + AUTO_INJECTED_TOOL_NAMES.length);
@@ -56,7 +59,7 @@ export const registrationCases: Case[] = [
     },
     {
         // telemetry on — only difference is report-problem.
-        name: 'should match spec default: actors,docs,apify/rag-web-browser when no params provided (telemetry on)',
+        name: 'should match spec default: actors,docs,apify/rag-web-browser,apify/web-fetch when no params provided (telemetry on)',
         isDeploymentTest: true,
         run: withClient({ telemetry: { enabled: true } }, async (client) => {
             const tools = await client.listTools();
@@ -64,7 +67,10 @@ export const registrationCases: Case[] = [
 
             const expectedActorsTools = ['fetch-actor-details', 'search-actors', 'call-actor'];
             const expectedDocsTools = ['search-apify-docs', 'fetch-apify-docs'];
-            const expectedActors = [actorNameToToolName('apify/rag-web-browser')];
+            const expectedActors = [
+                actorNameToToolName('apify/rag-web-browser'),
+                actorNameToToolName('apify/web-fetch'),
+            ];
             const expectedFeedbackTools = [HELPER_TOOLS.PROBLEM_REPORT];
 
             const expectedTotal = expectedActorsTools.concat(expectedDocsTools, expectedActors, expectedFeedbackTools);

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -32,8 +32,7 @@ const DOCS_RUNS_STORAGE_CATEGORIES = ['docs', 'runs', 'storage'] as ToolCategory
 /** Tool/Actor selection, categories, env loading, auto-inject, server mode. */
 export const registrationCases: Case[] = [
     {
-        // telemetry off so default tool set is deterministic across environments.
-        name: 'should match spec default: actors,docs,apify/rag-web-browser,apify/web-fetch when no params provided (telemetry off)',
+        name: 'matches spec default: actors,docs,apify/rag-web-browser,apify/web-fetch when no params provided',
         isDeploymentTest: true,
         run: withClient({ telemetry: { enabled: false } }, async (client) => {
             const tools = await client.listTools();
@@ -46,41 +45,30 @@ export const registrationCases: Case[] = [
                 actorNameToToolName('apify/rag-web-browser'),
                 actorNameToToolName('apify/web-fetch'),
             ];
-
             const expectedTotal = expectedActorsTools.concat(expectedDocsTools, expectedActors);
             expect(names).toHaveLength(expectedTotal.length + AUTO_INJECTED_TOOL_NAMES.length);
 
             expectToolNamesToContain(names, expectedActorsTools);
             expectToolNamesToContain(names, expectedDocsTools);
-            expect(names).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
             expectToolNamesToContain(names, expectedActors);
             expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
         }),
     },
     {
-        // telemetry on — only difference is report-problem.
-        name: 'should match spec default: actors,docs,apify/rag-web-browser,apify/web-fetch when no params provided (telemetry on)',
+        name: 'adds report-problem when telemetry is enabled',
         isDeploymentTest: true,
         run: withClient({ telemetry: { enabled: true } }, async (client) => {
-            const tools = await client.listTools();
-            const names = getToolNames(tools);
-
-            const expectedActorsTools = ['fetch-actor-details', 'search-actors', 'call-actor'];
-            const expectedDocsTools = ['search-apify-docs', 'fetch-apify-docs'];
-            const expectedActors = [
-                actorNameToToolName('apify/rag-web-browser'),
-                actorNameToToolName('apify/web-fetch'),
-            ];
-            const expectedFeedbackTools = [HELPER_TOOLS.PROBLEM_REPORT];
-
-            const expectedTotal = expectedActorsTools.concat(expectedDocsTools, expectedActors, expectedFeedbackTools);
-            expect(names).toHaveLength(expectedTotal.length + AUTO_INJECTED_TOOL_NAMES.length);
-
-            expectToolNamesToContain(names, expectedActorsTools);
-            expectToolNamesToContain(names, expectedDocsTools);
+            const names = getToolNames(await client.listTools());
+            expect(names).toHaveLength(8 + AUTO_INJECTED_TOOL_NAMES.length);
             expect(names).toContain(HELPER_TOOLS.PROBLEM_REPORT);
-            expectToolNamesToContain(names, expectedActors);
-            expectToolNamesToContain(names, AUTO_INJECTED_TOOL_NAMES);
+        }),
+    },
+    {
+        name: 'omits report-problem when telemetry is disabled',
+        isDeploymentTest: true,
+        run: withClient({ telemetry: { enabled: false } }, async (client) => {
+            const names = getToolNames(await client.listTools());
+            expect(names).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
         }),
     },
     {

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -902,6 +902,22 @@ describe('buildStatusTemplate', () => {
         expect(t.summary).not.toMatch(/\(50 keys\)/);
     });
 
+    it('SUCCEEDED with a truncated key-value store containing INPUT floors the count at 49, not 50', () => {
+        const truncatedKvWithInput: RunKeyValueStore = {
+            id: 'kv-1',
+            keys: ['INPUT', ...Array.from({ length: 49 }, (_, i) => `k-${i}`)],
+            // keyCount intentionally omitted — buildKeyValueStoreBlock omits it on truncation.
+        };
+        const t = buildStatusSummaryNextStep({
+            run: makeRun('SUCCEEDED'),
+            dataset: datasetEmpty,
+            keyValueStore: truncatedKvWithInput,
+        });
+        // Only 49 of the 50 fetched keys are real output; INPUT must not inflate the floor.
+        expect(t.summary).toContain('at least 49 keys');
+        expect(t.summary).not.toContain('at least 50 keys');
+    });
+
     it('TIMED-OUT with dataset routes to partial-output nextStep', () => {
         const t = buildStatusSummaryNextStep({
             run: makeRun('TIMED-OUT'),

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -836,10 +836,15 @@ describe('buildStatusTemplate', () => {
             dataset: datasetEmpty,
             keyValueStore: kvWithRecords,
         });
-        expect(t.summary).toContain('No dataset items found');
+        // The count is unverified-zero (it can lag past the probe window), so the summary must
+        // not state "no items" as a conclusion - agents quote the summary and give up on it.
+        expect(t.summary).toContain('Dataset item count reads 0');
+        expect(t.summary).toContain('can lag');
+        expect(t.summary).not.toContain('No dataset items found');
         expect(t.summary).toContain('Key-value store has 2 keys');
         expect(t.nextStep).toContain('get-dataset-items');
         expect(t.nextStep).toContain('datasetId=ds-1');
+        expect(t.nextStep).toContain('before concluding');
         expect(t.nextStep).not.toContain('get-key-value-store-record');
     });
 
@@ -860,6 +865,26 @@ describe('buildStatusTemplate', () => {
         expect(t.summary).toContain('Key-value store has 2 keys');
         expect(t.nextStep).toContain('get-dataset-items');
         expect(t.nextStep).not.toContain('get-key-value-store-record');
+    });
+
+    it('SUCCEEDED with a KV store holding only the INPUT record omits the KV suffix', () => {
+        const inputOnlyKv: RunKeyValueStore = { id: 'kv-1', keys: ['INPUT'], keyCount: 1 };
+        const t = buildStatusSummaryNextStep({
+            run: makeRun('SUCCEEDED'),
+            dataset: datasetWithItems,
+            keyValueStore: inputOnlyKv,
+        });
+        expect(t.summary).not.toContain('Key-value store');
+    });
+
+    it('SUCCEEDED does not count the INPUT record among KV keys', () => {
+        const kvWithInput: RunKeyValueStore = { id: 'kv-1', keys: ['INPUT', 'OUTPUT'], keyCount: 2 };
+        const t = buildStatusSummaryNextStep({
+            run: makeRun('SUCCEEDED'),
+            dataset: datasetWithItems,
+            keyValueStore: kvWithInput,
+        });
+        expect(t.summary).toContain('Key-value store has 1 key');
     });
 
     it('SUCCEEDED with truncated key-value store reports partial count, not exact 50', () => {

--- a/tests/unit/tools.structured_output_schemas.test.ts
+++ b/tests/unit/tools.structured_output_schemas.test.ts
@@ -181,6 +181,26 @@ describe('Structured Output Schemas', () => {
             expect(tool.outputSchema).toBe(actorRunOutputSchema);
         });
 
+        it("appends the http(s)-only scheme note to web-fetch's url parameter", async () => {
+            const tools = await getNormalActorsAsTools([createMockActorInfo('apify/web-fetch')]);
+
+            const tool = tools[0] as ActorTool;
+            const inputProps = (tool.inputSchema as { properties?: Record<string, unknown> }).properties ?? {};
+            const urlField = inputProps.url as { description?: string } | undefined;
+            expect(urlField?.description).toContain('The URL to process');
+            expect(urlField?.description).toContain('http(s) URLs only');
+            expect(urlField?.description).toContain('rather than substituting');
+        });
+
+        it("leaves other Actors' url parameters untouched", async () => {
+            const tools = await getNormalActorsAsTools([createMockActorInfo('apify/test-actor')]);
+
+            const tool = tools[0] as ActorTool;
+            const inputProps = (tool.inputSchema as { properties?: Record<string, unknown> }).properties ?? {};
+            const urlField = inputProps.url as { description?: string } | undefined;
+            expect(urlField?.description).toBe('The URL to process');
+        });
+
         it('injects waitSecs as an optional integer (0–45) into the input schema', async () => {
             const tools = await getNormalActorsAsTools([createMockActorInfo('apify/test-actor')]);
 


### PR DESCRIPTION
Adds `apify/web-fetch` to the default Actors next to `apify/rag-web-browser`, with client-agnostic steering so any model picks the right web tool (web-fetch: one specific URL, verbatim content; rag-web-browser: search by query). Also two run-response text fixes for all Actor runs, found by evals: an unverified `itemCount: 0` no longer reads as a "no items" conclusion, and the KV key-count summary no longer counts the INPUT record.

Tool description wording is eval-tuned — behavior validated by Langfuse eval ladders (`web-fetch-evals`, `web-selection-evals`) on claude-opus-5 / claude-sonnet-5 / claude-haiku-4-5; suites land in a follow-up PR stacked on #1294. Known residual documented there: claude-haiku-4-5 silently rewrites ftp:// URLs to https:// despite both notes.

While on this PR: fixed case when dataset returns 0 items.

**Follow-ups**
- apify/apify-mcp-server-internal#753 — hosted web UI default-Actor list, deploy sequencing, contract-suite strings
- #1303 — pre-existing cleanups kept out of this PR
- https://github.com/apify/apify-mcp-server/issues/1305
