### PR TITLE
feat: Add actorId filter to get-actor-run-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Legend for the **Enabled by default** column:
 | [`apify--rag-web-browser`](https://apify.com/apify/rag-web-browser) | Actor (see [tool configuration](#tools-configuration)) | An Actor tool to browse the web. | ✅ |
 | [`apify--web-fetch`](https://apify.com/apify/web-fetch) | Actor (see [tool configuration](#tools-configuration)) | An Actor tool to fetch a URL and return its content. | ✅ |
 | `report-problem` | dev | Report a problem with an Apify tool or Actor to the Apify team. | ✅¹ |
-| `get-actor-run-list` | runs | Get a list of an Actor's runs, filterable by status. |  |
+| `get-actor-run-list` | runs | Get a list of Actor runs, filterable by Actor and status. |  |
 | `get-actor-log` | runs | Retrieve the logs for a specific Actor run. |  |
 | `get-dataset` | storage | Get metadata about a specific dataset. |  |
 | `get-dataset-schema` | storage | Generate a JSON schema from dataset items. |  |

--- a/src/tools/runs/get_actor_run_list.ts
+++ b/src/tools/runs/get_actor_run_list.ts
@@ -4,10 +4,16 @@ import { HELPER_TOOLS } from '../../const.js';
 import type { InternalToolArgs, ToolEntry, ToolInputSchema } from '../../types.js';
 import { TOOL_TYPE } from '../../types.js';
 import { compileSchema } from '../../utils/ajv.js';
-import { respondRaw } from '../../utils/mcp.js';
+import { respondRaw, respondUserError } from '../../utils/mcp.js';
+import { catchNotFound } from '../storage/storage_helpers.js';
 import { actorRunListOutputSchema } from '../structured_output_schemas.js';
 
 const getUserRunsListArgs = z.object({
+    actorId: z
+        .string()
+        .min(1)
+        .optional()
+        .describe('Only list runs of this Actor; accepts an Actor ID or username/name.'),
     offset: z
         .number()
         .describe('Number of array elements that should be skipped at the start. The default value is 0.')
@@ -30,14 +36,16 @@ const getUserRunsListArgs = z.object({
 });
 
 /**
- * https://docs.apify.com/api/v2/act-runs-get
+ * https://docs.apify.com/api/v2/actor-runs-get (all runs of the user)
+ * https://docs.apify.com/api/v2/act-runs-get (runs of one Actor, when `actorId` is given)
  */
 export const getActorRunList: ToolEntry = Object.freeze({
     type: TOOL_TYPE.INTERNAL,
     name: HELPER_TOOLS.ACTOR_RUN_LIST_GET,
     title: 'Get user runs list',
     description: `List Actor runs for the authenticated user with optional filtering and sorting.
-The results will include run details (including defaultDatasetId and defaultKeyValueStoreId) and can be filtered by status.
+The results will include run details (including defaultDatasetId and defaultKeyValueStoreId) and can be filtered by Actor and by status.
+Pass actorId to list only the runs of one Actor, for example to find its latest run.
 Valid statuses: READY (not allocated), RUNNING (executing), SUCCEEDED (finished), FAILED (failed), TIMING-OUT, TIMED-OUT, ABORTING, ABORTED.
 
 USAGE:
@@ -45,7 +53,8 @@ USAGE:
 
 USAGE EXAMPLES:
 - user_input: List my last 10 runs (newest first)
-- user_input: Show only SUCCEEDED runs`,
+- user_input: Show only SUCCEEDED runs
+- user_input: Show the latest run of apify/web-scraper`,
     inputSchema: z.toJSONSchema(getUserRunsListArgs) as ToolInputSchema,
     outputSchema: actorRunListOutputSchema,
     ajvValidate: compileSchema(z.toJSONSchema(getUserRunsListArgs)),
@@ -59,9 +68,18 @@ USAGE EXAMPLES:
     call: async (toolArgs: InternalToolArgs) => {
         const { args, apifyClient } = toolArgs;
         const parsed = getUserRunsListArgs.parse(args);
-        const runs = await apifyClient
-            .runs()
-            .list({ limit: parsed.limit, offset: parsed.offset, desc: parsed.desc, status: parsed.status });
+        const listOptions = {
+            limit: parsed.limit,
+            offset: parsed.offset,
+            desc: parsed.desc,
+            status: parsed.status,
+        };
+        const runs = parsed.actorId
+            ? await catchNotFound(apifyClient.actor(parsed.actorId).runs().list(listOptions))
+            : await apifyClient.runs().list(listOptions);
+        if (!runs) {
+            return respondUserError(`Actor '${parsed.actorId}' not found.`);
+        }
         return respondRaw({
             content: [{ type: 'text', text: JSON.stringify(runs) }],
             structuredContent: runs as unknown as Record<string, unknown>,

--- a/tests/unit/tools.get_actor_run_list.test.ts
+++ b/tests/unit/tools.get_actor_run_list.test.ts
@@ -1,13 +1,24 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { HELPER_TOOLS } from '../../src/const.js';
 import { getActorRunList } from '../../src/tools/runs/get_actor_run_list.js';
+import { actorRunListOutputSchema } from '../../src/tools/structured_output_schemas.js';
 import type { HelperTool, InternalToolArgs } from '../../src/types.js';
-import { stubToolCallContext, type TextToolResult } from './helpers/tool_context.js';
+import {
+    expectSchemaConformingStructuredContent,
+    expectSoftFailInvalidInput,
+    stubToolCallContext,
+    type TextToolResult,
+} from './helpers/tool_context.js';
 
 const listMock = vi.fn();
+const actorListMock = vi.fn();
+const actorMock = vi.fn(() => ({ runs: () => ({ list: actorListMock }) }));
 
-const stubClient = { runs: () => ({ list: listMock }) } as unknown as InternalToolArgs['apifyClient'];
+const stubClient = {
+    runs: () => ({ list: listMock }),
+    actor: actorMock,
+} as unknown as InternalToolArgs['apifyClient'];
 
 const MOCK_RUNS = {
     total: 1,
@@ -29,6 +40,10 @@ const MOCK_RUNS = {
 };
 
 describe('get-actor-run-list', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     it('has the expected tool name', () => {
         expect(getActorRunList.name).toBe(HELPER_TOOLS.ACTOR_RUN_LIST_GET);
     });
@@ -42,6 +57,7 @@ describe('get-actor-run-list', () => {
         expect(JSON.parse(content[0].text)).toEqual(MOCK_RUNS);
         expect((result as TextToolResult).structuredContent).toEqual(MOCK_RUNS);
         expect((getActorRunList as HelperTool).outputSchema).toMatchObject({ type: 'object' });
+        expectSchemaConformingStructuredContent(result, actorRunListOutputSchema);
     });
 
     it('forwards pagination and status filters to runs().list()', async () => {
@@ -52,6 +68,7 @@ describe('get-actor-run-list', () => {
         );
 
         expect(listMock).toHaveBeenCalledWith({ limit: 5, offset: 2, desc: true, status: 'SUCCEEDED' });
+        expect(actorMock).not.toHaveBeenCalled();
     });
 
     it('applies defaults (limit=10, offset=0, desc=false) when no params given', async () => {
@@ -60,6 +77,49 @@ describe('get-actor-run-list', () => {
         await (getActorRunList as HelperTool).call(stubToolCallContext({}, stubClient));
 
         expect(listMock).toHaveBeenCalledWith({ limit: 10, offset: 0, desc: false, status: undefined });
+    });
+
+    it('lists through actor(actorId).runs().list() with the same options when actorId is given', async () => {
+        actorListMock.mockResolvedValue(MOCK_RUNS);
+
+        const result = await (getActorRunList as HelperTool).call(
+            stubToolCallContext({ actorId: 'apify/web-scraper', limit: 1, desc: true, status: 'FAILED' }, stubClient),
+        );
+
+        expect(actorMock).toHaveBeenCalledWith('apify/web-scraper');
+        expect(actorListMock).toHaveBeenCalledWith({ limit: 1, offset: 0, desc: true, status: 'FAILED' });
+        expect(listMock).not.toHaveBeenCalled();
+        expect((result as TextToolResult).structuredContent).toEqual(MOCK_RUNS);
+        expectSchemaConformingStructuredContent(result, actorRunListOutputSchema);
+    });
+
+    it('returns isError with a not-found message when the Actor does not exist', async () => {
+        actorListMock.mockRejectedValue(Object.assign(new Error('Actor was not found'), { statusCode: 404 }));
+
+        const result = await (getActorRunList as HelperTool).call(
+            stubToolCallContext({ actorId: 'missing' }, stubClient),
+        );
+        const { content, structuredContent } = result as TextToolResult & { structuredContent?: unknown };
+
+        expectSoftFailInvalidInput(result);
+        expect(structuredContent).toBeUndefined();
+        expect(content[0].text).toContain("Actor 'missing' not found");
+    });
+
+    it('rethrows non-404 errors from the Actor run list', async () => {
+        const serverError = Object.assign(new Error('Internal server error'), { statusCode: 500 });
+        actorListMock.mockRejectedValue(serverError);
+
+        await expect(
+            (getActorRunList as HelperTool).call(stubToolCallContext({ actorId: 'act-1' }, stubClient)),
+        ).rejects.toBe(serverError);
+    });
+
+    it('rejects an empty actorId via ajv validation', () => {
+        const tool = getActorRunList as HelperTool;
+        expect(tool.ajvValidate({ actorId: '' })).toBe(false);
+        expect(tool.ajvValidate({ actorId: 'act-1' })).toBe(true);
+        expect(tool.ajvValidate({})).toBe(true);
     });
 
     it('rejects limit above 10 via ajv validation', () => {


### PR DESCRIPTION
## What
Optional `actorId` (Actor ID or `username/name`) on `get-actor-run-list`, to list the runs of one Actor.

## Why
Listing one Actor's runs meant paging through the whole account and filtering client side. Closes #1354 (split from #1053, whose maintainer preferred adjusting this tool over adding a new one). Part of Epic #1351.

## How
- With `actorId`: `client.actor(actorId).runs().list(...)` with the same `limit`, `offset`, `desc`, and `status`. Without it: unchanged.
- An unknown Actor returns the storage tools' soft-fail not-found error. Response shape unchanged.

## Testing
Unit tests cover both paths and the not-found error. `type-check`, `lint`, `format`, `test:unit`, `check:agents` pass.

## Notes
- The README row now describes the filter; this may conflict with the README rewrite in #1329.
- The not-found path reuses `catchNotFound` from `storage_helpers.ts` (a cross-domain import). Say if you prefer letting the raw error propagate.

AI disclosure: implemented with Claude Code; awaiting human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
