### PR TITLE
fix: Gate every cross-tool mention in server instructions behind the session's tool set

### DIFF
--- a/src/mcp/legacy_server.ts
+++ b/src/mcp/legacy_server.ts
@@ -34,7 +34,7 @@ import {
 import log from '@apify/log';
 
 import type { ApifyClient } from '../apify_client.js';
-import { FAILURE_CATEGORY, TOOL_STATUS } from '../const.js';
+import { FAILURE_CATEGORY, HELPER_TOOLS, TOOL_STATUS } from '../const.js';
 import type { createPromptService } from '../prompts/prompt_service.js';
 import type { createResourceService } from '../resources/resource_service.js';
 import { getServerInfo } from '../server_card.js';
@@ -138,7 +138,9 @@ export class LegacyMcpServer {
                 prompts: {},
                 logging: {},
             },
-            instructions: getServerInstructions(),
+            // Placeholder, always overwritten below once the real tool set is known — matches
+            // the pre-gating default (everything but report-problem) rather than every mention.
+            instructions: getServerInstructions(undefined, { hasTool: (name) => name !== HELPER_TOOLS.PROBLEM_REPORT }),
         });
         this.setupInitializeHandler();
         this.setupLoggingProxy();

--- a/src/mcp/legacy_server.ts
+++ b/src/mcp/legacy_server.ts
@@ -138,8 +138,7 @@ export class LegacyMcpServer {
                 prompts: {},
                 logging: {},
             },
-            // Placeholder, always overwritten below once the real tool set is known — matches
-            // the pre-gating default (everything but report-problem) rather than every mention.
+            // Placeholder overwritten below once the real tool set is known; matches the pre-gating default (all but report-problem).
             instructions: getServerInstructions(undefined, { hasTool: (name) => name !== HELPER_TOOLS.PROBLEM_REPORT }),
         });
         this.setupInitializeHandler();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -271,11 +271,11 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
     }
 
     /**
-     * Server instructions for the current connection: mode plus whether report-problem is loaded.
+     * Server instructions for the current connection: mode plus the session's real tool set.
      * Read by the legacy adapter after `applyInitialize`, when the tool set is final.
      */
     public getServerInstructions(): string {
-        return getServerInstructions(this.serverMode, this.tools.has(HELPER_TOOLS.PROBLEM_REPORT));
+        return getServerInstructions(this.serverMode, { hasTool: (name) => this.tools.has(name) });
     }
 
     /**
@@ -286,7 +286,8 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
      * `initialize` rewrites `_serverMode`, which must not leak into later stateless requests.
      */
     public getStatelessServerInstructions(): string {
-        return getServerInstructions(resolveServerMode(this.serverModeOption, false));
+        const notReportProblem = (name: string) => name !== HELPER_TOOLS.PROBLEM_REPORT;
+        return getServerInstructions(resolveServerMode(this.serverModeOption, false), { hasTool: notReportProblem });
     }
 
     /**

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -9,22 +9,86 @@
 
 import { getApifyAPIBaseUrl } from '../../apify_client.js';
 import { HELPER_TOOLS, RAG_WEB_BROWSER, WEB_FETCH } from '../../const.js';
-import { SERVER_MODE } from '../../types.js';
+import { actorNameToToolName } from '../../tools/actor_tool_naming.js';
+import type { ToolDescriptionContext } from '../../types.js';
+import { ALL_TOOLS_PRESENT, SERVER_MODE } from '../../types.js';
+
+// hasTool checks registered tool names, not Actor full names — see call_actor.ts's RAG_WEB_BROWSER_TOOL.
+const RAG_WEB_BROWSER_TOOL = actorNameToToolName(RAG_WEB_BROWSER);
+const WEB_FETCH_TOOL = actorNameToToolName(WEB_FETCH);
 
 /**
- * Build server instructions for the given mode.
- *
- * Apps-only sections are omitted in default mode to prevent models from
- * attempting to call widget tools that are not registered. The report-problem line is
- * emitted only when `reportProblemAvailable` is true — i.e. `report-problem` is actually
- * served — so clients that never receive the tool (Anthropic surfaces, telemetry off, or a
- * `tools=` selection that omits report-problem) are not told to call it.
+ * Build server instructions for the given mode. Every cross-tool mention is gated on
+ * `ctx.hasTool(...)` so a session missing a tool is never told to call it.
  */
-export function getServerInstructions(mode: SERVER_MODE = SERVER_MODE.DEFAULT, reportProblemAvailable = false): string {
+export function getServerInstructions(
+    mode: SERVER_MODE = SERVER_MODE.DEFAULT,
+    { hasTool }: ToolDescriptionContext = ALL_TOOLS_PRESENT,
+): string {
     const isApps = mode === SERVER_MODE.APPS;
     // Derive the API base from config so examples match the gate/templates under an
     // APIFY_API_BASE_URL / staging override, instead of a hardcoded api.apify.com.
     const apiBaseUrl = getApifyAPIBaseUrl();
+
+    const hasSearch = hasTool(HELPER_TOOLS.STORE_SEARCH);
+    const hasDetails = hasTool(HELPER_TOOLS.ACTOR_GET_DETAILS);
+    const hasCall = hasTool(HELPER_TOOLS.ACTOR_CALL);
+    const hasRunsGet = hasTool(HELPER_TOOLS.ACTOR_RUNS_GET);
+
+    // get-actor-run-widget is auto-added alongside get-actor-run in apps mode, so gating on the
+    // base tool alone is enough.
+    const widgetWorkflowSection =
+        isApps && hasRunsGet
+            ? `
+## Widget workflow (applies when tool responses include widget metadata)
+Some clients render widget-backed Actor tools: the response includes a live UI that automatically polls run status. When a widget is rendered, follow-up status polling by the model is a forbidden duplicate.
+
+${
+    hasCall
+        ? `- **After \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` or \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\`, never call \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` or \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` for the same run.** Both widgets render live progress and poll themselves — stop after the widget response and defer to it for run status. Re-rendering the same run via \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` is a duplicate.
+- Polling \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` after \`${HELPER_TOOLS.ACTOR_CALL}\` is fine — that tool renders no UI, so polling is expected when the run is non-terminal and you need the latest status.
+`
+        : `- **After \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\`, never call \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` or \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` for the same run.** It renders live progress and polls itself — stop after the widget response and defer to it for run status. Re-rendering the same run via \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` is a duplicate.
+`
+}`
+            : '';
+
+    const toolDependencies = hasCall
+        ? `
+### Tool dependencies
+- \`${HELPER_TOOLS.ACTOR_CALL}\`:
+  - ${hasDetails ? `Use \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` first to obtain the Actor's input schema.` : `Check the Actor's input schema first.`}
+  - Then call with proper input to execute the Actor.
+  - For MCP server Actors, use format "actorName:toolName" to call specific tools.
+  - Supports a \`waitSecs\` parameter (default 30, max 45):
+    - \`waitSecs: 0\`: fire-and-forget — starts the run and returns immediately with a runId.
+    - \`waitSecs > 0\`: waits up to that many seconds for the run to complete, then returns its current status and storage IDs (never the output rows — fetch those with \`${HELPER_TOOLS.DATASET_GET_ITEMS}\`).
+`
+        : '';
+
+    // Compares both when loaded; names whichever one is loaded alone otherwise.
+    const searchVsDetailsDisambiguation =
+        hasSearch && hasDetails
+            ? `### Tool disambiguation
+- **\`${HELPER_TOOLS.STORE_SEARCH}\` vs \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\`:**
+  \`${HELPER_TOOLS.STORE_SEARCH}\` finds Actors; \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` retrieves detailed info, README, and schema for a specific Actor.
+`
+            : hasSearch
+              ? `### Tool disambiguation
+- \`${HELPER_TOOLS.STORE_SEARCH}\` finds Actors by keyword.
+`
+              : hasDetails
+                ? `### Tool disambiguation
+- \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` retrieves detailed info, README, and schema for a specific Actor.
+`
+                : '';
+
+    // Each bullet gates on its base tool; the widget sibling is auto-present alongside it.
+    const widgetToolDisambiguation =
+        isApps && (hasSearch || hasDetails || hasCall || hasRunsGet)
+            ? `- **Data vs widget Actor tools (when the client supports widgets):**
+${hasSearch ? `  - \`${HELPER_TOOLS.STORE_SEARCH}\` is a silent data lookup (Actor list for name resolution) with no UI; \`${HELPER_TOOLS.STORE_SEARCH_WIDGET}\` renders an interactive UI element (widget) with Actor search results for the user to browse — use it only when the user explicitly asks to search or discover Actors.\n` : ''}${hasDetails ? `  - \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` is a silent data lookup (input schema, README, metadata) with no UI; \`${HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET}\` renders an interactive UI element (widget) with Actor details — use it only when the user explicitly asks to see or browse the Actor.\n` : ''}${hasCall ? `  - \`${HELPER_TOOLS.ACTOR_CALL}\` runs the Actor and returns its run status and storage IDs (no UI); \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` renders an interactive UI element (widget) that tracks live Actor run progress — use it only when the user explicitly asks to see progress.\n` : ''}${hasRunsGet ? `  - \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` is a silent data lookup (run status, dataset IDs, stats) with no UI; \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` renders an interactive UI element (widget) showing live run progress for the user — use it only when the user explicitly asks to see run progress.\n` : ''}${hasSearch && hasDetails ? `  - When the next step is running an Actor, prefer silent lookups (\`${HELPER_TOOLS.STORE_SEARCH}\`, \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\`) over widget-backed variants.\n` : ''}`
+            : '';
 
     return `
 Apify is the world's largest marketplace of tools for web scraping, data extraction, and web automation.
@@ -64,52 +128,31 @@ These tools are called **Actors**. They enable you to extract structured data fr
 - Actor and tool results return storage IDs, not resource URLs — build the URL from the ID (e.g. a \`datasetId\` becomes \`${apiBaseUrl}/v2/datasets/{datasetId}/items\`) and read it via \`resources/read\`.
 - Reads inline up to ~256 KB; a larger response is not downloaded — it returns a short notice with a download URL instead of the body, so page large datasets/lists with \`limit\` and \`offset\` to stay under the cap.
 - Examples: \`${apiBaseUrl}/v2/datasets/{datasetId}/items?clean=true&format=json&limit=100\`, \`${apiBaseUrl}/v2/key-value-stores/{storeId}/records/{recordKey}\`. \`resources/templates/list\` enumerates the common shapes with their paging parameters.
-${
-    isApps
-        ? `
-## Widget workflow (applies when tool responses include widget metadata)
-Some clients render widget-backed Actor tools: the response includes a live UI that automatically polls run status. When a widget is rendered, follow-up status polling by the model is a forbidden duplicate.
-
-- **After \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` or \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\`, never call \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` or \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` for the same run.** Both widgets render live progress and poll themselves — stop after the widget response and defer to it for run status. Re-rendering the same run via \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` is a duplicate.
-- Polling \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` after \`${HELPER_TOOLS.ACTOR_CALL}\` is fine — that tool renders no UI, so polling is expected when the run is non-terminal and you need the latest status.
-`
-        : ''
-}
+${widgetWorkflowSection}
 ## Tool dependencies and disambiguation
-
-### Tool dependencies
-- \`${HELPER_TOOLS.ACTOR_CALL}\`:
-  - Use \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` first to obtain the Actor's input schema.
-  - Then call with proper input to execute the Actor.
-  - For MCP server Actors, use format "actorName:toolName" to call specific tools.
-  - Supports a \`waitSecs\` parameter (default 30, max 45):
-    - \`waitSecs: 0\`: fire-and-forget — starts the run and returns immediately with a runId.
-    - \`waitSecs > 0\`: waits up to that many seconds for the run to complete, then returns its current status and storage IDs (never the output rows — fetch those with \`${HELPER_TOOLS.DATASET_GET_ITEMS}\`).
-
-### Tool disambiguation
-- **\`${HELPER_TOOLS.STORE_SEARCH}\` vs \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\`:**
-  \`${HELPER_TOOLS.STORE_SEARCH}\` finds Actors; \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` retrieves detailed info, README, and schema for a specific Actor.
-${
-    isApps
-        ? `- **Data vs widget Actor tools (when the client supports widgets):**
-  - \`${HELPER_TOOLS.STORE_SEARCH}\` is a silent data lookup (Actor list for name resolution) with no UI; \`${HELPER_TOOLS.STORE_SEARCH_WIDGET}\` renders an interactive UI element (widget) with Actor search results for the user to browse — use it only when the user explicitly asks to search or discover Actors.
-  - \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` is a silent data lookup (input schema, README, metadata) with no UI; \`${HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET}\` renders an interactive UI element (widget) with Actor details — use it only when the user explicitly asks to see or browse the Actor.
-  - \`${HELPER_TOOLS.ACTOR_CALL}\` runs the Actor and returns its run status and storage IDs (no UI); \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` renders an interactive UI element (widget) that tracks live Actor run progress — use it only when the user explicitly asks to see progress.
-  - \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` is a silent data lookup (run status, dataset IDs, stats) with no UI; \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` renders an interactive UI element (widget) showing live run progress for the user — use it only when the user explicitly asks to see run progress.
-  - When the next step is running an Actor, prefer silent lookups (\`${HELPER_TOOLS.STORE_SEARCH}\`, \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\`) over widget-backed variants.
-`
-        : ''
-}- **\`${HELPER_TOOLS.STORE_SEARCH}\` vs ${RAG_WEB_BROWSER}:**
+${toolDependencies}${searchVsDetailsDisambiguation}${widgetToolDisambiguation}${
+        hasSearch && hasTool(RAG_WEB_BROWSER_TOOL)
+            ? `- **\`${HELPER_TOOLS.STORE_SEARCH}\` vs ${RAG_WEB_BROWSER}:**
   \`${HELPER_TOOLS.STORE_SEARCH}\` finds robust and reliable Actors for specific websites; ${RAG_WEB_BROWSER} is a general and versatile web scraping tool.
-- **${WEB_FETCH} vs ${RAG_WEB_BROWSER}:**
+`
+            : ''
+    }${
+        hasTool(WEB_FETCH_TOOL) && hasTool(RAG_WEB_BROWSER_TOOL)
+            ? `- **${WEB_FETCH} vs ${RAG_WEB_BROWSER}:**
   ${WEB_FETCH} fetches one specific URL and returns its full content verbatim; ${RAG_WEB_BROWSER} searches the web by query and returns content from the top results.
-- **Dedicated Actor tools (e.g. ${RAG_WEB_BROWSER}) vs \`${HELPER_TOOLS.ACTOR_CALL}\`:**
+`
+            : ''
+    }${
+        hasCall
+            ? `- **Dedicated Actor tools${hasTool(RAG_WEB_BROWSER_TOOL) ? ` (e.g. ${RAG_WEB_BROWSER})` : ''} vs \`${HELPER_TOOLS.ACTOR_CALL}\`:**
   Prefer dedicated tools when available; use \`${HELPER_TOOLS.ACTOR_CALL}\` only when no specialized tool exists in the Apify store.
-${
-    reportProblemAvailable
-        ? `
+`
+            : ''
+    }${
+        hasTool(HELPER_TOOLS.PROBLEM_REPORT)
+            ? `
 If a tool or Actor fails and you cannot resolve it, you can report it with \`${HELPER_TOOLS.PROBLEM_REPORT}\`.
 `
-        : ''
-}`;
+            : ''
+    }`;
 }

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -54,8 +54,7 @@ ${
             : '';
 
     const toolDependencies = hasCall
-        ? `
-### Tool dependencies
+        ? `### Tool dependencies
 - \`${HELPER_TOOLS.ACTOR_CALL}\`:
   - ${hasDetails ? `Use \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` first to obtain the Actor's input schema.` : `Check the Actor's input schema first.`}
   - Then call with proper input to execute the Actor.
@@ -89,6 +88,48 @@ ${
             ? `- **Data vs widget Actor tools (when the client supports widgets):**
 ${hasSearch ? `  - \`${HELPER_TOOLS.STORE_SEARCH}\` is a silent data lookup (Actor list for name resolution) with no UI; \`${HELPER_TOOLS.STORE_SEARCH_WIDGET}\` renders an interactive UI element (widget) with Actor search results for the user to browse — use it only when the user explicitly asks to search or discover Actors.\n` : ''}${hasDetails ? `  - \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\` is a silent data lookup (input schema, README, metadata) with no UI; \`${HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET}\` renders an interactive UI element (widget) with Actor details — use it only when the user explicitly asks to see or browse the Actor.\n` : ''}${hasCall ? `  - \`${HELPER_TOOLS.ACTOR_CALL}\` runs the Actor and returns its run status and storage IDs (no UI); \`${HELPER_TOOLS.ACTOR_CALL_WIDGET}\` renders an interactive UI element (widget) that tracks live Actor run progress — use it only when the user explicitly asks to see progress.\n` : ''}${hasRunsGet ? `  - \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` is a silent data lookup (run status, dataset IDs, stats) with no UI; \`${HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET}\` renders an interactive UI element (widget) showing live run progress for the user — use it only when the user explicitly asks to see run progress.\n` : ''}${hasSearch && hasDetails ? `  - When the next step is running an Actor, prefer silent lookups (\`${HELPER_TOOLS.STORE_SEARCH}\`, \`${HELPER_TOOLS.ACTOR_GET_DETAILS}\`) over widget-backed variants.\n` : ''}`
             : '';
+
+    const searchVsRagWebBrowser =
+        hasSearch && hasTool(RAG_WEB_BROWSER_TOOL)
+            ? `- **\`${HELPER_TOOLS.STORE_SEARCH}\` vs ${RAG_WEB_BROWSER}:**
+  \`${HELPER_TOOLS.STORE_SEARCH}\` finds robust and reliable Actors for specific websites; ${RAG_WEB_BROWSER} is a general and versatile web scraping tool.
+`
+            : '';
+
+    const webFetchVsRagWebBrowser =
+        hasTool(WEB_FETCH_TOOL) && hasTool(RAG_WEB_BROWSER_TOOL)
+            ? `- **${WEB_FETCH} vs ${RAG_WEB_BROWSER}:**
+  ${WEB_FETCH} fetches one specific URL and returns its full content verbatim; ${RAG_WEB_BROWSER} searches the web by query and returns content from the top results.
+`
+            : '';
+
+    const dedicatedToolsVsCallActor = hasCall
+        ? `- **Dedicated Actor tools${hasTool(RAG_WEB_BROWSER_TOOL) ? ` (e.g. ${RAG_WEB_BROWSER})` : ''} vs \`${HELPER_TOOLS.ACTOR_CALL}\`:**
+  Prefer dedicated tools when available; use \`${HELPER_TOOLS.ACTOR_CALL}\` only when no specialized tool exists in the Apify store.
+`
+        : '';
+
+    /**
+     * The section renders only when something under it survives gating — a session whose whole tool
+     * set is gated away (e.g. one Actor tool, no widgets) would otherwise end on a bare heading.
+     * `###` subsections keep a blank line before them; consecutive bullets stay contiguous.
+     */
+    const renderedBlocks = [
+        toolDependencies,
+        searchVsDetailsDisambiguation,
+        widgetToolDisambiguation,
+        searchVsRagWebBrowser,
+        webFetchVsRagWebBrowser,
+        dedicatedToolsVsCallActor,
+    ].filter((block) => block !== '');
+
+    const dependenciesAndDisambiguation =
+        renderedBlocks.length === 0
+            ? ''
+            : `
+## Tool dependencies and disambiguation
+
+${renderedBlocks.map((block, index) => (index > 0 && block.startsWith('###') ? `\n${block}` : block)).join('')}`;
 
     return `
 Apify is the world's largest marketplace of tools for web scraping, data extraction, and web automation.
@@ -128,27 +169,7 @@ These tools are called **Actors**. They enable you to extract structured data fr
 - Actor and tool results return storage IDs, not resource URLs — build the URL from the ID (e.g. a \`datasetId\` becomes \`${apiBaseUrl}/v2/datasets/{datasetId}/items\`) and read it via \`resources/read\`.
 - Reads inline up to ~256 KB; a larger response is not downloaded — it returns a short notice with a download URL instead of the body, so page large datasets/lists with \`limit\` and \`offset\` to stay under the cap.
 - Examples: \`${apiBaseUrl}/v2/datasets/{datasetId}/items?clean=true&format=json&limit=100\`, \`${apiBaseUrl}/v2/key-value-stores/{storeId}/records/{recordKey}\`. \`resources/templates/list\` enumerates the common shapes with their paging parameters.
-${widgetWorkflowSection}
-## Tool dependencies and disambiguation
-${toolDependencies}${searchVsDetailsDisambiguation}${widgetToolDisambiguation}${
-        hasSearch && hasTool(RAG_WEB_BROWSER_TOOL)
-            ? `- **\`${HELPER_TOOLS.STORE_SEARCH}\` vs ${RAG_WEB_BROWSER}:**
-  \`${HELPER_TOOLS.STORE_SEARCH}\` finds robust and reliable Actors for specific websites; ${RAG_WEB_BROWSER} is a general and versatile web scraping tool.
-`
-            : ''
-    }${
-        hasTool(WEB_FETCH_TOOL) && hasTool(RAG_WEB_BROWSER_TOOL)
-            ? `- **${WEB_FETCH} vs ${RAG_WEB_BROWSER}:**
-  ${WEB_FETCH} fetches one specific URL and returns its full content verbatim; ${RAG_WEB_BROWSER} searches the web by query and returns content from the top results.
-`
-            : ''
-    }${
-        hasCall
-            ? `- **Dedicated Actor tools${hasTool(RAG_WEB_BROWSER_TOOL) ? ` (e.g. ${RAG_WEB_BROWSER})` : ''} vs \`${HELPER_TOOLS.ACTOR_CALL}\`:**
-  Prefer dedicated tools when available; use \`${HELPER_TOOLS.ACTOR_CALL}\` only when no specialized tool exists in the Apify store.
-`
-            : ''
-    }${
+${widgetWorkflowSection}${dependenciesAndDisambiguation}${
         hasTool(HELPER_TOOLS.PROBLEM_REPORT)
             ? `
 If a tool or Actor fails and you cannot resolve it, you can report it with \`${HELPER_TOOLS.PROBLEM_REPORT}\`.

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -17,10 +17,7 @@ import { ALL_TOOLS_PRESENT, SERVER_MODE } from '../../types.js';
 const RAG_WEB_BROWSER_TOOL = actorNameToToolName(RAG_WEB_BROWSER);
 const WEB_FETCH_TOOL = actorNameToToolName(WEB_FETCH);
 
-/**
- * Build server instructions for the given mode. Every cross-tool mention is gated on
- * `ctx.hasTool(...)` so a session missing a tool is never told to call it.
- */
+/** Every cross-tool mention gates on `ctx.hasTool(...)`, so a session missing a tool is never told to call it. */
 export function getServerInstructions(
     mode: SERVER_MODE = SERVER_MODE.DEFAULT,
     { hasTool }: ToolDescriptionContext = ALL_TOOLS_PRESENT,
@@ -35,8 +32,7 @@ export function getServerInstructions(
     const hasCall = hasTool(HELPER_TOOLS.ACTOR_CALL);
     const hasRunsGet = hasTool(HELPER_TOOLS.ACTOR_RUNS_GET);
 
-    // get-actor-run-widget is auto-added alongside get-actor-run in apps mode, so gating on the
-    // base tool alone is enough.
+    // get-actor-run-widget auto-loads with get-actor-run in apps mode; gating the base tool suffices.
     const widgetWorkflowSection =
         isApps && hasRunsGet
             ? `

--- a/src/utils/server-instructions/index.ts
+++ b/src/utils/server-instructions/index.ts
@@ -105,11 +105,7 @@ ${hasSearch ? `  - \`${HELPER_TOOLS.STORE_SEARCH}\` is a silent data lookup (Act
 `
         : '';
 
-    /**
-     * The section renders only when something under it survives gating — a session whose whole tool
-     * set is gated away (e.g. one Actor tool, no widgets) would otherwise end on a bare heading.
-     * `###` subsections keep a blank line before them; consecutive bullets stay contiguous.
-     */
+    /** Renders only if a subsection survives gating, to avoid a bare heading; `###` subsections get a blank line before them, bullets stay contiguous. */
     const renderedBlocks = [
         toolDependencies,
         searchVsDetailsDisambiguation,

--- a/tests/unit/mcp.stateless.request_context.test.ts
+++ b/tests/unit/mcp.stateless.request_context.test.ts
@@ -389,6 +389,15 @@ describe('createStatelessServer() request context', () => {
                 );
             },
         );
+
+        // Regression: the pre-gating default is "everything but report-problem", not "nothing" —
+        // this configuration-level probe must still mention call-actor unconditionally.
+        it('mentions call-actor unconditionally, before any request establishes the real tool set', async () => {
+            await withStatelessServer(async ({ call }) => {
+                const discovered = await call('server/discover', {}, { client: { name: 'test-client' } });
+                expect(discovered.result?.instructions).toContain(HELPER_TOOLS.ACTOR_CALL);
+            });
+        });
     });
 
     describe('retained tool sources', () => {

--- a/tests/unit/mcp.stateless.request_context.test.ts
+++ b/tests/unit/mcp.stateless.request_context.test.ts
@@ -390,8 +390,7 @@ describe('createStatelessServer() request context', () => {
             },
         );
 
-        // Regression: the pre-gating default is "everything but report-problem", not "nothing" —
-        // this configuration-level probe must still mention call-actor unconditionally.
+        // Regression: pre-gating default is "all but report-problem", not "nothing" — must still mention call-actor.
         it('mentions call-actor unconditionally, before any request establishes the real tool set', async () => {
             await withStatelessServer(async ({ call }) => {
                 const discovered = await call('server/discover', {}, { client: { name: 'test-client' } });

--- a/tests/unit/server-instructions.test.ts
+++ b/tests/unit/server-instructions.test.ts
@@ -1,12 +1,28 @@
 import { describe, expect, it } from 'vitest';
 
-import { HELPER_TOOLS } from '../../src/const.js';
-import { SERVER_MODE } from '../../src/types.js';
+import { HELPER_TOOLS, RAG_WEB_BROWSER, WEB_FETCH } from '../../src/const.js';
+import { parseInputParamsFromUrl } from '../../src/mcp/utils.js';
+import { actorNameToToolName } from '../../src/tools/actor_tool_naming.js';
+import type { ToolDescriptionContext } from '../../src/types.js';
+import { ALL_TOOLS_PRESENT, SERVER_MODE } from '../../src/types.js';
 import { getServerInstructions } from '../../src/utils/server-instructions/index.js';
+import { getToolsForServerMode } from '../../src/utils/tools_loader.js';
+
+/** Context reporting every named tool present, everything else absent. */
+function only(...present: string[]): ToolDescriptionContext {
+    const set = new Set(present);
+    return { hasTool: (name) => set.has(name) };
+}
 
 describe('getServerInstructions()', () => {
+    it('defaults to ALL_TOOLS_PRESENT — no regression for the common case (every tool loaded)', () => {
+        expect(getServerInstructions(SERVER_MODE.DEFAULT)).toBe(
+            getServerInstructions(SERVER_MODE.DEFAULT, ALL_TOOLS_PRESENT),
+        );
+    });
+
     it('mentions report-problem with a gentle, non-mandatory nudge when feedback is available', () => {
-        const instructions = getServerInstructions(SERVER_MODE.DEFAULT, true);
+        const instructions = getServerInstructions(SERVER_MODE.DEFAULT, ALL_TOOLS_PRESENT);
         expect(instructions).toContain(HELPER_TOOLS.PROBLEM_REPORT);
         expect(instructions).toContain('you can report it');
         // No hard directive — the directory review rejects MUST-style solicitation.
@@ -14,14 +30,127 @@ describe('getServerInstructions()', () => {
         expect(instructions).not.toContain('Reporting problems and feedback');
     });
 
-    it('omits report-problem by default', () => {
-        expect(getServerInstructions()).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
-    });
-
     it('describes a capped wait as returning the current run status', () => {
-        const instructions = getServerInstructions();
-
+        const instructions = getServerInstructions(SERVER_MODE.DEFAULT, ALL_TOOLS_PRESENT);
         expect(instructions).toContain('returns its current status and storage IDs');
         expect(instructions).not.toContain('returns its final status and storage IDs');
+    });
+
+    it('mentions call-actor, apify/rag-web-browser and apify/web-fetch when all are loaded', () => {
+        const instructions = getServerInstructions(SERVER_MODE.DEFAULT, ALL_TOOLS_PRESENT);
+        expect(instructions).toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(instructions).toContain(RAG_WEB_BROWSER);
+        expect(instructions).toContain(WEB_FETCH);
+    });
+
+    it('omits every call-actor mention when call-actor is absent from the session', () => {
+        const instructions = getServerInstructions(SERVER_MODE.DEFAULT, only(HELPER_TOOLS.STORE_SEARCH));
+        expect(instructions).not.toContain(HELPER_TOOLS.ACTOR_CALL);
+        expect(instructions).toContain(HELPER_TOOLS.STORE_SEARCH); // no dead end
+    });
+
+    it('omits the apps-mode widget-disambiguation call-actor line when call-actor is absent', () => {
+        const instructions = getServerInstructions(SERVER_MODE.APPS, only(HELPER_TOOLS.STORE_SEARCH));
+        expect(instructions).not.toContain(HELPER_TOOLS.ACTOR_CALL);
+    });
+
+    it('omits report-problem when it is absent from the session', () => {
+        const instructions = getServerInstructions(SERVER_MODE.DEFAULT, only(HELPER_TOOLS.ACTOR_CALL));
+        expect(instructions).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
+        expect(instructions).toContain(HELPER_TOOLS.ACTOR_CALL); // no dead end
+    });
+
+    it('omits apify/rag-web-browser and apify/web-fetch mentions when both are absent', () => {
+        const instructions = getServerInstructions(SERVER_MODE.DEFAULT, only(HELPER_TOOLS.ACTOR_CALL));
+        expect(instructions).not.toContain(RAG_WEB_BROWSER);
+        expect(instructions).not.toContain(WEB_FETCH);
+        expect(instructions).toContain('Prefer dedicated tools when available'); // no dead end
+    });
+
+    // Regression: hasTool must match the registered tool name, not the Actor full name used for display text.
+    it('keeps the rag-web-browser/web-fetch comparisons when their real tool names are present', () => {
+        const instructions = getServerInstructions(
+            SERVER_MODE.DEFAULT,
+            only(HELPER_TOOLS.ACTOR_CALL, actorNameToToolName(RAG_WEB_BROWSER), actorNameToToolName(WEB_FETCH)),
+        );
+        expect(instructions).toContain(RAG_WEB_BROWSER);
+        expect(instructions).toContain(WEB_FETCH);
+    });
+
+    it('omits the search-vs-details disambiguation when only one side is loaded, but still names it', () => {
+        const searchOnly = getServerInstructions(SERVER_MODE.DEFAULT, only(HELPER_TOOLS.STORE_SEARCH));
+        expect(searchOnly).toContain(HELPER_TOOLS.STORE_SEARCH);
+        expect(searchOnly).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
+
+        const detailsOnly = getServerInstructions(SERVER_MODE.DEFAULT, only(HELPER_TOOLS.ACTOR_GET_DETAILS));
+        expect(detailsOnly).toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
+        expect(detailsOnly).not.toContain(HELPER_TOOLS.STORE_SEARCH);
+    });
+
+    it('omits the search-vs-details disambiguation entirely when neither is loaded', () => {
+        const instructions = getServerInstructions(SERVER_MODE.DEFAULT, only(HELPER_TOOLS.ACTOR_CALL));
+        expect(instructions).not.toContain(HELPER_TOOLS.STORE_SEARCH);
+        expect(instructions).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS);
+    });
+
+    it('omits both apps-mode Actor-run sections when get-actor-run is absent', () => {
+        const instructions = getServerInstructions(SERVER_MODE.APPS, only(HELPER_TOOLS.DOCS_SEARCH));
+        expect(instructions).not.toContain('Widget workflow');
+        expect(instructions).not.toContain('Data vs widget Actor tools');
+    });
+
+    it('renders the apps-mode widget-workflow block when get-actor-run is loaded', () => {
+        const instructions = getServerInstructions(SERVER_MODE.APPS, only(HELPER_TOOLS.ACTOR_RUNS_GET));
+        expect(instructions).toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
+    });
+
+    it('renders only the data-vs-widget bullets for tools actually loaded, in apps mode', () => {
+        const instructions = getServerInstructions(SERVER_MODE.APPS, only(HELPER_TOOLS.STORE_SEARCH));
+        expect(instructions).toContain(HELPER_TOOLS.STORE_SEARCH_WIDGET);
+        expect(instructions).not.toContain(HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET);
+        expect(instructions).not.toContain(HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET);
+    });
+
+    it('omits the search-actors-vs-rag-web-browser comparison when search-actors is absent', () => {
+        const instructions = getServerInstructions(SERVER_MODE.DEFAULT, only(actorNameToToolName(RAG_WEB_BROWSER)));
+        expect(instructions).not.toContain(HELPER_TOOLS.STORE_SEARCH);
+    });
+});
+
+/** Pins the Claude-connector tool surface (no call-actor). Offline — no network, no fixture. */
+describe('Claude-connector tool surface (no call-actor)', () => {
+    const url =
+        'https://mcp.apify.com/?tools=search-actors,search-actors-widget,fetch-actor-details,fetch-actor-details-widget,search-apify-docs,fetch-apify-docs,get-actor-run,get-actor-run-widget,get-actor-run-list,get-actor-log,abort-actor-run,get-dataset-list,get-dataset,get-dataset-items,get-key-value-store-list,get-key-value-store,get-key-value-store-record,apify/rag-web-browser,apify/web-fetch';
+
+    // Actor-tool selectors need a live fetch to resolve; checks the internal-tool subset only.
+    const expectedInternalToolNames = [
+        HELPER_TOOLS.STORE_SEARCH,
+        HELPER_TOOLS.STORE_SEARCH_WIDGET,
+        HELPER_TOOLS.ACTOR_GET_DETAILS,
+        HELPER_TOOLS.ACTOR_GET_DETAILS_WIDGET,
+        HELPER_TOOLS.DOCS_SEARCH,
+        HELPER_TOOLS.DOCS_FETCH,
+        HELPER_TOOLS.ACTOR_RUNS_GET,
+        HELPER_TOOLS.ACTOR_RUNS_GET_WIDGET,
+        HELPER_TOOLS.ACTOR_RUN_LIST_GET,
+        HELPER_TOOLS.ACTOR_RUNS_LOG,
+        HELPER_TOOLS.ACTOR_RUNS_ABORT,
+        HELPER_TOOLS.DATASET_LIST_GET,
+        HELPER_TOOLS.DATASET_GET,
+        HELPER_TOOLS.DATASET_GET_ITEMS,
+        HELPER_TOOLS.KEY_VALUE_STORE_LIST_GET,
+        HELPER_TOOLS.KEY_VALUE_STORE_GET,
+        HELPER_TOOLS.KEY_VALUE_STORE_RECORD_GET,
+    ];
+
+    it('resolves to exactly the expected internal tools, no call-actor, and instructions mention it nowhere', () => {
+        const resolved = new Set(
+            getToolsForServerMode(parseInputParamsFromUrl(url), [], SERVER_MODE.APPS).map((tool) => tool.name),
+        );
+        expect(resolved).toEqual(new Set(expectedInternalToolNames));
+        expect(resolved.has(HELPER_TOOLS.ACTOR_CALL)).toBe(false);
+
+        const instructions = getServerInstructions(SERVER_MODE.APPS, { hasTool: (name) => resolved.has(name) });
+        expect(instructions).not.toContain(HELPER_TOOLS.ACTOR_CALL);
     });
 });

--- a/tests/unit/server-instructions.test.ts
+++ b/tests/unit/server-instructions.test.ts
@@ -115,6 +115,40 @@ describe('getServerInstructions()', () => {
         const instructions = getServerInstructions(SERVER_MODE.DEFAULT, only(actorNameToToolName(RAG_WEB_BROWSER)));
         expect(instructions).not.toContain(HELPER_TOOLS.STORE_SEARCH);
     });
+
+    // The apps + call-actor render is what every hosted apps session gets, and the only untested
+    // combination: the other apps cases omit call-actor, the other full-tool-set cases use default mode.
+    it('keeps every call-actor mention in apps mode when the session has call-actor', () => {
+        const instructions = getServerInstructions(SERVER_MODE.APPS, ALL_TOOLS_PRESENT);
+        expect(instructions).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
+        expect(instructions).toContain(
+            `Polling \`${HELPER_TOOLS.ACTOR_RUNS_GET}\` after \`${HELPER_TOOLS.ACTOR_CALL}\` is fine`,
+        );
+        expect(instructions).toContain('### Tool dependencies');
+        expect(instructions).toContain('Prefer dedicated tools when available');
+    });
+
+    describe('"Tool dependencies and disambiguation" section', () => {
+        const HEADING = '## Tool dependencies and disambiguation';
+
+        it('omits the heading when every subsection is gated away', () => {
+            // A session with only Actor tools plus auto-injected run/storage helpers, no widgets:
+            // nothing under the heading renders, so the heading itself must not be emitted.
+            const instructions = getServerInstructions(SERVER_MODE.DEFAULT, only(HELPER_TOOLS.ACTOR_RUNS_GET));
+            expect(instructions).not.toContain(HEADING);
+        });
+
+        it('separates the two subsections with a blank line', () => {
+            expect(getServerInstructions(SERVER_MODE.DEFAULT, ALL_TOOLS_PRESENT)).toContain(
+                '\n\n### Tool disambiguation',
+            );
+        });
+
+        it('keeps a blank line after the heading when only bullets render', () => {
+            const instructions = getServerInstructions(SERVER_MODE.APPS, only(HELPER_TOOLS.ACTOR_RUNS_GET));
+            expect(instructions).toContain(`${HEADING}\n\n- **Data vs widget Actor tools`);
+        });
+    });
 });
 
 /** Pins the Claude-connector tool surface (no call-actor). Offline — no network, no fixture. */

--- a/tests/unit/server-instructions.test.ts
+++ b/tests/unit/server-instructions.test.ts
@@ -151,7 +151,7 @@ describe('getServerInstructions()', () => {
     });
 });
 
-/** Pins the Claude-connector tool surface (no call-actor). Offline — no network, no fixture. */
+/** Pins the Claude-connector tool surface (no call-actor); offline, no network or fixture. */
 describe('Claude-connector tool surface (no call-actor)', () => {
     const url =
         'https://mcp.apify.com/?tools=search-actors,search-actors-widget,fetch-actor-details,fetch-actor-details-widget,search-apify-docs,fetch-apify-docs,get-actor-run,get-actor-run-widget,get-actor-run-list,get-actor-log,abort-actor-run,get-dataset-list,get-dataset,get-dataset-items,get-key-value-store-list,get-key-value-store,get-key-value-store-record,apify/rag-web-browser,apify/web-fetch';

--- a/tests/unit/server-instructions.test.ts
+++ b/tests/unit/server-instructions.test.ts
@@ -116,8 +116,7 @@ describe('getServerInstructions()', () => {
         expect(instructions).not.toContain(HELPER_TOOLS.STORE_SEARCH);
     });
 
-    // The apps + call-actor render is what every hosted apps session gets, and the only untested
-    // combination: the other apps cases omit call-actor, the other full-tool-set cases use default mode.
+    // Apps mode with call-actor: every hosted apps session, and the one combination other cases don't cover.
     it('keeps every call-actor mention in apps mode when the session has call-actor', () => {
         const instructions = getServerInstructions(SERVER_MODE.APPS, ALL_TOOLS_PRESENT);
         expect(instructions).toContain(HELPER_TOOLS.ACTOR_CALL_WIDGET);
@@ -132,8 +131,7 @@ describe('getServerInstructions()', () => {
         const HEADING = '## Tool dependencies and disambiguation';
 
         it('omits the heading when every subsection is gated away', () => {
-            // A session with only Actor tools plus auto-injected run/storage helpers, no widgets:
-            // nothing under the heading renders, so the heading itself must not be emitted.
+            // Only run/storage helpers, no widgets: nothing under the heading renders, so it must not be emitted either.
             const instructions = getServerInstructions(SERVER_MODE.DEFAULT, only(HELPER_TOOLS.ACTOR_RUNS_GET));
             expect(instructions).not.toContain(HEADING);
         });


### PR DESCRIPTION
Closes apify/ai-team#266 — split out of apify/ai-team#232, which #1326 (stacked on top) closes.

Split out of #1326/#1327 — this is the one self-contained piece both depend on: `server-instructions.ts`'s own gating logic, generic over any tool set, needing zero wiring changes to test.

## What
Server instructions unconditionally named `call-actor`, `apify/rag-web-browser`, `apify/web-fetch`, `report-problem`, and several apps-mode widget/disambiguation tools regardless of whether the session actually loaded them.

## Why
A tool name the client never received in `tools/list` invites a hallucinated call.

- `getServerInstructions` now takes a `ToolDescriptionContext` (the same gating mechanism already used for per-tool descriptions, e.g. report-problem's own gating) instead of a bare `reportProblemAvailable` boolean, and gates every cross-tool mention through it — call-actor, rag-web-browser, web-fetch, report-problem, plus 4 more spots found during review: the apps-mode widget-workflow block, the search-actors-vs-fetch-actor-details disambiguation, the apps-mode data-vs-widget bullets, and call-actor's own tool-dependency block naming fetch-actor-details.
- The legacy adapter's real per-connection call site (`ActorsMcpServer.getServerInstructions()`) now passes the session's actual tool set instead of a report-problem-only check.
- Two other call sites needed an explicit context because the parameter's default flipped from "nothing present" to "everything present except report-problem": the legacy constructor's placeholder instructions (always overwritten once the real tool set is known) and the stateless `server/discover` probe (configuration-level, answered before any request envelope is seen — must never show report-problem or any per-session tool). Both now pass an explicit context with every tool except report-problem present, matching the new default's own exception.
- Follow-up commit: the `## Tool dependencies and disambiguation` heading is emitted only when at least one subsection under it survives gating (an Actor-only session with no widgets ended on a bare heading), blank lines around subsections restored to the pre-gating text, and the apps-mode render with `call-actor` loaded is now covered — breaking that arm previously passed the whole suite.

## Testing
Full case suite for the function, offline (fake `hasTool` contexts, no fixture, no live token): every gate present/absent, single-tool fallbacks so a tool loaded alone is never left with zero mention, apps vs default mode. `pnpm run type-check / lint / test:unit / format / check:agents` all green.