### PR TITLE
fix: require default alias on actorRunOutputSchema storage maps

### DIFF
--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -491,6 +491,8 @@ export const actorRunOutputSchema = {
                     properties: {
                         default: buildDatasetEntrySchema(),
                     },
+                    // `buildStorageEntries` (actor_run_response.ts) omits this whole map unless `default` is present.
+                    required: ['default'],
                     additionalProperties: buildDatasetEntrySchema(),
                 },
                 keyValueStores: {
@@ -500,6 +502,8 @@ export const actorRunOutputSchema = {
                     properties: {
                         default: buildKeyValueStoreEntrySchema(),
                     },
+                    // `buildStorageEntries` (actor_run_response.ts) omits this whole map unless `default` is present.
+                    required: ['default'],
                     additionalProperties: buildKeyValueStoreEntrySchema(),
                 },
             },

--- a/tests/unit/tools.structured_output_schemas.test.ts
+++ b/tests/unit/tools.structured_output_schemas.test.ts
@@ -130,6 +130,16 @@ describe('Structured Output Schemas', () => {
         });
     });
 
+    describe('actorRunOutputSchema', () => {
+        // buildStorageEntries (actor_run_response.ts) omits the whole map unless `default` is
+        // present, so every emitted `storages.datasets`/`storages.keyValueStores` has it (issue #1121).
+        it('requires the default alias on both storage maps', () => {
+            const { storages } = actorRunOutputSchema.properties;
+            expect(storages.properties.datasets.required).toEqual(['default']);
+            expect(storages.properties.keyValueStores.required).toEqual(['default']);
+        });
+    });
+
     describe('actorInfoSchema', () => {
         it('declares pictureUrl as an optional string', () => {
             expect(actorInfoSchema.properties.pictureUrl?.type).toBe('string');


### PR DESCRIPTION
## What
Adds `required: ['default']` to `storages.datasets` and `storages.keyValueStores` in `actorRunOutputSchema`. Plus a regression test pinning it.

## Why
`buildStorageEntries` (`actor_run_response.ts`) omits a storage map entirely unless it has a `default` entry — every real producer (`call-actor` start/wait, `get-actor-run`, `abort-actor-run`, direct Actor tools) already guarantees this. The schema didn't say so, so JSON-Schema-to-TypeScript codegen from `outputSchema` emitted `default?: T` next to an `additionalProperties`-typed index signature — TS2411. Schema-only fix, no response shape change.

Fixes #1121.

## Testing
`pnpm run type-check`, `pnpm run lint`, `pnpm run format`, `pnpm run check:agents` all clean. `pnpm exec vitest run tests/unit/tools.structured_output_schemas.test.ts` — 19/19 pass, including the new assertion. Full `pnpm run test:unit` — 1483 passed, 1 skipped, no regressions.