### PR TITLE
feat: Track ?client= URL param in Segment telemetry

### DIFF
--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -163,6 +163,7 @@ async function serveStatelessRequest(req: Request, res: Response, taskStore: InM
     const uiParam = urlParams.get('ui');
     const serverMode = uiParam !== null ? parseServerMode(uiParam) : parseServerMode(process.env.UI_MODE);
     const paymentProvider = await resolvePaymentProvider(urlParams.get('payment'));
+    const clientParam = urlParams.get('client') ?? undefined;
 
     // No token required in payment mode, mirroring `resolveRequestAuth`.
     const apifyToken = paymentProvider ? undefined : extractApiTokenFromRequest(req);
@@ -191,6 +192,7 @@ async function serveStatelessRequest(req: Request, res: Response, taskStore: InM
                 serverMode,
                 paymentProvider,
                 token: apifyToken,
+                clientParam,
             });
             // Client identity arrives per request in the `_meta` envelope (there is no initialize
             // handshake), so this fetch carries no request-origin tag.
@@ -303,6 +305,9 @@ export function createExpressApp(): express.Express {
                 // Resolve payment provider from URL parameter (e.g., ?payment=skyfire)
                 const paymentProvider = await resolvePaymentProvider(urlParams.get('payment'));
 
+                // Client attribution tag (e.g. ?client=cursor), for Segment — see mcp_url_client.
+                const clientParam = urlParams.get('client') ?? undefined;
+
                 // Mirror production: no token required in payment mode, else require Bearer header
                 const auth = resolveRequestAuth(req, res, paymentProvider);
                 if (!auth) return;
@@ -318,6 +323,7 @@ export function createExpressApp(): express.Express {
                     serverMode,
                     paymentProvider,
                     token: apifyToken,
+                    clientParam,
                 });
 
                 // Client info is already available here — unlike stdio.ts, which loads tools

--- a/src/mcp/legacy_server.ts
+++ b/src/mcp/legacy_server.ts
@@ -419,6 +419,7 @@ export class LegacyMcpServer {
                 mcpSessionId,
                 apifyToken,
                 clientContext,
+                clientParam: this.host.options.clientParam,
                 telemetryEnabled: this.host.telemetryEnabled,
                 transportType: this.host.options.transportType,
             });
@@ -566,6 +567,7 @@ export class LegacyMcpServer {
                             actorName,
                             actorId,
                             clientContext,
+                            clientParam: this.host.options.clientParam,
                             taskStore: this.taskStore,
                             server: this.server,
                             tools: this.host.tools,

--- a/src/mcp/stateless_server.ts
+++ b/src/mcp/stateless_server.ts
@@ -205,6 +205,7 @@ class StatelessMcpServer {
                 mcpSessionId,
                 apifyToken,
                 clientContext,
+                clientParam: this.host.options.clientParam,
                 telemetryEnabled: this.host.telemetryEnabled,
                 transportType: this.host.options.transportType,
             });

--- a/src/mcp/task_execution.ts
+++ b/src/mcp/task_execution.ts
@@ -81,6 +81,7 @@ export async function emitTaskStatusNotification(
  * @param params.mcpSessionId - MCP session ID for telemetry
  * @param params.actorName - Actor name, used for telemetry and error diagnostics
  * @param params.actorId - Actor ID, used for telemetry and error diagnostics
+ * @param params.clientParam - Raw `?client=` URL query-param value, for Segment attribution
  * @param params.taskStore - Task store (legacy) for status/result persistence
  * @param params.server - v1 SDK server (legacy) for task-status notifications and logging
  * @param params.sendNotification - Progress-notification sink for the running tool
@@ -100,6 +101,8 @@ export async function executeToolAndUpdateTask(params: {
     actorName?: string;
     actorId?: string;
     clientContext: McpClientContext | undefined;
+    /** Raw `?client=` URL query-param value for this connection, if any. */
+    clientParam?: string;
     taskStore: TaskStore;
     server: Server;
     tools: Map<string, ToolEntry>;
@@ -122,6 +125,7 @@ export async function executeToolAndUpdateTask(params: {
         actorName,
         actorId,
         clientContext,
+        clientParam,
         taskStore,
         server,
         tools,
@@ -154,6 +158,7 @@ export async function executeToolAndUpdateTask(params: {
         telemetryEnabled,
         transportType,
         clientContext,
+        clientParam,
     });
 
     const finishTaskTracking = (status: ToolStatus, diagnostics?: CallDiagnostics, result?: unknown) => {

--- a/src/mcp/tool_call_telemetry.ts
+++ b/src/mcp/tool_call_telemetry.ts
@@ -24,6 +24,8 @@ type PrepareTelemetryDataParams = {
     telemetryEnabled: boolean;
     transportType?: TransportType;
     clientContext: McpClientContext | undefined;
+    /** Raw `?client=` URL query-param value for this connection/request, if any. */
+    clientParam?: string;
 };
 
 /**
@@ -32,7 +34,7 @@ type PrepareTelemetryDataParams = {
 export async function prepareTelemetryData(
     params: PrepareTelemetryDataParams,
 ): Promise<{ telemetryData: ToolCallTelemetryProperties | null; userId: string | null }> {
-    const { toolName, mcpSessionId, apifyToken, telemetryEnabled, transportType, clientContext } = params;
+    const { toolName, mcpSessionId, apifyToken, telemetryEnabled, transportType, clientContext, clientParam } = params;
     if (!telemetryEnabled) {
         return { telemetryData: null, userId: null };
     }
@@ -54,6 +56,7 @@ export async function prepareTelemetryData(
         mcp_client_capabilities: clientContext?.capabilities || null,
         mcp_session_id: mcpSessionId || '',
         transport_type: transportType || '',
+        mcp_url_client: clientParam || '',
         tool_name: toolName,
         tool_status: TOOL_STATUS.SUCCEEDED, // Will be updated in finally
         tool_exec_time_ms: 0, // Will be calculated in finally

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -116,6 +116,7 @@ export function buildReportedProblemProperties(
         mcp_protocol_version: context.mcp_protocol_version,
         mcp_session_id: context.mcp_session_id,
         transport_type: context.transport_type,
+        mcp_url_client: context.mcp_url_client,
         message,
         ...(actorId !== undefined && { actor_id: actorId }),
         ...(actorRunId !== undefined && { actor_run_id: actorRunId }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -637,12 +637,7 @@ export type ActorsMcpServerOptions = {
      * - 'http': Remote HTTP streamable connection
      */
     transportType?: TransportType;
-    /**
-     * Raw `?client=` query-param value from the connecting URL, for Segment attribution.
-     * An explicit tag for which setup/connector path was used (e.g. `cursor`, `chatgpt`),
-     * independent of the MCP handshake's self-reported `clientInfo.name`. HTTP transport only;
-     * always undefined on stdio (no URL to read it from).
-     */
+    /** Raw `?client=` value from the connecting URL, for Segment attribution; independent of `clientInfo.name`, HTTP-only (undefined on stdio). */
     clientParam?: string;
     /**
      * Apify API token for authentication

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,6 +369,8 @@ export type ToolCallTelemetryProperties = {
     mcp_client_capabilities: Record<string, unknown> | null;
     mcp_session_id: string;
     transport_type: string;
+    /** Raw `?client=` URL query-param value, when the connecting request carried one. */
+    mcp_url_client: string;
     tool_name: string;
     tool_status: ToolStatus;
     tool_exec_time_ms: number;
@@ -409,6 +411,7 @@ export type ReportedProblemTelemetryProperties = Pick<
     | 'mcp_protocol_version'
     | 'mcp_session_id'
     | 'transport_type'
+    | 'mcp_url_client'
 > & {
     message: string;
     actor_id?: string;
@@ -634,6 +637,13 @@ export type ActorsMcpServerOptions = {
      * - 'http': Remote HTTP streamable connection
      */
     transportType?: TransportType;
+    /**
+     * Raw `?client=` query-param value from the connecting URL, for Segment attribution.
+     * An explicit tag for which setup/connector path was used (e.g. `cursor`, `chatgpt`),
+     * independent of the MCP handshake's self-reported `clientInfo.name`. HTTP transport only;
+     * always undefined on stdio (no URL to read it from).
+     */
+    clientParam?: string;
     /**
      * Apify API token for authentication
      * Primarily used by stdio transport when token is read from ~/.apify/auth.json file

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -29,7 +29,11 @@ const SINGLE_NORMAL_MODE_ACTOR = [ACTOR_NORMAL_MODE];
 const DOCS_CATEGORY = ['docs'] as ToolCategory[];
 const DOCS_RUNS_STORAGE_CATEGORIES = ['docs', 'runs', 'storage'] as ToolCategory[];
 
-// Claude-connector `?tools=` allowlist (no call-actor); Actor entries use slash names, served names differ — see CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES.
+// Claude-connector `?tools=` allowlist. No call-actor. Actor entries use their slash name here;
+// served tool names differ — see CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES.
+// NOTE: does not mirror the actual URL submitted to Anthropic for AUP review (ai-team#214) — that
+// one excludes report-problem and uses a different Actor/tool set. This fixture pins the server's
+// own tools/list behavior for a hypothetical selection, not the live, reviewed connector surface.
 const CLAUDE_CONNECTOR_TOOLS = [
     'search-actors',
     'search-actors-widget',
@@ -50,6 +54,7 @@ const CLAUDE_CONNECTOR_TOOLS = [
     'get-key-value-store-record',
     'apify/rag-web-browser',
     'apify/web-fetch',
+    HELPER_TOOLS.PROBLEM_REPORT,
 ];
 const CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES = CLAUDE_CONNECTOR_TOOLS.map((selector) =>
     selector.includes('/') ? actorNameToToolName(selector) : selector,
@@ -98,14 +103,15 @@ export const registrationCases: Case[] = [
         }),
     },
     {
-        // Pinned ?tools= wins even with telemetry on, which would otherwise auto-inject report-problem.
-        name: 'Claude connector: pinned tool surface excludes call-actor and report-problem even with telemetry enabled',
+        // Pinned ?tools= wins for call-actor even with the report-problem auto-inject path live
+        // (telemetry defaults on here — no ?telemetry-enabled= override, matching a real URL).
+        name: 'Claude connector: pinned tool surface excludes call-actor, includes report-problem, tagged ?client=claude+connector',
         isDeploymentTest: true,
         run: withClient(
-            { tools: CLAUDE_CONNECTOR_TOOLS, serverMode: 'apps', telemetry: { enabled: true } },
+            { tools: CLAUDE_CONNECTOR_TOOLS, serverMode: 'apps', client: 'claude connector', omitTelemetryParam: true },
             async (client) => {
                 const names = getToolNames(await client.listTools());
-                expect(names).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
+                expect(names).toContain(HELPER_TOOLS.PROBLEM_REPORT);
                 expect(names).not.toContain(HELPER_TOOLS.ACTOR_CALL);
                 expect(new Set(names)).toEqual(new Set(CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES));
             },

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -38,6 +38,10 @@ const DOCS_RUNS_STORAGE_CATEGORIES = ['docs', 'runs', 'storage'] as ToolCategory
 // NOTE: does not mirror the actual URL submitted to Anthropic for AUP review (ai-team#214) — that
 // one excludes report-problem and uses a different Actor/tool set. This fixture pins the server's
 // own tools/list behavior for a hypothetical selection, not the live, reviewed connector surface.
+// get-actor-run-widget is NOT listed as its own selector: getToolsForServerMode auto-pairs every
+// base tool with its widget sibling in apps mode, unconditionally (tools_loader.ts) — leaving it
+// out of ?tools= has no effect while get-actor-run stays and apps mode is on. Its low Mixpanel
+// usage (0.1% of get-actor-run calls) has no lever here without also dropping get-actor-run itself.
 const CLAUDE_CONNECTOR_TOOLS = [
     'search-actors',
     'search-actors-widget',
@@ -46,6 +50,7 @@ const CLAUDE_CONNECTOR_TOOLS = [
     'search-apify-docs',
     'fetch-apify-docs',
     'get-actor-run',
+    'get-actor-run-widget',
     'get-actor-run-list',
     'get-actor-log',
     'abort-actor-run',
@@ -106,8 +111,10 @@ export const registrationCases: Case[] = [
         }),
     },
     {
-        // Pinned ?tools= wins for call-actor even with the report-problem auto-inject path live
-        // (telemetry defaults on here — no ?telemetry-enabled= override, matching a real URL).
+        // Pinned ?tools= wins for call-actor even with the report-problem auto-inject path live.
+        // telemetry must be explicit here: the deployed target this runs against defaults it off
+        // (confirmed by CI — omitting the param served no report-problem there), unlike this
+        // package's own DEFAULT_TELEMETRY_ENABLED=true.
         // No ?ui= either: apps mode comes from the client's own UI-capability advertisement
         // (serverMode 'auto' default), same as a real MCP-Apps client — not a URL override.
         name: 'Claude connector: pinned tool surface excludes call-actor, includes report-problem, tagged ?client=claude+connector',
@@ -117,7 +124,7 @@ export const registrationCases: Case[] = [
             {
                 tools: CLAUDE_CONNECTOR_TOOLS,
                 client: 'claude connector',
-                omitTelemetryParam: true,
+                telemetry: { enabled: true },
                 clientCapabilities: {
                     extensions: { 'io.modelcontextprotocol/ui': { mimeTypes: [RESOURCE_MIME_TYPE] } },
                 },

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -7,7 +7,11 @@ import {
     getCategoryTools,
     getExpectedToolNamesByCategories,
 } from '@apify/actors-mcp-server/internals.js';
-import { HELPER_TOOLS } from '@apify/actors-mcp-server/internals/test-kit.js';
+import {
+    HELPER_TOOLS,
+    RESOURCE_MIME_TYPE,
+    SERVER_MODE_AUTO_DETECTION_ENABLED,
+} from '@apify/actors-mcp-server/internals/test-kit.js';
 
 import {
     ACTOR_NORMAL_MODE,
@@ -42,7 +46,6 @@ const CLAUDE_CONNECTOR_TOOLS = [
     'search-apify-docs',
     'fetch-apify-docs',
     'get-actor-run',
-    'get-actor-run-widget',
     'get-actor-run-list',
     'get-actor-log',
     'abort-actor-run',
@@ -105,10 +108,20 @@ export const registrationCases: Case[] = [
     {
         // Pinned ?tools= wins for call-actor even with the report-problem auto-inject path live
         // (telemetry defaults on here — no ?telemetry-enabled= override, matching a real URL).
+        // No ?ui= either: apps mode comes from the client's own UI-capability advertisement
+        // (serverMode 'auto' default), same as a real MCP-Apps client — not a URL override.
         name: 'Claude connector: pinned tool surface excludes call-actor, includes report-problem, tagged ?client=claude+connector',
         isDeploymentTest: true,
+        skipIf: () => !SERVER_MODE_AUTO_DETECTION_ENABLED,
         run: withClient(
-            { tools: CLAUDE_CONNECTOR_TOOLS, serverMode: 'apps', client: 'claude connector', omitTelemetryParam: true },
+            {
+                tools: CLAUDE_CONNECTOR_TOOLS,
+                client: 'claude connector',
+                omitTelemetryParam: true,
+                clientCapabilities: {
+                    extensions: { 'io.modelcontextprotocol/ui': { mimeTypes: [RESOURCE_MIME_TYPE] } },
+                },
+            },
             async (client) => {
                 const names = getToolNames(await client.listTools());
                 expect(names).toContain(HELPER_TOOLS.PROBLEM_REPORT);

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -35,13 +35,8 @@ const DOCS_RUNS_STORAGE_CATEGORIES = ['docs', 'runs', 'storage'] as ToolCategory
 
 // Claude-connector `?tools=` allowlist. No call-actor. Actor entries use their slash name here;
 // served tool names differ — see CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES.
-// NOTE: does not mirror the actual URL submitted to Anthropic for AUP review (ai-team#214) — that
-// one excludes report-problem and uses a different Actor/tool set. This fixture pins the server's
-// own tools/list behavior for a hypothetical selection, not the live, reviewed connector surface.
-// get-actor-run-widget is NOT listed as its own selector: getToolsForServerMode auto-pairs every
-// base tool with its widget sibling in apps mode, unconditionally (tools_loader.ts) — leaving it
-// out of ?tools= has no effect while get-actor-run stays and apps mode is on. Its low Mixpanel
-// usage (0.1% of get-actor-run calls) has no lever here without also dropping get-actor-run itself.
+// NOTE: hypothetical selection, not the actual reviewed connector URL (ai-team#214).
+// get-actor-run-widget omitted deliberately: apps mode auto-pairs it with get-actor-run regardless of ?tools= (tools_loader.ts).
 const CLAUDE_CONNECTOR_TOOLS = [
     'search-actors',
     'search-actors-widget',
@@ -111,12 +106,9 @@ export const registrationCases: Case[] = [
         }),
     },
     {
-        // Pinned ?tools= wins for call-actor even with the report-problem auto-inject path live.
-        // telemetry must be explicit here: the deployed target this runs against defaults it off
-        // (confirmed by CI — omitting the param served no report-problem there), unlike this
-        // package's own DEFAULT_TELEMETRY_ENABLED=true.
-        // No ?ui= either: apps mode comes from the client's own UI-capability advertisement
-        // (serverMode 'auto' default), same as a real MCP-Apps client — not a URL override.
+        // Pinned ?tools= wins for call-actor even with report-problem auto-inject live.
+        // telemetry: true is explicit — the deployed target defaults it off (confirmed by CI), unlike this package's own default.
+        // No ?ui=: apps mode comes from the client's own UI-capability advertisement (serverMode 'auto'), not a URL override.
         name: 'Claude connector: pinned tool surface excludes call-actor, includes report-problem, tagged ?client=claude+connector',
         isDeploymentTest: true,
         skipIf: () => !SERVER_MODE_AUTO_DETECTION_ENABLED,

--- a/tests/test_kit/mcp_client.ts
+++ b/tests/test_kit/mcp_client.ts
@@ -22,6 +22,10 @@ export interface SuiteClientOptions {
     };
     serverMode?: string; // ?ui=
     payment?: string; // ?payment=
+    /** Attribution tag for `?client=`. A space encodes as `+` on the wire (e.g. 'claude connector' -> `?client=claude+connector`). */
+    client?: string;
+    /** Skip appending `?telemetry-enabled=` entirely — matches a real URL that never sets it (server default applies). */
+    omitTelemetryParam?: boolean;
     clientCapabilities?: ClientCapabilities;
     /** Bearer token. Omitted → `APIFY_TOKEN`. `null` → no Authorization header. */
     token?: string | null;
@@ -49,13 +53,16 @@ function buildAuthHeaders(options?: SuiteClientOptions): Record<string, string> 
 }
 
 function appendSearchParams(url: URL, options?: SuiteClientOptions): void {
-    const { actors, tools, telemetry, serverMode, payment } = options ?? {};
+    const { actors, tools, telemetry, serverMode, payment, client, omitTelemetryParam } = options ?? {};
     if (actors !== undefined) url.searchParams.append('actors', actors.join(','));
     if (tools !== undefined) url.searchParams.append('tools', tools.join(','));
-    // Default to false for tests when not explicitly set.
-    url.searchParams.append('telemetry-enabled', (telemetry?.enabled ?? false).toString());
+    if (!omitTelemetryParam) {
+        // Default to false for tests when not explicitly set.
+        url.searchParams.append('telemetry-enabled', (telemetry?.enabled ?? false).toString());
+    }
     if (serverMode !== undefined) url.searchParams.append('ui', serverMode);
     if (payment) url.searchParams.append('payment', payment);
+    if (client !== undefined) url.searchParams.append('client', client);
 }
 
 export async function createMcpStreamableClient(serverUrl: string, options?: SuiteClientOptions): Promise<Client> {

--- a/tests/test_kit/mcp_client.ts
+++ b/tests/test_kit/mcp_client.ts
@@ -24,8 +24,6 @@ export interface SuiteClientOptions {
     payment?: string; // ?payment=
     /** Attribution tag for `?client=`. A space encodes as `+` on the wire (e.g. 'claude connector' -> `?client=claude+connector`). */
     client?: string;
-    /** Skip appending `?telemetry-enabled=` entirely — matches a real URL that never sets it (server default applies). */
-    omitTelemetryParam?: boolean;
     clientCapabilities?: ClientCapabilities;
     /** Bearer token. Omitted → `APIFY_TOKEN`. `null` → no Authorization header. */
     token?: string | null;
@@ -53,13 +51,11 @@ function buildAuthHeaders(options?: SuiteClientOptions): Record<string, string> 
 }
 
 function appendSearchParams(url: URL, options?: SuiteClientOptions): void {
-    const { actors, tools, telemetry, serverMode, payment, client, omitTelemetryParam } = options ?? {};
+    const { actors, tools, telemetry, serverMode, payment, client } = options ?? {};
     if (actors !== undefined) url.searchParams.append('actors', actors.join(','));
     if (tools !== undefined) url.searchParams.append('tools', tools.join(','));
-    if (!omitTelemetryParam) {
-        // Default to false for tests when not explicitly set.
-        url.searchParams.append('telemetry-enabled', (telemetry?.enabled ?? false).toString());
-    }
+    // Default to false for tests when not explicitly set.
+    url.searchParams.append('telemetry-enabled', (telemetry?.enabled ?? false).toString());
     if (serverMode !== undefined) url.searchParams.append('ui', serverMode);
     if (payment) url.searchParams.append('payment', payment);
     if (client !== undefined) url.searchParams.append('client', client);

--- a/tests/test_kit/mcp_client.ts
+++ b/tests/test_kit/mcp_client.ts
@@ -22,7 +22,7 @@ export interface SuiteClientOptions {
     };
     serverMode?: string; // ?ui=
     payment?: string; // ?payment=
-    /** Attribution tag for `?client=`. A space encodes as `+` on the wire (e.g. 'claude connector' -> `?client=claude+connector`). */
+    /** Attribution tag for `?client=`; a space encodes as `+` on the wire (e.g. 'claude connector' -> `?client=claude+connector`). */
     client?: string;
     clientCapabilities?: ClientCapabilities;
     /** Bearer token. Omitted → `APIFY_TOKEN`. `null` → no Authorization header. */

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -122,6 +122,7 @@ const BASE_TELEMETRY_KEYS = [
     'mcp_client_version',
     'mcp_protocol_version',
     'mcp_session_id',
+    'mcp_url_client',
     'tool_exec_time_ms',
     'tool_name',
     'tool_response_content_bytes',
@@ -361,6 +362,30 @@ describe('CallToolRequestSchema handler', () => {
 
         expect(trackSpy.mock.calls).toHaveLength(1);
         expectClientContextTelemetry(trackSpy.mock.calls[0][2]);
+    });
+
+    it('carries the ?client= query-param value into telemetry as mcp_url_client', async () => {
+        const trackSpy = vi.spyOn(telemetry, 'trackToolCall').mockImplementation(() => {});
+        await withServer(
+            async (server) => {
+                await runSync(server, makeRecorderTool('client-param-tool').tool);
+            },
+            { token: undefined, telemetry: { enabled: true }, allowUnauthMode: true, clientParam: 'cursor' },
+        );
+
+        expect(trackSpy.mock.calls[0][2]).toMatchObject({ mcp_url_client: 'cursor' });
+    });
+
+    it('defaults mcp_url_client to an empty string when no ?client= was given', async () => {
+        const trackSpy = vi.spyOn(telemetry, 'trackToolCall').mockImplementation(() => {});
+        await withServer(
+            async (server) => {
+                await runSync(server, makeRecorderTool('no-client-param-tool').tool);
+            },
+            { token: undefined, telemetry: { enabled: true }, allowUnauthMode: true },
+        );
+
+        expect(trackSpy.mock.calls[0][2]).toMatchObject({ mcp_url_client: '' });
     });
 });
 

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -32,6 +32,7 @@ describe('telemetry', () => {
             mcp_client_capabilities: {},
             mcp_session_id: 'session-123',
             transport_type: 'stdio',
+            mcp_url_client: 'cursor',
             tool_name: 'test-tool',
             tool_status: 'SUCCEEDED' as const,
             tool_exec_time_ms: 100,
@@ -51,6 +52,7 @@ describe('telemetry', () => {
                 mcp_client_capabilities: {},
                 mcp_session_id: 'session-123',
                 transport_type: 'stdio',
+                mcp_url_client: 'cursor',
                 tool_name: 'test-tool',
                 tool_status: 'SUCCEEDED',
                 tool_exec_time_ms: 100,
@@ -68,6 +70,7 @@ describe('telemetry', () => {
             mcp_client_capabilities: {},
             mcp_session_id: 'session-123',
             transport_type: 'stdio',
+            mcp_url_client: 'cursor',
             tool_name: 'test-tool',
             tool_status: 'SUCCEEDED' as const,
             tool_exec_time_ms: 100,
@@ -95,6 +98,7 @@ describe('telemetry', () => {
             mcp_client_capabilities: {},
             mcp_session_id: '',
             transport_type: 'stdio',
+            mcp_url_client: 'cursor',
             tool_name: 'test-tool',
             tool_status: 'SUCCEEDED' as const,
             tool_exec_time_ms: 100,
@@ -118,6 +122,7 @@ describe('telemetry', () => {
             mcp_client_capabilities: {},
             mcp_session_id: 'session-123',
             transport_type: 'stdio',
+            mcp_url_client: 'cursor',
             tool_name: 'call-actor',
             tool_status: 'SOFT_FAIL' as const,
             tool_exec_time_ms: 100,
@@ -147,6 +152,7 @@ describe('buildReportedProblemProperties', () => {
         mcp_client_capabilities: {},
         mcp_session_id: 'session-123',
         transport_type: 'stdio',
+        mcp_url_client: 'cursor',
         tool_name: 'report-problem',
         tool_status: 'SUCCEEDED',
         tool_exec_time_ms: 5,
@@ -168,6 +174,7 @@ describe('buildReportedProblemProperties', () => {
             mcp_protocol_version: '2024-11-05',
             mcp_session_id: 'session-123',
             transport_type: 'stdio',
+            mcp_url_client: 'cursor',
             message: 'stuck on call-actor',
             actor_id: 'apify/rag-web-browser',
             actor_run_id: 'run-1',
@@ -186,6 +193,7 @@ describe('buildReportedProblemProperties', () => {
             mcp_protocol_version: '2024-11-05',
             mcp_session_id: 'session-123',
             transport_type: 'stdio',
+            mcp_url_client: 'cursor',
             message: 'just a note',
         });
         expect(properties).not.toHaveProperty('tool_name');
@@ -207,6 +215,7 @@ describe('trackReportedProblem', () => {
             mcp_protocol_version: '2024-11-05',
             mcp_session_id: 'session-123',
             transport_type: 'stdio',
+            mcp_url_client: 'cursor',
             message: 'stuck on call-actor',
         };
 
@@ -228,6 +237,7 @@ describe('trackReportedProblem', () => {
             mcp_protocol_version: '2024-11-05',
             mcp_session_id: 'session-123',
             transport_type: 'stdio',
+            mcp_url_client: 'cursor',
             message: 'stuck on call-actor',
         };
 


### PR DESCRIPTION
Part of apify/apify-mcp-server-internal#736.

Stacked on #1327, which is stacked on #1326, which is stacked on #1334 — base branch is #1327's, not master; diff here is just this PR's own commit.

## What
Adds an optional `?client=` URL query param, threaded through both protocol eras into Segment tool-call telemetry as `mcp_url_client` (also carried into the `MCP Reported Problem` event).

## Why
Distributed connector setup URLs (Cursor, ChatGPT, Claude, ...) could each carry their own `?client=` tag for Segment attribution — more reliable than the MCP handshake's self-reported `clientInfo.name`, which varies across proxies (`mcp-remote`) and client SDK versions. Follows the same per-connection URL-param pattern already used for `?ui=`/`?payment=`/`?telemetry-enabled=`.

Flagging per this repo's own rule: this touches what the hosted server consumes (`ActorsMcpServerOptions`) — `apify-mcp-server-internal` needs a matching change (its own `src/server/shared.ts` URL-param extraction) before `?client=` does anything on `mcp.apify.com`; this PR alone is inert there.

## Testing
`pnpm run type-check / lint / test:unit / format / check:agents` all green (1617 tests + 1 pre-existing unrelated skip, on top of #1327's own additions). New tests: `?client=` value reaches `mcp_url_client` on a sync tool call, and defaults to `''` when absent; `BASE_TELEMETRY_KEYS`'s exact-key-set pin updated for the new field.