### PR TITLE
chore: Bump @modelcontextprotocol/sdk to 1.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@apify/utilities": "^2.25.1",
     "@modelcontextprotocol/ext-apps": "^1.1.2",
     "@modelcontextprotocol/node": "2.0.0",
-    "@modelcontextprotocol/sdk": "1.29.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@modelcontextprotocol/server": "2.0.0",
     "@segment/analytics-node": "^2.3.0",
     "@sentry/node": "^10.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,7 +205,7 @@ settings:
   injectWorkspacePackages: true
 
 overrides:
-  '@modelcontextprotocol/sdk': 1.29.0
+  '@modelcontextprotocol/sdk': 1.30.0
 
 importers:
 
@@ -222,13 +222,13 @@ importers:
         version: 2.31.0
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.1.2
-        version: 1.7.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.4.3)
+        version: 1.7.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.4.3)
       '@modelcontextprotocol/node':
         specifier: 2.0.0
         version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.19)
       '@modelcontextprotocol/sdk':
-        specifier: 1.29.0
-        version: 1.29.0(zod@4.4.3)
+        specifier: 1.30.0
+        version: 1.30.0(zod@4.4.3)
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0
@@ -271,7 +271,7 @@ importers:
         version: 3.0.64(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk':
         specifier: 0.3.206
-        version: 0.3.206(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        version: 0.3.206(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)
       '@apify/mcpc':
         specifier: ^0.6.0
         version: 0.6.0(zod@4.4.3)
@@ -355,7 +355,7 @@ importers:
         version: 1.141.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.1.2
-        version: 1.7.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.4.3)
+        version: 1.7.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.4.3)
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0
@@ -527,7 +527,7 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
-      '@modelcontextprotocol/sdk': 1.29.0
+      '@modelcontextprotocol/sdk': 1.30.0
       zod: ^4.0.0
 
   '@apify/consts@2.53.1':
@@ -1134,7 +1134,7 @@ packages:
     resolution: {integrity: sha512-OOWKDxdAjYDcgHkmzVzccyyag3FK+jBWPaWu4WvTxFsU4R/cgOX4eep66zPRA5n4v6WfxUNibPyvX4iJ7egYTg==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0
+      '@modelcontextprotocol/sdk': 1.30.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
       zod: ^3.25.0 || ^4.0.0
@@ -1154,8 +1154,8 @@ packages:
       hono:
         optional: true
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -4839,9 +4839,9 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.206':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.206(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.206(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.206
@@ -4866,7 +4866,7 @@ snapshots:
     dependencies:
       '@modelcontextprotocol/client': 2.0.0
       '@modelcontextprotocol/core': 2.0.0
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       '@napi-rs/keyring': 1.3.0
       chalk: 5.6.2
       commander: 15.0.0
@@ -5402,7 +5402,7 @@ snapshots:
 
   '@modelcontextprotocol/conformance@0.2.0-alpha.9':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       '@octokit/rest': 22.0.1
       commander: 14.0.3
       eventsource-parser: 3.0.8
@@ -5419,9 +5419,9 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@modelcontextprotocol/ext-apps@1.7.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.4.3)':
+  '@modelcontextprotocol/ext-apps@1.7.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       '@standard-schema/spec': 1.1.0
       zod: 4.4.3
     optionalDependencies:
@@ -5435,7 +5435,7 @@ snapshots:
     optionalDependencies:
       hono: 4.12.19
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.19)
       ajv: 8.20.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ strictDepBuilds: false
 
 # Dependency version overrides. pnpm 11 reads these from the workspace manifest, not package.json.
 overrides:
-  "@modelcontextprotocol/sdk": "1.29.0"
+  "@modelcontextprotocol/sdk": "1.30.0"
 
 # Required by pnpm v10+ modern `pnpm deploy`: workspace deps get copied ("injected")
 # into consumers' node_modules instead of symlinked, so deploy output is portable.


### PR DESCRIPTION
## What
Bumps `@modelcontextprotocol/sdk` from 1.29.0 to 1.30.0 in `package.json` and the `pnpm-workspace.yaml` override that pins it.

## Why
Found while investigating a production 409 storm in `apify-mcp-server-internal`: `WebStandardStreamableHTTPServerTransport.replayEvents`'s `cancel` callback was a no-op (unlike the fresh-GET path's `cancel`, which correctly clears its map entry), so once a standalone SSE stream was resumed, its `_streamMapping` entry never cleared on client disconnect — a permanent leak for any consumer with resumability (an `EventStore`) enabled, not just a narrow race. Fixed upstream in 1.30.0 (released ~30 days ago, clears this org's usual freshness floor).

This repo's own `dev_server.ts` uses `StreamableHTTPServerTransport`; keeping the SDK current avoids the same class of bug here.

## Testing
- `pnpm run type-check`, `lint`, `test:unit` (97 files, 1483 tests), `format`, `check:agents` — all pass.
- Clean `rm -rf node_modules && pnpm install --frozen-lockfile` succeeds, confirming the regenerated lockfile is self-consistent (CI-equivalent check, not just re-running against already-warm state).
- Lockfile diff is small (34 lines) and limited to the SDK version bump.

---
AI-assisted (Poisson agent), reviewed before submission.
