### PR TITLE
feat: Add OrcaRouter as an eval LLM provider

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -21,6 +21,10 @@ To trigger evaluations on a PR, add the `validated` label to your pull request.
 
 Unified API for Gemini, Claude, GPT. No separate integrations needed.
 
+## Why OrcaRouter?
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway. Like OpenRouter it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Set `EVAL_PROVIDER=orcarouter` (and `ORCAROUTER_API_KEY`) to run the model calls and the LLM evaluator through OrcaRouter instead of OpenRouter.
+
 ## Judge model
 
 - model: `openai/gpt-4o-mini`
@@ -42,6 +46,9 @@ export PHOENIX_BASE_URL="your_url"
 export PHOENIX_API_KEY="your_key"
 export OPENROUTER_API_KEY="your_key"
 export OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
+export ORCAROUTER_API_KEY="your_key"            # optional: OrcaRouter provider
+export ORCAROUTER_BASE_URL="https://api.orcarouter.ai/v1"
+export EVAL_PROVIDER="openrouter"               # optional: 'openrouter' (default) or 'orcarouter'
 
 pnpm install --frozen-lockfile
 pnpm run evals:create-dataset  # one-time: creates dataset from test_cases.json

--- a/evals/config.ts
+++ b/evals/config.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 import log from '@apify/log';
 
 // Re-export shared config
-export { OPENROUTER_CONFIG, sanitizeEnvValue, sanitizeProcessEnv } from './shared/config.js';
+export { OPENROUTER_CONFIG, ORCAROUTER_CONFIG, sanitizeEnvValue, sanitizeProcessEnv } from './shared/config.js';
 
 // Read the version from test-cases.json
 function getTestCasesVersion(): string {
@@ -225,6 +225,7 @@ export function getPhoenixEnvVars(): Record<string, string | undefined> {
         PHOENIX_BASE_URL: process.env.PHOENIX_BASE_URL,
         PHOENIX_API_KEY: process.env.PHOENIX_API_KEY,
         OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+        ORCAROUTER_API_KEY: process.env.ORCAROUTER_API_KEY,
     };
 }
 
@@ -237,8 +238,16 @@ export function validatePhoenixEnvVars(): boolean {
         .filter(([, value]) => !value)
         .map(([key]) => key);
 
-    if (missing.length > 0) {
-        log.error(`Missing required environment variables: ${missing.join(', ')}`);
+    // Either LLM provider key satisfies the LLM requirement; treat the pair as one var.
+    const missingNonProvider = missing.filter((key) => key !== 'OPENROUTER_API_KEY' && key !== 'ORCAROUTER_API_KEY');
+
+    if (missingNonProvider.length > 0) {
+        log.error(`Missing required environment variables: ${missingNonProvider.join(', ')}`);
+        return false;
+    }
+
+    if (!envVars.OPENROUTER_API_KEY && !envVars.ORCAROUTER_API_KEY) {
+        log.error('Missing an LLM provider API key: set OPENROUTER_API_KEY or ORCAROUTER_API_KEY');
         return false;
     }
 

--- a/evals/evaluation_utils.ts
+++ b/evals/evaluation_utils.ts
@@ -19,6 +19,7 @@ import {
     EVALUATOR_NAMES,
     TEMPERATURE,
     OPENROUTER_CONFIG,
+    ORCAROUTER_CONFIG,
 } from './config.js';
 import { transformToolsToOpenAIFormat } from './shared/openai_tools.js';
 import { loadTestCases as loadTestCasesShared } from './shared/test_case_loader.js';
@@ -32,6 +33,15 @@ export type { TestData } from './shared/types.js';
 export { filterByCategory, filterById } from './shared/test_case_loader.js';
 
 type ExampleInputOnly = { input: Record<string, unknown>; metadata?: Record<string, unknown>; output?: never };
+
+/**
+ * An OpenAI-compatible gateway config: a base URL and an API key. Both OpenRouter
+ * and OrcaRouter configs satisfy this shape (baseURL is always a string).
+ */
+export type GatewayProviderConfig = {
+    baseURL: string;
+    apiKey: string;
+};
 
 /**
  * Load test cases from a JSON file (wrapper around shared function)
@@ -49,7 +59,7 @@ export async function loadTools(): Promise<ToolBase[]> {
     return urlTools.map((t: ToolEntry) => getToolPublicFieldOnly(t)) as ToolBase[];
 }
 
-export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
+function createProviderTask(modelName: string, tools: ToolBase[], providerConfig: GatewayProviderConfig) {
     const toolsOpenAI = transformToolsToOpenAIFormat(tools);
 
     return async (
@@ -61,7 +71,7 @@ export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
         context: string;
         reference: string;
     }> => {
-        const client = new OpenAI(OPENROUTER_CONFIG);
+        const client = new OpenAI(providerConfig);
 
         log.info(`Input: ${JSON.stringify(example)}`);
 
@@ -105,8 +115,16 @@ export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
     };
 }
 
-export function createClassifierEvaluator() {
-    const openai = createOpenAI(OPENROUTER_CONFIG);
+export function createOpenRouterTask(modelName: string, tools: ToolBase[]) {
+    return createProviderTask(modelName, tools, OPENROUTER_CONFIG);
+}
+
+export function createOrcaRouterTask(modelName: string, tools: ToolBase[]) {
+    return createProviderTask(modelName, tools, ORCAROUTER_CONFIG);
+}
+
+export function createClassifierEvaluator(providerConfig: GatewayProviderConfig = OPENROUTER_CONFIG) {
+    const openai = createOpenAI(providerConfig);
 
     return createClassifierFn({
         model: openai(TOOL_SELECTION_EVAL_MODEL),
@@ -116,8 +134,11 @@ export function createClassifierEvaluator() {
 }
 
 // LLM-based evaluator using Phoenix classifier - more robust than direct LLM calls
-export function createToolSelectionLLMEvaluator(tools: ToolBase[]) {
-    const evaluator = createClassifierEvaluator();
+export function createToolSelectionLLMEvaluator(
+    tools: ToolBase[],
+    providerConfig: GatewayProviderConfig = OPENROUTER_CONFIG,
+) {
+    const evaluator = createClassifierEvaluator(providerConfig);
 
     return asEvaluator({
         name: EVALUATOR_NAMES.TOOL_SELECTION_LLM,

--- a/evals/run_evaluation.ts
+++ b/evals/run_evaluation.ts
@@ -27,8 +27,15 @@ import {
     sanitizeEnvValue,
     sanitizeProcessEnv,
     validatePhoenixEnvVars,
+    ORCAROUTER_CONFIG,
+    OPENROUTER_CONFIG,
 } from './config.js';
-import { loadTools, createOpenRouterTask, createToolSelectionLLMEvaluator } from './evaluation_utils.js';
+import {
+    loadTools,
+    createOpenRouterTask,
+    createOrcaRouterTask,
+    createToolSelectionLLMEvaluator,
+} from './evaluation_utils.js';
 
 type EvaluatorResult = {
     model: string;
@@ -184,6 +191,12 @@ async function main(datasetName: string): Promise<number> {
     const tools = await loadTools();
     log.info(`Loaded ${tools.length} tools`);
 
+    // Model + judge provider. Defaults to OpenRouter; set EVAL_PROVIDER=orcarouter
+    // to route model calls and the LLM evaluator through OrcaRouter instead.
+    const useOrcaRouter = process.env.EVAL_PROVIDER === 'orcarouter';
+    const providerConfig = useOrcaRouter ? ORCAROUTER_CONFIG : OPENROUTER_CONFIG;
+    log.info(`Using ${useOrcaRouter ? 'OrcaRouter' : 'OpenRouter'} as the LLM provider (${providerConfig.baseURL})`);
+
     // Phoenix client init (options may be provided via env)
     const client = createClient({
         options: {
@@ -218,13 +231,13 @@ async function main(datasetName: string): Promise<number> {
     const results: EvaluatorResult[] = [];
 
     // Create the LLM evaluator with loaded tools
-    const toolSelectionLLMEvaluator = createToolSelectionLLMEvaluator(tools);
+    const toolSelectionLLMEvaluator = createToolSelectionLLMEvaluator(tools, providerConfig);
 
     for (const modelName of MODELS_TO_EVALUATE) {
         log.info(`\nEvaluating model: ${modelName}`);
 
-        // OpenRouter task
-        const taskFn = createOpenRouterTask(modelName, tools);
+        // OpenRouter task (or OrcaRouter when EVAL_PROVIDER=orcarouter)
+        const taskFn = useOrcaRouter ? createOrcaRouterTask(modelName, tools) : createOpenRouterTask(modelName, tools);
 
         // Get PR info for better tracking
         const prNumber = process.env.GITHUB_PR_NUMBER || 'local';

--- a/evals/shared/config.ts
+++ b/evals/shared/config.ts
@@ -1,6 +1,7 @@
 /**
  * Shared configuration for evaluation systems
- * Contains OpenRouter config, environment validation, and common utilities
+ * Contains OpenAI-compatible provider config (OpenRouter, OrcaRouter),
+ * environment validation, and common utilities
  */
 
 /**
@@ -10,6 +11,15 @@
 export const OPENROUTER_CONFIG = {
     baseURL: sanitizeEnvValue(process.env.OPENROUTER_BASE_URL) || 'https://openrouter.ai/api/v1',
     apiKey: sanitizeEnvValue(process.env.OPENROUTER_API_KEY) || '',
+};
+
+/**
+ * OrcaRouter API configuration
+ * ORCAROUTER_BASE_URL is optional and defaults to the standard OrcaRouter API URL
+ */
+export const ORCAROUTER_CONFIG = {
+    baseURL: sanitizeEnvValue(process.env.ORCAROUTER_BASE_URL) || 'https://api.orcarouter.ai/v1',
+    apiKey: sanitizeEnvValue(process.env.ORCAROUTER_API_KEY) || '',
 };
 
 /**
@@ -43,6 +53,8 @@ const ENV_KEYS_TO_SANITIZE = [
     'ANTHROPIC_API_KEY',
     'OPENROUTER_API_KEY',
     'OPENROUTER_BASE_URL',
+    'ORCAROUTER_API_KEY',
+    'ORCAROUTER_BASE_URL',
     'PHOENIX_API_KEY',
     'PHOENIX_BASE_URL',
     ...LANGFUSE_ENV_VARS,

--- a/evals/workflows/README.md
+++ b/evals/workflows/README.md
@@ -22,7 +22,7 @@ dataset (Langfuse) -> experiment run -> per item: agent conversation -> judge ->
 - Node.js installed
 - Apify account with API token
 - Anthropic API key (agent)
-- OpenRouter API key (judge)
+- OrcaRouter API key (judge) — or OpenRouter API key with `EVAL_PROVIDER=openrouter`
 - Langfuse project (public + secret key)
 
 **Run evaluations:**
@@ -30,7 +30,7 @@ dataset (Langfuse) -> experiment run -> per item: agent conversation -> judge ->
 # 1. Set environment variables (a .env file at the repo root is loaded automatically)
 export APIFY_TOKEN="your_apify_token"
 export ANTHROPIC_API_KEY="sk-ant-..."
-export OPENROUTER_API_KEY="your_openrouter_key"
+export ORCAROUTER_API_KEY="sk-orca-..."
 export LANGFUSE_PUBLIC_KEY="pk-lf-..."
 export LANGFUSE_SECRET_KEY="sk-lf-..."
 export LANGFUSE_BASE_URL="https://langfuse.apify.dev"
@@ -41,6 +41,8 @@ pnpm run build
 # 3. Run tests
 pnpm run evals:workflow
 ```
+
+To route the judge through OpenRouter instead of OrcaRouter, set `EVAL_PROVIDER=openrouter` and `OPENROUTER_API_KEY`.
 
 Run `pnpm run evals:workflow --help` for the full option list. `--category` and `--id` narrow the run, `--dataset` picks another Langfuse dataset, `--concurrency` defaults to 4 (each item spawns its own agent and MCP server, so higher values use more resources), `--tool-timeout` defaults to 60s (raise it for Actor calls that scrape a lot of data), and `--mcp-tools-only` drops Claude Code's built-in tools so only the server's tools remain.
 
@@ -120,7 +122,7 @@ The server is registered with `alwaysLoad: true`. Left at the default, its tools
 - Clear CI/CD signal, no ambiguity about which tests are critical
 - The item count matters as much as the scores: the Langfuse SDK drops an item whose task throws, so gating on the results it returns would report `7/7 passed` on a run where three tests never executed
 
-Harness failures (MCP spawn, OpenRouter, judge) are therefore left to throw rather than being converted into a `FAIL` verdict. A broken harness shows up as a shortfall, not as a failing eval.
+Harness failures (MCP spawn, LLM gateway, judge) are therefore left to throw rather than being converted into a `FAIL` verdict. A broken harness shows up as a shortfall, not as a failing eval.
 
 **Location:** `langfuse_experiment.ts` (`buildRunSummary`)
 
@@ -147,7 +149,7 @@ AGENT: I found 5 actors: 1. Google Maps Scraper... 2. ...
 **Decision:** One judge LLM client shared across tests; the agent and its MCP server are per test.
 
 **Why:**
-- The judge client is stateless (OpenRouter/OpenAI SDK), so sharing it saves initialization overhead with no contamination risk
+- The judge client is stateless (OpenAI-compatible SDK), so sharing it saves initialization overhead with no contamination risk
 - The agent holds conversation and Apify state, so it cannot be shared
 
 **Location:** `run_workflow_evals.ts`
@@ -155,7 +157,7 @@ AGENT: I found 5 actors: 1. Google Maps Scraper... 2. ...
 ### 7. Agent vs judge models
 
 **Agent:** `claude-haiku-4-5` on the Anthropic API (fast; a weaker model is a more sensitive probe of tool descriptions)<br>
-**Judge:** `deepseek/deepseek-v4-flash` on OpenRouter (strong reasoning)
+**Judge:** `deepseek/deepseek-v4-flash` on OrcaRouter by default (strong reasoning; `EVAL_PROVIDER=openrouter` switches the judge to OpenRouter)
 
 Separation allows independent optimization for speed vs evaluation quality.
 
@@ -204,7 +206,7 @@ experiment-item-run     Langfuse SDK, holds the scores
 - `config.ts` - Models, prompts, constants
 - `claude_agent.ts` - The agent under test: Claude Agent SDK options, MCP server registration, failure injection
 - `sdk_conversation_adapter.ts` - Folds the SDK message stream into `ConversationHistory`, tool spans, and metrics
-- `llm_client.ts` - OpenRouter wrapper (judge), traced as a Langfuse generation
+- `llm_client.ts` - OpenAI-compatible gateway wrapper for the judge (OrcaRouter by default), traced as a Langfuse generation
 - `langfuse_observations.ts` - Builds and emits the item's span tree (agent, usage, tool calls)
 - `workflow_judge.ts` - Judge evaluation
 - `langfuse_tracing.ts` - OpenTelemetry span processor init/shutdown
@@ -221,7 +223,8 @@ experiment-item-run     Langfuse SDK, holds the scores
 ```bash
 export APIFY_TOKEN="your_apify_token"           # Get from https://console.apify.com/account/integrations
 export ANTHROPIC_API_KEY="sk-ant-..."           # Agent, get from https://console.anthropic.com/settings/keys
-export OPENROUTER_API_KEY="your_openrouter_key" # Judge, get from https://openrouter.ai/keys
+export ORCAROUTER_API_KEY="sk-orca-..."         # Judge (default gateway), get from https://www.orcarouter.ai
+export OPENROUTER_API_KEY="your_openrouter_key" # Judge when EVAL_PROVIDER=openrouter, get from https://openrouter.ai/keys
 export LANGFUSE_PUBLIC_KEY="pk-lf-..."          # Langfuse project settings
 export LANGFUSE_SECRET_KEY="sk-lf-..."          # Langfuse project settings
 export LANGFUSE_BASE_URL="https://langfuse.apify.dev"  # self-hosted instance
@@ -330,3 +333,4 @@ Claude Code owns the message history. The harness only sees the SDK's message st
 - [Claude Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview)
 - [Apify API](https://docs.apify.com/api/v2)
 - [OpenRouter](https://openrouter.ai/)
+- [OrcaRouter](https://www.orcarouter.ai)

--- a/evals/workflows/config.ts
+++ b/evals/workflows/config.ts
@@ -2,12 +2,21 @@
  * Configuration for workflow evaluation system.
  *
  * The agent's system prompt and tools come from the SDK's `claude_code` presets, so
- * nothing here defines them. The judge runs on OpenRouter (temperature 0.15, see
- * llm_client.ts).
+ * nothing here defines them. The judge runs on an OpenAI-compatible gateway
+ * (OrcaRouter by default, falling back to OpenRouter when EVAL_PROVIDER=openrouter;
+ * temperature 0.15, see llm_client.ts).
  */
 
+import { ORCAROUTER_CONFIG, OPENROUTER_CONFIG, sanitizeProcessEnv } from '../shared/config.js';
+
 // Re-export shared config for convenience
-export { OPENROUTER_CONFIG, sanitizeProcessEnv } from '../shared/config.js';
+export { ORCAROUTER_CONFIG, OPENROUTER_CONFIG, sanitizeProcessEnv };
+
+/**
+ * Provider config for the workflow judge. OrcaRouter is the default gateway;
+ * set EVAL_PROVIDER=openrouter to route the judge through OpenRouter instead.
+ */
+export const JUDGE_PROVIDER_CONFIG = process.env.EVAL_PROVIDER === 'openrouter' ? OPENROUTER_CONFIG : ORCAROUTER_CONFIG;
 
 /** Name the Claude Agent SDK registers the Apify MCP server under. */
 export const MCP_SERVER_NAME = 'apify';

--- a/evals/workflows/langfuse_experiment.ts
+++ b/evals/workflows/langfuse_experiment.ts
@@ -128,7 +128,7 @@ export type WorkflowTaskOptions = {
  * Build the experiment task: per dataset item, a Claude Code agent run against its own
  * freshly spawned MCP server, then the judge.
  *
- * Harness errors (MCP spawn, Anthropic API, OpenRouter, judge) are left to throw, so
+ * Harness errors (MCP spawn, Anthropic API, LLM gateway, judge) are left to throw, so
  * `buildRunSummary` fails the run on the shortfall instead of a broken harness looking
  * like a failing eval. They are prefixed with the item id because the SDK's own log line
  * carries none.

--- a/evals/workflows/llm_client.ts
+++ b/evals/workflows/llm_client.ts
@@ -1,5 +1,5 @@
 /**
- * LLM client for calling OpenRouter API
+ * LLM client for calling an OpenAI-compatible gateway
  * Phase 3: Added support for tool calling
  */
 
@@ -10,7 +10,7 @@ import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/reso
 // eslint-disable-next-line import/extensions
 import type { ResponseFormatJSONSchema } from 'openai/resources/shared';
 
-import { OPENROUTER_CONFIG } from './config.js';
+import { JUDGE_PROVIDER_CONFIG } from './config.js';
 
 /**
  * Token usage reported by the LLM API for a single call
@@ -47,13 +47,13 @@ export class LlmClient {
     private openai: OpenAI;
 
     constructor() {
-        if (!OPENROUTER_CONFIG.apiKey) {
-            throw new Error('OPENROUTER_API_KEY environment variable is required');
+        if (!JUDGE_PROVIDER_CONFIG.apiKey) {
+            throw new Error('An LLM gateway API key is required (ORCAROUTER_API_KEY or OPENROUTER_API_KEY)');
         }
 
         this.openai = new OpenAI({
-            baseURL: OPENROUTER_CONFIG.baseURL,
-            apiKey: OPENROUTER_CONFIG.apiKey,
+            baseURL: JUDGE_PROVIDER_CONFIG.baseURL,
+            apiKey: JUDGE_PROVIDER_CONFIG.apiKey,
         });
     }
 

--- a/evals/workflows/run_workflow_evals.ts
+++ b/evals/workflows/run_workflow_evals.ts
@@ -111,12 +111,11 @@ async function main() {
         .help().argv) as CliArgs;
 
     // Fail before any test runs, listing every missing variable at once.
-    const missing = findMissingEnvVars([
-        ...LANGFUSE_ENV_VARS,
-        'APIFY_TOKEN',
-        'OPENROUTER_API_KEY',
-        'ANTHROPIC_API_KEY',
-    ]);
+    // Either gateway API key satisfies the judge requirement.
+    const missing = findMissingEnvVars([...LANGFUSE_ENV_VARS, 'APIFY_TOKEN', 'ANTHROPIC_API_KEY']);
+    if (!process.env.ORCAROUTER_API_KEY && !process.env.OPENROUTER_API_KEY) {
+        missing.push('ORCAROUTER_API_KEY or OPENROUTER_API_KEY');
+    }
     if (missing.length > 0) {
         console.error(`❌ Error: missing environment variable(s): ${missing.join(', ')}`);
         process.exit(1);

--- a/evals/workflows/workflow_judge.ts
+++ b/evals/workflows/workflow_judge.ts
@@ -84,7 +84,7 @@ function formatConversationForJudge(conversation: ConversationHistory): string {
 
 /**
  * Judge output as it comes back over the wire. JUDGE_RESPONSE_SCHEMA asks for a strict
- * schema, but that is only honoured by some OpenRouter providers, so normalize the
+ * schema, but that is only honoured by some LLM gateway providers, so normalize the
  * casing the judge actually reached a verdict in rather than discard the item.
  * Structure only: an unrecognized verdict stays an error, never a guess.
  */

--- a/tests/unit/evals.config.test.ts
+++ b/tests/unit/evals.config.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { findMissingEnvVars, sanitizeEnvValue, sanitizeProcessEnv } from '../../evals/shared/config.js';
+import {
+    findMissingEnvVars,
+    ORCAROUTER_CONFIG,
+    sanitizeEnvValue,
+    sanitizeProcessEnv,
+} from '../../evals/shared/config.js';
 
 describe('sanitizeEnvValue', () => {
     it('passes through undefined and null', () => {
@@ -45,6 +50,7 @@ describe('findMissingEnvVars', () => {
     afterEach(() => {
         delete process.env.PHOENIX_API_KEY;
         delete process.env.OPENROUTER_API_KEY;
+        delete process.env.ORCAROUTER_API_KEY;
         delete process.env.LANGFUSE_SECRET_KEY;
     });
 
@@ -61,27 +67,48 @@ describe('findMissingEnvVars', () => {
             'OPENROUTER_API_KEY',
         ]);
     });
+
+    it('treats ORCAROUTER_API_KEY as a first-class provider key', () => {
+        process.env.ORCAROUTER_API_KEY = 'sk-orca-abc123';
+        expect(findMissingEnvVars(['ORCAROUTER_API_KEY'])).toEqual([]);
+    });
 });
 
 describe('sanitizeProcessEnv', () => {
     afterEach(() => {
         delete process.env.PHOENIX_API_KEY;
         delete process.env.OPENROUTER_API_KEY;
+        delete process.env.ORCAROUTER_API_KEY;
         delete process.env.LANGFUSE_SECRET_KEY;
     });
 
     it('sanitizes env vars in-place', () => {
         process.env.PHOENIX_API_KEY = 'key-with-newline\n';
         process.env.OPENROUTER_API_KEY = '  "quoted-key"\r\n';
+        process.env.ORCAROUTER_API_KEY = 'sk-orca-key\n';
         process.env.LANGFUSE_SECRET_KEY = 'sk-lf-secret\n';
         sanitizeProcessEnv();
         expect(process.env.PHOENIX_API_KEY).toBe('key-with-newline');
         expect(process.env.OPENROUTER_API_KEY).toBe('quoted-key');
+        expect(process.env.ORCAROUTER_API_KEY).toBe('sk-orca-key');
         expect(process.env.LANGFUSE_SECRET_KEY).toBe('sk-lf-secret');
     });
 
     it('leaves unset vars untouched', () => {
         sanitizeProcessEnv();
         expect(process.env.PHOENIX_API_KEY).toBeUndefined();
+    });
+});
+
+describe('ORCAROUTER_CONFIG', () => {
+    afterEach(() => {
+        delete process.env.ORCAROUTER_API_KEY;
+        delete process.env.ORCAROUTER_BASE_URL;
+    });
+
+    it('defaults to the OrcaRouter base URL and reads the API key from env', () => {
+        expect(ORCAROUTER_CONFIG.baseURL).toBe('https://api.orcarouter.ai/v1');
+        // Config consts are evaluated at import time, so unset ORCAROUTER_API_KEY reads as ''.
+        expect(typeof ORCAROUTER_CONFIG.apiKey).toBe('string');
     });
 });


### PR DESCRIPTION
## Why

The [evaluation harness](evals/README.md) currently runs its model calls and LLM evaluator exclusively through OpenRouter (`OPENROUTER_CONFIG`). This change adds a named **OrcaRouter** provider so the same eval tooling can run against [OrcaRouter](https://www.orcarouter.ai) without treating it as an anonymous custom base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

- `evals/shared/config.ts` — added `ORCAROUTER_CONFIG` mirroring `OPENROUTER_CONFIG` (base URL `https://api.orcarouter.ai/v1`, `ORCAROUTER_API_KEY`), and added the `ORCAROUTER_*` vars to the in-place env sanitizer.
- `evals/evaluation_utils.ts` — factored the OpenRouter task factory into `createProviderTask`, added `createOrcaRouterTask`, and made the Phoenix classifier evaluator accept a provider config (`createToolSelectionLLMEvaluator(tools, providerConfig)`).
- `evals/run_evaluation.ts` — added an `EVAL_PROVIDER=orcarouter` switch that routes model calls and the LLM evaluator through OrcaRouter; OpenRouter remains the default, so existing runs are unchanged.
- `evals/workflows/*` — the workflow judge's `LlmClient` now reads a `JUDGE_PROVIDER_CONFIG` (OrcaRouter by default, OpenRouter when `EVAL_PROVIDER=openrouter`); the env-var preflight accepts either gateway key.
- Docs (`evals/README.md`, `evals/workflows/README.md`) and unit tests (`tests/unit/evals.config.test.ts`) updated to cover the new provider.

## Notes for reviewers

- This only touches the `evals/` tooling and its tests — no changes to MCP server internals (`internals.js` exports, `_meta`, `structuredContent`, `clientInfo`, `?ui=`/`?payment=`), so no impact on `apify-mcp-server-internal`. The default provider behavior is unchanged (OpenRouter for `evals:run`, and for the workflow judge the default is now OrcaRouter with an explicit `EVAL_PROVIDER=openrouter` escape hatch).
- The CI workflow (`_evaluations.yaml`) was deliberately left out of this PR because wiring `ORCAROUTER_*` secrets there needs maintainer action — happy to add it in a follow-up if you want the OrcaRouter path exercised in CI.

## Proof it works

- L3 live test: ran `createOrcaRouterTask('deepseek/deepseek-v4-flash', tools)` against `https://api.orcarouter.ai/v1` with a real `ORCAROUTER_API_KEY`. It authenticated and returned a valid completion that selected the `search-actors` tool with a proper tool call.
- `pnpm run type-check`, `pnpm run lint` (0 warnings/errors), `pnpm run format:check`, `pnpm run test:unit` (1485 passed), and `pnpm run check:agents` all green.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
