### PR TITLE
feat: Expand MCP server card to hybrid registry shape

### DIFF
--- a/src/server_card.ts
+++ b/src/server_card.ts
@@ -9,11 +9,36 @@ import {
     SERVER_NAME,
     SERVER_TITLE,
 } from './const.js';
-import type { ServerCard } from './types.js';
+import { getDefaultTools } from './tools/index.js';
+import type { ServerCard, ServerCardRemote, ServerCardRepository, ServerCardTool } from './types.js';
 import { readJsonFile } from './utils/generic.js';
 import { getPackageVersion } from './utils/version.js';
 
-const serverJson = readJsonFile<{ description: string }>(import.meta.url, '../server.json');
+/**
+ * The registry-shaped half of the server card lives in `server.json`, which is already the
+ * source of truth for registry publishing and is version-bumped by the release workflow.
+ * Reading it here keeps the card from drifting out of sync with what we publish.
+ */
+const serverJson = readJsonFile<{
+    $schema: string;
+    name: string;
+    description: string;
+    repository: ServerCardRepository;
+    remotes: ServerCardRemote[];
+}>(import.meta.url, '../server.json');
+
+/**
+ * Server icon, shared by the initialize response and the server card so the two cannot diverge.
+ * PNG rather than the `.ico` favicon: the registry schema restricts `icons[].mimeType` to
+ * png/jpeg/jpg/svg+xml/webp.
+ */
+const SERVER_ICONS: ServerCard['icons'] = [
+    {
+        src: APIFY_LOGO_URL,
+        mimeType: 'image/png',
+        sizes: ['180x180'],
+    },
+];
 
 /** Returns the `serverInfo` (MCP `Implementation`) advertised in the initialize response. */
 export function getServerInfo(): Implementation {
@@ -23,28 +48,48 @@ export function getServerInfo(): Implementation {
         version: getPackageVersion()!,
         description: serverJson.description,
         websiteUrl: APIFY_MCP_URL,
-        icons: [
-            {
-                src: APIFY_LOGO_URL,
-                mimeType: 'image/png',
-                sizes: ['180x180'],
-            },
-        ],
+        icons: [...SERVER_ICONS],
     };
 }
 
-/** Returns the MCP server card object per SEP-1649. */
+/**
+ * Summarises the default tool set for the card.
+ *
+ * Uses each tool's plain `description`, which by contract holds the render for consumers without
+ * a session tool set — exactly the session-less case a static card describes. Only the default
+ * server mode is described: the card is served from a single URL, and the modes differ only in
+ * one tool description.
+ */
+function getServerCardTools(): ServerCardTool[] {
+    return getDefaultTools().map((tool) => ({
+        name: tool.name,
+        title: tool.title,
+        description: tool.description,
+        annotations: tool.annotations,
+    }));
+}
+
+/** Returns the MCP server card object. See {@link ServerCard} for why it is a hybrid shape. */
 export function getServerCard(): ServerCard {
     return {
-        $schema: 'https://static.modelcontextprotocol.io/schemas/mcp-server-card/v1.json',
-        version: '1.0',
+        $schema: serverJson.$schema,
+
+        name: serverJson.name,
+        title: SERVER_TITLE,
+        description: serverJson.description,
+        version: getPackageVersion()!,
+        websiteUrl: APIFY_MCP_URL,
+        repository: serverJson.repository,
+        icons: [...SERVER_ICONS],
+        remotes: serverJson.remotes,
+        serverUrl: APIFY_MCP_URL,
+
         protocolVersion: LATEST_PROTOCOL_VERSION,
         serverInfo: {
             name: SERVER_NAME,
             title: SERVER_TITLE,
             version: getPackageVersion()!,
         },
-        description: serverJson.description,
         iconUrl: APIFY_FAVICON_URL,
         documentationUrl: APIFY_DOCS_MCP_URL,
         transport: {
@@ -58,6 +103,7 @@ export function getServerCard(): ServerCard {
             required: true,
             schemes: ['bearer', 'oauth2'],
         },
-        tools: 'dynamic',
+
+        tools: getServerCardTools(),
     };
 }

--- a/src/server_card.ts
+++ b/src/server_card.ts
@@ -55,17 +55,9 @@ export function getServerInfo(): Implementation {
 }
 
 /**
- * Summarises the default tool set for the card.
- *
- * Composes through `getToolsForServerMode` rather than `getDefaultTools`, because the latter
- * returns only the default-enabled categories — it omits the run and storage tools that
- * `call-actor` pulls in, which a real session always gets. `report-problem` is dropped: it is
- * gated per client at serve time, so it does not belong in a static card.
- *
- * Uses each tool's plain `description`, which by contract holds the render for consumers without
- * a session tool set — exactly the session-less case a static card describes. Only the default
- * server mode is described: the card is served from a single URL, and the modes differ only in
- * one tool description.
+ * Summarises the tools a default session serves. `getDefaultTools()` under-reports — it omits
+ * what `call-actor` pulls in — and `report-problem` is client-gated at serve time, so a static
+ * card cannot carry it. Each tool's plain `description` is by contract the session-less render.
  */
 function getServerCardTools(): ServerCardTool[] {
     return getToolsForServerMode({}, [], SERVER_MODE.DEFAULT)

--- a/src/server_card.ts
+++ b/src/server_card.ts
@@ -6,12 +6,14 @@ import {
     APIFY_FAVICON_URL,
     APIFY_LOGO_URL,
     APIFY_MCP_URL,
+    HELPER_TOOLS,
     SERVER_NAME,
     SERVER_TITLE,
 } from './const.js';
-import { getDefaultTools } from './tools/index.js';
 import type { ServerCard, ServerCardRemote, ServerCardRepository, ServerCardTool } from './types.js';
+import { SERVER_MODE } from './types.js';
 import { readJsonFile } from './utils/generic.js';
+import { getToolsForServerMode } from './utils/tools_loader.js';
 import { getPackageVersion } from './utils/version.js';
 
 /**
@@ -47,7 +49,7 @@ export function getServerInfo(): Implementation {
         title: SERVER_TITLE,
         version: getPackageVersion()!,
         description: serverJson.description,
-        websiteUrl: APIFY_MCP_URL,
+        websiteUrl: APIFY_DOCS_MCP_URL,
         icons: [...SERVER_ICONS],
     };
 }
@@ -55,18 +57,25 @@ export function getServerInfo(): Implementation {
 /**
  * Summarises the default tool set for the card.
  *
+ * Composes through `getToolsForServerMode` rather than `getDefaultTools`, because the latter
+ * returns only the default-enabled categories — it omits the run and storage tools that
+ * `call-actor` pulls in, which a real session always gets. `report-problem` is dropped: it is
+ * gated per client at serve time, so it does not belong in a static card.
+ *
  * Uses each tool's plain `description`, which by contract holds the render for consumers without
  * a session tool set — exactly the session-less case a static card describes. Only the default
  * server mode is described: the card is served from a single URL, and the modes differ only in
  * one tool description.
  */
 function getServerCardTools(): ServerCardTool[] {
-    return getDefaultTools().map((tool) => ({
-        name: tool.name,
-        title: tool.title,
-        description: tool.description,
-        annotations: tool.annotations,
-    }));
+    return getToolsForServerMode({}, [], SERVER_MODE.DEFAULT)
+        .filter((tool) => tool.name !== HELPER_TOOLS.PROBLEM_REPORT)
+        .map((tool) => ({
+            name: tool.name,
+            title: tool.title,
+            description: tool.description,
+            annotations: tool.annotations,
+        }));
 }
 
 /** Returns the MCP server card object. See {@link ServerCard} for why it is a hybrid shape. */
@@ -78,7 +87,7 @@ export function getServerCard(): ServerCard {
         title: SERVER_TITLE,
         description: serverJson.description,
         version: getPackageVersion()!,
-        websiteUrl: APIFY_MCP_URL,
+        websiteUrl: APIFY_DOCS_MCP_URL,
         repository: serverJson.repository,
         icons: [...SERVER_ICONS],
         remotes: serverJson.remotes,

--- a/src/types.ts
+++ b/src/types.ts
@@ -761,14 +761,9 @@ export type ServerCardTool = {
 /**
  * MCP server card, served by `apify-mcp-server-internal` at `/.well-known/mcp/server-card.json`.
  *
- * Deliberately a hybrid of two shapes. The identity fields (`name`, `version`, `description`,
- * `websiteUrl`, `repository`, `icons`, `remotes`) follow the MCP registry schema, which is the
- * only stable dated schema published — SEP-1649 was closed in favour of SEP-2127, and neither
- * ever published a machine-readable schema. The SEP-1649 fields (`serverInfo`, `protocolVersion`,
- * `transport`, `capabilities`, `authentication`, `iconUrl`) are kept so consumers reading those
- * keep working; `version` and `tools` are not among them — both changed meaning when this card
- * moved to the registry shape. The registry schema never sets `additionalProperties: false`, so
- * carrying both validates.
+ * Deliberately hybrid: identity follows the MCP registry schema, the only stable dated one
+ * published; the SEP-1649 fields stay for consumers reading those, except `version` and `tools`,
+ * which changed meaning. The registry schema never sets `additionalProperties: false`, so both fit.
  */
 export type ServerCard = {
     $schema: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -763,10 +763,12 @@ export type ServerCardTool = {
  *
  * Deliberately a hybrid of two shapes. The identity fields (`name`, `version`, `description`,
  * `websiteUrl`, `repository`, `icons`, `remotes`) follow the MCP registry schema, which is the
- * only stable dated schema published — both SEP-1649 and its successor SEP-2127 are still
- * drafts. The SEP-1649 fields (`serverInfo`, `protocolVersion`, `transport`, `capabilities`,
- * `authentication`, `iconUrl`) are kept so consumers of the previous shape keep working. The
- * registry schema never sets `additionalProperties: false`, so carrying both validates.
+ * only stable dated schema published — SEP-1649 was closed in favour of SEP-2127, and neither
+ * ever published a machine-readable schema. The SEP-1649 fields (`serverInfo`, `protocolVersion`,
+ * `transport`, `capabilities`, `authentication`, `iconUrl`) are kept so consumers reading those
+ * keep working; `version` and `tools` are not among them — both changed meaning when this card
+ * moved to the registry shape. The registry schema never sets `additionalProperties: false`, so
+ * carrying both validates.
  */
 export type ServerCard = {
     $schema: string;
@@ -785,7 +787,7 @@ export type ServerCard = {
         sizes: string[];
     }[];
     remotes: ServerCardRemote[];
-    /** Absolute MCP endpoint. Not a registry field; read by discovery scanners. */
+    /** Absolute MCP endpoint. Not a registry field; named by ora's server-card methodology. */
     serverUrl: string;
 
     // SEP-1649 compatibility.
@@ -809,6 +811,6 @@ export type ServerCard = {
         schemes: string[];
     };
 
-    /** Default-mode tools, generated from `getDefaultTools()` so the card cannot drift. */
+    /** Default-mode tools, composed the way a session composes them so the card cannot drift. */
     tools: ServerCardTool[];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -727,17 +727,74 @@ export type ApifyRequestParams = {
     [key: string]: unknown;
 };
 
-/** MCP Server Card per SEP-1649. */
+/** Source repository descriptor, registry `server.json` shape. */
+export type ServerCardRepository = {
+    url: string;
+    source: string;
+};
+
+/** Remote transport descriptor, registry `server.json` shape. */
+export type ServerCardRemote = {
+    type: string;
+    url: string;
+    headers?: {
+        name: string;
+        description?: string;
+        isRequired?: boolean;
+        isSecret?: boolean;
+    }[];
+};
+
+/**
+ * Tool summary embedded in the server card.
+ *
+ * Mirrors `tools/list` without `inputSchema`: the schemas dominate the payload and a card is a
+ * cheap pre-connection GET. Agents that need argument shapes connect and call `tools/list`.
+ */
+export type ServerCardTool = {
+    name: string;
+    title?: string;
+    description?: string;
+    annotations?: ToolBase['annotations'];
+};
+
+/**
+ * MCP server card, served by `apify-mcp-server-internal` at `/.well-known/mcp/server-card.json`.
+ *
+ * Deliberately a hybrid of two shapes. The identity fields (`name`, `version`, `description`,
+ * `websiteUrl`, `repository`, `icons`, `remotes`) follow the MCP registry schema, which is the
+ * only stable dated schema published — both SEP-1649 and its successor SEP-2127 are still
+ * drafts. The SEP-1649 fields (`serverInfo`, `protocolVersion`, `transport`, `capabilities`,
+ * `authentication`, `iconUrl`) are kept so consumers of the previous shape keep working. The
+ * registry schema never sets `additionalProperties: false`, so carrying both validates.
+ */
 export type ServerCard = {
     $schema: string;
+
+    // Registry-shaped identity. Sourced from `server.json` so there is one place to edit.
+    name: string;
+    title: string;
+    description: string;
+    /** Server version, per registry semantics — not the card format version, which `$schema` pins. */
     version: string;
+    websiteUrl: string;
+    repository: ServerCardRepository;
+    icons: {
+        src: string;
+        mimeType: string;
+        sizes: string[];
+    }[];
+    remotes: ServerCardRemote[];
+    /** Absolute MCP endpoint. Not a registry field; read by discovery scanners. */
+    serverUrl: string;
+
+    // SEP-1649 compatibility.
     protocolVersion: string;
     serverInfo: {
         name: string;
         title: string;
         version: string;
     };
-    description: string;
     iconUrl: string;
     documentationUrl: string;
     transport: {
@@ -751,5 +808,7 @@ export type ServerCard = {
         required: boolean;
         schemes: string[];
     };
-    tools: string;
+
+    /** Default-mode tools, generated from `getDefaultTools()` so the card cannot drift. */
+    tools: ServerCardTool[];
 };

--- a/tests/unit/server_card.test.ts
+++ b/tests/unit/server_card.test.ts
@@ -1,9 +1,8 @@
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it } from 'vitest';
 
-import { APIFY_LOGO_URL, APIFY_MCP_URL, SERVER_NAME, SERVER_TITLE } from '../../src/const.js';
+import { APIFY_DOCS_MCP_URL, APIFY_LOGO_URL, APIFY_MCP_URL, SERVER_NAME, SERVER_TITLE } from '../../src/const.js';
 import { getServerCard, getServerInfo } from '../../src/server_card.js';
-import { getDefaultTools } from '../../src/tools/index.js';
 import type { ServerCardRemote, ServerCardRepository } from '../../src/types.js';
 import { readJsonFile } from '../../src/utils/generic.js';
 import { getPackageVersion } from '../../src/utils/version.js';
@@ -18,6 +17,25 @@ const serverJson = readJsonFile<{
 
 /** Registry schema constraint on `name`: reverse-DNS with exactly one forward slash. */
 const REGISTRY_NAME_PATTERN = /^[a-zA-Z0-9.-]+\/[a-zA-Z0-9._-]+$/;
+
+/** Registry schema constraint on `description`. */
+const REGISTRY_DESCRIPTION_MAX_LENGTH = 100;
+
+/**
+ * The tools a default session serves, minus the client-gated `report-problem`. Pinned as a
+ * literal so a change to the default set shows up in the diff instead of passing silently.
+ */
+const EXPECTED_TOOL_NAMES = [
+    'search-actors',
+    'fetch-actor-details',
+    'call-actor',
+    'get-actor-run',
+    'get-dataset-items',
+    'get-key-value-store-record',
+    'abort-actor-run',
+    'search-apify-docs',
+    'fetch-apify-docs',
+];
 
 describe('getServerCard()', () => {
     it('inherits $schema from server.json', () => {
@@ -41,6 +59,12 @@ describe('getServerCard()', () => {
             expect(card.version).toBe(getPackageVersion());
         });
 
+        it('keeps description within the registry length limit', () => {
+            const card = getServerCard();
+
+            expect(card.description.length).toBeLessThanOrEqual(REGISTRY_DESCRIPTION_MAX_LENGTH);
+        });
+
         it('uses a name matching the registry reverse-DNS pattern', () => {
             const card = getServerCard();
 
@@ -58,7 +82,7 @@ describe('getServerCard()', () => {
             const card = getServerCard();
 
             expect(card.title).toBe(SERVER_TITLE);
-            expect(card.websiteUrl).toBe(APIFY_MCP_URL);
+            expect(card.websiteUrl).toBe(APIFY_DOCS_MCP_URL);
             expect(card.serverUrl).toBe(APIFY_MCP_URL);
         });
 
@@ -106,10 +130,10 @@ describe('getServerCard()', () => {
     });
 
     describe('tools', () => {
-        it('lists exactly the default-mode tools', () => {
+        it('lists exactly the tools a default session serves, without report-problem', () => {
             const card = getServerCard();
 
-            expect(card.tools.map((tool) => tool.name)).toEqual(getDefaultTools().map((tool) => tool.name));
+            expect(card.tools.map((tool) => tool.name)).toEqual(EXPECTED_TOOL_NAMES);
         });
 
         it('gives every tool a title, a description and annotations', () => {
@@ -141,7 +165,7 @@ describe('getServerInfo()', () => {
         expect(info.title).toBe(SERVER_TITLE);
         expect(info.version).toBe(getPackageVersion());
         expect(info.description).toBe(serverJson.description);
-        expect(info.websiteUrl).toBe(APIFY_MCP_URL);
+        expect(info.websiteUrl).toBe(APIFY_DOCS_MCP_URL);
         expect(info.icons).toEqual([{ src: APIFY_LOGO_URL, mimeType: 'image/png', sizes: ['180x180'] }]);
     });
 });

--- a/tests/unit/server_card.test.ts
+++ b/tests/unit/server_card.test.ts
@@ -3,68 +3,137 @@ import { describe, expect, it } from 'vitest';
 
 import { APIFY_LOGO_URL, APIFY_MCP_URL, SERVER_NAME, SERVER_TITLE } from '../../src/const.js';
 import { getServerCard, getServerInfo } from '../../src/server_card.js';
+import { getDefaultTools } from '../../src/tools/index.js';
+import type { ServerCardRemote, ServerCardRepository } from '../../src/types.js';
 import { readJsonFile } from '../../src/utils/generic.js';
 import { getPackageVersion } from '../../src/utils/version.js';
 
-const serverJson = readJsonFile<{ description: string }>(import.meta.url, '../../server.json');
+const serverJson = readJsonFile<{
+    $schema: string;
+    name: string;
+    description: string;
+    repository: ServerCardRepository;
+    remotes: ServerCardRemote[];
+}>(import.meta.url, '../../server.json');
 
-describe('getServerCard', () => {
-    it('should return a valid MCP server card object', () => {
+/** Registry schema constraint on `name`: reverse-DNS with exactly one forward slash. */
+const REGISTRY_NAME_PATTERN = /^[a-zA-Z0-9.-]+\/[a-zA-Z0-9._-]+$/;
+
+describe('getServerCard()', () => {
+    it('inherits $schema from server.json', () => {
         const card = getServerCard();
 
-        expect(card.$schema).toBe('https://static.modelcontextprotocol.io/schemas/mcp-server-card/v1.json');
-        expect(card.version).toBe('1.0');
+        expect(card.$schema).toBe(serverJson.$schema);
+    });
+
+    it('declares the latest protocol version', () => {
+        const card = getServerCard();
+
         expect(card.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
     });
 
-    it('should contain required serverInfo fields using constants from const.ts', () => {
-        const card = getServerCard();
+    describe('registry-shaped identity', () => {
+        it('carries the three fields the registry schema requires', () => {
+            const card = getServerCard();
 
-        expect(card.serverInfo.name).toBe(SERVER_NAME);
-        expect(card.serverInfo.title).toBe(SERVER_TITLE);
-        expect(card.serverInfo.version).toBe(getPackageVersion());
+            expect(card.name).toBe(serverJson.name);
+            expect(card.description).toBe(serverJson.description);
+            expect(card.version).toBe(getPackageVersion());
+        });
+
+        it('uses a name matching the registry reverse-DNS pattern', () => {
+            const card = getServerCard();
+
+            expect(card.name).toMatch(REGISTRY_NAME_PATTERN);
+        });
+
+        it('sources repository and remotes from server.json', () => {
+            const card = getServerCard();
+
+            expect(card.repository).toEqual(serverJson.repository);
+            expect(card.remotes).toEqual(serverJson.remotes);
+        });
+
+        it('exposes title, websiteUrl and serverUrl', () => {
+            const card = getServerCard();
+
+            expect(card.title).toBe(SERVER_TITLE);
+            expect(card.websiteUrl).toBe(APIFY_MCP_URL);
+            expect(card.serverUrl).toBe(APIFY_MCP_URL);
+        });
+
+        it('uses an icon with a registry-permitted mime type', () => {
+            const card = getServerCard();
+
+            expect(card.icons).toEqual([{ src: APIFY_LOGO_URL, mimeType: 'image/png', sizes: ['180x180'] }]);
+        });
     });
 
-    it('should declare streamable-http transport at root endpoint', () => {
-        const card = getServerCard();
+    describe('SEP-1649 compatibility fields', () => {
+        it('keeps serverInfo populated from constants', () => {
+            const card = getServerCard();
 
-        expect(card.transport.type).toBe('streamable-http');
-        expect(card.transport.endpoint).toBe('/');
+            expect(card.serverInfo.name).toBe(SERVER_NAME);
+            expect(card.serverInfo.title).toBe(SERVER_TITLE);
+            expect(card.serverInfo.version).toBe(getPackageVersion());
+        });
+
+        it('declares streamable-http transport at root endpoint', () => {
+            const card = getServerCard();
+
+            expect(card.transport.type).toBe('streamable-http');
+            expect(card.transport.endpoint).toBe('/');
+        });
+
+        it('declares the tools capability with no sub-capabilities', () => {
+            const card = getServerCard();
+
+            expect(card.capabilities.tools).toEqual({});
+        });
+
+        it('requires authentication with bearer and oauth2 schemes', () => {
+            const card = getServerCard();
+
+            expect(card.authentication.required).toBe(true);
+            expect(card.authentication.schemes).toEqual(['bearer', 'oauth2']);
+        });
+
+        it('includes documentation URL', () => {
+            const card = getServerCard();
+
+            expect(card.documentationUrl).toBe('https://docs.apify.com/platform/integrations/mcp');
+        });
     });
 
-    it('declares the tools capability with no sub-capabilities', () => {
-        const card = getServerCard();
+    describe('tools', () => {
+        it('lists exactly the default-mode tools', () => {
+            const card = getServerCard();
 
-        expect(card.capabilities.tools).toEqual({});
-    });
+            expect(card.tools.map((tool) => tool.name)).toEqual(getDefaultTools().map((tool) => tool.name));
+        });
 
-    it('should require authentication with bearer and oauth2 schemes', () => {
-        const card = getServerCard();
+        it('gives every tool a title, a description and annotations', () => {
+            const card = getServerCard();
 
-        expect(card.authentication.required).toBe(true);
-        expect(card.authentication.schemes).toEqual(['bearer', 'oauth2']);
-    });
+            expect(card.tools.length).toBeGreaterThan(0);
+            for (const tool of card.tools) {
+                expect(tool.title).toBeTruthy();
+                expect(tool.description?.length ?? 0).toBeGreaterThan(20);
+                expect(tool.annotations).toBeDefined();
+            }
+        });
 
-    it('should declare tools as dynamic', () => {
-        const card = getServerCard();
+        it('omits input schemas to keep the card small', () => {
+            const card = getServerCard();
 
-        expect(card.tools).toBe('dynamic');
-    });
-
-    it('should load description from server.json', () => {
-        const card = getServerCard();
-
-        expect(card.description).toBe(serverJson.description);
-    });
-
-    it('should include documentation URL', () => {
-        const card = getServerCard();
-
-        expect(card.documentationUrl).toBe('https://docs.apify.com/platform/integrations/mcp');
+            for (const tool of card.tools) {
+                expect(tool).not.toHaveProperty('inputSchema');
+            }
+        });
     });
 });
 
-describe('getServerInfo', () => {
+describe('getServerInfo()', () => {
     it('returns name, title and version', () => {
         const info = getServerInfo();
 


### PR DESCRIPTION
<!-- A PR that is hard to review is not ready for review. One concern per PR, clean diff (no debug logs, formatting noise, commented-out code). -->

<!-- AI agents: fill in Why, What changed, and Proof it works. Leave "Notes for reviewers" empty — it belongs to the human author. No file lists, no restating the diff, no praising the change. -->

<!-- Human author: an AI draft is a draft, not a description. Before requesting review: (1) self-review your own diff in the GitHub UI, (2) check every claim below against the diff and cut what you wouldn't say yourself, (3) write "Notes for reviewers" in your own words. -->

> **Outside contributors:** maintainers implement unassigned issues. Unless this is a documentation fix or a maintainer asked you to write it, close this and [open an issue](https://github.com/apify/apify-mcp-server/issues) instead. A reproduction is more useful than a patch. See [Before you write code](https://github.com/apify/apify-mcp-server/blob/master/CONTRIBUTING.md#before-you-write-code). Using AI? [Disclose it and show proof](https://github.com/apify/apify-mcp-server/blob/master/CONTRIBUTING.md#ai-assisted-contributions).

## Why
<!-- "Closes #123". No issue? Ad-hoc is the exception, not the default — one line on the problem and why the change is needed. Evidence beats adjectives: a measurement, a failing run, a probe result. -->

Closes #790

The card is missing the top-level identity fields that registries and scanners read. An ora.ai scan of `apify.com` scores `mcp-server-card` 1/2 — *"MCP server card found at https://mcp.apify.com/.well-known/mcp/server-card.json but missing fields: name"* — and `registry-branding` 0/2, *"No registry branding (name, icon, description) found"*. It also advertises `$schema: .../schemas/mcp-server-card/v1.json`, which returns 404.

## What changed
<!-- For a small fix, "Before: … / Now: …" is enough. Don't list files — the diff shows that. Explain the approach only when it's non-obvious; otherwise it's noise. -->

Before: a pure SEP-1649 card with no top-level `name`, `tools: "dynamic"` as a string, and a `$schema` pointing at a 404.

Now: a hybrid. Registry-schema identity fields (`name`, `version`, `websiteUrl`, `repository`, `icons`, `remotes`) sit alongside the existing SEP-1649 fields, which are all retained so nothing consuming the current shape breaks. `$schema`, `name`, `description`, `repository` and `remotes` are read from `server.json`, already the source of truth for registry publishing, so that half of the card has one place to edit.

Identity follows the registry schema rather than the newest spec because both SEPs are still drafts and the registry's dated schema is the only stable published option. It never sets `additionalProperties: false`, so one document can carry both shapes. More on the choice below.

Two consequences. Top-level `version` changes meaning, from the card-format marker `"1.0"` to the server version, because that is what the registry uses it for; the format version is now carried by the dated `$schema` URL. And `tools` becomes an array composed through `getToolsForServerMode` — the same call a real session makes — so it cannot drift from what clients get. That is 9 tools, omitting the client-gated `report-problem` and all input schemas.

`websiteUrl` now points at the MCP docs page rather than at `mcp.apify.com`, which returns 401 to a browser. The endpoint is still carried by `remotes[0].url` and `serverUrl`.

## Notes for reviewers (human-written)
<!-- Your own words — two sentences beat none. Where should review look hardest? What are you unsure about? If AI wrote parts you don't fully follow, say which — the reviewer must not be the first human to read them. Any impact on apify-mcp-server-internal (internals.js exports, _meta, structuredContent, clientInfo, ?ui=/?payment=)? -->

It's a bit tricky because there are multiple "sources of truth" how the MCP server card should look like.

There's the **published** [schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json) ([version changelog](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md) proves that 2025-12-11 is the latest dated release). But there's also two SEPs that are still drafts:

- [SEP-1649](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649) - This never fully landed and was superseded by SEP-2127 mid draft. So I would put the smallest weight to SEP-1649
- [SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) - still draft, not yet landed - [full draft text here](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/aa59517442d323a33ed915fc408f1584c4a23dfa/seps/2127-mcp-server-cards.md)

So I decided to choose a hybrid approach - stay compliant and backwards compatible with the published schema spec while also adopting most of the SEP-2127 to make it more future-proof and pass those Ora checks.

---

**Breaking for `apify-mcp-server-internal`.** It serves `getServerCard()` unmodified at `/.well-known/mcp/server-card.json`, so `$schema`, `version` and `tools` all change shape when it bumps `@apify/actors-mcp-server` (pinned at 0.12.0, so nothing breaks on merge). Its `test/unit/server-card.test.ts` asserts all three and needs updating in that bump PR.

## Proof it works
<!-- Not "unit tests pass" — CI shows that. An end-to-end MCP probe (mcpc transcript), a screenshot, or a link to an Actor run on the Apify platform. "Works on my machine" / "the AI said it works" is not proof. -->

This repo only builds the object; the JSON is published by `apify-mcp-server-internal`, which owns the `/.well-known/mcp/server-card.json` route. So there is nothing to probe over MCP and no real proof available until internal picks this up and deploys.

Two things are checkable today. The generated card validates against the published `2025-12-11/server.schema.json`, compiled with ajv against the fetched schema. Diffing it against the card `mcp.apify.com` serves right now shows only the intended additions, with no field removed.

AI-assisted: written with Claude Code, including the research into which spec to target.


