### PR TITLE
fix: Use canonical Apify docs MCP URL in server card

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -241,7 +241,7 @@ export const STAGING_MCP_HOSTNAME = 'mcp-securitybyobscurity.apify.com';
 export const APIFY_FAVICON_URL = `${APIFY_STORE_URL}/favicon.ico`;
 export const APIFY_LOGO_URL = `${APIFY_STORE_URL}/apple-icon.png`;
 export const APIFY_MCP_URL = 'https://mcp.apify.com';
-export const APIFY_DOCS_MCP_URL = 'https://docs.apify.com/platform/integrations/mcp';
+export const APIFY_DOCS_MCP_URL = 'https://docs.apify.com/integrations/mcp';
 
 // Telemetry
 export const TELEMETRY_ENV = {

--- a/tests/unit/server_card.test.ts
+++ b/tests/unit/server_card.test.ts
@@ -125,7 +125,7 @@ describe('getServerCard()', () => {
         it('includes documentation URL', () => {
             const card = getServerCard();
 
-            expect(card.documentationUrl).toBe('https://docs.apify.com/platform/integrations/mcp');
+            expect(card.documentationUrl).toBe('https://docs.apify.com/integrations/mcp');
         });
     });
 


### PR DESCRIPTION
<!-- A PR that is hard to review is not ready for review. One concern per PR, clean diff (no debug logs, formatting noise, commented-out code). -->

<!-- AI agents: fill in Why, What changed, and Proof it works. Leave "Notes for reviewers" empty — it belongs to the human author. No file lists, no restating the diff, no praising the change. -->

<!-- Human author: an AI draft is a draft, not a description. Before requesting review: (1) self-review your own diff in the GitHub UI, (2) check every claim below against the diff and cut what you wouldn't say yourself, (3) write "Notes for reviewers" in your own words. -->

> **Outside contributors:** maintainers implement unassigned issues. Unless this is a documentation fix or a maintainer asked you to write it, close this and [open an issue](https://github.com/apify/apify-mcp-server/issues) instead. A reproduction is more useful than a patch. See [Before you write code](https://github.com/apify/apify-mcp-server/blob/master/CONTRIBUTING.md#before-you-write-code). Using AI? [Disclose it and show proof](https://github.com/apify/apify-mcp-server/blob/master/CONTRIBUTING.md#ai-assisted-contributions).

## Why
<!-- "Closes #123". No issue? Ad-hoc is the exception, not the default — one line on the problem and why the change is needed. Evidence beats adjectives: a measurement, a failing run, a probe result. -->

The server card advertised a URL that 301s, and registries and scanners read that field:

```
$ curl -s -o /dev/null -w '%{http_code} -> %{redirect_url}\n' https://docs.apify.com/platform/integrations/mcp
301 -> https://docs.apify.com/integrations/mcp
```

## What changed
<!-- For a small fix, "Before: … / Now: …" is enough. Don't list files — the diff shows that. Explain the approach only when it's non-obvious; otherwise it's noise. -->

Before: `APIFY_DOCS_MCP_URL` = `https://docs.apify.com/platform/integrations/mcp` (301).
Now: `https://docs.apify.com/integrations/mcp` (200).

Every `/platform/...` docs path redirects to its bare form, but this PR changes only the constant that ships in the server card. Prose links, test fixtures for the docs URL→`.md` transform, and the `docs.apify.com/platform` string that `search-apify-docs` uses as a classification heuristic are left alone — that last one needs checking against live search output first, and is not a link fix.

## Notes for reviewers (human-written)
<!-- Your own words — two sentences beat none. Where should review look hardest? What are you unsure about? If AI wrote parts you don't fully follow, say which — the reviewer must not be the first human to read them. Any impact on apify-mcp-server-internal (internals.js exports, _meta, structuredContent, clientInfo, ?ui=/?payment=)? -->

👨: When dealing with tests on web for the server card, I've noticed we have the "legacy" docs url here containing `/platform` which is 301 redirected to a url without the `/platform/` url segment.

old: `/platform/integrations/mcp`
new (canonical): `/integrations/mcp`

## Proof it works
<!-- Not "unit tests pass" — CI shows that. An end-to-end MCP probe (mcpc transcript), a screenshot, or a link to an Actor run on the Apify platform. "Works on my machine" / "the AI said it works" is not proof. -->

The card endpoint itself lives in `apify-mcp-server-internal`, so this is the built `dist` output that internal serves, plus the `serverInfo` clients see on `initialize`:

```
$ node -e "import('./dist/server_card.js').then(m => console.log(JSON.stringify(m.getServerCard()), JSON.stringify(m.getServerInfo())))"
{"websiteUrl":"https://docs.apify.com/integrations/mcp","documentationUrl":"https://docs.apify.com/integrations/mcp", …}
{"name":"apify-mcp-server", …,"websiteUrl":"https://docs.apify.com/integrations/mcp", …}
```

And the new URL resolves without a redirect:

```
$ curl -s -o /dev/null -w '%{http_code}\n' https://docs.apify.com/integrations/mcp
200
```

No mcpc transcript: mcpc is not installed in this environment and is not fetchable from the registry, so the probe above is the built artifact, not a live session.

Downstream: apify/apify-web#6578 bundles a fallback copy of this card and its drift test normalises the `/platform` prefix away, so both forms pass and this lands without breaking it.

---

AI-assisted (Claude Code). The curl and `node` output above was run locally, unedited.
