### PR TITLE
feat(evals): Add --claude-judge to run the judge on the Agent SDK

### DIFF
--- a/evals/workflows/README.md
+++ b/evals/workflows/README.md
@@ -21,8 +21,8 @@ dataset (Langfuse) -> experiment run -> per item: agent conversation -> judge ->
 **Prerequisites:**
 - Node.js installed
 - Apify account with API token
-- Anthropic API key (agent)
-- OpenRouter API key (judge)
+- Anthropic API key (agent) — or a local Claude Code login with `--subscription`
+- OpenRouter API key (judge) — or a local Claude Code login with `--claude-judge`
 - Langfuse project (public + secret key)
 
 **Run evaluations:**
@@ -42,7 +42,7 @@ pnpm run build
 pnpm run evals:workflow
 ```
 
-Run `pnpm run evals:workflow --help` for the full option list. `--category` and `--id` narrow the run, `--dataset` picks another Langfuse dataset, `--concurrency` defaults to 8 (each item spawns its own agent and MCP server, so higher values use more resources), `--tool-timeout` defaults to 60s (raise it for Actor calls that scrape a lot of data), `--mcp-tools-only` drops Claude Code's built-in tools so only the server's tools remain, and `--subscription` runs the agent on the local Claude Code login instead of `ANTHROPIC_API_KEY` (the key is removed from the process environment so the run cannot bill the API).
+Run `pnpm run evals:workflow --help` for the full option list. `--category` and `--id` narrow the run, `--dataset` picks another Langfuse dataset, `--concurrency` defaults to 8 (each item spawns its own agent and MCP server, so higher values use more resources), `--tool-timeout` defaults to 60s (raise it for Actor calls that scrape a lot of data), `--mcp-tools-only` drops Claude Code's built-in tools so only the server's tools remain, `--subscription` runs the agent on the local Claude Code login instead of `ANTHROPIC_API_KEY` (the key is removed from the process environment so the run cannot bill the API), and `--claude-judge` runs the judge on the Claude Agent SDK too, so no `OPENROUTER_API_KEY` is needed (`--judge-model` then takes an Anthropic model ID, default `claude-sonnet-5`; note a Claude judge scoring a Claude agent can be self-lenient, so prefer the OpenRouter judge for comparable numbers). With `--subscription --claude-judge` a run needs only `APIFY_TOKEN` and the Langfuse keys.
 
 ### Proper suites vs error-handling suites
 
@@ -352,6 +352,14 @@ Claude Code owns the message history. The harness only sees the SDK's message st
 ### Tests interfere with each other
 **Symptom:** Test 2 fails after Test 1, passes alone.<br>
 **Solution:** ✅ Isolated agent + MCP instance per test.
+
+### Agent claims the Apify MCP server is "still connecting" (remote/sandboxed environments)
+**Symptom:** A transcript shows the agent reading a system notice that MCP servers are still
+connecting, concluding the Apify tools are unavailable, and falling back to a built-in tool.<br>
+**Cause:** In sandboxed remote Claude Code environments the MCP handshake can race the first
+turn; a fast model sometimes doesn't wait or retry. On a local machine the CLI completes the
+handshake before the first turn, so this doesn't reproduce there.<br>
+**Solution:** Retry the item once; a repeat failure on a local machine is real.
 
 ### Agent answers from memory or shells out instead of using our tools
 **Symptom:** The judge reports the agent used `Bash`, `WebSearch`, or its own knowledge.<br>

--- a/evals/workflows/claude_judge_client.ts
+++ b/evals/workflows/claude_judge_client.ts
@@ -95,7 +95,8 @@ export class ClaudeLlmClient {
         })) {
             if (message.type !== 'result') continue;
             if (message.subtype !== 'success') {
-                throw new Error(`Claude judge run ended with "${message.subtype}"`);
+                const detail = message.errors.join('; ') || 'no error detail';
+                throw new Error(`Claude judge run ended with "${message.subtype}": ${detail}`);
             }
             let usage: LlmUsage | undefined;
             if (message.usage) {

--- a/evals/workflows/claude_judge_client.ts
+++ b/evals/workflows/claude_judge_client.ts
@@ -1,0 +1,127 @@
+/**
+ * Judge LLM client backed by the Claude Agent SDK, for runs without an OpenRouter key.
+ *
+ * Selected with `--claude-judge`. Each call spawns a short-lived Claude Code subprocess
+ * (no tools, one turn) that authenticates like the `--subscription` agent does: local
+ * Claude Code login, or whatever provider the environment supplies. The SDK exposes no
+ * temperature control, so verdicts are less deterministic than OpenRouter's 0.15 — the
+ * structured verdict schema keeps that from mattering in practice.
+ */
+
+// eslint-disable-next-line import/extensions
+import { tmpdir } from 'node:os';
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { startActiveObservation } from '@langfuse/tracing';
+// eslint-disable-next-line import/extensions
+import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
+// eslint-disable-next-line import/extensions
+import type { ResponseFormatJSONSchema } from 'openai/resources/shared';
+
+import type { LlmResponse, LlmUsage } from './llm_client.js';
+
+/**
+ * The model's answer may wrap the verdict JSON in code fences or prose. Return the JSON
+ * object substring (first '{' to last '}'), or the input unchanged when there is none —
+ * the caller's JSON parse then fails with the raw text in the error.
+ */
+export function extractJsonObject(text: string): string {
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+    if (start === -1 || end <= start) return text;
+    return text.slice(start, end + 1);
+}
+
+/** Flatten chat messages into one prompt; the judge sends a single user message. */
+function messagesToPrompt(messages: ChatCompletionMessageParam[]): string {
+    return messages
+        .map((message) => (typeof message.content === 'string' ? message.content : JSON.stringify(message.content)))
+        .join('\n\n');
+}
+
+export class ClaudeLlmClient {
+    /**
+     * Same surface as `LlmClient.callLlm`, judge subset: no tool support (the judge never
+     * passes tools), `responseFormat` is enforced by instruction + extraction rather than
+     * by the API. Traced as a Langfuse generation like the OpenRouter client.
+     */
+    async callLlm(
+        messages: ChatCompletionMessageParam[],
+        model: string,
+        tools?: ChatCompletionTool[],
+        responseFormat?: ResponseFormatJSONSchema,
+    ): Promise<LlmResponse> {
+        if (tools && tools.length > 0) {
+            throw new Error('ClaudeLlmClient supports judge calls only (no tools)');
+        }
+
+        let prompt = messagesToPrompt(messages);
+        if (responseFormat) {
+            prompt +=
+                `\n\nRespond with a single JSON object only - no prose, no code fences - ` +
+                `matching this JSON schema:\n${JSON.stringify(responseFormat.json_schema.schema)}`;
+        }
+
+        return startActiveObservation(
+            model,
+            async (generation) => {
+                generation.update({ model, input: messages });
+                const llmResponse = await this.sendRequest(prompt, model, Boolean(responseFormat));
+                generation.update({
+                    output: llmResponse.content,
+                    ...(llmResponse.usage
+                        ? {
+                              usageDetails: {
+                                  input: llmResponse.usage.promptTokens,
+                                  output: llmResponse.usage.completionTokens,
+                                  total: llmResponse.usage.totalTokens,
+                              },
+                          }
+                        : {}),
+                });
+                return llmResponse;
+            },
+            { asType: 'generation' },
+        );
+    }
+
+    /** One single-turn, tool-less Claude Code run; its result text is the LLM response. */
+    private async sendRequest(prompt: string, model: string, extractJson: boolean): Promise<LlmResponse> {
+        // No tools and one turn: nothing needs permissions, so the default permission mode
+        // works everywhere (bypassPermissions would refuse to run as root without a sandbox).
+        for await (const message of query({
+            prompt,
+            options: {
+                model,
+                maxTurns: 1,
+                tools: [],
+                settingSources: [],
+                cwd: tmpdir(),
+            },
+        })) {
+            if (message.type !== 'result') continue;
+            if (message.subtype !== 'success') {
+                throw new Error(`Claude judge run ended with "${message.subtype}"`);
+            }
+            const usage: LlmUsage | undefined = message.usage
+                ? {
+                      promptTokens:
+                          message.usage.input_tokens +
+                          (message.usage.cache_read_input_tokens ?? 0) +
+                          (message.usage.cache_creation_input_tokens ?? 0),
+                      completionTokens: message.usage.output_tokens,
+                      totalTokens:
+                          message.usage.input_tokens +
+                          (message.usage.cache_read_input_tokens ?? 0) +
+                          (message.usage.cache_creation_input_tokens ?? 0) +
+                          message.usage.output_tokens,
+                  }
+                : undefined;
+            return {
+                content: extractJson ? extractJsonObject(message.result) : message.result,
+                usage,
+            };
+        }
+        throw new Error('Claude judge run produced no result message');
+    }
+}

--- a/evals/workflows/claude_judge_client.ts
+++ b/evals/workflows/claude_judge_client.ts
@@ -8,7 +8,6 @@
  * structured verdict schema keeps that from mattering in practice.
  */
 
-// eslint-disable-next-line import/extensions
 import { tmpdir } from 'node:os';
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
@@ -18,7 +17,7 @@ import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/reso
 // eslint-disable-next-line import/extensions
 import type { ResponseFormatJSONSchema } from 'openai/resources/shared';
 
-import type { LlmResponse, LlmUsage } from './llm_client.js';
+import { type LlmResponse, type LlmUsage, toUsageDetails } from './llm_client.js';
 
 /**
  * The model's answer may wrap the verdict JSON in code fences or prose. Return the JSON
@@ -66,18 +65,13 @@ export class ClaudeLlmClient {
             model,
             async (generation) => {
                 generation.update({ model, input: messages });
-                const llmResponse = await this.sendRequest(prompt, model, Boolean(responseFormat));
+                const llmResponse = await this.sendRequest(prompt, model);
+                if (responseFormat && llmResponse.content) {
+                    llmResponse.content = extractJsonObject(llmResponse.content);
+                }
                 generation.update({
                     output: llmResponse.content,
-                    ...(llmResponse.usage
-                        ? {
-                              usageDetails: {
-                                  input: llmResponse.usage.promptTokens,
-                                  output: llmResponse.usage.completionTokens,
-                                  total: llmResponse.usage.totalTokens,
-                              },
-                          }
-                        : {}),
+                    ...toUsageDetails(llmResponse.usage),
                 });
                 return llmResponse;
             },
@@ -86,7 +80,7 @@ export class ClaudeLlmClient {
     }
 
     /** One single-turn, tool-less Claude Code run; its result text is the LLM response. */
-    private async sendRequest(prompt: string, model: string, extractJson: boolean): Promise<LlmResponse> {
+    private async sendRequest(prompt: string, model: string): Promise<LlmResponse> {
         // No tools and one turn: nothing needs permissions, so the default permission mode
         // works everywhere (bypassPermissions would refuse to run as root without a sandbox).
         for await (const message of query({
@@ -103,24 +97,20 @@ export class ClaudeLlmClient {
             if (message.subtype !== 'success') {
                 throw new Error(`Claude judge run ended with "${message.subtype}"`);
             }
-            const usage: LlmUsage | undefined = message.usage
-                ? {
-                      promptTokens:
-                          message.usage.input_tokens +
-                          (message.usage.cache_read_input_tokens ?? 0) +
-                          (message.usage.cache_creation_input_tokens ?? 0),
-                      completionTokens: message.usage.output_tokens,
-                      totalTokens:
-                          message.usage.input_tokens +
-                          (message.usage.cache_read_input_tokens ?? 0) +
-                          (message.usage.cache_creation_input_tokens ?? 0) +
-                          message.usage.output_tokens,
-                  }
-                : undefined;
-            return {
-                content: extractJson ? extractJsonObject(message.result) : message.result,
-                usage,
-            };
+            let usage: LlmUsage | undefined;
+            if (message.usage) {
+                // Cached input tokens count as prompt tokens, like OpenRouter reports them.
+                const promptTokens =
+                    message.usage.input_tokens +
+                    (message.usage.cache_read_input_tokens ?? 0) +
+                    (message.usage.cache_creation_input_tokens ?? 0);
+                usage = {
+                    promptTokens,
+                    completionTokens: message.usage.output_tokens,
+                    totalTokens: promptTokens + message.usage.output_tokens,
+                };
+            }
+            return { content: message.result, usage };
         }
         throw new Error('Claude judge run produced no result message');
     }

--- a/evals/workflows/config.ts
+++ b/evals/workflows/config.ts
@@ -37,6 +37,9 @@ export const MODELS = {
 
     // Judge model - evaluates conversation quality
     judge: 'deepseek/deepseek-v4-flash',
+
+    // Judge model when the judge runs on the Claude Agent SDK (--claude-judge).
+    claudeJudge: 'claude-sonnet-5',
 };
 
 /**

--- a/evals/workflows/config.ts
+++ b/evals/workflows/config.ts
@@ -3,7 +3,8 @@
  *
  * The agent's system prompt and tools come from the SDK's `claude_code` presets, so
  * nothing here defines them. The judge runs on OpenRouter (temperature 0.15, see
- * llm_client.ts).
+ * llm_client.ts) by default, or on the Claude Agent SDK with `--claude-judge` (see
+ * claude_judge_client.ts).
  */
 
 // Re-export shared config for convenience

--- a/evals/workflows/langfuse_experiment.ts
+++ b/evals/workflows/langfuse_experiment.ts
@@ -12,7 +12,7 @@ import type { Evaluation } from '@langfuse/client';
 import { runAgentConversation } from './claude_agent.js';
 import { parseWorkflowItem } from './langfuse_dataset.js';
 import { buildAgentObservations, emitObservations } from './langfuse_observations.js';
-import type { LlmClient } from './llm_client.js';
+import type { JudgeLlmClient } from './llm_client.js';
 import type { TranscriptEntry } from './sdk_conversation_adapter.js';
 import type { JudgeResult } from './workflow_judge.js';
 import { evaluateConversation } from './workflow_judge.js';
@@ -167,7 +167,7 @@ export function isTransientAgentError(error: unknown): boolean {
 }
 
 export type WorkflowTaskOptions = {
-    llmClient: LlmClient;
+    llmClient: JudgeLlmClient;
     apifyToken: string;
     agentModel: string;
     judgeModel: string;

--- a/evals/workflows/llm_client.ts
+++ b/evals/workflows/llm_client.ts
@@ -46,6 +46,18 @@ const TEMPERATURE = 0.15;
  */
 export type JudgeLlmClient = Pick<LlmClient, 'callLlm'>;
 
+/** Langfuse generation-update fields for a usage report; empty when the provider sent none. */
+export function toUsageDetails(usage?: LlmUsage): { usageDetails?: { input: number; output: number; total: number } } {
+    if (!usage) return {};
+    return {
+        usageDetails: {
+            input: usage.promptTokens,
+            output: usage.completionTokens,
+            total: usage.totalTokens,
+        },
+    };
+}
+
 /**
  * LLM client for chat completions with optional tool support
  */
@@ -85,15 +97,7 @@ export class LlmClient {
                 const llmResponse = await this.sendRequest(messages, model, tools, responseFormat);
                 generation.update({
                     output: llmResponse.toolCalls ?? llmResponse.content,
-                    ...(llmResponse.usage
-                        ? {
-                              usageDetails: {
-                                  input: llmResponse.usage.promptTokens,
-                                  output: llmResponse.usage.completionTokens,
-                                  total: llmResponse.usage.totalTokens,
-                              },
-                          }
-                        : {}),
+                    ...toUsageDetails(llmResponse.usage),
                 });
                 return llmResponse;
             },

--- a/evals/workflows/llm_client.ts
+++ b/evals/workflows/llm_client.ts
@@ -41,6 +41,12 @@ export type LlmResponse = {
 const TEMPERATURE = 0.15;
 
 /**
+ * What the judge needs from an LLM client. Implemented by {@link LlmClient} (OpenRouter)
+ * and `ClaudeLlmClient` (Claude Agent SDK, `--claude-judge`).
+ */
+export type JudgeLlmClient = Pick<LlmClient, 'callLlm'>;
+
+/**
  * LLM client for chat completions with optional tool support
  */
 export class LlmClient {

--- a/evals/workflows/run_workflow_evals.ts
+++ b/evals/workflows/run_workflow_evals.ts
@@ -32,6 +32,7 @@ import { readJsonFile } from '../../src/utils/generic.js';
 import { findMissingEnvVars, LANGFUSE_ENV_VARS } from '../shared/config.js';
 import { filterByCategory, filterById } from '../shared/test_case_loader.js';
 import { assertStdioBinExists } from './claude_agent.js';
+import { ClaudeLlmClient } from './claude_judge_client.js';
 import { DEFAULT_TOOL_TIMEOUT_SECONDS, MODELS, sanitizeProcessEnv } from './config.js';
 import { fetchWorkflowCases, WORKFLOW_DATASET_NAME } from './langfuse_dataset.js';
 import { buildRunSummary, countPassed, evaluators, makeTask } from './langfuse_experiment.js';
@@ -49,11 +50,12 @@ type CliArgs = {
     id?: string;
     dataset: string;
     agentModel: string;
-    judgeModel: string;
+    judgeModel?: string;
     toolTimeout: number;
     concurrency: number;
     mcpToolsOnly: boolean;
     subscription: boolean;
+    claudeJudge: boolean;
     allowToolErrors: boolean;
 };
 
@@ -91,7 +93,10 @@ async function main() {
                 default: WORKFLOW_DATASET_NAME,
             },
             'agent-model': { type: 'string', description: 'LLM model for the agent', default: MODELS.agent },
-            'judge-model': { type: 'string', description: 'LLM model for the judge', default: MODELS.judge },
+            'judge-model': {
+                type: 'string',
+                description: `LLM model for the judge (default: ${MODELS.judge}, or ${MODELS.claudeJudge} with --claude-judge)`,
+            },
             'tool-timeout': {
                 type: 'number',
                 description: 'Tool call timeout in seconds',
@@ -106,6 +111,13 @@ async function main() {
             subscription: {
                 type: 'boolean',
                 description: 'Run the agent on the local Claude Code login (subscription) instead of ANTHROPIC_API_KEY',
+                default: false,
+            },
+            'claude-judge': {
+                type: 'boolean',
+                description:
+                    'Run the judge on the Claude Agent SDK (local Claude Code login) instead of OpenRouter, ' +
+                    'so no OPENROUTER_API_KEY is needed. --judge-model then takes an Anthropic model ID.',
                 default: false,
             },
             'allow-tool-errors': {
@@ -126,11 +138,15 @@ async function main() {
         })
         .help().argv) as CliArgs;
 
+    // Different defaults per judge provider, so an unset --judge-model never sends an
+    // OpenRouter slug to the Anthropic API or vice versa.
+    const judgeModel = argv.judgeModel ?? (argv.claudeJudge ? MODELS.claudeJudge : MODELS.judge);
+
     // Fail before any test runs, listing every missing variable at once.
     const missing = findMissingEnvVars([
         ...LANGFUSE_ENV_VARS,
         'APIFY_TOKEN',
-        'OPENROUTER_API_KEY',
+        ...(argv.claudeJudge ? [] : ['OPENROUTER_API_KEY']),
         ...(argv.subscription ? [] : ['ANTHROPIC_API_KEY']),
     ]);
     if (missing.length > 0) {
@@ -178,7 +194,7 @@ async function main() {
         initTracing();
 
         // Traces each judge call as a generation nested under the item's trace.
-        const llmClient = new LlmClient();
+        const llmClient = argv.claudeJudge ? new ClaudeLlmClient() : new LlmClient();
 
         const agentSdkVersion = resolveAgentSdkVersion();
         const runName = `${getGitBranch()}-${argv.agentModel.split('/').pop()}-${Date.now()}`;
@@ -197,7 +213,7 @@ async function main() {
                 llmClient,
                 apifyToken,
                 agentModel: argv.agentModel,
-                judgeModel: argv.judgeModel,
+                judgeModel,
                 toolTimeout: argv.toolTimeout,
                 mcpToolsOnly: argv.mcpToolsOnly,
             }),
@@ -213,7 +229,8 @@ async function main() {
             maxConcurrency: argv.concurrency,
             metadata: {
                 agentModel: argv.agentModel,
-                judgeModel: argv.judgeModel,
+                judgeModel,
+                judgeProvider: argv.claudeJudge ? 'claude-agent-sdk' : 'openrouter',
                 toolTimeout: argv.toolTimeout,
                 mcpToolsOnly: argv.mcpToolsOnly,
                 agentSdkVersion,

--- a/evals/workflows/workflow_judge.ts
+++ b/evals/workflows/workflow_judge.ts
@@ -8,7 +8,7 @@ import type { ResponseFormatJSONSchema } from 'openai/resources/shared';
 import { z } from 'zod';
 
 import { JUDGE_PROMPT_TEMPLATE, MODELS } from './config.js';
-import type { LlmClient } from './llm_client.js';
+import type { JudgeLlmClient } from './llm_client.js';
 import type { ConversationHistory } from './types.js';
 
 /**
@@ -101,12 +101,26 @@ const JudgeResponseValidator = z.object({
 });
 
 /**
- * Parse structured JSON response from judge
+ * Some providers answer in prose that still opens with the verdict ("FAIL. The agent ...").
+ * Recover the verdict and use the rest as the reason before spending a retry call on it.
+ * Anything not opening with PASS/FAIL stays unparsed.
  */
-function parseJudgeResponse(response: string): { verdict: 'PASS' | 'FAIL'; reason: string } {
+const PROSE_VERDICT_PATTERN = /^\s*(PASS|FAIL)\b[.:!-]?\s*(.*)$/is;
+
+/**
+ * Parse the judge response: strict JSON first, prose-verdict fallback second.
+ */
+export function parseJudgeResponse(response: string): { verdict: 'PASS' | 'FAIL'; reason: string } {
     try {
         return JudgeResponseValidator.parse(JSON.parse(response));
     } catch (error) {
+        const prose = PROSE_VERDICT_PATTERN.exec(response);
+        if (prose) {
+            return {
+                verdict: prose[1].toUpperCase() as 'PASS' | 'FAIL',
+                reason: prose[2].trim() || 'no reason given',
+            };
+        }
         // No raw response here: the retry loop's final throw already carries it.
         throw new Error(
             `Failed to parse judge JSON response: ${error instanceof Error ? error.message : String(error)}`,
@@ -120,7 +134,7 @@ function parseJudgeResponse(response: string): { verdict: 'PASS' | 'FAIL'; reaso
 export async function evaluateConversation(
     reference: string,
     conversation: ConversationHistory,
-    llmClient: LlmClient,
+    llmClient: JudgeLlmClient,
     judgeModel: string = MODELS.judge,
 ): Promise<JudgeResult> {
     // Format conversation for judge

--- a/evals/workflows/workflow_judge.ts
+++ b/evals/workflows/workflow_judge.ts
@@ -116,10 +116,7 @@ export function parseJudgeResponse(response: string): { verdict: 'PASS' | 'FAIL'
     } catch (error) {
         const prose = PROSE_VERDICT_PATTERN.exec(response);
         if (prose) {
-            return {
-                verdict: prose[1].toUpperCase() as 'PASS' | 'FAIL',
-                reason: prose[2].trim() || 'no reason given',
-            };
+            return JudgeResponseValidator.parse({ verdict: prose[1], reason: prose[2].trim() || 'no reason given' });
         }
         // No raw response here: the retry loop's final throw already carries it.
         throw new Error(

--- a/evals/workflows/workflow_judge.ts
+++ b/evals/workflows/workflow_judge.ts
@@ -145,9 +145,10 @@ export async function evaluateConversation(
         () => formattedConversation,
     );
 
-    // Some OpenRouter providers occasionally ignore the JSON schema and answer in plain
-    // text (e.g. "PASS: ..."). One fresh judge call recovers those without rerunning the
-    // far more expensive agent conversation; a second malformed answer still throws.
+    // parseJudgeResponse already recovers a prose verdict (e.g. "PASS: ..."); this retry
+    // is for answers that carry no parsable verdict at all. One fresh judge call recovers
+    // those without rerunning the far more expensive agent conversation; a second
+    // malformed answer still throws.
     let lastError: unknown;
     let lastRawResponse = '';
     for (let attempt = 1; attempt <= JUDGE_PARSE_ATTEMPTS; attempt++) {

--- a/tests/unit/evals.claude_judge_client.test.ts
+++ b/tests/unit/evals.claude_judge_client.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractJsonObject } from '../../evals/workflows/claude_judge_client.js';
+
+describe('extractJsonObject()', () => {
+    it('returns a bare JSON object unchanged', () => {
+        expect(extractJsonObject('{"verdict":"PASS","reason":"ok"}')).toBe('{"verdict":"PASS","reason":"ok"}');
+    });
+
+    it('strips code fences around the object', () => {
+        expect(extractJsonObject('```json\n{"verdict":"FAIL","reason":"no"}\n```')).toBe(
+            '{"verdict":"FAIL","reason":"no"}',
+        );
+    });
+
+    it('strips prose around the object', () => {
+        expect(extractJsonObject('Here is my verdict:\n{"verdict":"PASS","reason":"ok"}\nDone.')).toBe(
+            '{"verdict":"PASS","reason":"ok"}',
+        );
+    });
+
+    it('keeps nested braces intact', () => {
+        expect(extractJsonObject('x {"a":{"b":1}} y')).toBe('{"a":{"b":1}}');
+    });
+
+    it('returns text without an object unchanged so the parse error carries it', () => {
+        expect(extractJsonObject('no json here')).toBe('no json here');
+    });
+});

--- a/tests/unit/evals.workflow_judge.test.ts
+++ b/tests/unit/evals.workflow_judge.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { LlmClient } from '../../evals/workflows/llm_client.js';
 import type { ConversationHistory } from '../../evals/workflows/types.js';
-import { evaluateConversation } from '../../evals/workflows/workflow_judge.js';
+import { evaluateConversation, parseJudgeResponse } from '../../evals/workflows/workflow_judge.js';
 
 /** LLM client that returns the given judge responses in order, repeating the last one. */
 function makeJudgeClient(...responses: string[]): LlmClient & { callLlm: ReturnType<typeof vi.fn> } {
@@ -72,8 +72,18 @@ describe('evaluateConversation()', () => {
         expect(result.verdict).toBe('PASS');
     });
 
-    it('retries once when the judge answers in plain text instead of JSON', async () => {
-        const client = makeJudgeClient('PASS: looks good but not JSON', '{"verdict":"PASS","reason":"ok"}');
+    it('recovers a prose verdict without spending a retry call', async () => {
+        const client = makeJudgeClient('PASS: looks good but not JSON');
+
+        const result = await evaluateConversation(reference, conversation, client);
+
+        expect(result.verdict).toBe('PASS');
+        expect(result.reason).toBe('looks good but not JSON');
+        expect(client.callLlm).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries once when the judge answer carries no parsable verdict', async () => {
+        const client = makeJudgeClient('I think the agent did well overall.', '{"verdict":"PASS","reason":"ok"}');
 
         const result = await evaluateConversation(reference, conversation, client);
 
@@ -86,5 +96,25 @@ describe('evaluateConversation()', () => {
 
         await expect(evaluateConversation(reference, conversation, client)).rejects.toThrow('after 2 attempts');
         expect(client.callLlm).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('parseJudgeResponse()', () => {
+    it('parses a strict JSON verdict', () => {
+        expect(parseJudgeResponse('{"verdict":"PASS","reason":"ok"}')).toEqual({ verdict: 'PASS', reason: 'ok' });
+    });
+
+    it('recovers a prose verdict when the provider ignores the schema', () => {
+        const parsed = parseJudgeResponse('FAIL. The agent never called the tool.');
+        expect(parsed.verdict).toBe('FAIL');
+        expect(parsed.reason).toBe('The agent never called the tool.');
+    });
+
+    it('rejects prose that only mentions a verdict mid-sentence', () => {
+        expect(() => parseJudgeResponse('The agent should FAIL here.')).toThrow('Failed to parse judge JSON');
+    });
+
+    it('rejects an unrecognized verdict in JSON', () => {
+        expect(() => parseJudgeResponse('{"verdict":"MAYBE","reason":"?"}')).toThrow('Failed to parse judge JSON');
     });
 });


### PR DESCRIPTION
Stacked on #1294. Lets the whole eval harness run on a Claude Code subscription login with zero API keys: `--subscription` (from #1294) covers the agent, `--claude-judge` (this PR) covers the judge.

The main motivation is to run judge from claude.ai/code so that it can run over-night.
I would like to run the judge also from claude.ai

Used to run the web-fetch/web-selection eval ladders (suites in the follow-up PR) both in a remote Claude Code sandbox (no keys available) and locally.