### PR TITLE
feat: Warn when a discovered Actor cannot be run in this session

### DIFF
--- a/src/mcp/tool_dispatch.ts
+++ b/src/mcp/tool_dispatch.ts
@@ -15,7 +15,7 @@ import { logHttpError } from '../utils/logging.js';
 import { respondErrorNoTelemetry } from '../utils/mcp.js';
 import type { createProgressTracker } from '../utils/progress.js';
 import { applyToolTelemetry, buildExecutionDiagnostics } from '../utils/tool_status.js';
-import { buildActorFields } from '../utils/tools.js';
+import { buildActorFields, extractActorId } from '../utils/tools.js';
 import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC } from './const.js';
 import type { RemoteMcpCallOutcome } from './remote_tool_call.js';
 import { withRemoteMcpClient } from './remote_tool_call.js';
@@ -108,6 +108,9 @@ export async function dispatchToolCall(params: {
                     actorStore,
                     paymentProvider,
                     loadedToolNames: Array.from(tools.keys()),
+                    loadedActorIds: new Set(
+                        Array.from(tools.values(), extractActorId).filter((id): id is string => id !== undefined),
+                    ),
                     progressTracker,
                     mcpSessionId,
                     taskMode,

--- a/src/tools/actor_tool_naming.ts
+++ b/src/tools/actor_tool_naming.ts
@@ -82,10 +82,7 @@ export function getToolSchemaID(actorName: string): string {
     return `https://apify.com/mcp/${actorNameToToolName(actorName)}/schema.json`;
 }
 
-/**
- * Whether this session can run this Actor: call-actor loaded, or the Actor's own tool loaded
- * (direct or Actor-MCP). Soft check for a guidance hint, not a hard gate.
- */
+/** Whether this session can run this Actor (call-actor, or the Actor's own tool, loaded); soft check for a guidance hint, not a hard gate. */
 export function canRunActor(
     actorId: string,
     loadedToolNames: readonly string[],

--- a/src/tools/actor_tool_naming.ts
+++ b/src/tools/actor_tool_naming.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 
 import log from '@apify/log';
 
+import { HELPER_TOOLS } from '../const.js';
 import { MAX_TOOL_NAME_LENGTH, TOOL_NAME_HASH_LENGTH } from '../mcp/const.js';
 import type { ActorInfo } from '../types.js';
 import { ACTOR_TOOL_MODE } from '../types.js';
@@ -79,4 +80,13 @@ export function legacyToolNameToNew(name: string): string | null {
 
 export function getToolSchemaID(actorName: string): string {
     return `https://apify.com/mcp/${actorNameToToolName(actorName)}/schema.json`;
+}
+
+/** Whether this session can run this Actor: call-actor loaded, or its own dedicated tool is. Soft
+ *  check — false negative for a hash-capped MCP-proxy tool name (`../mcp/proxy.ts`). */
+export function canRunActor(actorFullName: string, loadedToolNames: readonly string[]): boolean {
+    return (
+        loadedToolNames.includes(HELPER_TOOLS.ACTOR_CALL) ||
+        loadedToolNames.includes(actorNameToToolName(actorFullName))
+    );
 }

--- a/src/tools/actor_tool_naming.ts
+++ b/src/tools/actor_tool_naming.ts
@@ -82,11 +82,13 @@ export function getToolSchemaID(actorName: string): string {
     return `https://apify.com/mcp/${actorNameToToolName(actorName)}/schema.json`;
 }
 
-/** Whether this session can run this Actor: call-actor loaded, or its own dedicated tool is. Soft
- *  check — false negative for a hash-capped MCP-proxy tool name (`../mcp/proxy.ts`). */
+/**
+ * Whether this session can run this Actor: call-actor loaded, its own dedicated tool is, or (for an
+ * Actor MCP server, `../mcp/proxy.ts`) at least one of its `{tool}--{originTool}`-prefixed sub-tools is.
+ * Soft check — false negative only when hash-capping (`MAX_TOOL_NAME_LENGTH`) altered the prefix.
+ */
 export function canRunActor(actorFullName: string, loadedToolNames: readonly string[]): boolean {
-    return (
-        loadedToolNames.includes(HELPER_TOOLS.ACTOR_CALL) ||
-        loadedToolNames.includes(actorNameToToolName(actorFullName))
-    );
+    if (loadedToolNames.includes(HELPER_TOOLS.ACTOR_CALL)) return true;
+    const toolName = actorNameToToolName(actorFullName);
+    return loadedToolNames.some((name) => name === toolName || name.startsWith(`${toolName}--`));
 }

--- a/src/tools/actor_tool_naming.ts
+++ b/src/tools/actor_tool_naming.ts
@@ -83,12 +83,13 @@ export function getToolSchemaID(actorName: string): string {
 }
 
 /**
- * Whether this session can run this Actor: call-actor loaded, its own dedicated tool is, or (for an
- * Actor MCP server, `../mcp/proxy.ts`) at least one of its `{tool}--{originTool}`-prefixed sub-tools is.
- * Soft check — false negative only when hash-capping (`MAX_TOOL_NAME_LENGTH`) altered the prefix.
+ * Whether this session can run this Actor: call-actor loaded, or the Actor's own tool loaded
+ * (direct or Actor-MCP). Soft check for a guidance hint, not a hard gate.
  */
-export function canRunActor(actorFullName: string, loadedToolNames: readonly string[]): boolean {
-    if (loadedToolNames.includes(HELPER_TOOLS.ACTOR_CALL)) return true;
-    const toolName = actorNameToToolName(actorFullName);
-    return loadedToolNames.some((name) => name === toolName || name.startsWith(`${toolName}--`));
+export function canRunActor(
+    actorId: string,
+    loadedToolNames: readonly string[],
+    loadedActorIds: ReadonlySet<string>,
+): boolean {
+    return loadedToolNames.includes(HELPER_TOOLS.ACTOR_CALL) || loadedActorIds.has(actorId);
 }

--- a/src/tools/actors/fetch_actor_details.ts
+++ b/src/tools/actors/fetch_actor_details.ts
@@ -24,6 +24,7 @@ import { buildConsoleActorUrl, getConsoleLinkContext, VERBATIM_LINKS_NUDGE } fro
 import { wrapJsonText } from '../../utils/encode_text.js';
 import { respondOk, respondUserError, type ToolResponse } from '../../utils/mcp.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
+import { canRunActor } from '../actor_tool_naming.js';
 import { actorDetailsOutputSchema } from '../structured_output_schemas.js';
 import { fixActorNameInputAndLog } from './actor_tools_factory.js';
 
@@ -150,6 +151,15 @@ export function buildActorNotFoundResponse(actorName: string, loadedToolNames: r
     );
 }
 
+/** Guidance appended when the Actor exists but `canRunActor` says this session can't run it. */
+export function buildActorNotRunnableGuidance(actorFullName: string, loadedToolNames: readonly string[]): string {
+    if (canRunActor(actorFullName, loadedToolNames)) return '';
+    return dedent`
+        This Actor is not exposed as a tool and cannot be run in this configuration. Open its
+        Apify page or configure it separately to use it.
+    `;
+}
+
 /**
  * Build text and structured response for actor details.
  * Pure/sync: the caller pre-resolves `mcpToolsMessage` when `output.mcpTools` is true.
@@ -270,6 +280,12 @@ export async function buildFetchActorDetailsResult(toolArgs: InternalToolArgs): 
         mcpToolsMessage,
         linkContext,
     });
+
+    // Canonical full name, not the raw `actor` input — that may be an ID, which canRunActor
+    // (via actorNameToToolName) can't match against a loaded dedicated-tool name.
+    const actorFullName = `${details.actorInfo.username}/${details.actorInfo.name}`;
+    const runnableGuidance = buildActorNotRunnableGuidance(actorFullName, loadedToolNames);
+    if (runnableGuidance) texts.push(runnableGuidance);
 
     return respondOk(texts, { structuredContent });
 }

--- a/src/tools/actors/fetch_actor_details.ts
+++ b/src/tools/actors/fetch_actor_details.ts
@@ -152,8 +152,12 @@ export function buildActorNotFoundResponse(actorName: string, loadedToolNames: r
 }
 
 /** Guidance appended when the Actor exists but `canRunActor` says this session can't run it. */
-export function buildActorNotRunnableGuidance(actorFullName: string, loadedToolNames: readonly string[]): string {
-    if (canRunActor(actorFullName, loadedToolNames)) return '';
+export function buildActorNotRunnableGuidance(
+    actorId: string,
+    loadedToolNames: readonly string[],
+    loadedActorIds: ReadonlySet<string>,
+): string {
+    if (canRunActor(actorId, loadedToolNames, loadedActorIds)) return '';
     return dedent`
         This Actor is not exposed as a tool and cannot be run in this configuration. Open its
         Apify page or configure it separately to use it.
@@ -241,7 +245,16 @@ export function buildActorDetailsTextResponse(options: {
  * Returns the same text + structured response in both modes.
  */
 export async function buildFetchActorDetailsResult(toolArgs: InternalToolArgs): Promise<ToolResponse> {
-    const { args, apifyToken, apifyClient, actorStore, paymentProvider, mcpSessionId, loadedToolNames } = toolArgs;
+    const {
+        args,
+        apifyToken,
+        apifyClient,
+        actorStore,
+        paymentProvider,
+        mcpSessionId,
+        loadedToolNames,
+        loadedActorIds,
+    } = toolArgs;
     const parsed = fetchActorDetailsToolArgsSchema.parse(args);
     const actorName = fixActorNameInputAndLog(parsed.actor, { mcpSessionId, route: HELPER_TOOLS.ACTOR_GET_DETAILS });
 
@@ -281,10 +294,8 @@ export async function buildFetchActorDetailsResult(toolArgs: InternalToolArgs): 
         linkContext,
     });
 
-    // Canonical full name, not the raw `actor` input — that may be an ID, which canRunActor
-    // (via actorNameToToolName) can't match against a loaded dedicated-tool name.
-    const actorFullName = `${details.actorInfo.username}/${details.actorInfo.name}`;
-    const runnableGuidance = buildActorNotRunnableGuidance(actorFullName, loadedToolNames);
+    // Resolved Actor ID, not the raw `actor` input — that may itself be an ID.
+    const runnableGuidance = buildActorNotRunnableGuidance(details.actorInfo.id, loadedToolNames, loadedActorIds);
     if (runnableGuidance) texts.push(runnableGuidance);
 
     return respondOk(texts, { structuredContent });

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -140,7 +140,7 @@ export function buildActorCallabilityCaveat(
     const anyResultCannotRun = actorIds.some((id) => !canRunActor(id, loadedToolNames, loadedActorIds));
     if (!anyResultCannotRun) return '';
     return dedent`
-        This connector can run only Actors already exposed as dedicated tools. Other Actors found
+        This session can run only Actors already exposed as dedicated tools. Other Actors found
         here are informational and cannot be run in this configuration. To use another Actor, open
         its Apify page or configure it separately.
     `;

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -130,6 +130,16 @@ export function buildNoActorsFoundInstructions(keywords: string): string {
     `;
 }
 
+/** Session-level caveat: without call-actor, only already-dedicated-tool Actors can run — one caveat covers every result. */
+export function buildActorCallabilityCaveat(loadedToolNames: readonly string[]): string {
+    if (loadedToolNames.includes(HELPER_TOOLS.ACTOR_CALL)) return '';
+    return dedent`
+        This connector can run only Actors already exposed as dedicated tools. Other Actors found
+        here are informational and cannot be run in this configuration. To use another Actor, open
+        its Apify page or configure it separately.
+    `;
+}
+
 /**
  * Builds the footer/instructions guidance for successful search results.
  * Interpolates the verbatim links nudge if applicable.
@@ -152,7 +162,8 @@ export function buildSearchActorsFooter(verbatimLinksNudge: string, loadedToolNa
         (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
         you haven't missed a better Actor.${verbatimLinksNudge}
     `;
-    return detailsHint ? `${detailsHint}\n${secondSearch}` : secondSearch;
+    const callabilityCaveat = buildActorCallabilityCaveat(loadedToolNames);
+    return [detailsHint, secondSearch, callabilityCaveat].filter(Boolean).join('\n');
 }
 
 /**

--- a/src/tools/actors/search_actors.ts
+++ b/src/tools/actors/search_actors.ts
@@ -20,6 +20,7 @@ import { getConsoleLinkContext, VERBATIM_LINKS_NUDGE } from '../../utils/console
 import { respondOk } from '../../utils/mcp.js';
 import type { PricingTier } from '../../utils/pricing_info.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
+import { canRunActor } from '../actor_tool_naming.js';
 import { actorSearchOutputSchema } from '../structured_output_schemas.js';
 
 /**
@@ -130,9 +131,14 @@ export function buildNoActorsFoundInstructions(keywords: string): string {
     `;
 }
 
-/** Session-level caveat: without call-actor, only already-dedicated-tool Actors can run — one caveat covers every result. */
-export function buildActorCallabilityCaveat(loadedToolNames: readonly string[]): string {
-    if (loadedToolNames.includes(HELPER_TOOLS.ACTOR_CALL)) return '';
+/** Caveat for the whole result list — appended only when at least one result lacks a run path. */
+export function buildActorCallabilityCaveat(
+    actorIds: readonly string[],
+    loadedToolNames: readonly string[],
+    loadedActorIds: ReadonlySet<string>,
+): string {
+    const anyResultCannotRun = actorIds.some((id) => !canRunActor(id, loadedToolNames, loadedActorIds));
+    if (!anyResultCannotRun) return '';
     return dedent`
         This connector can run only Actors already exposed as dedicated tools. Other Actors found
         here are informational and cannot be run in this configuration. To use another Actor, open
@@ -149,7 +155,12 @@ export function buildActorCallabilityCaveat(loadedToolNames: readonly string[]):
  * otherwise be told to call a tool absent from its own `tools/list`.
  * See apify/apify-mcp-server#1296.
  */
-export function buildSearchActorsFooter(verbatimLinksNudge: string, loadedToolNames: readonly string[]): string {
+export function buildSearchActorsFooter(
+    verbatimLinksNudge: string,
+    actorIds: readonly string[],
+    loadedToolNames: readonly string[],
+    loadedActorIds: ReadonlySet<string>,
+): string {
     const detailsHint = loadedToolNames.includes(HELPER_TOOLS.ACTOR_GET_DETAILS)
         ? dedent`
             If you need more detailed information about any of these Actors, including their input
@@ -162,7 +173,7 @@ export function buildSearchActorsFooter(verbatimLinksNudge: string, loadedToolNa
         (e.g., just the platform name like "TikTok" instead of "TikTok posts") to make sure
         you haven't missed a better Actor.${verbatimLinksNudge}
     `;
-    const callabilityCaveat = buildActorCallabilityCaveat(loadedToolNames);
+    const callabilityCaveat = buildActorCallabilityCaveat(actorIds, loadedToolNames, loadedActorIds);
     return [detailsHint, secondSearch, callabilityCaveat].filter(Boolean).join('\n');
 }
 
@@ -187,7 +198,7 @@ export const searchActors: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyClient, paymentProvider, loadedToolNames } = toolArgs;
+        const { args, apifyToken, apifyClient, paymentProvider, loadedToolNames, loadedActorIds } = toolArgs;
         const parsed = searchActorsBaseArgsSchema.parse(args);
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
@@ -213,12 +224,14 @@ export const searchActors: ToolEntry = Object.freeze({
         const linkContext = await getConsoleLinkContext(apifyToken, apifyClient);
         const { actorCardText, actorCardStructured } = buildSearchActorsResult(actors, userPlanTier, linkContext);
         const verbatimLinksNudge = linkContext ? `\n${VERBATIM_LINKS_NUDGE}` : '';
+        const actorIds = actors.map((actor) => actor.id);
+        const footer = buildSearchActorsFooter(verbatimLinksNudge, actorIds, loadedToolNames, loadedActorIds);
         const structuredContent = {
             actors: actorCardStructured,
             query: parsed.keywords,
             count: actors.length,
             userTier: userPlanTier,
-            instructions: buildSearchActorsFooter(verbatimLinksNudge, loadedToolNames),
+            instructions: footer,
         };
 
         // Build header and footer with separate `dedent` calls and concatenate around
@@ -232,7 +245,6 @@ export const searchActors: ToolEntry = Object.freeze({
 
             # Actors:
         `;
-        const footer = buildSearchActorsFooter(verbatimLinksNudge, loadedToolNames);
         return respondOk(`${header}\n\n${actorCardText}\n\n${footer}`, { structuredContent });
     },
 } as const satisfies HelperTool);

--- a/src/tools/widgets/fetch_actor_details_widget.ts
+++ b/src/tools/widgets/fetch_actor_details_widget.ts
@@ -10,7 +10,11 @@ import { compileSchema } from '../../utils/ajv.js';
 import { respondOk } from '../../utils/mcp.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
 import { fixActorNameInputAndLog } from '../actors/actor_tools_factory.js';
-import { actorDetailsOutputDefaults, buildActorNotFoundResponse } from '../actors/fetch_actor_details.js';
+import {
+    actorDetailsOutputDefaults,
+    buildActorNotFoundResponse,
+    buildActorNotRunnableGuidance,
+} from '../actors/fetch_actor_details.js';
 import { actorDetailsWidgetOutputSchema } from '../structured_output_schemas.js';
 
 const widgetConfig = getWidgetConfig(WIDGET_URIS.SEARCH_ACTORS);
@@ -95,6 +99,10 @@ export const fetchActorDetailsWidget: ToolEntry = Object.freeze({
             An interactive widget has been rendered with detailed Actor information.
         `,
         ];
+        // Canonical full name, not the raw `actor` input — see fetch_actor_details.ts.
+        const actorFullName = `${details.actorInfo.username}/${details.actorInfo.name}`;
+        const runnableGuidance = buildActorNotRunnableGuidance(actorFullName, loadedToolNames);
+        if (runnableGuidance) texts.push(runnableGuidance);
 
         return respondOk(texts, {
             structuredContent,

--- a/src/tools/widgets/fetch_actor_details_widget.ts
+++ b/src/tools/widgets/fetch_actor_details_widget.ts
@@ -67,7 +67,7 @@ export const fetchActorDetailsWidget: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { apifyToken, apifyClient, mcpSessionId, loadedToolNames } = toolArgs;
+        const { apifyToken, apifyClient, mcpSessionId, loadedToolNames, loadedActorIds } = toolArgs;
         const parsed = fetchActorDetailsWidgetArgsSchema.parse(toolArgs.args);
         const actorName = fixActorNameInputAndLog(parsed.actor, {
             mcpSessionId,
@@ -99,9 +99,8 @@ export const fetchActorDetailsWidget: ToolEntry = Object.freeze({
             An interactive widget has been rendered with detailed Actor information.
         `,
         ];
-        // Canonical full name, not the raw `actor` input — see fetch_actor_details.ts.
-        const actorFullName = `${details.actorInfo.username}/${details.actorInfo.name}`;
-        const runnableGuidance = buildActorNotRunnableGuidance(actorFullName, loadedToolNames);
+        // Resolved Actor ID, not the raw `actor` input.
+        const runnableGuidance = buildActorNotRunnableGuidance(details.actorInfo.id, loadedToolNames, loadedActorIds);
         if (runnableGuidance) texts.push(runnableGuidance);
 
         return respondOk(texts, {

--- a/src/tools/widgets/search_actors_widget.ts
+++ b/src/tools/widgets/search_actors_widget.ts
@@ -59,7 +59,7 @@ export const searchActorsWidget: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyClient, paymentProvider, loadedToolNames } = toolArgs;
+        const { args, apifyToken, apifyClient, paymentProvider, loadedToolNames, loadedActorIds } = toolArgs;
         const parsed = searchActorsWidgetArgsSchema.parse(args);
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
@@ -108,7 +108,11 @@ export const searchActorsWidget: ToolEntry = Object.freeze({
             in your response.
         `,
         ];
-        const callabilityCaveat = buildActorCallabilityCaveat(loadedToolNames);
+        const callabilityCaveat = buildActorCallabilityCaveat(
+            actors.map((actor) => actor.id),
+            loadedToolNames,
+            loadedActorIds,
+        );
         if (callabilityCaveat) texts.push(callabilityCaveat);
 
         const widgetConfig = getWidgetConfig(WIDGET_URIS.SEARCH_ACTORS);

--- a/src/tools/widgets/search_actors_widget.ts
+++ b/src/tools/widgets/search_actors_widget.ts
@@ -11,6 +11,7 @@ import { compileSchema } from '../../utils/ajv.js';
 import { respondOk } from '../../utils/mcp.js';
 import { getUserInfoCached } from '../../utils/userid_cache.js';
 import {
+    buildActorCallabilityCaveat,
     buildNoActorsFoundInstructions,
     buildSearchActorsResult,
     searchActorsBaseArgsSchema,
@@ -58,7 +59,7 @@ export const searchActorsWidget: ToolEntry = Object.freeze({
         openWorldHint: false,
     },
     call: async (toolArgs: InternalToolArgs) => {
-        const { args, apifyToken, apifyClient, paymentProvider } = toolArgs;
+        const { args, apifyToken, apifyClient, paymentProvider, loadedToolNames } = toolArgs;
         const parsed = searchActorsWidgetArgsSchema.parse(args);
         // Actor search and user-info fetch are independent; run in parallel to avoid a
         // sequential round-trip on cache miss.
@@ -107,6 +108,8 @@ export const searchActorsWidget: ToolEntry = Object.freeze({
             in your response.
         `,
         ];
+        const callabilityCaveat = buildActorCallabilityCaveat(loadedToolNames);
+        if (callabilityCaveat) texts.push(callabilityCaveat);
 
         const widgetConfig = getWidgetConfig(WIDGET_URIS.SEARCH_ACTORS);
         return respondOk(texts, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,8 @@ export type InternalToolArgs = {
     paymentProvider?: PaymentProvider;
     /** Names of all currently loaded tools. */
     loadedToolNames: readonly string[];
+    /** IDs of Actors backing all currently loaded Actor / Actor-MCP tools. */
+    loadedActorIds: ReadonlySet<string>;
     /** Optional progress tracker for long running internal tools, like call-actor */
     progressTracker?: ProgressTracker | null;
     /** MCP session ID for logging context */

--- a/tests/unit/mcp.server.stateless_instructions.test.ts
+++ b/tests/unit/mcp.server.stateless_instructions.test.ts
@@ -57,8 +57,7 @@ describe('ActorsMcpServer.getStatelessServerInstructions()', () => {
         expect(instructions).toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
     });
 
-    // report-problem is identity-dependent, never derivable from the URL alone; ?tools=dev puts
-    // it in the candidate set so this actually exercises the filter, not an always-true check.
+    // ?tools=dev seeds report-problem into the candidate set so this exercises the filter, not an always-true check.
     it('never mentions report-problem via a requestUrl, even when explicitly selected', () => {
         const instructions = makeServer().getStatelessServerInstructions('http://localhost/?tools=dev');
         expect(instructions).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);

--- a/tests/unit/mcp.server.stateless_instructions.test.ts
+++ b/tests/unit/mcp.server.stateless_instructions.test.ts
@@ -57,17 +57,10 @@ describe('ActorsMcpServer.getStatelessServerInstructions()', () => {
         expect(instructions).toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
     });
 
-    it('pins the Claude-connector tool surface: call-actor absent, its own dedicated Actor tools present', () => {
-        const url =
-            'http://localhost/?tools=search-actors,search-actors-widget,fetch-actor-details,fetch-actor-details-widget,search-apify-docs,fetch-apify-docs,get-actor-run,get-actor-run-widget,get-actor-run-list,get-actor-log,abort-actor-run,get-dataset-list,get-dataset,get-dataset-items,get-key-value-store-list,get-key-value-store,get-key-value-store-record,apify/rag-web-browser,apify/web-fetch';
-        const instructions = makeServer().getStatelessServerInstructions(url);
-        expect(instructions).not.toContain(HELPER_TOOLS.ACTOR_CALL);
-        expect(instructions).toContain(RAG_WEB_BROWSER);
-        expect(instructions).toContain(WEB_FETCH);
-    });
-
-    it('never mentions report-problem via a requestUrl — not derivable, identity-dependent', () => {
-        const instructions = makeServer().getStatelessServerInstructions('http://localhost/?tools=search-actors');
+    // report-problem is identity-dependent, never derivable from the URL alone; ?tools=dev puts
+    // it in the candidate set so this actually exercises the filter, not an always-true check.
+    it('never mentions report-problem via a requestUrl, even when explicitly selected', () => {
+        const instructions = makeServer().getStatelessServerInstructions('http://localhost/?tools=dev');
         expect(instructions).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
     });
 });

--- a/tests/unit/tools.actor.test.ts
+++ b/tests/unit/tools.actor.test.ts
@@ -134,22 +134,20 @@ describe('resolveActorToolMode()', () => {
 
 describe('canRunActor()', () => {
     it('returns true when call-actor is loaded, regardless of the Actor', () => {
-        expect(canRunActor('apify/rag-web-browser', [HELPER_TOOLS.ACTOR_CALL])).toBe(true);
+        expect(canRunActor('actor-id-1', [HELPER_TOOLS.ACTOR_CALL], new Set())).toBe(true);
     });
 
-    it('returns true when call-actor is absent but the Actor has its own dedicated tool loaded', () => {
-        expect(canRunActor('apify/rag-web-browser', [actorNameToToolName('apify/rag-web-browser')])).toBe(true);
+    it('returns true when call-actor is absent but the Actor ID is in loadedActorIds', () => {
+        expect(canRunActor('actor-id-1', [], new Set(['actor-id-1']))).toBe(true);
     });
 
-    it('returns false when call-actor is absent and no matching dedicated tool is loaded', () => {
-        expect(canRunActor('apify/rag-web-browser', [actorNameToToolName('apify/web-scraper')])).toBe(false);
-        expect(canRunActor('apify/rag-web-browser', [])).toBe(false);
+    it('returns false when call-actor is absent and the Actor ID is not in loadedActorIds', () => {
+        expect(canRunActor('actor-id-1', [], new Set(['other-actor-id']))).toBe(false);
+        expect(canRunActor('actor-id-1', [], new Set())).toBe(false);
     });
 
-    // Regression: an Actor MCP server (`../../src/mcp/proxy.ts`) registers each of its sub-tools as
-    // `{actorToolName}--{originToolName}`, never as the bare actorToolName — an exact-match check
-    // alone is always false for this Actor type, not just for a hash-capped name.
-    it('returns true when a loaded tool is an MCP-proxy sub-tool of the Actor', () => {
-        expect(canRunActor('apify/actors-mcp-server', ['apify--actors-mcp-server--fetch-apify-docs'])).toBe(true);
+    // loadedActorIds covers both ACTOR and ACTOR_MCP entries, so either tool shape counts.
+    it('returns true when the Actor ID comes from a loaded Actor-MCP sub-tool', () => {
+        expect(canRunActor('mcp-actor-id', [], new Set(['mcp-actor-id']))).toBe(true);
     });
 });

--- a/tests/unit/tools.actor.test.ts
+++ b/tests/unit/tools.actor.test.ts
@@ -2,8 +2,14 @@ import { createHash } from 'node:crypto';
 
 import { describe, expect, it } from 'vitest';
 
+import { HELPER_TOOLS } from '../../src/const.js';
 import { MAX_TOOL_NAME_LENGTH, TOOL_NAME_HASH_LENGTH } from '../../src/mcp/const.js';
-import { actorNameToToolName, legacyToolNameToNew, resolveActorToolMode } from '../../src/tools/actor_tool_naming.js';
+import {
+    actorNameToToolName,
+    canRunActor,
+    legacyToolNameToNew,
+    resolveActorToolMode,
+} from '../../src/tools/actor_tool_naming.js';
 import type { ActorInfo, ActorInputSchema } from '../../src/types.js';
 import { ACTOR_TOOL_MODE } from '../../src/types.js';
 
@@ -123,5 +129,20 @@ describe('resolveActorToolMode()', () => {
         ],
     ] as const)('resolves %s to %s', (_label, opts, expected) => {
         expect(resolveActorToolMode(makeActorInfo({ input: NON_EMPTY_INPUT, ...opts }))).toBe(expected);
+    });
+});
+
+describe('canRunActor()', () => {
+    it('returns true when call-actor is loaded, regardless of the Actor', () => {
+        expect(canRunActor('apify/rag-web-browser', [HELPER_TOOLS.ACTOR_CALL])).toBe(true);
+    });
+
+    it('returns true when call-actor is absent but the Actor has its own dedicated tool loaded', () => {
+        expect(canRunActor('apify/rag-web-browser', [actorNameToToolName('apify/rag-web-browser')])).toBe(true);
+    });
+
+    it('returns false when call-actor is absent and no matching dedicated tool is loaded', () => {
+        expect(canRunActor('apify/rag-web-browser', [actorNameToToolName('apify/web-scraper')])).toBe(false);
+        expect(canRunActor('apify/rag-web-browser', [])).toBe(false);
     });
 });

--- a/tests/unit/tools.actor.test.ts
+++ b/tests/unit/tools.actor.test.ts
@@ -145,9 +145,4 @@ describe('canRunActor()', () => {
         expect(canRunActor('actor-id-1', [], new Set(['other-actor-id']))).toBe(false);
         expect(canRunActor('actor-id-1', [], new Set())).toBe(false);
     });
-
-    // loadedActorIds covers both ACTOR and ACTOR_MCP entries, so either tool shape counts.
-    it('returns true when the Actor ID comes from a loaded Actor-MCP sub-tool', () => {
-        expect(canRunActor('mcp-actor-id', [], new Set(['mcp-actor-id']))).toBe(true);
-    });
 });

--- a/tests/unit/tools.actor.test.ts
+++ b/tests/unit/tools.actor.test.ts
@@ -145,4 +145,11 @@ describe('canRunActor()', () => {
         expect(canRunActor('apify/rag-web-browser', [actorNameToToolName('apify/web-scraper')])).toBe(false);
         expect(canRunActor('apify/rag-web-browser', [])).toBe(false);
     });
+
+    // Regression: an Actor MCP server (`../../src/mcp/proxy.ts`) registers each of its sub-tools as
+    // `{actorToolName}--{originToolName}`, never as the bare actorToolName — an exact-match check
+    // alone is always false for this Actor type, not just for a hash-capped name.
+    it('returns true when a loaded tool is an MCP-proxy sub-tool of the Actor', () => {
+        expect(canRunActor('apify/actors-mcp-server', ['apify--actors-mcp-server--fetch-apify-docs'])).toBe(true);
+    });
 });

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -273,29 +273,11 @@ describe('buildFetchActorDetailsResult()', () => {
 
         expect(text).not.toContain('cannot be run in this configuration');
     });
-
-    // The guidance check matches by resolved Actor ID — querying by ID or full name resolves identically.
-    it('omits not-runnable guidance when queried by Actor ID and the dedicated tool is loaded', async () => {
-        const result = await buildFetchActorDetailsResult(
-            stubInternalToolArgs(
-                { actor: 'aXeS4nzT3S9RRAQEy', output: { inputSchema: true } },
-                [],
-                [MOCK_DETAILS.actorInfo.id],
-            ),
-        );
-        const text = ((result as { content: { text: string }[] }).content ?? []).map((c) => c.text).join('\n');
-
-        expect(text).not.toContain('cannot be run in this configuration');
-    });
 });
 
 describe('buildActorNotRunnableGuidance()', () => {
     it('is empty when call-actor is loaded', () => {
         expect(buildActorNotRunnableGuidance('actor-id-1', [HELPER_TOOLS.ACTOR_CALL], new Set())).toBe('');
-    });
-
-    it('is empty when the Actor has its own dedicated tool loaded', () => {
-        expect(buildActorNotRunnableGuidance('actor-id-1', [], new Set(['actor-id-1']))).toBe('');
     });
 
     it('names no tool, only states the Actor cannot run, when neither is loaded', () => {

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -5,6 +5,7 @@ import {
     actorDetailsOutputDefaults,
     buildActorDetailsTextResponse,
     buildActorNotFoundResponse,
+    buildActorNotRunnableGuidance,
     buildFetchActorDetailsResult,
 } from '../../src/tools/actors/fetch_actor_details.js';
 import type { ActorDetailsResult } from '../../src/utils/actor_details.js';
@@ -178,9 +179,12 @@ describe('buildFetchActorDetailsResult()', () => {
     });
 
     // pricing: false → the users/me lookup is needed only for Console UI tokens.
+    // call-actor loaded so these unrelated assertions aren't perturbed by the not-runnable guidance.
     const callWithToken = async (apifyToken: string) => {
         const result = await buildFetchActorDetailsResult({
-            ...stubInternalToolArgs({ actor: 'apify/example-mcp-server', output: { inputSchema: true } }),
+            ...stubInternalToolArgs({ actor: 'apify/example-mcp-server', output: { inputSchema: true } }, [
+                HELPER_TOOLS.ACTOR_CALL,
+            ]),
             apifyToken,
         });
         return result as { content: { type: string; text: string }[] };
@@ -235,6 +239,66 @@ describe('buildFetchActorDetailsResult()', () => {
         );
 
         await expect(callWithToken('apify_api_test')).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('appends not-runnable guidance when neither call-actor nor a dedicated tool is loaded', async () => {
+        const result = await buildFetchActorDetailsResult(
+            stubInternalToolArgs({ actor: 'apify/example-mcp-server', output: { inputSchema: true } }),
+        );
+        const text = ((result as { content: { text: string }[] }).content ?? []).map((c) => c.text).join('\n');
+
+        expect(text).toContain('This Actor is not exposed as a tool and cannot be run in this configuration.');
+    });
+
+    it('omits not-runnable guidance when call-actor is loaded', async () => {
+        const result = await buildFetchActorDetailsResult(
+            stubInternalToolArgs({ actor: 'apify/example-mcp-server', output: { inputSchema: true } }, [
+                HELPER_TOOLS.ACTOR_CALL,
+            ]),
+        );
+        const text = ((result as { content: { text: string }[] }).content ?? []).map((c) => c.text).join('\n');
+
+        expect(text).not.toContain('cannot be run in this configuration');
+    });
+
+    it('omits not-runnable guidance when the Actor has its own dedicated tool loaded', async () => {
+        const result = await buildFetchActorDetailsResult(
+            stubInternalToolArgs({ actor: 'apify/example-mcp-server', output: { inputSchema: true } }, [
+                'apify--example-mcp-server',
+            ]),
+        );
+        const text = ((result as { content: { text: string }[] }).content ?? []).map((c) => c.text).join('\n');
+
+        expect(text).not.toContain('cannot be run in this configuration');
+    });
+
+    // Regression: the guidance check must use the resolved actorInfo (canonical username/name),
+    // not the raw `actor` input — an Actor ID resolves fine but never matches a dedicated tool
+    // name via actorNameToToolName, which would falsely claim it can't run.
+    it('omits not-runnable guidance when queried by Actor ID and the dedicated tool is loaded', async () => {
+        const result = await buildFetchActorDetailsResult(
+            stubInternalToolArgs({ actor: 'aXeS4nzT3S9RRAQEy', output: { inputSchema: true } }, [
+                'apify--example-mcp-server',
+            ]),
+        );
+        const text = ((result as { content: { text: string }[] }).content ?? []).map((c) => c.text).join('\n');
+
+        expect(text).not.toContain('cannot be run in this configuration');
+    });
+});
+
+describe('buildActorNotRunnableGuidance()', () => {
+    it('is empty when call-actor is loaded', () => {
+        expect(buildActorNotRunnableGuidance('apify/example-mcp-server', [HELPER_TOOLS.ACTOR_CALL])).toBe('');
+    });
+
+    it('is empty when the Actor has its own dedicated tool loaded', () => {
+        expect(buildActorNotRunnableGuidance('apify/example-mcp-server', ['apify--example-mcp-server'])).toBe('');
+    });
+
+    it('names no tool, only states the Actor cannot run, when neither is loaded', () => {
+        const text = buildActorNotRunnableGuidance('apify/example-mcp-server', []);
+        expect(text).toContain('cannot be run in this configuration');
     });
 });
 

--- a/tests/unit/tools.fetch_actor_details.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.response.test.ts
@@ -263,23 +263,25 @@ describe('buildFetchActorDetailsResult()', () => {
 
     it('omits not-runnable guidance when the Actor has its own dedicated tool loaded', async () => {
         const result = await buildFetchActorDetailsResult(
-            stubInternalToolArgs({ actor: 'apify/example-mcp-server', output: { inputSchema: true } }, [
-                'apify--example-mcp-server',
-            ]),
+            stubInternalToolArgs(
+                { actor: 'apify/example-mcp-server', output: { inputSchema: true } },
+                [],
+                [MOCK_DETAILS.actorInfo.id],
+            ),
         );
         const text = ((result as { content: { text: string }[] }).content ?? []).map((c) => c.text).join('\n');
 
         expect(text).not.toContain('cannot be run in this configuration');
     });
 
-    // Regression: the guidance check must use the resolved actorInfo (canonical username/name),
-    // not the raw `actor` input — an Actor ID resolves fine but never matches a dedicated tool
-    // name via actorNameToToolName, which would falsely claim it can't run.
+    // The guidance check matches by resolved Actor ID — querying by ID or full name resolves identically.
     it('omits not-runnable guidance when queried by Actor ID and the dedicated tool is loaded', async () => {
         const result = await buildFetchActorDetailsResult(
-            stubInternalToolArgs({ actor: 'aXeS4nzT3S9RRAQEy', output: { inputSchema: true } }, [
-                'apify--example-mcp-server',
-            ]),
+            stubInternalToolArgs(
+                { actor: 'aXeS4nzT3S9RRAQEy', output: { inputSchema: true } },
+                [],
+                [MOCK_DETAILS.actorInfo.id],
+            ),
         );
         const text = ((result as { content: { text: string }[] }).content ?? []).map((c) => c.text).join('\n');
 
@@ -289,15 +291,15 @@ describe('buildFetchActorDetailsResult()', () => {
 
 describe('buildActorNotRunnableGuidance()', () => {
     it('is empty when call-actor is loaded', () => {
-        expect(buildActorNotRunnableGuidance('apify/example-mcp-server', [HELPER_TOOLS.ACTOR_CALL])).toBe('');
+        expect(buildActorNotRunnableGuidance('actor-id-1', [HELPER_TOOLS.ACTOR_CALL], new Set())).toBe('');
     });
 
     it('is empty when the Actor has its own dedicated tool loaded', () => {
-        expect(buildActorNotRunnableGuidance('apify/example-mcp-server', ['apify--example-mcp-server'])).toBe('');
+        expect(buildActorNotRunnableGuidance('actor-id-1', [], new Set(['actor-id-1']))).toBe('');
     });
 
     it('names no tool, only states the Actor cannot run, when neither is loaded', () => {
-        const text = buildActorNotRunnableGuidance('apify/example-mcp-server', []);
+        const text = buildActorNotRunnableGuidance('actor-id-1', [], new Set());
         expect(text).toContain('cannot be run in this configuration');
     });
 });

--- a/tests/unit/tools.fetch_actor_details.widget.response.test.ts
+++ b/tests/unit/tools.fetch_actor_details.widget.response.test.ts
@@ -65,8 +65,9 @@ describe('fetch-actor-details-widget response', () => {
     it('returns { actorDetails: { actorInfo, actorCard, readme } } as structuredContent plus widget _meta', async () => {
         vi.mocked(fetchActorDetails).mockResolvedValue(MOCK_DETAILS);
 
+        // call-actor loaded: this assertion is about the widget's content shape, not the guidance.
         const result = await (fetchActorDetailsWidget as HelperTool).call(
-            stubInternalToolArgs({ actor: 'apify/web-scraper' }),
+            stubInternalToolArgs({ actor: 'apify/web-scraper' }, [HELPER_TOOLS.ACTOR_CALL]),
         );
 
         const { structuredContent, content, _meta } = result as {
@@ -153,6 +154,28 @@ describe('fetch-actor-details-widget response', () => {
         const unservedText = (unserved.content ?? []).map(textOf).join('\n');
         expect(unservedText).toContain('was not found');
         expect(unservedText).not.toContain(HELPER_TOOLS.STORE_SEARCH);
+    });
+
+    it('appends not-runnable guidance when neither call-actor nor a dedicated tool is loaded', async () => {
+        vi.mocked(fetchActorDetails).mockResolvedValue(MOCK_DETAILS);
+
+        const result = await (fetchActorDetailsWidget as HelperTool).call(
+            stubInternalToolArgs({ actor: 'apify/web-scraper' }),
+        );
+        const text = ((result.content ?? []) as { text: string }[]).map((c) => c.text).join('\n');
+
+        expect(text).toContain('cannot be run in this configuration');
+    });
+
+    it('omits not-runnable guidance when call-actor is loaded', async () => {
+        vi.mocked(fetchActorDetails).mockResolvedValue(MOCK_DETAILS);
+
+        const result = await (fetchActorDetailsWidget as HelperTool).call(
+            stubInternalToolArgs({ actor: 'apify/web-scraper' }, [HELPER_TOOLS.ACTOR_CALL]),
+        );
+        const text = ((result.content ?? []) as { text: string }[]).map((c) => c.text).join('\n');
+
+        expect(text).not.toContain('cannot be run in this configuration');
     });
 
     // Regression: same fix as tools.fetch_actor_details.response.test.ts — the widget variant

--- a/tests/unit/tools.search_actors.default.response.test.ts
+++ b/tests/unit/tools.search_actors.default.response.test.ts
@@ -272,4 +272,35 @@ describe('search-actors without widget (searchActors)', () => {
         expect(structuredContent.instructions).not.toContain('cannot be run in this configuration');
         expect(content[0].text).not.toContain('cannot be run in this configuration');
     });
+
+    it('omits the not-runnable caveat when call-actor is absent but every result is already loaded', async () => {
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+
+        const result = await (searchActors as HelperTool).call(
+            stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }, [], [MOCK_STORE_ACTOR.id]),
+        );
+        const { structuredContent, content } = result as {
+            structuredContent: { instructions?: string };
+            content: { type: string; text: string }[];
+        };
+
+        expect(structuredContent.instructions).not.toContain('cannot be run in this configuration');
+        expect(content[0].text).not.toContain('cannot be run in this configuration');
+    });
+
+    it('adds the not-runnable caveat for mixed results when call-actor is absent and only one result is loaded', async () => {
+        const otherActor = { ...MOCK_STORE_ACTOR, id: 'actor-id-2' };
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR, otherActor]);
+
+        const result = await (searchActors as HelperTool).call(
+            stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }, [], [MOCK_STORE_ACTOR.id]),
+        );
+        const { structuredContent, content } = result as {
+            structuredContent: { instructions?: string };
+            content: { type: string; text: string }[];
+        };
+
+        expect(structuredContent.instructions).toContain('cannot be run in this configuration');
+        expect(content[0].text).toContain('cannot be run in this configuration');
+    });
 });

--- a/tests/unit/tools.search_actors.default.response.test.ts
+++ b/tests/unit/tools.search_actors.default.response.test.ts
@@ -242,4 +242,34 @@ describe('search-actors without widget (searchActors)', () => {
         expect(content[0].text).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
         expect(content[0].text).toContain('second search with broader');
     });
+
+    it('adds the not-runnable caveat to text and structured content when call-actor is absent', async () => {
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+
+        const result = await (searchActors as HelperTool).call(
+            stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }),
+        );
+        const { structuredContent, content } = result as {
+            structuredContent: { instructions?: string };
+            content: { type: string; text: string }[];
+        };
+
+        expect(structuredContent.instructions).toContain('cannot be run in this configuration');
+        expect(content[0].text).toContain('cannot be run in this configuration');
+    });
+
+    it('omits the not-runnable caveat when call-actor is loaded', async () => {
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+
+        const result = await (searchActors as HelperTool).call(
+            stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }, [HELPER_TOOLS.ACTOR_CALL]),
+        );
+        const { structuredContent, content } = result as {
+            structuredContent: { instructions?: string };
+            content: { type: string; text: string }[];
+        };
+
+        expect(structuredContent.instructions).not.toContain('cannot be run in this configuration');
+        expect(content[0].text).not.toContain('cannot be run in this configuration');
+    });
 });

--- a/tests/unit/tools.search_actors.fixtures.ts
+++ b/tests/unit/tools.search_actors.fixtures.ts
@@ -29,6 +29,7 @@ export const SEARCH_KEYWORDS = 'web scraper';
 export function stubInternalToolArgs(
     args: Record<string, unknown>,
     loadedToolNames: readonly string[] = [],
+    loadedActorIds: readonly string[] = [],
 ): InternalToolArgs {
     return {
         args,
@@ -37,5 +38,6 @@ export function stubInternalToolArgs(
         signal: new AbortController().signal,
         paymentProvider: undefined,
         loadedToolNames,
+        loadedActorIds: new Set(loadedActorIds),
     };
 }

--- a/tests/unit/tools.search_actors.widget.response.test.ts
+++ b/tests/unit/tools.search_actors.widget.response.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { HELPER_TOOLS } from '../../src/const.js';
 import { WIDGET_URIS } from '../../src/resources/widgets.js';
 import { searchActorsWidget } from '../../src/tools/widgets/search_actors_widget.js';
 import type { HelperTool } from '../../src/types.js';
@@ -33,12 +34,16 @@ describe('search-actors-widget response', () => {
     it('returns widgetActors plus widget _meta and short pointer text', async () => {
         vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
 
+        // call-actor loaded: this assertion is about the widget's content shape, not the caveat.
         const result = await (searchActorsWidget as HelperTool).call(
-            stubInternalToolArgs({
-                keywords: SEARCH_KEYWORDS,
-                limit: 5,
-                offset: 0,
-            }),
+            stubInternalToolArgs(
+                {
+                    keywords: SEARCH_KEYWORDS,
+                    limit: 5,
+                    offset: 0,
+                },
+                [HELPER_TOOLS.ACTOR_CALL],
+            ),
         );
 
         const { structuredContent, content, _meta } = result as {
@@ -102,6 +107,28 @@ describe('search-actors-widget response', () => {
         expect(content).toHaveLength(1);
         expect(content[0].text).toContain('No Actors were found');
         expect(_meta).toBeUndefined();
+    });
+
+    it('appends the not-runnable caveat when call-actor is absent', async () => {
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+
+        const result = await (searchActorsWidget as HelperTool).call(
+            stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }),
+        );
+        const { content } = result as { content: { type: string; text: string }[] };
+
+        expect(content.at(-1)?.text).toContain('cannot be run in this configuration');
+    });
+
+    it('omits the not-runnable caveat when call-actor is loaded', async () => {
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+
+        const result = await (searchActorsWidget as HelperTool).call(
+            stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }, [HELPER_TOOLS.ACTOR_CALL]),
+        );
+        const { content } = result as { content: { type: string; text: string }[] };
+
+        expect(content.every((c) => !c.text.includes('cannot be run in this configuration'))).toBe(true);
     });
 
     it('carries widget _meta on the tool definition', () => {

--- a/tests/unit/tools.search_actors.widget.response.test.ts
+++ b/tests/unit/tools.search_actors.widget.response.test.ts
@@ -131,6 +131,17 @@ describe('search-actors-widget response', () => {
         expect(content.every((c) => !c.text.includes('cannot be run in this configuration'))).toBe(true);
     });
 
+    it('omits the not-runnable caveat when call-actor is absent but every result is already loaded', async () => {
+        vi.mocked(searchAgentSafeActors).mockResolvedValue([MOCK_STORE_ACTOR]);
+
+        const result = await (searchActorsWidget as HelperTool).call(
+            stubInternalToolArgs({ keywords: SEARCH_KEYWORDS, limit: 5, offset: 0 }, [], [MOCK_STORE_ACTOR.id]),
+        );
+        const { content } = result as { content: { type: string; text: string }[] };
+
+        expect(content.every((c) => !c.text.includes('cannot be run in this configuration'))).toBe(true);
+    });
+
     it('carries widget _meta on the tool definition', () => {
         const tool = searchActorsWidget as HelperTool;
         const meta = tool._meta as { ui?: { resourceUri?: string; visibility?: readonly string[]; csp?: unknown } };


### PR DESCRIPTION
Closes apify/ai-team#231

Stacked on #1326, which is stacked on #1334 — base branch is #1326's, not master; diff here is just this PR's own commits.

## What
`search-actors` and `fetch-actor-details` (+ widget variants) now say something when a found Actor can't actually be run in the current session — neither `call-actor` nor a dedicated tool for it is loaded.

## Why
Previously silent: the model was left to guess or hallucinate a call for an Actor that showed up in search results or details but has no runnable path in this configuration.

- `actor_tool_naming.ts`: new `canRunActor(actorId, loadedToolNames, loadedActorIds)` — true when `call-actor` is loaded or the Actor's ID is among the session's loaded Actor/Actor-MCP tools. Matches by stable Actor ID, not by reconstructing a tool-name string, so it's immune to username-length capping and to `--` inside Actor names. Soft check for a guidance hint, not a hard gate.
- `search_actors.ts`: per-result check — the caveat fires only when at least one returned Actor actually lacks a run path, not whenever `call-actor` is absent.
- `fetch_actor_details.ts`: per-Actor guidance on the success path, mirroring `buildActorNotFoundResponse`'s existing `loadedToolNames` gating pattern for the not-found case; matches by the API-resolved Actor ID directly, so querying by ID or `username/name` resolves identically.
- Both widget variants build their own response text and needed their own gated append.

## Testing
`canRunActor` covered directly (call-actor, dedicated tool, Actor-MCP sub-tool, ID-vs-full-name), the per-result search-actors caveat (single result, mixed results, all-already-loaded), guidance-present/absent for both tools and both widget variants. `pnpm run type-check / lint / test:unit / format / check:agents` all green.
