### PR TITLE
feat(actors): surface run tip from key-value store

### DIFF
--- a/src/tools/actors/actor_run_response.ts
+++ b/src/tools/actors/actor_run_response.ts
@@ -21,6 +21,9 @@ import { DEFAULT_DATASET_ITEMS_LIMIT } from '../storage/get_dataset_items.js';
 /** Cap on `storages.keyValueStores.default.keys` array length. */
 const KV_KEYS_LIMIT = 50;
 
+/** Reserved key-value store key some Actors use to advertise advisory guidance about the run. */
+const TIP_KVS_KEY = 'TIP';
+
 /** nextStep text for widget-rendered responses: suppresses LLM polling. */
 export const WIDGET_NO_POLL_NEXT_STEP =
     'Widget is rendering live progress. Do NOT poll — the widget self-updates until completion.';
@@ -144,6 +147,8 @@ export type RunResponse = {
         memMaxBytes?: number;
     };
     storages: RunStorages;
+    /** Advisory guidance an Actor wrote under the reserved {@link TIP_KVS_KEY}, if any. */
+    tip?: { message: string; level: 'info' | 'warning' };
     summary: string;
     nextStep: string;
 };
@@ -307,6 +312,29 @@ async function fetchKvKeys(
             errMessage: errMessage(error),
         });
         return null;
+    }
+}
+
+/** Defensive parse of a TIP record's value: any Actor can write it, so shape isn't trusted. */
+function parseActorTip(value: unknown): RunResponse['tip'] {
+    if (!value || typeof value !== 'object') return undefined;
+    const { message, level } = value as { message?: unknown; level?: unknown };
+    if (typeof message !== 'string') return undefined;
+    return { message, level: level === 'warning' ? 'warning' : 'info' };
+}
+
+/** Fetch the run's advisory tip; a transient failure or malformed record logs and yields undefined. */
+async function fetchActorTip(
+    client: ApifyClient,
+    keyValueStoreId: string,
+    mcpSessionId?: string,
+): Promise<RunResponse['tip']> {
+    try {
+        const record = await client.keyValueStore(keyValueStoreId).getRecord(TIP_KVS_KEY);
+        return parseActorTip(record?.value);
+    } catch (error) {
+        log.warning('Failed to fetch Actor tip', { keyValueStoreId, mcpSessionId, errMessage: errMessage(error) });
+        return undefined;
     }
 }
 
@@ -894,6 +922,11 @@ export async function fetchActorRunData(params: {
         keyValueStore: keyValueStores?.default,
     });
 
+    // Only fetch the record when the key was actually listed — avoids a round trip on every run.
+    const tip = keyValueStores?.default?.keys?.includes(TIP_KVS_KEY)
+        ? await fetchActorTip(client, keyValueStores.default.id, mcpSessionId)
+        : undefined;
+
     const structuredContent: RunResponse = {
         runId: run.id,
         actorId: run.actId,
@@ -908,6 +941,7 @@ export async function fetchActorRunData(params: {
             ...(datasets && { datasets }),
             ...(keyValueStores && { keyValueStores }),
         },
+        tip,
         summary,
         nextStep,
     };

--- a/src/tools/runs/get_actor_run.ts
+++ b/src/tools/runs/get_actor_run.ts
@@ -70,10 +70,11 @@ export function buildGetActorRunResponse(
 
     // Mints the `apifyConsoleUrl` fields onto structuredContent and returns the narrative suffix in one pass.
     const consoleLinks = applyConsoleLinks(structuredContent, linkContext);
+    const tipText = structuredContent.tip ? `\nTip: ${structuredContent.tip.message}` : '';
     return respondOk(
         [
             JSON.stringify(structuredContent),
-            `${structuredContent.summary}\n${structuredContent.nextStep}${consoleLinks}`,
+            `${structuredContent.summary}\n${structuredContent.nextStep}${consoleLinks}${tipText}`,
         ],
         { structuredContent, meta: buildUsageMeta(run) },
     );

--- a/src/tools/structured_output_schemas.ts
+++ b/src/tools/structured_output_schemas.ts
@@ -508,6 +508,14 @@ export const actorRunOutputSchema = {
                 },
             },
         },
+        tip: {
+            type: 'object' as const,
+            description: 'Advisory guidance an Actor wrote to its key-value store under the reserved "TIP" key',
+            properties: {
+                message: { type: 'string' },
+                level: { type: 'string', enum: ['info', 'warning'] },
+            },
+        },
         summary: { type: 'string', description: 'Past-tense summary of the run state' },
         nextStep: { type: 'string', description: 'One primary follow-up action with identifiers interpolated' },
     },

--- a/tests/unit/tools.get_actor_run.response.test.ts
+++ b/tests/unit/tools.get_actor_run.response.test.ts
@@ -512,6 +512,95 @@ describe('get-actor-run default response', () => {
         });
     });
 
+    it('fetches and surfaces the TIP record when the key-value store lists a TIP key', async () => {
+        const run = mockSucceededRun();
+        let getRecordCalls = 0;
+        const client = {
+            run: (_id: string) => ({ get: async () => run, waitForFinish: async () => run }),
+            actor: (_id: string) => ({ get: async () => ACTOR }),
+            dataset: (_id: string) => ({
+                get: async () => mockDataset(),
+                listItems: async () => ({ items: [], total: 0 }),
+            }),
+            keyValueStore: (_id: string) => ({
+                listKeys: async () => ({ items: [{ key: 'OUTPUT' }, { key: 'TIP' }], isTruncated: false }),
+                getRecord: async (key: string) => {
+                    getRecordCalls += 1;
+                    return key === 'TIP'
+                        ? { key, value: { message: 'Use the Instagram Scraper instead.', level: 'info' } }
+                        : undefined;
+                },
+            }),
+        } as unknown as InternalToolArgs['apifyClient'];
+
+        const result = await (getActorRun as HelperTool).call(
+            stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client),
+        );
+        const { structuredContent, content } = result as {
+            structuredContent: RunResponse;
+            content: { type: string; text: string }[];
+        };
+
+        expect(structuredContent.tip).toEqual({ message: 'Use the Instagram Scraper instead.', level: 'info' });
+        expect(content[1].text.endsWith('\nTip: Use the Instagram Scraper instead.')).toBe(true);
+        expect(getRecordCalls).toBe(1);
+    });
+
+    it('omits tip and never fetches the TIP record when the key-value store does not list it', async () => {
+        const run = mockSucceededRun();
+        let getRecordCalls = 0;
+        const client = {
+            run: (_id: string) => ({ get: async () => run, waitForFinish: async () => run }),
+            actor: (_id: string) => ({ get: async () => ACTOR }),
+            dataset: (_id: string) => ({
+                get: async () => mockDataset(),
+                listItems: async () => ({ items: [], total: 0 }),
+            }),
+            keyValueStore: (_id: string) => ({
+                listKeys: async () => ({ items: [{ key: 'OUTPUT' }], isTruncated: false }),
+                getRecord: async () => {
+                    getRecordCalls += 1;
+                    return undefined;
+                },
+            }),
+        } as unknown as InternalToolArgs['apifyClient'];
+
+        const result = await (getActorRun as HelperTool).call(
+            stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client),
+        );
+        const { structuredContent, content } = result as {
+            structuredContent: RunResponse;
+            content: { type: string; text: string }[];
+        };
+
+        expect(structuredContent.tip).toBeUndefined();
+        expect(content[1].text).not.toContain('Tip:');
+        expect(getRecordCalls).toBe(0);
+    });
+
+    it('discards a malformed TIP record instead of throwing', async () => {
+        const run = mockSucceededRun();
+        const client = {
+            run: (_id: string) => ({ get: async () => run, waitForFinish: async () => run }),
+            actor: (_id: string) => ({ get: async () => ACTOR }),
+            dataset: (_id: string) => ({
+                get: async () => mockDataset(),
+                listItems: async () => ({ items: [], total: 0 }),
+            }),
+            keyValueStore: (_id: string) => ({
+                listKeys: async () => ({ items: [{ key: 'TIP' }], isTruncated: false }),
+                getRecord: async () => ({ key: 'TIP', value: { level: 'warning' } }), // no `message`
+            }),
+        } as unknown as InternalToolArgs['apifyClient'];
+
+        const result = await (getActorRun as HelperTool).call(
+            stubToolCallContext({ runId: 'run-1', waitSecs: 0 }, client),
+        );
+        const { structuredContent } = result as { structuredContent: RunResponse };
+
+        expect(structuredContent.tip).toBeUndefined();
+    });
+
     it('emits progress with formatted status messages on wait + terminal flip', async () => {
         // RUNNING with a non-terminal statusMessage at start; SUCCEEDED with a terminal statusMessage
         // at end. formatRunStatusMessage suppresses non-terminal-marked statusMessages on terminal


### PR DESCRIPTION
## What
Surface an Actor's advisory `TIP` key-value-store record (e.g. rag-web-browser's specialized-Actor recommendation) in `call-actor` / `get-actor-run` responses: `structuredContent.tip` (`{message, level}`) plus a `Tip: <message>` line appended to the text summary.

## Why
Closes #1361 — the TIP record was written by the Actor but never surfaced to the MCP client. Fetched only when the key is actually listed in the run's default key-value store, so no extra round trip on the common case (no tip). Record shape isn't trusted since any Actor can write the reserved key — a malformed record is discarded, not surfaced.

## Testing
`pnpm run type-check`, `lint`, `test:unit` (1678 passed), `format`, `check:agents` all clean. Added unit tests: tip surfaced in structuredContent + text when present, no fetch and no field when the key isn't listed, malformed record discarded without throwing.

E2E against the live `apify/rag-web-browser` Actor via `mcpc` (this branch's built `dist/stdio.js`), both call sites that share `fetchActorRunData`/`buildGetActorRunResponse`:

**`call-actor`** (waitSecs=40, single call to terminal, run `CneLWC7Nmmk4rA5MF`):
```
SUCCEEDED in 16.528s. 1 item; 31 fields available. Key-value store has 4 keys.
Use get-dataset-items with datasetId=PIauqKzQ3xtLuVDKe and limit (for example 20) to fetch items (1 total). Available fields (dot notation): query, markdown, ... — pass via fields="..." to project.
Tip: For scraping booking.com, we recommend using [Booking Scraper](https://apify.com/voyager/booking-scraper)
```
`structuredContent.tip = {"message": "For scraping booking.com, we recommend using [Booking Scraper](https://apify.com/voyager/booking-scraper)", "level": "info"}`

**`get-actor-run`** (started via call-actor waitSecs=0, then polled, run `HBaQEFBBW1AormCR1`):
```
SUCCEEDED in 12.685s. 1 item; 13 fields available. Key-value store has 4 keys.
Use get-dataset-items with datasetId=RDz6SySuSyuk8MNJd and limit (for example 20) to fetch items (1 total). Full output is ~899 bytes. Available fields (dot notation): text, crawl.httpStatusCode, ... — pass via fields="..." to project.
Tip: For scraping zillow.com, we recommend using [Zillow Detail Scraper](https://apify.com/maxcopell/zillow-detail-scraper)
```

Both confirm: the key-value store's `keys` listed `TIP` alongside `INPUT`/SDK state keys, the record was fetched once, and `Tip: ...` landed at the end of the text after the console-link suffix.