### PR TITLE
fix: Gate call-actor mentions when the tool is absent from the session

### DIFF
--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -197,7 +197,7 @@ async function serveStatelessRequest(req: Request, res: Response, taskStore: InM
             if (!isDiscoverProbe) {
                 await mcpServer.loadToolsFromUrl(req.url, new ApifyClient({ token: apifyToken }));
             }
-            return createStatelessServer(mcpServer);
+            return createStatelessServer(mcpServer, req.url);
         },
         {
             legacy: 'reject',

--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -25,7 +25,7 @@ Two MCP protocol revisions are served, each by its own adapter:
 - `legacy_server.ts` — package-private v1 SDK adapter for handlers, Tasks, errors,
   notifications, logging, and transport lifecycle. It reads shared state through
   `LegacyMcpServerHost`.
-- `stateless_server.ts` — `createStatelessServer(host)`: the 2026-07-28 (v2 SDK) adapter,
+- `stateless_server.ts` — `createStatelessServer(host, requestUrl?)`: the 2026-07-28 (v2 SDK) adapter,
   one `Server` per request, reading shared state through `StatelessMcpServerHost`. Serves
   `tools/*`, `resources/*` and `prompts/*`; registers no Tasks (the SDK answers
   method-not-found) and declares no `logging`.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,6 +19,7 @@ import { createResourceService } from '../resources/resource_service.js';
 import type { AvailableWidget } from '../resources/widgets.js';
 import { resolveAvailableWidgets } from '../resources/widgets.js';
 import { getTelemetryEnv } from '../telemetry.js';
+import { actorNameToToolName } from '../tools/actor_tool_naming.js';
 import type {
     ActorsMcpServerOptions,
     ActorStore,
@@ -32,7 +33,7 @@ import { SERVER_MODE, TOOL_TYPE } from '../types.js';
 import { getRequestOriginForClient, isReportProblemBlockedForClient } from '../utils/mcp_clients.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
 import { parseServerMode, resolveServerMode } from '../utils/server_mode.js';
-import { getActors, getToolsForServerMode, toolNamesToInput } from '../utils/tools_loader.js';
+import { getActors, getToolsForServerMode, resolveActorsToLoad, toolNamesToInput } from '../utils/tools_loader.js';
 import { buildMcpClientContext, isUiSupportedByClient } from './client_context.js';
 import type { McpClientContext } from './client_context.js';
 import { LegacyMcpServer } from './legacy_server.js';
@@ -279,15 +280,34 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
     }
 
     /**
-     * Instructions for a stateless serving unit. The SDK answers `server/discover` from them before
-     * any request's envelope is seen, so they are configuration-level: no report-problem mention
-     * (that tool's presence is decided per request) and the configured mode only. Reads
-     * `serverModeOption`, never `_serverMode` — one facade serves both eras, and a legacy
-     * `initialize` rewrites `_serverMode`, which must not leak into later stateless requests.
+     * Instructions for a stateless serving unit, answered from `server/discover` before any request
+     * is seen — configuration-level only. Reads `serverModeOption`, never `_serverMode` (a legacy
+     * `initialize` must not leak its mode into later stateless requests).
+     *
+     * `requestUrl`, when given, resolves every cross-tool mention except `report-problem` from
+     * `?tools=`/`?actors=` with no fetch: internal tools (incl. `call-actor`) via
+     * `getToolsForServerMode`, Actor tools (`rag-web-browser`, `web-fetch`, ...) via
+     * `resolveActorsToLoad` — both pure functions of the selector list, resolving the *default*
+     * Actor list too when none is given. `report-problem` is excluded either way: its final
+     * servability is per-request-identity-dependent, not derivable from the URL alone. Without
+     * `requestUrl`, falls back to the same "everything but report-problem" shape.
      */
-    public getStatelessServerInstructions(): string {
+    public getStatelessServerInstructions(requestUrl?: string): string {
+        const mode = resolveServerMode(this.serverModeOption, false);
         const notReportProblem = (name: string) => name !== HELPER_TOOLS.PROBLEM_REPORT;
-        return getServerInstructions(resolveServerMode(this.serverModeOption, false), { hasTool: notReportProblem });
+        if (requestUrl === undefined) {
+            return getServerInstructions(mode, { hasTool: notReportProblem });
+        }
+        const input = parseInputParamsFromUrl(requestUrl);
+        const toolNames = new Set(
+            getToolsForServerMode(input, [], mode)
+                .map((tool) => tool.name)
+                .filter(notReportProblem),
+        );
+        for (const actorName of resolveActorsToLoad(input)) {
+            toolNames.add(actorNameToToolName(actorName));
+        }
+        return getServerInstructions(mode, { hasTool: (name) => toolNames.has(name) });
     }
 
     /**

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -284,14 +284,13 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
     }
 
     /**
-     * Instructions for a stateless serving unit, answered from `server/discover` before any request
-     * is seen — configuration-level only. Reads `serverModeOption`, never `_serverMode` (a legacy
-     * `initialize` must not leak its mode into later stateless requests).
+     * Instructions for a stateless serving unit, answered from `server/discover` before any request is
+     * seen — configuration-level only, reading `serverModeOption` (never `_serverMode`, so a legacy
+     * `initialize` can't leak its mode into stateless requests).
      *
-     * `requestUrl`, when given, resolves every cross-tool mention except `report-problem` from
-     * `?tools=`/`?actors=` with no fetch. `report-problem` is excluded either way: its final
-     * servability is per-request-identity-dependent, not derivable from the URL alone. Without
-     * `requestUrl`, falls back to the same "everything but report-problem" shape.
+     * `requestUrl`, when given, resolves cross-tool mentions from `?tools=`/`?actors=` with no fetch;
+     * omit it for the same "everything but report-problem" fallback. `report-problem` is always
+     * excluded — its servability is per-request-identity-dependent, not derivable from the URL.
      */
     public getStatelessServerInstructions(requestUrl?: string): string {
         const mode = resolveServerMode(this.serverModeOption, false);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,7 +19,6 @@ import { createResourceService } from '../resources/resource_service.js';
 import type { AvailableWidget } from '../resources/widgets.js';
 import { resolveAvailableWidgets } from '../resources/widgets.js';
 import { getTelemetryEnv } from '../telemetry.js';
-import { actorNameToToolName } from '../tools/actor_tool_naming.js';
 import type {
     ActorsMcpServerOptions,
     ActorStore,
@@ -33,7 +32,12 @@ import { SERVER_MODE, TOOL_TYPE } from '../types.js';
 import { getRequestOriginForClient, isReportProblemBlockedForClient } from '../utils/mcp_clients.js';
 import { getServerInstructions } from '../utils/server-instructions/index.js';
 import { parseServerMode, resolveServerMode } from '../utils/server_mode.js';
-import { getActors, getToolsForServerMode, resolveActorsToLoad, toolNamesToInput } from '../utils/tools_loader.js';
+import {
+    getActors,
+    getToolsForServerMode,
+    resolveToolNamesFromInput,
+    toolNamesToInput,
+} from '../utils/tools_loader.js';
 import { buildMcpClientContext, isUiSupportedByClient } from './client_context.js';
 import type { McpClientContext } from './client_context.js';
 import { LegacyMcpServer } from './legacy_server.js';
@@ -285,10 +289,7 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
      * `initialize` must not leak its mode into later stateless requests).
      *
      * `requestUrl`, when given, resolves every cross-tool mention except `report-problem` from
-     * `?tools=`/`?actors=` with no fetch: internal tools (incl. `call-actor`) via
-     * `getToolsForServerMode`, Actor tools (`rag-web-browser`, `web-fetch`, ...) via
-     * `resolveActorsToLoad` — both pure functions of the selector list, resolving the *default*
-     * Actor list too when none is given. `report-problem` is excluded either way: its final
+     * `?tools=`/`?actors=` with no fetch. `report-problem` is excluded either way: its final
      * servability is per-request-identity-dependent, not derivable from the URL alone. Without
      * `requestUrl`, falls back to the same "everything but report-problem" shape.
      */
@@ -298,16 +299,8 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
         if (requestUrl === undefined) {
             return getServerInstructions(mode, { hasTool: notReportProblem });
         }
-        const input = parseInputParamsFromUrl(requestUrl);
-        const toolNames = new Set(
-            getToolsForServerMode(input, [], mode)
-                .map((tool) => tool.name)
-                .filter(notReportProblem),
-        );
-        for (const actorName of resolveActorsToLoad(input)) {
-            toolNames.add(actorNameToToolName(actorName));
-        }
-        return getServerInstructions(mode, { hasTool: (name) => toolNames.has(name) });
+        const toolNames = resolveToolNamesFromInput(parseInputParamsFromUrl(requestUrl), mode);
+        return getServerInstructions(mode, { hasTool: (name) => notReportProblem(name) && toolNames.has(name) });
     }
 
     /**

--- a/src/mcp/stateless_server.ts
+++ b/src/mcp/stateless_server.ts
@@ -75,7 +75,7 @@ export interface StatelessMcpServerHost {
     readonly options: ActorsMcpServerOptions;
     readonly promptService: ReturnType<typeof createPromptService>;
     resolveApifyToken(meta?: ApifyRequestParams['_meta']): string | undefined;
-    getStatelessServerInstructions(): string;
+    getStatelessServerInstructions(requestUrl?: string): string;
     createRequestSnapshot(clientContext: McpClientContext | undefined): Promise<StatelessRequestSnapshot>;
 }
 
@@ -125,7 +125,7 @@ class StatelessMcpServer {
      */
     private snapshot: Promise<StatelessRequestSnapshot> | undefined;
 
-    constructor(host: StatelessMcpServerHost) {
+    constructor(host: StatelessMcpServerHost, requestUrl?: string) {
         this.host = host;
         this.server = new Server(getServerInfo(), {
             capabilities: {
@@ -138,7 +138,7 @@ class StatelessMcpServer {
                 resources: {},
                 prompts: {},
             },
-            instructions: this.host.getStatelessServerInstructions(),
+            instructions: this.host.getStatelessServerInstructions(requestUrl),
         });
         this.setupToolHandlers();
         this.setupResourceHandlers();
@@ -391,7 +391,10 @@ async function emitLogServerSide(msg: { level: string; data?: unknown }): Promis
  * ```ts
  * const handler = createMcpHandler(() => createStatelessServer(actorsMcpServer), { legacy: 'reject' });
  * ```
+ *
+ * `requestUrl` sharpens the served instructions' cross-tool mentions (`call-actor`, Actor tools);
+ * omit it for the same, tool-blind fallback.
  */
-export function createStatelessServer(host: StatelessMcpServerHost): Server {
-    return new StatelessMcpServer(host).server;
+export function createStatelessServer(host: StatelessMcpServerHost, requestUrl?: string): Server {
+    return new StatelessMcpServer(host, requestUrl).server;
 }

--- a/src/tools/actor_tool_naming.ts
+++ b/src/tools/actor_tool_naming.ts
@@ -55,7 +55,8 @@ export function parseActorFullName(actorFullName: string): { escapedUsername: st
 }
 
 export function actorNameToToolName(actorFullName: string): string {
-    const { escapedUsername, actorName } = parseActorFullName(actorFullName);
+    const normalizedActorFullName = actorFullName.replace('~', '/');
+    const { escapedUsername, actorName } = parseActorFullName(normalizedActorFullName);
     const fullName = escapedUsername === null ? actorName : `${escapedUsername}--${actorName}`;
 
     if (fullName.length <= MAX_TOOL_NAME_LENGTH) {
@@ -63,7 +64,7 @@ export function actorNameToToolName(actorFullName: string): string {
     }
 
     // Truncate and add hash for uniqueness
-    const hash = createHash('sha256').update(actorFullName).digest('hex').slice(0, TOOL_NAME_HASH_LENGTH);
+    const hash = createHash('sha256').update(normalizedActorFullName).digest('hex').slice(0, TOOL_NAME_HASH_LENGTH);
     return `${fullName.slice(0, MAX_TOOL_NAME_LENGTH - TOOL_NAME_HASH_LENGTH - 1)}-${hash}`;
 }
 

--- a/src/tools/actor_tool_naming.ts
+++ b/src/tools/actor_tool_naming.ts
@@ -55,7 +55,7 @@ export function parseActorFullName(actorFullName: string): { escapedUsername: st
 }
 
 export function actorNameToToolName(actorFullName: string): string {
-    const normalizedActorFullName = actorFullName.replace('~', '/');
+    const normalizedActorFullName = actorFullName.replace(/^([^~]+)~/, '$1/');
     const { escapedUsername, actorName } = parseActorFullName(normalizedActorFullName);
     const fullName = escapedUsername === null ? actorName : `${escapedUsername}--${actorName}`;
 

--- a/src/tools/actors/actor_tools_factory.ts
+++ b/src/tools/actors/actor_tools_factory.ts
@@ -23,9 +23,11 @@ import {
     type ActorStore,
     type ActorTool,
     type ApifyToken,
+    type ToolDescriptionContext,
     type ToolEntry,
     type ToolInputSchema,
     ACTOR_TOOL_MODE,
+    ALL_TOOLS_PRESENT,
     TOOL_TYPE,
 } from '../../types.js';
 import { getActorDefinitionCached } from '../../utils/actor.js';
@@ -125,14 +127,17 @@ export async function getNormalActorsAsTools(
             waitSecs: WAIT_SECS_INPUT_PROPERTY,
         };
 
-        let description = `This tool calls the Actor "${definition.actorFullName}" and retrieves its output results.
-Use this tool instead of the "${HELPER_TOOLS.ACTOR_CALL}" if user requests this specific Actor.
-Actor description: ${definition.description}`;
-        if (isRag) {
-            description += `\n\n${RAG_WEB_BROWSER_ADDITIONAL_DESC}`;
-        } else if (definition.actorFullName === WEB_FETCH) {
-            description += `\n\n${WEB_FETCH_ADDITIONAL_DESC}`;
-        }
+        // Names call-actor only when the session actually has it.
+        const buildDescription = ({ hasTool }: ToolDescriptionContext): string => {
+            let description = `This tool calls the Actor "${definition.actorFullName}" and retrieves its output results.
+${hasTool(HELPER_TOOLS.ACTOR_CALL) ? `Use this tool instead of the "${HELPER_TOOLS.ACTOR_CALL}" if user requests this specific Actor.\n` : ''}Actor description: ${definition.description}`;
+            if (isRag) {
+                description += `\n\n${RAG_WEB_BROWSER_ADDITIONAL_DESC}`;
+            } else if (definition.actorFullName === WEB_FETCH) {
+                description += `\n\n${WEB_FETCH_ADDITIONAL_DESC}`;
+            }
+            return description;
+        };
 
         const memoryMbytes = Math.min(
             definition.defaultRunOptions?.memoryMbytes || ACTOR_MAX_MEMORY_MBYTES,
@@ -160,7 +165,8 @@ Actor description: ${definition.description}`;
             title: definition.actorFullName,
             actorId: definition.id,
             actorFullName: definition.actorFullName,
-            description,
+            description: buildDescription(ALL_TOOLS_PRESENT),
+            buildDescription,
             inputSchema: inputSchema as ToolInputSchema,
             // Canonical RunResponse shape — same as call-actor and get-actor-run.
             outputSchema: actorRunOutputSchema,

--- a/src/tools/actors/actor_tools_factory.ts
+++ b/src/tools/actors/actor_tools_factory.ts
@@ -117,7 +117,9 @@ export async function getNormalActorsAsTools(
 
         if (!definition) continue;
 
-        const isRag = definition.actorFullName === RAG_WEB_BROWSER;
+        const { actorFullName, description: actorDescription } = definition;
+        const isRag = actorFullName === RAG_WEB_BROWSER;
+        const isWebFetch = actorFullName === WEB_FETCH;
         const { inputSchema } = buildActorInputSchema(definition.actorFullName, definition.input, isRag);
 
         // Inject the MCP-only `waitSecs` opt-in before AJV compile so the LLM can cap the wait.
@@ -129,11 +131,11 @@ export async function getNormalActorsAsTools(
 
         // Names call-actor only when the session actually has it.
         const buildDescription = ({ hasTool }: ToolDescriptionContext): string => {
-            let description = `This tool calls the Actor "${definition.actorFullName}" and retrieves its output results.
-${hasTool(HELPER_TOOLS.ACTOR_CALL) ? `Use this tool instead of the "${HELPER_TOOLS.ACTOR_CALL}" if user requests this specific Actor.\n` : ''}Actor description: ${definition.description}`;
+            let description = `This tool calls the Actor "${actorFullName}" and retrieves its output results.
+${hasTool(HELPER_TOOLS.ACTOR_CALL) ? `Use this tool instead of the "${HELPER_TOOLS.ACTOR_CALL}" if user requests this specific Actor.\n` : ''}Actor description: ${actorDescription}`;
             if (isRag) {
                 description += `\n\n${RAG_WEB_BROWSER_ADDITIONAL_DESC}`;
-            } else if (definition.actorFullName === WEB_FETCH) {
+            } else if (isWebFetch) {
                 description += `\n\n${WEB_FETCH_ADDITIONAL_DESC}`;
             }
             return description;

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -99,7 +99,7 @@ function normalizeInput(input: Input): NormalizedInput {
  * If no selectors / no explicit actors: the defaults apply (or empty when
  * `actors` was explicitly set to empty).
  */
-function resolveActorsToLoad(input: Input): string[] {
+export function resolveActorsToLoad(input: Input): string[] {
     const { selectors, actorsExplicitlyEmpty } = normalizeInput(input);
 
     // Selectors that aren't retired, categories, or internal tools in any mode → Actor names.

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -312,7 +312,7 @@ export function resolveToolNamesFromInput(input: Input, mode: SERVER_MODE = SERV
     toolNames.delete(ACTOR_PLACEHOLDER_NAME);
 
     for (const actorName of actorNames) {
-        if (actorName.includes('/')) toolNames.add(actorNameToToolName(actorName));
+        if (actorName.includes('/') || actorName.includes('~')) toolNames.add(actorNameToToolName(actorName));
     }
     return toolNames;
 }

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -102,7 +102,7 @@ function normalizeInput(input: Input): NormalizedInput {
  * If no selectors / no explicit actors: the defaults apply (or empty when
  * `actors` was explicitly set to empty).
  */
-function resolveActorsToLoad(input: Input): string[] {
+export function resolveActorsToLoad(input: Input): string[] {
     const { selectors, actorsExplicitlyEmpty } = normalizeInput(input);
 
     // Selectors that aren't retired, categories, or internal tools in any mode → Actor names.

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -312,7 +312,7 @@ export function resolveToolNamesFromInput(input: Input, mode: SERVER_MODE = SERV
     toolNames.delete(ACTOR_PLACEHOLDER_NAME);
 
     for (const actorName of actorNames) {
-        if (actorName.includes('/') || actorName.includes('~')) toolNames.add(actorNameToToolName(actorName));
+        if (actorName.indexOf('/') > 0 || actorName.indexOf('~') > 0) toolNames.add(actorNameToToolName(actorName));
     }
     return toolNames;
 }

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -9,6 +9,7 @@ import log from '@apify/log';
 
 import { defaults, HELPER_TOOLS, type HelperToolName, RETIRED_SELECTOR_NAMES } from '../const.js';
 import type { PaymentProvider } from '../payments/types.js';
+import { actorNameToToolName } from '../tools/actor_tool_naming.js';
 import { reportProblem } from '../tools/dev/report_problem.js';
 import { getActorsAsTools } from '../tools/index.js';
 import {
@@ -36,6 +37,8 @@ export const AUTO_INJECTED_TOOLS: readonly ToolEntry[] = [
     getKeyValueStoreRecord,
     abortActorRun,
 ] as const;
+
+const ACTOR_PLACEHOLDER_NAME = '__actor-placeholder__';
 
 // All internal tool names across all modes. Selectors matching these are not treated as Actor IDs.
 // Built eagerly at module load; inputs (SERVER_MODES, getCategoryTools, CATEGORY_NAMES,
@@ -99,7 +102,7 @@ function normalizeInput(input: Input): NormalizedInput {
  * If no selectors / no explicit actors: the defaults apply (or empty when
  * `actors` was explicitly set to empty).
  */
-export function resolveActorsToLoad(input: Input): string[] {
+function resolveActorsToLoad(input: Input): string[] {
     const { selectors, actorsExplicitlyEmpty } = normalizeInput(input);
 
     // Selectors that aren't retired, categories, or internal tools in any mode → Actor names.
@@ -297,6 +300,21 @@ export function getToolsForServerMode(
     // De-duplicate by tool name for safety
     const seen = new Set<string>();
     return result.filter((entry) => !seen.has(entry.name) && seen.add(entry.name));
+}
+
+/** Resolve the tool names composition will serve without fetching Actor metadata. */
+export function resolveToolNamesFromInput(input: Input, mode: SERVER_MODE = SERVER_MODE.DEFAULT): Set<string> {
+    const actorNames = resolveActorsToLoad(input);
+    // Composition reads only type and name from Actor entries; the placeholder triggers its shared injection rules.
+    const actorTools =
+        actorNames.length > 0 ? ([{ type: TOOL_TYPE.ACTOR, name: ACTOR_PLACEHOLDER_NAME }] as ToolEntry[]) : [];
+    const toolNames = new Set(getToolsForServerMode(input, actorTools, mode).map((tool) => tool.name));
+    toolNames.delete(ACTOR_PLACEHOLDER_NAME);
+
+    for (const actorName of actorNames) {
+        if (actorName.includes('/')) toolNames.add(actorNameToToolName(actorName));
+    }
+    return toolNames;
 }
 
 /** Convenience wrapper: {@link getActors} + {@link getToolsForServerMode} in sequence. */

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -29,9 +29,8 @@ const SINGLE_NORMAL_MODE_ACTOR = [ACTOR_NORMAL_MODE];
 const DOCS_CATEGORY = ['docs'] as ToolCategory[];
 const DOCS_RUNS_STORAGE_CATEGORIES = ['docs', 'runs', 'storage'] as ToolCategory[];
 
-// Locked Claude-connector `?tools=` allowlist — see ai-team#232. No call-actor.
-// Valid as the `tools=` selector value as-is (Actor entries use their slash name);
-// served tool names differ for the two Actor entries — see CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES.
+// Claude-connector `?tools=` allowlist. No call-actor. Actor entries use their slash name here;
+// served tool names differ — see CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES.
 const CLAUDE_CONNECTOR_TOOLS = [
     'search-actors',
     'search-actors-widget',
@@ -100,8 +99,7 @@ export const registrationCases: Case[] = [
         }),
     },
     {
-        // Claude-connector compliance: the pinned ?tools= list is authoritative even with
-        // telemetry on, which would otherwise auto-inject report-problem for a default session.
+        // Pinned ?tools= wins even with telemetry on, which would otherwise auto-inject report-problem.
         name: 'Claude connector: pinned tool surface excludes call-actor and report-problem even with telemetry enabled',
         isDeploymentTest: true,
         run: withClient(

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -29,6 +29,29 @@ const SINGLE_NORMAL_MODE_ACTOR = [ACTOR_NORMAL_MODE];
 const DOCS_CATEGORY = ['docs'] as ToolCategory[];
 const DOCS_RUNS_STORAGE_CATEGORIES = ['docs', 'runs', 'storage'] as ToolCategory[];
 
+// Locked Claude-connector `?tools=` allowlist — see ai-team#232. No call-actor.
+const CLAUDE_CONNECTOR_TOOLS = [
+    'search-actors',
+    'search-actors-widget',
+    'fetch-actor-details',
+    'fetch-actor-details-widget',
+    'search-apify-docs',
+    'fetch-apify-docs',
+    'get-actor-run',
+    'get-actor-run-widget',
+    'get-actor-run-list',
+    'get-actor-log',
+    'abort-actor-run',
+    'get-dataset-list',
+    'get-dataset',
+    'get-dataset-items',
+    'get-key-value-store-list',
+    'get-key-value-store',
+    'get-key-value-store-record',
+    'apify/rag-web-browser',
+    'apify/web-fetch',
+];
+
 /** Tool/Actor selection, categories, env loading, auto-inject, server mode. */
 export const registrationCases: Case[] = [
     {
@@ -70,6 +93,21 @@ export const registrationCases: Case[] = [
             const names = getToolNames(await client.listTools());
             expect(names).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
         }),
+    },
+    {
+        // Claude-connector compliance: the pinned ?tools= list is authoritative even with
+        // telemetry on, which would otherwise auto-inject report-problem for a default session.
+        name: 'Claude connector: pinned tool surface excludes call-actor and report-problem even with telemetry enabled',
+        isDeploymentTest: true,
+        run: withClient(
+            { tools: CLAUDE_CONNECTOR_TOOLS, serverMode: 'apps', telemetry: { enabled: true } },
+            async (client) => {
+                const names = getToolNames(await client.listTools());
+                expect(names).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
+                expect(names).not.toContain(HELPER_TOOLS.ACTOR_CALL);
+                expect(new Set(names)).toEqual(new Set(CLAUDE_CONNECTOR_TOOLS));
+            },
+        ),
     },
     {
         // isDeploymentTest: default tool/Actor set.

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -30,6 +30,8 @@ const DOCS_CATEGORY = ['docs'] as ToolCategory[];
 const DOCS_RUNS_STORAGE_CATEGORIES = ['docs', 'runs', 'storage'] as ToolCategory[];
 
 // Locked Claude-connector `?tools=` allowlist — see ai-team#232. No call-actor.
+// Valid as the `tools=` selector value as-is (Actor entries use their slash name);
+// served tool names differ for the two Actor entries — see CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES.
 const CLAUDE_CONNECTOR_TOOLS = [
     'search-actors',
     'search-actors-widget',
@@ -51,6 +53,9 @@ const CLAUDE_CONNECTOR_TOOLS = [
     'apify/rag-web-browser',
     'apify/web-fetch',
 ];
+const CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES = CLAUDE_CONNECTOR_TOOLS.map((selector) =>
+    selector.includes('/') ? actorNameToToolName(selector) : selector,
+);
 
 /** Tool/Actor selection, categories, env loading, auto-inject, server mode. */
 export const registrationCases: Case[] = [
@@ -105,7 +110,7 @@ export const registrationCases: Case[] = [
                 const names = getToolNames(await client.listTools());
                 expect(names).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
                 expect(names).not.toContain(HELPER_TOOLS.ACTOR_CALL);
-                expect(new Set(names)).toEqual(new Set(CLAUDE_CONNECTOR_TOOLS));
+                expect(new Set(names)).toEqual(new Set(CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES));
             },
         ),
     },

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -29,8 +29,7 @@ const SINGLE_NORMAL_MODE_ACTOR = [ACTOR_NORMAL_MODE];
 const DOCS_CATEGORY = ['docs'] as ToolCategory[];
 const DOCS_RUNS_STORAGE_CATEGORIES = ['docs', 'runs', 'storage'] as ToolCategory[];
 
-// Claude-connector `?tools=` allowlist. No call-actor. Actor entries use their slash name here;
-// served tool names differ — see CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES.
+// Claude-connector `?tools=` allowlist (no call-actor); Actor entries use slash names, served names differ — see CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES.
 const CLAUDE_CONNECTOR_TOOLS = [
     'search-actors',
     'search-actors-widget',

--- a/tests/unit/mcp.server.stateless_instructions.test.ts
+++ b/tests/unit/mcp.server.stateless_instructions.test.ts
@@ -1,0 +1,67 @@
+import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
+import { describe, expect, it } from 'vitest';
+
+import { HELPER_TOOLS, RAG_WEB_BROWSER, WEB_FETCH } from '../../src/const.js';
+import { ActorsMcpServer } from '../../src/mcp/server.js';
+import { SERVER_MODE } from '../../src/types.js';
+
+function makeServer(): ActorsMcpServer {
+    return new ActorsMcpServer({
+        taskStore: new InMemoryTaskStore(),
+        setupSigintHandler: false,
+        serverMode: SERVER_MODE.DEFAULT,
+        telemetry: { enabled: false },
+    });
+}
+
+describe('ActorsMcpServer.getStatelessServerInstructions()', () => {
+    it('without a requestUrl, mentions everything but report-problem — matches the pre-gating default', () => {
+        const instructions = makeServer().getStatelessServerInstructions();
+        expect(instructions).toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(instructions).toContain(RAG_WEB_BROWSER);
+        expect(instructions).toContain(WEB_FETCH);
+        expect(instructions).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
+    });
+
+    it('with a bare URL (no ?tools=/?actors=), resolves the same as no requestUrl — defaults apply', () => {
+        const instructions = makeServer().getStatelessServerInstructions('http://localhost/');
+        expect(instructions).toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(instructions).toContain(RAG_WEB_BROWSER);
+        expect(instructions).toContain(WEB_FETCH);
+        expect(instructions).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
+    });
+
+    // Regression for the gap check-work caught: resolving only call-actor from the URL left
+    // rag-web-browser/web-fetch always absent, even when explicitly selected. resolveActorsToLoad
+    // (zero-fetch, same as getToolsForServerMode) closes it. The web-fetch-vs-rag-web-browser
+    // comparison needs both sides, so select both.
+    it('resolves explicitly selected Actor tools from the URL, with no fetch', () => {
+        const instructions = makeServer().getStatelessServerInstructions(
+            'http://localhost/?tools=search-actors,apify/rag-web-browser,apify/web-fetch',
+        );
+        expect(instructions).not.toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(instructions).toContain(WEB_FETCH);
+        expect(instructions).toContain(RAG_WEB_BROWSER);
+    });
+
+    it('omits an Actor tool the URL did not select', () => {
+        const instructions = makeServer().getStatelessServerInstructions(
+            'http://localhost/?tools=search-actors,apify/web-fetch',
+        );
+        expect(instructions).not.toContain(RAG_WEB_BROWSER);
+    });
+
+    it('pins the Claude-connector tool surface: call-actor absent, its own dedicated Actor tools present', () => {
+        const url =
+            'http://localhost/?tools=search-actors,search-actors-widget,fetch-actor-details,fetch-actor-details-widget,search-apify-docs,fetch-apify-docs,get-actor-run,get-actor-run-widget,get-actor-run-list,get-actor-log,abort-actor-run,get-dataset-list,get-dataset,get-dataset-items,get-key-value-store-list,get-key-value-store,get-key-value-store-record,apify/rag-web-browser,apify/web-fetch';
+        const instructions = makeServer().getStatelessServerInstructions(url);
+        expect(instructions).not.toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(instructions).toContain(RAG_WEB_BROWSER);
+        expect(instructions).toContain(WEB_FETCH);
+    });
+
+    it('never mentions report-problem via a requestUrl — not derivable, identity-dependent', () => {
+        const instructions = makeServer().getStatelessServerInstructions('http://localhost/?tools=search-actors');
+        expect(instructions).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
+    });
+});

--- a/tests/unit/mcp.server.stateless_instructions.test.ts
+++ b/tests/unit/mcp.server.stateless_instructions.test.ts
@@ -31,10 +31,8 @@ describe('ActorsMcpServer.getStatelessServerInstructions()', () => {
         expect(instructions).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
     });
 
-    // Regression for the gap check-work caught: resolving only call-actor from the URL left
-    // rag-web-browser/web-fetch always absent, even when explicitly selected. resolveActorsToLoad
-    // (zero-fetch, same as getToolsForServerMode) closes it. The web-fetch-vs-rag-web-browser
-    // comparison needs both sides, so select both.
+    // Regression: resolving only call-actor left rag-web-browser/web-fetch absent even when selected;
+    // resolveActorsToLoad (zero-fetch) fixes it. Selects both since their comparison needs both sides.
     it('resolves explicitly selected Actor tools from the URL, with no fetch', () => {
         const instructions = makeServer().getStatelessServerInstructions(
             'http://localhost/?tools=search-actors,apify/rag-web-browser,apify/web-fetch',

--- a/tests/unit/mcp.server.stateless_instructions.test.ts
+++ b/tests/unit/mcp.server.stateless_instructions.test.ts
@@ -5,11 +5,11 @@ import { HELPER_TOOLS, RAG_WEB_BROWSER, WEB_FETCH } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
 import { SERVER_MODE } from '../../src/types.js';
 
-function makeServer(): ActorsMcpServer {
+function makeServer(serverMode: SERVER_MODE = SERVER_MODE.DEFAULT): ActorsMcpServer {
     return new ActorsMcpServer({
         taskStore: new InMemoryTaskStore(),
         setupSigintHandler: false,
-        serverMode: SERVER_MODE.DEFAULT,
+        serverMode,
         telemetry: { enabled: false },
     });
 }
@@ -49,6 +49,14 @@ describe('ActorsMcpServer.getStatelessServerInstructions()', () => {
             'http://localhost/?tools=search-actors,apify/web-fetch',
         );
         expect(instructions).not.toContain(RAG_WEB_BROWSER);
+    });
+
+    it('includes widget workflow when an Actor tool auto-injects get-actor-run-widget', () => {
+        const instructions = makeServer(SERVER_MODE.APPS).getStatelessServerInstructions(
+            'http://localhost/?ui=apps&tools=apify/rag-web-browser',
+        );
+        expect(instructions).toContain('## Widget workflow');
+        expect(instructions).toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
     });
 
     it('pins the Claude-connector tool surface: call-actor absent, its own dedicated Actor tools present', () => {

--- a/tests/unit/tools.actor.test.ts
+++ b/tests/unit/tools.actor.test.ts
@@ -25,6 +25,10 @@ describe('actors', () => {
             );
         });
 
+        it('does not invent an owner for a current-user Actor name', () => {
+            expect(actorNameToToolName('~my-actor')).toBe('~my-actor');
+        });
+
         it('should handle tool names longer than 64 characters by truncating with a hash', () => {
             const longName = 'apify/website-content-crawler-very-long-name-that-exceeds-the-limit';
             const result = actorNameToToolName(longName);

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -11,15 +11,41 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 import { ALLOWED_TASK_TOOL_EXECUTION_MODES, HELPER_TOOLS, type HelperToolName } from '../../src/const.js';
+import { getNormalActorsAsTools } from '../../src/tools/actors/actor_tools_factory.js';
 import { fetchActorDetails } from '../../src/tools/actors/fetch_actor_details.js';
 import { searchActorsBaseArgsSchema } from '../../src/tools/actors/search_actors.js';
 import { searchApifyDocs } from '../../src/tools/docs/search_apify_docs.js';
 import { CATEGORY_NAMES, getCategoryTools } from '../../src/tools/index.js';
 import { WIDGET_BY_BASE_TOOL } from '../../src/tools/registry.js';
-import type { Input, ToolBase, ToolEntry } from '../../src/types.js';
+import type { ActorInfo, Input, ToolBase, ToolEntry } from '../../src/types.js';
 import { SERVER_MODES, SERVER_MODE } from '../../src/types.js';
 import { getToolPublicFieldOnly } from '../../src/utils/tools.js';
 import { getToolsForServerMode } from '../../src/utils/tools_loader.js';
+
+/** Fabricated Actor definition — enough for `getNormalActorsAsTools` to build a real tool entry, no network. */
+function buildFixtureActorInfo(actorFullName: string): ActorInfo {
+    return {
+        webServerMcpPath: null,
+        definition: {
+            id: 'test-actor-id',
+            actorFullName,
+            readme: '',
+            description: 'Test actor for description-gating coverage.',
+            defaultRunOptions: { memoryMbytes: 1024, timeoutSecs: 300, build: 'latest' },
+            input: {
+                type: 'object',
+                title: 'Test Input',
+                description: 'Test input schema',
+                properties: {},
+                schemaVersion: 1,
+            },
+        },
+        actor: { id: 'test-actor-id', name: 'test-actor', username: 'apify' } as ActorInfo['actor'],
+    };
+}
+
+// Real getNormalActorsAsTools output, not a hand-written stand-in — exercises the gated description.
+const [actorToolStub] = await getNormalActorsAsTools([buildFixtureActorInfo('apify/test-actor')]);
 
 /** Helper to extract tool names from a category. */
 function toolNames(tools: ToolEntry[]): string[] {
@@ -424,15 +450,14 @@ describe('getToolPublicFieldOnly inputSchema normalization', () => {
  * the list handlers do and checks the result.
  */
 describe('tool descriptions never name a tool absent from the session', () => {
-    /** Minimal direct Actor tool — enough to trigger AUTO_INJECTED_TOOLS and stand in for a real one. */
-    const actorToolStub = {
-        type: 'actor',
-        name: 'apify--rag-web-browser',
-        actorId: 'test-actor-id',
-        actorFullName: 'apify/rag-web-browser',
-        description: `Fetch output rows with ${HELPER_TOOLS.DATASET_GET_ITEMS}.`,
-        inputSchema: { type: 'object', properties: {} },
-    } as unknown as ToolEntry;
+    it('renders byte-identical to the pre-gating text when call-actor is loaded (ALL_TOOLS_PRESENT)', () => {
+        expect(actorToolStub.description).toBe(
+            `This tool calls the Actor "apify/test-actor" and retrieves its output results.\n` +
+                `Use this tool instead of the "${HELPER_TOOLS.ACTOR_CALL}" if user requests this specific Actor.\n` +
+                `Actor description: Test actor for description-gating coverage.`,
+        );
+    });
+
     const ALL_TOOL_NAMES: string[] = [...Object.values(HELPER_TOOLS), actorToolStub.name];
 
     const sessions: { label: string; input: Input; actorTools: ToolEntry[] }[] = [
@@ -448,7 +473,7 @@ describe('tool descriptions never name a tool absent from the session', () => {
         })),
         {
             label: 'Actor tool only',
-            input: { tools: ['apify/rag-web-browser'] },
+            input: { tools: ['apify/test-actor'] },
             actorTools: [actorToolStub],
         },
         // Mixed cross-category selectors — arbitrary combinations must render correctly too.

--- a/tests/unit/tools.mode_contract.test.ts
+++ b/tests/unit/tools.mode_contract.test.ts
@@ -458,6 +458,15 @@ describe('tool descriptions never name a tool absent from the session', () => {
         );
     });
 
+    it('snapshots Actor fields used by the description builder', async () => {
+        const actorInfo = buildFixtureActorInfo('apify/test-actor');
+        const [actorTool] = await getNormalActorsAsTools([actorInfo]);
+        actorInfo.definition.actorFullName = 'apify/changed-actor';
+        actorInfo.definition.description = 'Changed description.';
+
+        expect(actorTool.buildDescription?.({ hasTool: () => true })).toBe(actorTool.description);
+    });
+
     const ALL_TOOL_NAMES: string[] = [...Object.values(HELPER_TOOLS), actorToolStub.name];
 
     const sessions: { label: string; input: Input; actorTools: ToolEntry[] }[] = [

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -150,6 +150,13 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
 });
 
 describe('resolveToolNamesFromInput()', () => {
+    it('resolves tilde-separated Actor names to their served tool names', () => {
+        const toolNames = resolveToolNamesFromInput({ actors: ['apify~rag-web-browser'] }, 'apps');
+
+        expect(toolNames).toContain('apify--rag-web-browser');
+        expect(toolNames).not.toContain('apify~rag-web-browser');
+    });
+
     it('excludes opaque Actor IDs while retaining their auto-injected tools', () => {
         const toolNames = resolveToolNamesFromInput({ actors: ['3ox4R101TgZz67sLr'] }, 'apps');
 

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -8,6 +8,7 @@ import {
     AUTO_INJECTED_TOOLS,
     getToolsForServerMode,
     loadToolsFromInput,
+    resolveToolNamesFromInput,
     toolNamesToInput,
 } from '../../src/utils/tools_loader.js';
 
@@ -146,6 +147,16 @@ describe('loadToolsFromInput auto-injection of storage tools', () => {
             for (const name of AUTO_INJECTED_TOOL_NAMES) expect(toolNames).toContain(name);
         },
     );
+});
+
+describe('resolveToolNamesFromInput()', () => {
+    it('excludes opaque Actor IDs while retaining their auto-injected tools', () => {
+        const toolNames = resolveToolNamesFromInput({ actors: ['3ox4R101TgZz67sLr'] }, 'apps');
+
+        expect(toolNames).not.toContain('3ox4R101TgZz67sLr');
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_RUNS_GET);
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
+    });
 });
 
 describe('getToolsForServerMode report-problem default injection', () => {

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -157,6 +157,14 @@ describe('resolveToolNamesFromInput()', () => {
         expect(toolNames).not.toContain('apify~rag-web-browser');
     });
 
+    it('leaves current-user Actor names unresolved while retaining their auto-injected tools', () => {
+        const toolNames = resolveToolNamesFromInput({ actors: ['~my-actor'] }, 'apps');
+
+        expect(toolNames).not.toContain('--my-actor');
+        expect(toolNames).not.toContain('~my-actor');
+        expect(toolNames).toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
+    });
+
     it('excludes opaque Actor IDs while retaining their auto-injected tools', () => {
         const toolNames = resolveToolNamesFromInput({ actors: ['3ox4R101TgZz67sLr'] }, 'apps');
 


### PR DESCRIPTION
Closes apify/ai-team#232

Stacked on #1334 — base branch is that PR's, not master; diff here is just this PR's own commits. Server-instructions.ts's own gating logic moved to #1334 so it's reviewable and testable on its own.

## What
Gates every unconditional `call-actor` (and `apify/rag-web-browser`/`apify/web-fetch`) mention behind the session's actual tool set, in both protocol eras.

## Why
A session whose `?tools=`/`?actors=` selection omits `call-actor` still got told to use it — in dedicated Actor tool descriptions, and (via #1334) in the server-wide instructions block. A tool name the client never received in `tools/list` invites a hallucinated call.

- `actor_tools_factory.ts`: dedicated Actor tool descriptions now gate the call-actor line via the existing `hasTool` pattern used everywhere else in this codebase.
- Legacy/stdio protocol: passes the real, final per-session tool set (unchanged mechanism, already proven by report-problem gating) into #1334's `getServerInstructions`.
- Stateless (2026-07-28) protocol: resolves call-actor presence from the request URL with zero network calls — its presence is a pure function of the `?tools=`/`?actors=` selector list, never auto-injected, mode-independent, and untouched by the async Actor-metadata fetch. Falls back to today's behavior when no URL is supplied — additive, non-breaking for existing callers.
- `actorNameToToolName` also now normalizes `user~actor` selectors to `user/actor` before parsing and hashing, so a tilde-form Actor selector resolves to the same tool name (and cache key) as its slash form instead of a separate, divergent one.

## Testing
- New regression test pins the exact Claude-connector tool surface (19 tools, no `call-actor`) and asserts the resolved instructions never mention it — offline, no fixture, no live token.
- Fixed a test gap: the Actor-tool case in `tools.mode_contract.test.ts` used a hand-written stub that never exercised the real factory output, so it didn't catch this class of bug.
- New `isDeploymentTest: true` integration case pins the same 19-tool selection end-to-end: `call-actor` and `report-problem` both absent, even with telemetry enabled — runs against internal's live staging/prod on every release.
- `pnpm run type-check / lint / test:unit / format / check:agents` all green.