### PR TITLE
chore: Add the creating-workflow-evals skill to the repo

### DIFF
--- a/.claude/skills/creating-workflow-evals/SKILL.md
+++ b/.claude/skills/creating-workflow-evals/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: creating-workflow-evals
+description: Use when adding Langfuse workflow evals for a tool family of the Apify MCP server ("create evals for the storage tools"), when eval cases fail and you must decide whether the case, the tool, or its description is at fault, or when eval runs show tool errors in Langfuse traces.
+---
+
+# Creating workflow evals for an MCP tool family
+
+## Overview
+
+Build a small, calibrated Langfuse eval suite for one tool family (tasks, storage, runs, …), then use its failures to fix the tools. Core principle: **evals are designed from user intent, never from tool descriptions** — the eval defines what should work; descriptions get fixed afterward to make naive agents pass it.
+
+Commands, item shapes, probe patterns, and sweep queries: [reference.md](reference.md).
+
+## The flow
+
+1. **Inventory the tools** — every tool and every argument group needs at least one case (the coverage matrix at the end proves it).
+2. **Probe the platform first.** Before writing any case that depends on API behavior (required fields, uniqueness rules, limits, error messages), verify it with a throwaway `tsx` script against the real API. Never write a case on an assumed contract — that's how you get input values the schema rejects.
+3. **Two datasets, never one**: `<family>-evals` (proper suite, zero tool errors tolerated) and `<family>-evals-errors` (cases that provoke errors on purpose: collisions, not-found, requirement discovery). Mixing them masks real failures.
+4. **Write cases in waves**: 2–3 easy (single tool, explicit input) → 1–2 medium (cross-tool chains, run options) → 2–3 hard (vague user language, error recovery, collisions). Run and review each wave before writing the next.
+5. **Calibrate on the strongest model first** (Opus). A failure there is a case defect or a product gap — never a description problem. Only a calibrated suite (strong model 100%) can attribute weaker-model failures to descriptions.
+6. **Ladder down** (Sonnet → Haiku). Passes-on-Opus-fails-on-Haiku = the tool description or output doesn't carry a naive agent. That's the signal you built the suite for.
+7. **Fix tools via outputs before descriptions.** A steering sentence in the tool's response summary/nextStep reaches every agent on every call; description text gets skimmed. Both output nudges that fixed Haiku failures in the original build were response-text changes.
+
+## Diagnosing a failed case — in this order
+
+| Suspect | Symptoms | Fix |
+|---|---|---|
+| **The case** | Query references context the agent can't obtain ("my usual setup"); input violates the actor's schema; the smart model's "wrong" behavior is actually defensible | Rewrite query self-contained; give round trips a purpose ("confirm it's live, then take it down") |
+| **The judge/reference** | Agent did the right thing, reference demands the impossible (e.g. echo values the tool never returns) | Reword `expectedOutput`; it must only require what's observable (judge sees tool calls + args + final text, never tool results) |
+| **The product** | The tool cannot satisfy a natural user request by design | Surface as a decision, don't silently adjust the case or the tool |
+| **The description/output** | Naive model stalls to ask, guesses instead of using a discovery tool, hallucinates from an ambiguously named field | Output nudge first, description second; rename fields whose names invite misreading |
+| **The world** | The live target page is down, changed, or empty (a 503 outage, a profile with zero posts) — the agent behaved correctly | Move content-bearing cases to stable hosts; where HTTP behavior IS the axis, make the reference outage-tolerant (a truthfully reported upstream error is a PASS path) |
+| **The model** | Correct tool choice but a policy-shaped refusal (long verbatim reproduction, "placeholder domain"), or a bad habit that survives nudges at every layer you own | Refusal → scope the deliverable below the threshold (one section, public-domain text); reproducible habit after description + parameter fixes → keep the case, document the residual, stop tuning |
+
+Always read the transcript before assigning blame. The judge's one-liner is a hint, not a diagnosis.
+
+## Rules that prevent rework
+
+- **References are judge-checkable contracts**: "PASS only if `<tool>` was called with `<arg>` and the final answer states `<fact>`. FAIL if …". Never "the agent should handle it well".
+- **Queries in user language.** A query that names tools tests parroting, not descriptions. Hard cases must never name a tool.
+- **Truth in telemetry.** Never downgrade span levels to hide expected errors — that masks real ones. Expected errors live in the error suite; the proper suite's gate is `tool_errors == 0` over **server (MCP) tool calls** (failed read-only probes count: guessing a slug instead of searching is a failure; the agent's built-in tools are exempt — their stumbles are client noise, not ours).
+- **Write judge-blindness clauses.** The judge never sees tool results, so references must pre-empt misreadings: an agent narrating a quirk ("the count read 0 but the items were there") is not admitting failure; content delivered via a clearly-attributed fallback is retrieved, not fabricated; and never require narrating an event (a block, an error) that a legitimate alternative path skips entirely.
+- **Fail false claims, not silent success.** Outcome and honesty are the axes; etiquette (announcing a tool switch, apologizing for a detour) is a bonus, never a PASS condition.
+- **Selection cases need exactly one right answer.** A target a second legitimate tool also serves (an Apify docs URL when `fetch-apify-docs` is loaded) makes defensible behavior fail; pick targets where only the tool under test fits.
+- **Probe the target, not just the mechanism.** For live-web cases, fetch the exact URL at authoring time and check the *content* supports the premise (a probed-working scraper still returned nothing for a profile that turned out to have zero posts).
+- **State is account-global.** Fixed `eval-` prefixed resource names + a fixtures seed/cleanup script; each conversation self-contained (create → act → clean up); one permanent read-only fixture for pure "get" cases.
+- **Dataset item ids are project-unique forever** — they cannot move between datasets or be reused after archiving. Choose ids you can live with; "moving" a case = new id + archive old.
+- **Snapshot after every dataset edit** (`evals:workflow:export-dataset --dataset X`) so git reviews the cases.
+
+## Red flags — stop and rethink
+
+- Writing a case while looking at the tool's description → you're testing parroting. Close the file.
+- Adding an expected-error match/filter to the proper suite → move the case to the error suite instead.
+- A rerun "fixed" a failure you didn't diagnose → known harness flake ("task threw, never completed") is retry-once; a judged FAIL is never a flake, read the transcript.
+- Editing the tool because one model failed once → reproduce or diagnose first; single runs are stochastic.
+- An obviously fake URL in a query (`ftp.example.com`, `this-is-a-test.com`) → models defensibly refuse "placeholder" targets; use a real host, and a nonexistent path on it when the fetch must fail.
+- A deliverable demanding word-for-word reproduction of more than a few hundred words → some models refuse on reproduction grounds with zero tool calls, regardless of licensing; the case then measures refusal thresholds, not tool selection.
+- A case whose side quests aren't the tested axis (huge payloads inviting file delivery or byte-exact verification) → have the user ask for in-chat delivery and pre-authorize truncation, and budget `maxTurns` for the recovery path, not the happy path.
+
+## Common mistakes
+
+| Mistake | Consequence |
+|---|---|
+| One dataset for everything | Error-provoking cases force error tolerance onto clean cases; red spans everywhere mean nothing |
+| Calibrating on the cheap model | Can't tell case bugs from description bugs; you'll "fix" descriptions against broken cases |
+| `maxTurns` too low on chain cases | Agent runs out of turns mid-flow and the judge sees an unfinished transcript |
+| Fixed names without cleanup | Second run collides with the first run's leftovers; nondeterministic failures |
+| Skipping the wave review | A systematic case-authoring flaw (e.g. unknowable context) replicates into every hard case |

--- a/.claude/skills/creating-workflow-evals/reference.md
+++ b/.claude/skills/creating-workflow-evals/reference.md
@@ -1,0 +1,124 @@
+# Reference: commands, shapes, probes
+
+Repo: `apify-mcp-server`. Harness docs: `evals/workflows/README.md` (read it first; it documents the two-suite doctrine, scores, and flags).
+
+## Running evals
+
+```bash
+# Proper suite: strict gate (judge PASS and tool_errors == 0)
+pnpm run evals:workflow --dataset <family>-evals --agent-model claude-opus-5 --subscription
+
+# Error suite: drops only the zero-error condition
+pnpm run evals:workflow --dataset <family>-evals-errors --allow-tool-errors --agent-model <m> --subscription
+
+# Narrow: --id '<regex>' or --category <name>; --concurrency N; --tool-timeout secs
+```
+
+- `--subscription` deletes `ANTHROPIC_API_KEY` from the process env so the Agent SDK's Claude Code subprocess uses the local login. Without it the run bills the API key.
+- `--claude-judge` runs the judge on the Agent SDK too (`--judge-model` then takes an Anthropic ID, default `claude-sonnet-5`); with `--subscription --claude-judge` a run needs only `APIFY_TOKEN` + Langfuse keys. Caveat: a Claude judge scoring a Claude agent can be self-lenient — prefer the OpenRouter judge for comparable numbers.
+- Ladder: `claude-opus-5` (calibration) → `claude-sonnet-5` → `claude-haiku-4-5` (default; the sensitive probe). A chained shell command's exit code is the LAST run's — read each log's `📊` line, not the chain status.
+- Known flakes, retry the single item once before diagnosing: `🔥 Never completed (task threw)` (harness/SDK spawn); in remote/sandboxed environments, the agent reading "MCP servers still connecting" and falling back to built-ins (doesn't reproduce locally).
+- Between runs of suites that create named resources: `pnpm run evals:workflow:tasks-fixtures` (adapt per family) deletes leftover `eval-*` resources and reseeds the permanent fixture. Web-target families that create no named state need no fixtures script — say so in the README instead.
+
+## Dataset item shape (Langfuse)
+
+```json
+{
+  "datasetName": "<family>-evals",
+  "id": "<family>-<tool>-<difficulty>-1",
+  "input": { "query": "<user-language prompt, no tool names>" },
+  "expectedOutput": "PASS only if <tool> was called with <args> and the final answer states <fact>. FAIL if <specific bad behavior>.",
+  "metadata": { "category": "<tool-or-chain>", "maxTurns": 10, "tools": ["<family>", "actors"] }
+}
+```
+
+- `metadata` is strict-validated (`langfuse_dataset.ts`): unknown keys fail the run before LLM spend. Knobs: `category`, `maxTurns`, `tools`, `failTools`.
+- `category` = tool under test (what `--category` filters); difficulty goes in the id.
+- Items upsert on `id`. Ids are **project-unique forever**, across datasets, even after archive/delete-and-recreate elsewhere. Retire a case by upserting `"status": "ARCHIVED"`.
+- `maxTurns` guide: single tool 6–8, create+verify 10, chains 12–18. Budget for the longest path the reference permits (explore → decline → fallback), not the happy path; Actor-run cases need headroom for a poll cycle when the run outlives the wait cap.
+
+## Langfuse environment
+
+Instance: `https://langfuse.apify.dev`, project **MCP Workflow**. The harness and CLI need:
+
+```bash
+LANGFUSE_PUBLIC_KEY=pk-lf-...     # project settings → API keys
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_BASE_URL=https://langfuse.apify.dev
+```
+
+They live in the repo-root `.env` (the harness loads it via dotenv). Git **worktrees don't share
+`.env`** — copy it from the main checkout first (`cp <main-checkout>/.env .env`). The CLI reads
+`LANGFUSE_HOST`, not `LANGFUSE_BASE_URL`, so export both.
+
+## Langfuse CLI
+
+`npx` refuses to run inside the repo (pnpm-pinned `devEngines`) — run from any other directory.
+Working preamble for CLI calls:
+
+```bash
+cd /tmp && export $(grep -E '^LANGFUSE' <repo>/.env | xargs) && export LANGFUSE_HOST="$LANGFUSE_BASE_URL"
+```
+
+```bash
+npx -y langfuse-cli api datasets list --json                # check what exists before creating
+npx -y langfuse-cli api datasets create --body-json '{"name":"<family>-evals","description":"..."}'
+jq -c '.[0]' items.json | npx -y langfuse-cli api dataset-items create --body-file -   # create = UPSERT on id: iterate on a case by re-posting the same id
+npx -y langfuse-cli api dataset-items get <id>
+npx -y langfuse-cli api dataset-items delete <id>          # irreversible, frees nothing (id stays burned) — archive instead (status: "ARCHIVED")
+```
+
+The edit loop per case: upsert item → `pnpm run evals:workflow:export-dataset --dataset <name>` →
+re-run just that item with `--id '<substring-regex>'` → read the transcript.
+
+Read failing transcripts (judge reason + per-turn tool calls). `--from-start-time` is **required**;
+the item's `output` field is a JSON **string** — pipe through `fromjson`:
+
+```bash
+npx -y langfuse-cli api experiment-items list \
+  --experiment-name "<runName from console>" --from-start-time "<ISO>" --fields core,io --all --json \
+  | jq -r '.body.data[] | (.output | fromjson) as $o | $o.id + " " + $o.judgeResult.verdict + "\n"
+      + ([$o.transcript[] | to_entries[] | "  " + .key + ": " + (.value | tostring | .[0:300])] | join("\n"))'
+```
+
+Sweep for unexpected errors after a run (proper-suite runs must contribute zero rows):
+
+```bash
+npx -y langfuse-cli api observations list --level ERROR \
+  --from-start-time "<run start ISO>" --fields core,basic,io --limit 100
+```
+
+## Snapshot to git (after every dataset edit)
+
+```bash
+pnpm run evals:workflow:export-dataset --dataset <family>-evals          # dataset_snapshot_<name>.json
+pnpm run evals:workflow:export-dataset --dataset <family>-evals-errors
+```
+
+## API probe pattern (before writing platform-dependent cases)
+
+Throwaway script in `evals/workflows/probe_*_tmp.ts`, run with `pnpm exec tsx`, **delete after use**. Probe with the real `apify-client` exactly what the case will depend on: required fields, uniqueness errors, publish requirements, length limits, secret handling. Capture exact error messages and `type` slugs — references can require the agent to react to them (tool errors include `(API error type: <slug>)`). For live-web cases, probe the exact target URL and verify the fetched *content* supports the premise (status, body, the fact the answer needs) — and prefer stable hosts (rfc-editor.org, example.com) over flaky ones (httpbin.org 503s regularly) wherever content is the deliverable.
+
+```ts
+import 'dotenv/config';
+import { ApifyClient } from 'apify-client';
+const client = new ApifyClient({ token: process.env.APIFY_TOKEN });
+// create the thing the case assumes, read it back, print the error/shape, delete it
+```
+
+## Fixtures script pattern
+
+One script per stateful family (`evals/workflows/tasks_fixtures.ts` is the template): delete leftover `eval-*` resources except the permanent fixture, create the fixture if missing, and **reset the fixture's mutable state** every run (an eval agent may have mutated it). Wire as `evals:workflow:<family>-fixtures` in package.json.
+
+## Coverage matrix (definition of done for the dataset)
+
+For each tool: at least one dedicated case, plus every argument group exercised somewhere (create: input/name/config; get: found + not-found; update: each independently updatable group; lifecycle tools: happy path in proper suite, requirement-discovery in error suite). A tool exercised only as the tail of another case (like unpublish) is acceptable if a dedicated case would duplicate an existing one — say so explicitly when reporting coverage.
+
+## Fixing tools from findings (order of preference)
+
+1. **Response summary/nextStep text** — e.g. "stored values are never returned…", "to re-check publication state, use get-actor-task". Reaches every agent on every call. Summaries must never state conclusions the platform can't back yet (an unverified zero count is "reads 0, can lag", not "no items found") — agents quote the summary and give up on it.
+2. **Argument schema constraints + describe()** — encode API limits (`.max(60)`) so invalid calls fail client-side before the API. Parameter descriptions are read at argument-writing time, so a constraint note there beats a description tail — but even that has limits (a weak model kept silently rewriting ftp:// to https:// through both); after fixing every owned layer, document the residual.
+3. **Field renames / shape alignment** — if a field name invites misreading or diverges from the API contract, align with the API object (`structuredContent` changes must be flagged for the internal repo's contract suite).
+4. **Description USAGE lines** — bias-to-act nudges ("resolve loose Actor references with search-actors instead of asking"), conditional on `hasTool()`.
+
+After any tool change: `pnpm run build` happens via `evals:workflow` automatically; rerun only the affected model/case pairs first, full ladder last.


### PR DESCRIPTION
This skill is specific for a tool family (because I started with tasks and then web-fetch, rag-web-browser).
We can update it later to be generic.

- probe-first case design, the two-suite split (proper vs error-provoking), waves, Opus-calibrate-then-ladder
- the failure diagnosis order: case / judge / world (live target down or changed) / model (policy refusals, reproducible habits) / product / description
- rules that prevent rework: judge-blindness clauses, one-right-answer selection targets, fail-false-claims-not-silent-success, snapshot after every dataset edit
- the Langfuse env vars and CLI iteration loop (upsert-on-id case editing, transcript dumps, error sweeps)

Distilled from the tasks (#1294), web-fetch, and web-selection (#1300) suite builds