### PR TITLE
ci: write CHANGELOG.md via heredoc instead of write-file-action

### DIFF
--- a/.github/workflows/_update_release_metadata.yaml
+++ b/.github/workflows/_update_release_metadata.yaml
@@ -75,12 +75,14 @@ jobs:
             -   name: Update server.json version
                 run: jq '.version = "${{ needs.release_metadata.outputs.version_number }}"' server.json > server.json.tmp && mv server.json.tmp server.json
 
+            # Written via heredoc, not an action `with:` input: action inputs become env vars,
+            # and Linux caps a single env var at 128 KiB (MAX_ARG_STRLEN) — the changelog
+            # already exceeds that, which crashed write-file-action with "Argument list too long".
             -   name: Update CHANGELOG.md
-                uses: DamianReeves/write-file-action@master
-                with:
-                    path: CHANGELOG.md
-                    write-mode: overwrite
-                    contents: ${{ needs.release_metadata.outputs.changelog }}
+                run: |
+                    cat > CHANGELOG.md << 'CHANGELOG_EOF'
+                    ${{ needs.release_metadata.outputs.changelog }}
+                    CHANGELOG_EOF
 
             -   name: Commit changes
                 id: commit


### PR DESCRIPTION
## What
Replace the `DamianReeves/write-file-action` step in `_update_release_metadata.yaml` with a plain `run:` heredoc that writes `CHANGELOG.md` directly.

## Why
The "Update pre-release metadata / Update changelog" job has been failing on every master push with `Argument list too long`. The action passes the full changelog as an input, which GH turns into an env var for the action's node subprocess — Linux caps a single env var at 128 KiB (`MAX_ARG_STRLEN`), and `CHANGELOG.md` is already ~127 KiB and only grows. A `run:` heredoc substitutes the expression into the script text instead of process env, so it isn't subject to that limit.

## Testing
No test harness for GH workflow YAML in this repo. Validated the file parses correctly with `js-yaml` and the `run:` script renders as expected (heredoc body = literal changelog content, closing `CHANGELOG_EOF` matches). Not run end-to-end — that only happens on an actual master push; will confirm once merged and the pre-release job runs.