### PR TITLE
fix: Gate the Actor-not-found recovery hint on the loaded tools

### DIFF
--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -53,6 +53,18 @@ reference in `ctx.hasTool(...)`, and set `description` to the `ALL_TOOLS_PRESENT
 happens once, at the tools/list boundary (`getToolPublicFieldOnly` in `../utils/tools.ts`). Enforced
 by `tests/unit/tools.mode_contract.test.ts`.
 
+**Result text is a second surface, and `hasTool` does not reach it.** A tool name in a response
+body (`summary`, `nextStep`, `instructions`, an error's recovery sentence) is built while the tool
+runs, not at the tools/list boundary, so nothing gates it for you and `tools.mode_contract.test.ts`
+— which renders descriptions only — cannot see it. Gate it on `toolArgs.loadedToolNames`
+(`InternalToolArgs` in `../types.ts`), the names the session was actually served: see
+`suggestTool` in `storage/storage_helpers.ts` and the recovery hints in `actors/call_actor.ts`,
+`actors/fetch_actor_details.ts` and `actors/search_actors.ts`. Two rules when the name drops out:
+never leave a dead end — if the sentence *is* the recovery path, replace it rather than omit it
+(`storage_helpers.ts` substitutes "Inspect the returned items directly") — and keep the text
+byte-identical for a session that holds every tool, so gating a hint is never also a rewording.
+Each gate needs its own test; there is no sweeping guard for this surface.
+
 ## Related, owned elsewhere (don't restate)
 
 - Tool-name cap + hash dedupe, transport: [`../mcp/AGENTS.md`](../mcp/AGENTS.md).

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -61,9 +61,11 @@ runs, not at the tools/list boundary, so nothing gates it for you and `tools.mod
 `suggestTool` in `storage/storage_helpers.ts` and the recovery hints in `actors/call_actor.ts`,
 `actors/fetch_actor_details.ts` and `actors/search_actors.ts`. Two rules when the name drops out:
 never leave a dead end — if the sentence *is* the recovery path, replace it rather than omit it
-(`storage_helpers.ts` substitutes "Inspect the returned items directly") — and keep the text
-byte-identical for a session that holds every tool, so gating a hint is never also a rewording.
-Each gate needs its own test; there is no sweeping guard for this surface.
+(`storage_helpers.ts` substitutes "Inspect the returned items directly") — and gate in place, so a
+session holding every tool gets byte-identical text and gating a hint is never also a rewording
+(`call_actor.ts` and `search_actors.ts` were gated that way; the reworded sentence in
+`fetch_actor_details.ts` is a deliberate wording change that rode along with its gate, not the
+pattern to copy). Each gate needs its own test; there is no sweeping guard for this surface.
 
 ## Related, owned elsewhere (don't restate)
 

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -465,13 +465,17 @@ export async function resolveAndValidateActor(params: {
     const actor = tools[0];
 
     if (!actor) {
-        const hint = buildActorNotFoundHint(loadedToolNames);
+        // Only search-actors: the Actor does not exist, so buildActorNotFoundHint's second
+        // offer (get Actor details) would send the model to a lookup that fails the same way.
+        const recovery = loadedToolNames.includes(HELPER_TOOLS.STORE_SEARCH)
+            ? `\nYou can search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}.`
+            : '';
         return {
             error: respondUserError(
                 dedent`
                     Actor '${actorName}' was not found.
                     Please verify Actor ID or name format (e.g., "username/name" like "apify/rag-web-browser") and ensure that the Actor exists.
-                ` + (hint ? `\n${hint}` : ''),
+                ` + recovery,
                 { httpStatus: 404, detail: `Actor '${actorName}' was not found` },
             ),
         };

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -469,6 +469,7 @@ export async function resolveAndValidateActor(params: {
     const actor = tools[0];
 
     if (!actor) {
+        // See apify/apify-mcp-server#1296.
         // Only search-actors: the Actor does not exist, so buildCallFailureRecoveryHint's second
         // offer (get Actor details) would send the model to a lookup that fails the same way.
         const recovery = loadedToolNames.includes(HELPER_TOOLS.STORE_SEARCH)

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -449,7 +449,7 @@ export async function resolveAndValidateActor(params: {
     toolArgs: InternalToolArgs;
 }): Promise<{ error: ToolResponse } | { actor: ToolEntry }> {
     const { actorName, input, toolArgs } = params;
-    const { apifyClient } = toolArgs;
+    const { apifyClient, loadedToolNames } = toolArgs;
 
     const { tools, errors } = await getActorsAsTools([actorName], apifyClient, {
         mcpSessionId: toolArgs.mcpSessionId,
@@ -465,13 +465,13 @@ export async function resolveAndValidateActor(params: {
     const actor = tools[0];
 
     if (!actor) {
+        const hint = buildActorNotFoundHint(loadedToolNames);
         return {
             error: respondUserError(
                 dedent`
                     Actor '${actorName}' was not found.
                     Please verify Actor ID or name format (e.g., "username/name" like "apify/rag-web-browser") and ensure that the Actor exists.
-                    You can search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}.
-                `,
+                ` + (hint ? `\n${hint}` : ''),
                 { httpStatus: 404, detail: `Actor '${actorName}' was not found` },
             ),
         };

--- a/src/tools/actors/call_actor.ts
+++ b/src/tools/actors/call_actor.ts
@@ -99,8 +99,12 @@ type CallActorErrorResponseParams = {
     loadedToolNames: readonly string[];
 };
 
-/** Names only the recovery tools actually loaded in this session — omits the sentence if none are. */
-function buildActorNotFoundHint(loadedToolNames: readonly string[]): string {
+/**
+ * Recovery offers for a failed call, naming only the tools actually loaded in this session —
+ * omits the sentence if none are. Not for the not-found branch of `resolveAndValidateActor`:
+ * there the Actor does not exist, so the detail-lookup offer is a dead end.
+ */
+function buildCallFailureRecoveryHint(loadedToolNames: readonly string[]): string {
     const hints = [
         loadedToolNames.includes(HELPER_TOOLS.STORE_SEARCH)
             ? `search for available Actors using ${HELPER_TOOLS.STORE_SEARCH}`
@@ -216,7 +220,7 @@ export function buildCallActorErrorResponse(params: CallActorErrorResponseParams
         [
             `Failed to call Actor '${actorName}': ${errMsg}`,
             `Please verify the Actor name, input parameters, and ensure the Actor exists.`,
-            buildActorNotFoundHint(loadedToolNames),
+            buildCallFailureRecoveryHint(loadedToolNames),
         ].filter(Boolean),
         { error, detail: errMsg.slice(0, 200), actorId },
     );
@@ -465,7 +469,7 @@ export async function resolveAndValidateActor(params: {
     const actor = tools[0];
 
     if (!actor) {
-        // Only search-actors: the Actor does not exist, so buildActorNotFoundHint's second
+        // Only search-actors: the Actor does not exist, so buildCallFailureRecoveryHint's second
         // offer (get Actor details) would send the model to a lookup that fails the same way.
         const recovery = loadedToolNames.includes(HELPER_TOOLS.STORE_SEARCH)
             ? `\nYou can search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}.`

--- a/src/tools/actors/fetch_actor_details.ts
+++ b/src/tools/actors/fetch_actor_details.ts
@@ -110,13 +110,14 @@ export const fetchActorDetailsToolArgsSchema = z.object({
 
 function buildDescription({ hasTool }: ToolDescriptionContext): string {
     return `Get detailed information about an Actor by its ID or full name (format: "username/name", e.g., "apify/rag-web-browser").
-${
-    hasTool(HELPER_TOOLS.STORE_SEARCH)
-        ? `\nRequires the exact ID or full name. If you only have a description, a partial name, or a name you \
-have not seen in this conversation, find it with ${HELPER_TOOLS.STORE_SEARCH} first — do not construct a \
-plausible-looking name and call this tool with it.\n`
-        : ''
-}
+
+Requires the exact ID or full name — do not construct a plausible-looking name and call this tool with it.${
+        hasTool(HELPER_TOOLS.STORE_SEARCH)
+            ? ` If you only have a description, a partial name, or a name you have not seen in this conversation, \
+find it with ${HELPER_TOOLS.STORE_SEARCH} first.`
+            : ''
+    }
+
 Use 'output' parameter with boolean flags to control returned information:
 - Default: All fields true except mcpTools
 - Selective: Set desired fields to true (e.g., output: { inputSchema: true })

--- a/src/tools/actors/fetch_actor_details.ts
+++ b/src/tools/actors/fetch_actor_details.ts
@@ -2,8 +2,15 @@ import dedent from 'dedent';
 import { z } from 'zod';
 
 import { HELPER_TOOLS } from '../../const.js';
-import type { ConsoleLinkContext, HelperTool, InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
-import { TOOL_TYPE } from '../../types.js';
+import type {
+    ConsoleLinkContext,
+    HelperTool,
+    InternalToolArgs,
+    ToolDescriptionContext,
+    ToolEntry,
+    ToolInputSchema,
+} from '../../types.js';
+import { ALL_TOOLS_PRESENT, TOOL_TYPE } from '../../types.js';
 import {
     type ActorDetailsResult,
     buildCardOptions,
@@ -101,8 +108,15 @@ export const fetchActorDetailsToolArgsSchema = z.object({
         .describe('Specify which information to include in the response to save tokens.'),
 });
 
-const FETCH_ACTOR_DETAILS_DESCRIPTION = `Get detailed information about an Actor by its ID or full name (format: "username/name", e.g., "apify/rag-web-browser").
-
+function buildDescription({ hasTool }: ToolDescriptionContext): string {
+    return `Get detailed information about an Actor by its ID or full name (format: "username/name", e.g., "apify/rag-web-browser").
+${
+    hasTool(HELPER_TOOLS.STORE_SEARCH)
+        ? `\nRequires the exact ID or full name. If you only have a description, a partial name, or a name you \
+have not seen in this conversation, find it with ${HELPER_TOOLS.STORE_SEARCH} first — do not construct a \
+plausible-looking name and call this tool with it.\n`
+        : ''
+}
 Use 'output' parameter with boolean flags to control returned information:
 - Default: All fields true except mcpTools
 - Selective: Set desired fields to true (e.g., output: { inputSchema: true })
@@ -115,16 +129,23 @@ EXAMPLES:
 - What does apify/rag-web-browser do?
 - What is the input schema for apify/web-scraper?
 - What tools does apify/actors-mcp-server provide?`;
+}
 
 /**
- * Build error response for when actor is not found.
+ * Build error response for when actor is not found. The recovery tool is named only when the
+ * session was served it: a name the client never received in `tools/list` invites a call to a
+ * tool that does not exist.
  */
-export function buildActorNotFoundResponse(actorName: string): ToolResponse {
-    return respondUserError(dedent`
-        Actor information for '${actorName}' was not found.
-        Please verify Actor ID or name format and ensure that the Actor exists.
-        You can search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}.
-    `);
+export function buildActorNotFoundResponse(actorName: string, loadedToolNames: readonly string[]): ToolResponse {
+    const recovery = loadedToolNames.includes(HELPER_TOOLS.STORE_SEARCH)
+        ? `\nSearch for the Actor by keyword with ${HELPER_TOOLS.STORE_SEARCH} rather than trying another spelling.`
+        : '';
+    return respondUserError(
+        dedent`
+            Actor information for '${actorName}' was not found.
+            Please verify Actor ID or name format and ensure that the Actor exists.
+        ` + recovery,
+    );
 }
 
 /**
@@ -208,7 +229,7 @@ export function buildActorDetailsTextResponse(options: {
  * Returns the same text + structured response in both modes.
  */
 export async function buildFetchActorDetailsResult(toolArgs: InternalToolArgs): Promise<ToolResponse> {
-    const { args, apifyToken, apifyClient, actorStore, paymentProvider, mcpSessionId } = toolArgs;
+    const { args, apifyToken, apifyClient, actorStore, paymentProvider, mcpSessionId, loadedToolNames } = toolArgs;
     const parsed = fetchActorDetailsToolArgsSchema.parse(args);
     const actorName = fixActorNameInputAndLog(parsed.actor, { mcpSessionId, route: HELPER_TOOLS.ACTOR_GET_DETAILS });
 
@@ -225,7 +246,7 @@ export async function buildFetchActorDetailsResult(toolArgs: InternalToolArgs): 
     const cardOptions = { ...buildCardOptions(resolvedOutput), userTier: userPlanTier, linkContext };
     const details = await fetchActorDetailsFromApi(apifyClient, actorName, cardOptions);
     if (!details) {
-        return buildActorNotFoundResponse(actorName);
+        return buildActorNotFoundResponse(actorName, loadedToolNames);
     }
 
     let actorOutputSchema: Record<string, unknown> | null | undefined;
@@ -259,7 +280,8 @@ export const fetchActorDetails: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.ACTOR_GET_DETAILS,
     title: 'Fetch Actor details',
-    description: FETCH_ACTOR_DETAILS_DESCRIPTION,
+    description: buildDescription(ALL_TOOLS_PRESENT),
+    buildDescription,
     inputSchema: z.toJSONSchema(fetchActorDetailsToolArgsSchema) as ToolInputSchema,
     outputSchema: actorDetailsOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(fetchActorDetailsToolArgsSchema)),

--- a/src/tools/actors/fetch_actor_details.ts
+++ b/src/tools/actors/fetch_actor_details.ts
@@ -109,7 +109,7 @@ export const fetchActorDetailsToolArgsSchema = z.object({
 });
 
 function buildDescription({ hasTool }: ToolDescriptionContext): string {
-    return `Get detailed information about an Actor by its ID or full name (format: "username/name", e.g., "apify/rag-web-browser").
+    return dedent`Get detailed information about an Actor by its ID or full name (format: "username/name", e.g., "apify/rag-web-browser").
 
 Requires the exact ID or full name — do not construct a plausible-looking name and call this tool with it.${
         hasTool(HELPER_TOOLS.STORE_SEARCH)
@@ -136,6 +136,7 @@ EXAMPLES:
  * Build error response for when actor is not found. The recovery tool is named only when the
  * session was served it: a name the client never received in `tools/list` invites a call to a
  * tool that does not exist.
+ * See apify/apify-mcp-server#1296.
  */
 export function buildActorNotFoundResponse(actorName: string, loadedToolNames: readonly string[]): ToolResponse {
     const recovery = loadedToolNames.includes(HELPER_TOOLS.STORE_SEARCH)

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -132,18 +132,26 @@ export function buildNoActorsFoundInstructions(keywords: string): string {
 
 /**
  * Builds the footer/instructions guidance for successful search results.
- * Includes guidance on using ACTOR_GET_DETAILS and performing a second broader search.
  * Interpolates the verbatim links nudge if applicable.
+ *
+ * The ACTOR_GET_DETAILS sentence is named only when the session was served that tool: this is
+ * result text, which no `hasTool` gate reaches, so a `?tools=search-actors` session would
+ * otherwise be told to call a tool absent from its own `tools/list`.
  */
-export function buildSearchActorsFooter(verbatimLinksNudge: string): string {
-    return dedent`
-        If you need more detailed information about any of these Actors, including their input
-        schemas and usage instructions, use the ${HELPER_TOOLS.ACTOR_GET_DETAILS} tool with the
-        specific Actor name.
+export function buildSearchActorsFooter(verbatimLinksNudge: string, loadedToolNames: readonly string[]): string {
+    const detailsHint = loadedToolNames.includes(HELPER_TOOLS.ACTOR_GET_DETAILS)
+        ? dedent`
+            If you need more detailed information about any of these Actors, including their input
+            schemas and usage instructions, use the ${HELPER_TOOLS.ACTOR_GET_DETAILS} tool with the
+            specific Actor name.
+        `
+        : '';
+    const secondSearch = dedent`
         IMPORTANT: You MUST always do a second search with broader, more generic keywords
         (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
         you haven't missed a better Actor.${verbatimLinksNudge}
     `;
+    return [detailsHint, secondSearch].filter(Boolean).join('\n');
 }
 
 /**
@@ -167,7 +175,7 @@ export const searchActors: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyClient, paymentProvider } = toolArgs;
+        const { args, apifyToken, apifyClient, paymentProvider, loadedToolNames } = toolArgs;
         const parsed = searchActorsBaseArgsSchema.parse(args);
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
@@ -198,7 +206,7 @@ export const searchActors: ToolEntry = Object.freeze({
             query: parsed.keywords,
             count: actors.length,
             userTier: userPlanTier,
-            instructions: buildSearchActorsFooter(verbatimLinksNudge),
+            instructions: buildSearchActorsFooter(verbatimLinksNudge, loadedToolNames),
         };
 
         // Build header and footer with separate `dedent` calls and concatenate around
@@ -212,7 +220,7 @@ export const searchActors: ToolEntry = Object.freeze({
 
             # Actors:
         `;
-        const footer = buildSearchActorsFooter(verbatimLinksNudge);
+        const footer = buildSearchActorsFooter(verbatimLinksNudge, loadedToolNames);
         return respondOk(`${header}\n\n${actorCardText}\n\n${footer}`, { structuredContent });
     },
 } as const satisfies HelperTool);

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -137,6 +137,7 @@ export function buildNoActorsFoundInstructions(keywords: string): string {
  * The ACTOR_GET_DETAILS sentence is named only when the session was served that tool: this is
  * result text, which no `hasTool` gate reaches, so a `?tools=search-actors` session would
  * otherwise be told to call a tool absent from its own `tools/list`.
+ * See apify/apify-mcp-server#1296.
  */
 export function buildSearchActorsFooter(verbatimLinksNudge: string, loadedToolNames: readonly string[]): string {
     const detailsHint = loadedToolNames.includes(HELPER_TOOLS.ACTOR_GET_DETAILS)
@@ -151,7 +152,7 @@ export function buildSearchActorsFooter(verbatimLinksNudge: string, loadedToolNa
         (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
         you haven't missed a better Actor.${verbatimLinksNudge}
     `;
-    return [detailsHint, secondSearch].filter(Boolean).join('\n');
+    return detailsHint ? `${detailsHint}\n${secondSearch}` : secondSearch;
 }
 
 /**

--- a/src/tools/widgets/fetch_actor_details_widget.ts
+++ b/src/tools/widgets/fetch_actor_details_widget.ts
@@ -63,7 +63,7 @@ export const fetchActorDetailsWidget: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { apifyToken, apifyClient, mcpSessionId } = toolArgs;
+        const { apifyToken, apifyClient, mcpSessionId, loadedToolNames } = toolArgs;
         const parsed = fetchActorDetailsWidgetArgsSchema.parse(toolArgs.args);
         const actorName = fixActorNameInputAndLog(parsed.actor, {
             mcpSessionId,
@@ -74,7 +74,7 @@ export const fetchActorDetailsWidget: ToolEntry = Object.freeze({
         const cardOptions = { ...buildCardOptions(actorDetailsOutputDefaults), userTier: userPlanTier };
         const details = await fetchActorDetails(apifyClient, actorName, cardOptions);
         if (!details) {
-            return buildActorNotFoundResponse(actorName);
+            return buildActorNotFoundResponse(actorName, loadedToolNames);
         }
 
         const { actorUrl, actorDetails } = buildActorDetailsForWidget(details, userPlanTier);

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -347,13 +347,17 @@ describe('call_actor_common', () => {
             const resolution = await resolveAndValidateActor({
                 actorName: 'apify/missing',
                 input: { query: 'x' },
-                toolArgs: { ...stubToolArgs, loadedToolNames: [HELPER_TOOLS.STORE_SEARCH] },
+                toolArgs: {
+                    ...stubToolArgs,
+                    loadedToolNames: [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.ACTOR_GET_DETAILS],
+                },
             });
 
             const { error } = resolution as { error: TextToolResult };
             const allText = (error.content ?? []).map(textOf).join('\n');
             expect(allText).toContain(`search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}`);
-            // A detail lookup on a non-existent Actor fails the same way, so it is never offered.
+            // Served here, and still not offered: a detail lookup on an Actor that does not exist
+            // fails the same way. Passing both names is what makes this assertion bite.
             expect(allText).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
         });
 

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -323,8 +323,8 @@ describe('call_actor_common', () => {
             });
         });
 
-        // Result text has no `hasTool`, so tools.mode_contract.test.ts cannot see it. The stub above
-        // loads no tools, so the assertion on the message body already covers the ungated case.
+        // Result text has no `hasTool`, so tools.mode_contract.test.ts cannot see it: it renders
+        // descriptions only. `?tools=call-actor` is served no search-actors.
         it('names no recovery tool in the not-found message when the session was served none', async () => {
             vi.mocked(getActorsAsTools).mockResolvedValue({ tools: [], errors: [] });
 
@@ -341,7 +341,7 @@ describe('call_actor_common', () => {
             expect(allText).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
         });
 
-        it('names only the recovery tools the session was served in the not-found message', async () => {
+        it('points at the search tool in the not-found message when the session was served it', async () => {
             vi.mocked(getActorsAsTools).mockResolvedValue({ tools: [], errors: [] });
 
             const resolution = await resolveAndValidateActor({
@@ -352,7 +352,8 @@ describe('call_actor_common', () => {
 
             const { error } = resolution as { error: TextToolResult };
             const allText = (error.content ?? []).map(textOf).join('\n');
-            expect(allText).toContain(`search for available Actors using ${HELPER_TOOLS.STORE_SEARCH}`);
+            expect(allText).toContain(`search for available Actors using the tool: ${HELPER_TOOLS.STORE_SEARCH}`);
+            // A detail lookup on a non-existent Actor fails the same way, so it is never offered.
             expect(allText).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
         });
 

--- a/tests/unit/tools.call_actor_common.test.ts
+++ b/tests/unit/tools.call_actor_common.test.ts
@@ -280,7 +280,11 @@ describe('call_actor_common', () => {
 
     describe('resolveAndValidateActor', () => {
         const INPUT_SCHEMA = { type: 'object', properties: { query: { type: 'string' } } };
-        const stubToolArgs = { apifyClient: {}, mcpSessionId: 'session-1' } as unknown as InternalToolArgs;
+        const stubToolArgs = {
+            apifyClient: {},
+            mcpSessionId: 'session-1',
+            loadedToolNames: [],
+        } as unknown as InternalToolArgs;
 
         beforeEach(() => {
             vi.mocked(getActorsAsTools).mockReset();
@@ -317,6 +321,39 @@ describe('call_actor_common', () => {
                 failureHttpStatus: 404,
                 failureDetail: "Actor 'apify/missing' was not found",
             });
+        });
+
+        // Result text has no `hasTool`, so tools.mode_contract.test.ts cannot see it. The stub above
+        // loads no tools, so the assertion on the message body already covers the ungated case.
+        it('names no recovery tool in the not-found message when the session was served none', async () => {
+            vi.mocked(getActorsAsTools).mockResolvedValue({ tools: [], errors: [] });
+
+            const resolution = await resolveAndValidateActor({
+                actorName: 'apify/missing',
+                input: { query: 'x' },
+                toolArgs: stubToolArgs,
+            });
+
+            const { error } = resolution as { error: TextToolResult };
+            const allText = (error.content ?? []).map(textOf).join('\n');
+            expect(allText).toContain("Actor 'apify/missing' was not found");
+            expect(allText).not.toContain(HELPER_TOOLS.STORE_SEARCH);
+            expect(allText).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
+        });
+
+        it('names only the recovery tools the session was served in the not-found message', async () => {
+            vi.mocked(getActorsAsTools).mockResolvedValue({ tools: [], errors: [] });
+
+            const resolution = await resolveAndValidateActor({
+                actorName: 'apify/missing',
+                input: { query: 'x' },
+                toolArgs: { ...stubToolArgs, loadedToolNames: [HELPER_TOOLS.STORE_SEARCH] },
+            });
+
+            const { error } = resolution as { error: TextToolResult };
+            const allText = (error.content ?? []).map(textOf).join('\n');
+            expect(allText).toContain(`search for available Actors using ${HELPER_TOOLS.STORE_SEARCH}`);
+            expect(allText).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
         });
 
         // Byte-identity guard for #937: the input-required error embeds the input schema in a

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -1,15 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { HELPER_TOOLS } from '../../src/const.js';
 import {
     actorDetailsOutputDefaults,
     buildActorDetailsTextResponse,
+    buildActorNotFoundResponse,
     buildFetchActorDetailsResult,
 } from '../../src/tools/actors/fetch_actor_details.js';
 import type { ActorDetailsResult } from '../../src/utils/actor_details.js';
 import { fetchActorDetails } from '../../src/utils/actor_details.js';
 import { VERBATIM_LINKS_NUDGE } from '../../src/utils/console_link.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
-import { mockUserInfo } from './helpers/tool_context.js';
+import { mockUserInfo, textOf } from './helpers/tool_context.js';
 import { stubInternalToolArgs } from './tools.search_actors.fixtures.js';
 
 vi.mock('../../src/utils/actor_details.js', async () => {
@@ -217,5 +219,24 @@ describe('buildFetchActorDetailsResult()', () => {
         );
 
         await expect(callWithToken('apify_api_test')).rejects.toMatchObject({ statusCode: 401 });
+    });
+});
+
+// Result text has no `hasTool`, so tools.mode_contract.test.ts does not cover it. A guessed Actor
+// name is the common way to land here, and naming a recovery tool the session never received
+// sends the model after something that does not exist.
+describe('buildActorNotFoundResponse()', () => {
+    it('points at the search tool when the session was served it', () => {
+        const text = (buildActorNotFoundResponse('jane.doe/typo', [HELPER_TOOLS.STORE_SEARCH]).content ?? [])
+            .map(textOf)
+            .join('\n');
+        expect(text).toContain('was not found');
+        expect(text).toContain(HELPER_TOOLS.STORE_SEARCH);
+    });
+
+    it('names no tool when the session was not served one', () => {
+        const text = (buildActorNotFoundResponse('jane.doe/typo', []).content ?? []).map(textOf).join('\n');
+        expect(text).toContain('was not found');
+        expect(text).not.toContain(HELPER_TOOLS.STORE_SEARCH);
     });
 });

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -207,6 +207,22 @@ describe('buildFetchActorDetailsResult()', () => {
         expect(content.at(-1)?.text).toBe(VERBATIM_LINKS_NUDGE);
     });
 
+    // The direct buildActorNotFoundResponse() tests below cannot see whether this function
+    // forwards the session's tool names, so a hardcoded [] here would go unnoticed.
+    it('forwards the session tool names to the not-found response', async () => {
+        vi.mocked(fetchActorDetails).mockResolvedValue(null as unknown as ActorDetailsResult);
+
+        // output narrowed as in callWithToken above: pricing: false skips the users/me lookup.
+        const notFoundArgs = { actor: 'jane.doe/typo', output: { inputSchema: true } };
+        const served = await buildFetchActorDetailsResult(
+            stubInternalToolArgs(notFoundArgs, [HELPER_TOOLS.STORE_SEARCH]),
+        );
+        const unserved = await buildFetchActorDetailsResult(stubInternalToolArgs(notFoundArgs));
+
+        expect((served.content ?? []).map(textOf).join('\n')).toContain(HELPER_TOOLS.STORE_SEARCH);
+        expect((unserved.content ?? []).map(textOf).join('\n')).not.toContain(HELPER_TOOLS.STORE_SEARCH);
+    });
+
     // Regression: a 401 (invalid/expired APIFY_TOKEN) must not surface as "Actor ... was not
     // found" — that message wrongly nudges the caller to retry search-actors instead of fixing
     // the credential. fetchActorDetails() is expected to propagate auth errors (see

--- a/tests/unit/tools.fetch_actor_details.widget.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.widget.response.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { HELPER_TOOLS } from '../../src/const.js';
 import { WIDGET_URIS } from '../../src/resources/widgets.js';
 import { fetchActorDetailsWidget } from '../../src/tools/widgets/fetch_actor_details_widget.js';
 import type { HelperTool } from '../../src/types.js';
 import type { ActorDetailsResult } from '../../src/utils/actor_details.js';
 import { fetchActorDetails } from '../../src/utils/actor_details.js';
 import { getUserInfoCached } from '../../src/utils/userid_cache.js';
-import { mockUserInfo } from './helpers/tool_context.js';
+import { mockUserInfo, textOf } from './helpers/tool_context.js';
 import { stubInternalToolArgs } from './tools.search_actors.fixtures.js';
 
 /**
@@ -132,6 +133,26 @@ describe('fetch-actor-details-widget response', () => {
         const tool = fetchActorDetailsWidget as HelperTool;
         const ok = tool.ajvValidate({ actor: 'apify/web-scraper' });
         expect(ok).toBe(true);
+    });
+
+    // The widget shares buildActorNotFoundResponse with the base tool, so it must forward the
+    // session's tool names too — an apps session can be served the widget without search-actors.
+    it('gates the not-found recovery tool on the names the session was served', async () => {
+        vi.mocked(fetchActorDetails).mockResolvedValue(null as unknown as ActorDetailsResult);
+
+        const served = await (fetchActorDetailsWidget as HelperTool).call(
+            stubInternalToolArgs({ actor: 'jane.doe/typo' }, [HELPER_TOOLS.STORE_SEARCH]),
+        );
+        const servedText = (served.content ?? []).map(textOf).join('\n');
+        expect(servedText).toContain('was not found');
+        expect(servedText).toContain(HELPER_TOOLS.STORE_SEARCH);
+
+        const unserved = await (fetchActorDetailsWidget as HelperTool).call(
+            stubInternalToolArgs({ actor: 'jane.doe/typo' }),
+        );
+        const unservedText = (unserved.content ?? []).map(textOf).join('\n');
+        expect(unservedText).toContain('was not found');
+        expect(unservedText).not.toContain(HELPER_TOOLS.STORE_SEARCH);
     });
 
     // Regression: same fix as tools.fetch_actor_details.response.test.ts — the widget variant

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 import { ALLOWED_TASK_TOOL_EXECUTION_MODES, HELPER_TOOLS, type HelperToolName } from '../../src/const.js';
+import { fetchActorDetails } from '../../src/tools/actors/fetch_actor_details.js';
 import { searchActorsBaseArgsSchema } from '../../src/tools/actors/search_actors.js';
 import { searchApifyDocs } from '../../src/tools/docs/search_apify_docs.js';
 import { CATEGORY_NAMES, getCategoryTools } from '../../src/tools/index.js';
@@ -172,6 +173,28 @@ describe('getCategoryTools mode contract (tool-mode separation)', () => {
             expect(defaultCallActor).toBeDefined();
             expect(defaultCallActor!.description).not.toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
             expect(defaultCallActor!.description).not.toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+        });
+    });
+
+    describe('fetch-actor-details name-resolution guidance', () => {
+        it('sends the model to search-actors for an inexact name when that tool is served', () => {
+            const { description } = getToolPublicFieldOnly(fetchActorDetails, {
+                presentTools: new Set([HELPER_TOOLS.ACTOR_GET_DETAILS, HELPER_TOOLS.STORE_SEARCH]),
+            });
+
+            expect(description).toContain('Requires the exact ID or full name');
+            expect(description).toContain(`find it with ${HELPER_TOOLS.STORE_SEARCH} first`);
+        });
+
+        // The half of the guidance that names no tool must survive a session without
+        // search-actors — it is the only instruction there against inventing a name.
+        it('keeps the exact-name requirement when search-actors is absent', () => {
+            const { description } = getToolPublicFieldOnly(fetchActorDetails, {
+                presentTools: new Set([HELPER_TOOLS.ACTOR_GET_DETAILS]),
+            });
+
+            expect(description).toContain('do not construct a plausible-looking name');
+            expect(description).not.toContain(HELPER_TOOLS.STORE_SEARCH);
         });
     });
 

--- a/tests/unit/tools.search_actors.default.response.test.ts
+++ b/tests/unit/tools.search_actors.default.response.test.ts
@@ -50,11 +50,7 @@ describe('search-actors without widget (searchActors)', () => {
         vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
 
         const result = await (searchActors as HelperTool).call(
-            stubInternalToolArgs({
-                keywords: SEARCH_KEYWORDS,
-                limit: 5,
-                offset: 0,
-            }),
+            stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }, [HELPER_TOOLS.ACTOR_GET_DETAILS]),
         );
 
         const { structuredContent, content } = result as {
@@ -226,5 +222,24 @@ describe('search-actors without widget (searchActors)', () => {
         expect(structuredContent.actors[0].url).toBe(consoleUrl);
         expect(content[0].text).toContain(`## [${MOCK_STORE_ACTOR.title}](${consoleUrl})`);
         expect(content[0].text).not.toContain(`${APIFY_STORE_URL}/apify/web-scraper`);
+    });
+
+    // The footer is result text, which `tools.mode_contract.test.ts` cannot see — it renders
+    // descriptions only. A `?tools=search-actors` session is served no fetch-actor-details.
+    it('names no follow-up tool in the footer when the session was not served one', async () => {
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+
+        const result = await (searchActors as HelperTool).call(
+            stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }),
+        );
+        const { structuredContent, content } = result as {
+            structuredContent: { instructions?: string };
+            content: { type: string; text: string }[];
+        };
+
+        expect(structuredContent.instructions).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
+        expect(structuredContent.instructions).toContain('second search with broader');
+        expect(content[0].text).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
+        expect(content[0].text).toContain('second search with broader');
     });
 });

--- a/tests/unit/tools.search_actors.fixtures.ts
+++ b/tests/unit/tools.search_actors.fixtures.ts
@@ -26,13 +26,16 @@ export const MOCK_STORE_ACTOR = {
 
 export const SEARCH_KEYWORDS = 'web scraper';
 
-export function stubInternalToolArgs(args: Record<string, unknown>): InternalToolArgs {
+export function stubInternalToolArgs(
+    args: Record<string, unknown>,
+    loadedToolNames: readonly string[] = [],
+): InternalToolArgs {
     return {
         args,
         apifyToken: 'test-token',
         apifyClient: {} as InternalToolArgs['apifyClient'],
         signal: new AbortController().signal,
         paymentProvider: undefined,
-        loadedToolNames: [],
+        loadedToolNames,
     };
 }


### PR DESCRIPTION
Third instance of the #1295 bug (tracked in #1296), this time in the actors family. Review turned up two more, all fixed here.

Result text is gated by nothing, and `tools.mode_contract.test.ts` scans `description` only, so none of this was covered.

| Site | Names, ungated | Session that hits it |
| --- | --- | --- |
| `fetch-actor-details` not-found | `search-actors` | `?tools=fetch-actor-details` |
| `call-actor` not-found | `search-actors` | `?tools=call-actor` |
| `search-actors` footer | `fetch-actor-details` | `?tools=search-actors`, on every success |

None of those names are in `AUTO_INJECTED_TOOLS`. The first two need only a typo to reach.

All three are gated in place, so a session holding every tool gets byte-identical output. Verified against master, not assumed. `call-actor`'s not-found branch does not reuse `buildCallFailureRecoveryHint`, because its second offer is a detail lookup, which for a nonexistent Actor fails the same way.

`fetch-actor-details`'s description also gained the missing "resolve the name first" instruction. Only the `search-actors` half is gated; the rest names no tool and renders everywhere.

## This does not fix the guessing habit

`task-chain-hard-1` (#1294's `tasks-evals`): Sonnet 3/3, Haiku ~7/10 before this wording and 5/8 with it. No measurable change. The case is well-formed and the Haiku gap is a capability limit, so further rewording is not the lever.

That 5/8 predates the review, which split the sentence, so it does not describe what ships. Re-running is a one-variable comparison: the case loads `tasks` + `actors`, so every gate here is a no-op for it.

## Not fixed here

Same bug, unfiled, left out to keep this one thing:

- `actor_tools_factory.ts:124`: Actor tool descriptions name `call-actor`, and `?tools=<actor>` serves none. `mode_contract`'s stub description hides it from the sweeping guard.
- `call_actor_widget.ts:96`: names `call-actor` in an apps widget-only session. That sentence is the whole recovery path, so it needs replacement wording, not a gate.

1464 unit tests, type-check, lint, format, and `check:agents` clean. Merges cleanly with #1190 and #1294.

Written and reviewed with Claude Code.