### PR TITLE
fix: Let explicit report-problem selection bypass the client blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Here is an overview list of all the tools provided by the Apify MCP Server.
 Legend for the **Enabled by default** column:
 - ✅ — in the default tool set.
 - ⚡ — auto-injected when `call-actor`, an Actor tool, or `get-actor-run` is present (which is true in the default configuration).
-- ✅¹ — served by default, but only when telemetry is enabled and the client is not withheld: Anthropic surfaces (Claude.ai / Claude Desktop / Claude Code) or `local-agent-mode-apify`. To disable, pass an explicit `tools=` list that omits it.
+- ✅¹ — served by default, but only when telemetry is enabled and the client is not withheld: Anthropic surfaces (Claude.ai / Claude Desktop / Claude Code) or `local-agent-mode-apify`. To disable, pass an explicit `tools=` list that omits it. Explicitly selecting it (`tools=report-problem` or `tools=dev`) serves it regardless of client — telemetry still must be enabled.
 
 | Tool name | Category | Description | Enabled by default |
 | :--- | :--- | :--- | :---: |

--- a/src/const.ts
+++ b/src/const.ts
@@ -85,7 +85,8 @@ export const RETIRED_SELECTOR_NAMES: ReadonlySet<string> = new Set(['add-actor',
  * connection on the 2025 path, per request on the 2026-07-28 one. Stateless `client-info` is
  * optional; a request declaring no client name matches no blocked substring and is served the tool
  * by policy. Substring matching covers new client builds without a maintained allowlist;
- * over-matching only hides an optional tool.
+ * over-matching only hides an optional tool. Bypassed when `report-problem` (or the `dev` category)
+ * is explicitly selected via `?tools=` — see `isReportProblemExplicitlySelected`.
  */
 export const REPORT_PROBLEM_BLOCKED_CLIENTS: string[] = ['claude', 'anthropic', 'local-agent-mode-apify'];
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -85,8 +85,7 @@ export const RETIRED_SELECTOR_NAMES: ReadonlySet<string> = new Set(['add-actor',
  * connection on the 2025 path, per request on the 2026-07-28 one. Stateless `client-info` is
  * optional; a request declaring no client name matches no blocked substring and is served the tool
  * by policy. Substring matching covers new client builds without a maintained allowlist;
- * over-matching only hides an optional tool. Bypassed when `report-problem` (or the `dev` category)
- * is explicitly selected via `?tools=` — see `isReportProblemExplicitlySelected`.
+ * over-matching only hides an optional tool. Bypassed by explicit `?tools=report-problem`/`dev`.
  */
 export const REPORT_PROBLEM_BLOCKED_CLIENTS: string[] = ['claude', 'anthropic', 'local-agent-mode-apify'];
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -35,6 +35,7 @@ import { parseServerMode, resolveServerMode } from '../utils/server_mode.js';
 import {
     getActors,
     getToolsForServerMode,
+    isReportProblemExplicitlySelected,
     resolveToolNamesFromInput,
     toolNamesToInput,
 } from '../utils/tools_loader.js';
@@ -350,11 +351,14 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
      * Compose one source's tool list against `view`: resolve mode-specific tools, then drop
      * report-problem unless servable for that view ({@link isReportProblemServable}). Load paths
      * and the initialize flush pass the instance's own {@link servingContext};
-     * {@link createRequestSnapshot} passes a view derived from one stateless request.
+     * {@link createRequestSnapshot} passes a view derived from one stateless request — but
+     * `source.input` is the retained session-level input, shared across every request that reuses
+     * this source, so an explicit opt-in made under one identity applies to all of them if a host
+     * shares one facade across requests with different declared clients.
      */
     private composeToolsForClient(source: ToolSource, view: ServingContext): ToolEntry[] {
         const tools = getToolsForServerMode(source.input, source.actorTools, view.serverMode);
-        if (this.isReportProblemServable(view)) return tools;
+        if (this.isReportProblemServable(view, source.input)) return tools;
         return tools.filter((tool) => tool.name !== HELPER_TOOLS.PROBLEM_REPORT);
     }
 
@@ -363,14 +367,16 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
      * would vanish into the void) and never before a client context exists — on a stateful
      * connection the initialize flush re-adds it once the handshake supplies one.
      *
+     * Explicitly selecting the tool ({@link isReportProblemExplicitlySelected}) lifts the
+     * client-name blocklist below — telemetry and client-known still apply unconditionally.
+     *
      * The stateless envelope requires protocol and capability metadata but not `clientInfo`. A
      * request declaring no client name matches no blocked substring and is served the tool by
      * policy.
      */
-    private isReportProblemServable(view: ServingContext): boolean {
-        return (
-            this.telemetryEnabled && view.clientContext != null && !isReportProblemBlockedForClient(view.clientContext)
-        );
+    private isReportProblemServable(view: ServingContext, input: Input): boolean {
+        if (!this.telemetryEnabled || view.clientContext == null) return false;
+        return isReportProblemExplicitlySelected(input) || !isReportProblemBlockedForClient(view.clientContext);
     }
 
     private composePendingToolsForClient(): void {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -351,10 +351,8 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
      * Compose one source's tool list against `view`: resolve mode-specific tools, then drop
      * report-problem unless servable for that view ({@link isReportProblemServable}). Load paths
      * and the initialize flush pass the instance's own {@link servingContext};
-     * {@link createRequestSnapshot} passes a view derived from one stateless request — but
-     * `source.input` is the retained session-level input, shared across every request that reuses
-     * this source, so an explicit opt-in made under one identity applies to all of them if a host
-     * shares one facade across requests with different declared clients.
+     * {@link createRequestSnapshot} passes a view derived from one stateless request.
+     * An explicit opt-in in `source.input` applies to every request reusing this retained source.
      */
     private composeToolsForClient(source: ToolSource, view: ServingContext): ToolEntry[] {
         const tools = getToolsForServerMode(source.input, source.actorTools, view.serverMode);
@@ -367,8 +365,7 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
      * would vanish into the void) and never before a client context exists — on a stateful
      * connection the initialize flush re-adds it once the handshake supplies one.
      *
-     * Explicitly selecting the tool ({@link isReportProblemExplicitlySelected}) lifts the
-     * client-name blocklist below — telemetry and client-known still apply unconditionally.
+     * Explicit selection ({@link isReportProblemExplicitlySelected}) bypasses the blocklist only.
      *
      * The stateless envelope requires protocol and capability metadata but not `clientInfo`. A
      * request declaring no client name matches no blocked substring and is served the tool by

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -291,7 +291,8 @@ export class ActorsMcpServer implements LegacyMcpServerHost, StatelessMcpServerH
      *
      * `requestUrl`, when given, resolves cross-tool mentions from `?tools=`/`?actors=` with no fetch;
      * omit it for the same "everything but report-problem" fallback. `report-problem` is always
-     * excluded — its servability is per-request-identity-dependent, not derivable from the URL.
+     * excluded here even when explicitly selected — telemetry state (the other bypass guard) isn't
+     * known yet at `server/discover` time, only at request time.
      */
     public getStatelessServerInstructions(requestUrl?: string): string {
         const mode = resolveServerMode(this.serverModeOption, false);

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -83,6 +83,22 @@ function normalizeInput(input: Input): NormalizedInput {
     };
 }
 
+/** report-problem is the `dev` category's only member, so naming the category is the same opt-in. */
+const REPORT_PROBLEM_CATEGORY = 'dev' satisfies ToolCategory;
+
+/**
+ * True when `input` names report-problem or its `dev` category — a deliberate opt-in that lifts the
+ * client-name blocklist in the server's compose step (telemetry-off and unknown-client still
+ * refuse). The default (no `tools=`) injection is not an opt-in. A restore input built by
+ * `toolNamesToInput` counts as one: it can only list tools the session was already served.
+ * Reuses `normalizeInput` so it never reports an opt-in for a selector composition ignores
+ * (e.g. the un-split `'a,b'` string form).
+ */
+export function isReportProblemExplicitlySelected(input: Input): boolean {
+    const { selectors } = normalizeInput(input);
+    return selectors?.some((sel) => sel === HELPER_TOOLS.PROBLEM_REPORT || sel === REPORT_PROBLEM_CATEGORY) ?? false;
+}
+
 /**
  * Resolve the list of Actor names (`username/name`) to fetch from the input.
  *

--- a/src/utils/tools_loader.ts
+++ b/src/utils/tools_loader.ts
@@ -83,16 +83,12 @@ function normalizeInput(input: Input): NormalizedInput {
     };
 }
 
-/** report-problem is the `dev` category's only member, so naming the category is the same opt-in. */
+/** report-problem's only category — selecting it is the same opt-in as the literal name. */
 const REPORT_PROBLEM_CATEGORY = 'dev' satisfies ToolCategory;
 
 /**
- * True when `input` names report-problem or its `dev` category — a deliberate opt-in that lifts the
- * client-name blocklist in the server's compose step (telemetry-off and unknown-client still
- * refuse). The default (no `tools=`) injection is not an opt-in. A restore input built by
- * `toolNamesToInput` counts as one: it can only list tools the session was already served.
- * Reuses `normalizeInput` so it never reports an opt-in for a selector composition ignores
- * (e.g. the un-split `'a,b'` string form).
+ * True when `input` explicitly names report-problem or `dev` — lifts the client blocklist below.
+ * A `toolNamesToInput` restore counts: it can only list tools the session was already served.
  */
 export function isReportProblemExplicitlySelected(input: Input): boolean {
     const { selectors } = normalizeInput(input);

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -65,8 +65,7 @@ const CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES = CLAUDE_CONNECTOR_TOOLS.map((selecto
     selector.includes('/') ? actorNameToToolName(selector) : selector,
 );
 // telemetry: true is explicit — the deployed target defaults it off, unlike this package's own default.
-// clientName: a real Claude client's handshake name — report-problem's client blocklist matches on
-// this, not on the `client=` URL tag, so this is what actually exercises the explicit-select bypass.
+// clientName: real Claude handshake name — exercises the blocklist bypass (client= URL tag doesn't gate it).
 const CLAUDE_CONNECTOR_CLIENT_OPTIONS: SuiteClientOptions = {
     tools: CLAUDE_CONNECTOR_TOOLS,
     client: 'claude connector',

--- a/tests/test_kit/cases/registration.cases.ts
+++ b/tests/test_kit/cases/registration.cases.ts
@@ -65,9 +65,12 @@ const CLAUDE_CONNECTOR_EXPECTED_TOOL_NAMES = CLAUDE_CONNECTOR_TOOLS.map((selecto
     selector.includes('/') ? actorNameToToolName(selector) : selector,
 );
 // telemetry: true is explicit — the deployed target defaults it off, unlike this package's own default.
+// clientName: a real Claude client's handshake name — report-problem's client blocklist matches on
+// this, not on the `client=` URL tag, so this is what actually exercises the explicit-select bypass.
 const CLAUDE_CONNECTOR_CLIENT_OPTIONS: SuiteClientOptions = {
     tools: CLAUDE_CONNECTOR_TOOLS,
     client: 'claude connector',
+    clientName: 'claude-ai',
     telemetry: { enabled: true },
 };
 

--- a/tests/unit/mcp.server.report_problem_gating.test.ts
+++ b/tests/unit/mcp.server.report_problem_gating.test.ts
@@ -6,15 +6,14 @@ import { HELPER_TOOLS } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
 import { SERVER_MODE } from '../../src/types.js';
 import type * as ToolsLoaderModule from '../../src/utils/tools_loader.js';
-import { getActors } from '../../src/utils/tools_loader.js';
 import { getLegacyServer } from './helpers/mcp_server.js';
 
 // Stub getActors so default-injection seeding needs no network.
+// Default-resolves to [] so tests that never call loadReportProblemByDefault still get a valid array.
 vi.mock('../../src/utils/tools_loader.js', async (importOriginal) => {
     const actual = await importOriginal<typeof ToolsLoaderModule>();
-    return { ...actual, getActors: vi.fn() };
+    return { ...actual, getActors: vi.fn().mockResolvedValue([]) };
 });
-const getActorsMock = vi.mocked(getActors);
 
 type InitHandler = (req: InitializeRequest, ctx: unknown) => Promise<unknown>;
 
@@ -58,7 +57,6 @@ async function loadReportProblemByName(server: ActorsMcpServer): Promise<void> {
 
 // Default (no tools=) injection — not an explicit opt-in, so the client blocklist still applies.
 async function loadReportProblemByDefault(server: ActorsMcpServer): Promise<void> {
-    getActorsMock.mockResolvedValue([]);
     await server.loadToolsFromInput({}, {} as never);
 }
 

--- a/tests/unit/mcp.server.report_problem_gating.test.ts
+++ b/tests/unit/mcp.server.report_problem_gating.test.ts
@@ -1,11 +1,21 @@
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import type { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { HELPER_TOOLS } from '../../src/const.js';
 import { ActorsMcpServer } from '../../src/mcp/server.js';
 import { SERVER_MODE } from '../../src/types.js';
+import type * as ToolsLoaderModule from '../../src/utils/tools_loader.js';
+import { getActors } from '../../src/utils/tools_loader.js';
 import { getLegacyServer } from './helpers/mcp_server.js';
+
+// Stub getActors so the default-injection path (used to seed report-problem without an explicit
+// ?tools= selector) never hits the network. The compose path stays real.
+vi.mock('../../src/utils/tools_loader.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof ToolsLoaderModule>();
+    return { ...actual, getActors: vi.fn() };
+});
+const getActorsMock = vi.mocked(getActors);
 
 type InitHandler = (req: InitializeRequest, ctx: unknown) => Promise<unknown>;
 
@@ -44,8 +54,16 @@ async function dispatchInitialize(server: ActorsMcpServer, clientName: string): 
 
 // report-problem carries no actor name, so getActors short-circuits and never touches the client —
 // this drives the real compose path (getToolsForServerMode + blocklist filter) without any network.
+// loadToolsByName restores tools by explicit name (toolNamesToInput builds `{tools: [...]}`), so
+// this seeds report-problem as an explicit selection — it bypasses the client blocklist by design.
 async function loadReportProblemByName(server: ActorsMcpServer): Promise<void> {
     await server.loadToolsByName([HELPER_TOOLS.PROBLEM_REPORT], {} as never);
+}
+
+// Default (no tools=) injection — not an explicit opt-in, so the client blocklist still applies.
+async function loadReportProblemByDefault(server: ActorsMcpServer): Promise<void> {
+    getActorsMock.mockResolvedValue([]);
+    await server.loadToolsFromInput({}, {} as never);
 }
 
 describe('report-problem client gating', () => {
@@ -67,7 +85,8 @@ describe('report-problem client gating', () => {
     it('hides report-problem from an Anthropic client when composed before initialize', async () => {
         const server = track(makeServer());
         // Fixed mode: tools are requested before the client is known — they must wait for initialize.
-        await loadReportProblemByName(server);
+        // Default (non-explicit) seeding: the blocklist must still apply.
+        await loadReportProblemByDefault(server);
         expect(server.tools.has(HELPER_TOOLS.PROBLEM_REPORT)).toBe(false);
 
         await dispatchInitialize(server, 'claude-ai');
@@ -84,13 +103,16 @@ describe('report-problem client gating', () => {
         expect(server.tools.has(HELPER_TOOLS.PROBLEM_REPORT)).toBe(true);
     });
 
-    it('hides report-problem from an Anthropic client loaded after initialize (recovery path)', async () => {
+    it('serves report-problem to an Anthropic client restored after initialize (recovery path)', async () => {
+        // Recovery restores tools by name (loadToolsByName), which the session was already legitimately
+        // serving — treated as explicit, so it bypasses the blocklist regardless of the reconnecting
+        // client's declared name.
         const server = track(makeServer());
         await dispatchInitialize(server, 'claude-ai');
 
         await loadReportProblemByName(server);
 
-        expect(server.tools.has(HELPER_TOOLS.PROBLEM_REPORT)).toBe(false);
+        expect(server.tools.has(HELPER_TOOLS.PROBLEM_REPORT)).toBe(true);
     });
 
     it('serves report-problem to a non-Anthropic client loaded after initialize', async () => {
@@ -102,9 +124,11 @@ describe('report-problem client gating', () => {
         expect(server.tools.has(HELPER_TOOLS.PROBLEM_REPORT)).toBe(true);
     });
 
+    // Recovery restore (loadReportProblemByName) is treated as explicit — available regardless of
+    // client, same reasoning as the recovery-path test above.
     it.each([
         { clientName: 'test-client', isAvailable: true },
-        { clientName: 'claude-ai', isAvailable: false },
+        { clientName: 'claude-ai', isAvailable: true },
     ])(
         'uses constructor recovery data for client gating: $clientName available=$isAvailable',
         async ({ clientName, isAvailable }) => {

--- a/tests/unit/mcp.server.report_problem_gating.test.ts
+++ b/tests/unit/mcp.server.report_problem_gating.test.ts
@@ -9,8 +9,7 @@ import type * as ToolsLoaderModule from '../../src/utils/tools_loader.js';
 import { getActors } from '../../src/utils/tools_loader.js';
 import { getLegacyServer } from './helpers/mcp_server.js';
 
-// Stub getActors so the default-injection path (used to seed report-problem without an explicit
-// ?tools= selector) never hits the network. The compose path stays real.
+// Stub getActors so default-injection seeding needs no network.
 vi.mock('../../src/utils/tools_loader.js', async (importOriginal) => {
     const actual = await importOriginal<typeof ToolsLoaderModule>();
     return { ...actual, getActors: vi.fn() };
@@ -52,10 +51,7 @@ async function dispatchInitialize(server: ActorsMcpServer, clientName: string): 
     await handler(makeInitializeRequest(clientName), {});
 }
 
-// report-problem carries no actor name, so getActors short-circuits and never touches the client —
-// this drives the real compose path (getToolsForServerMode + blocklist filter) without any network.
-// loadToolsByName restores tools by explicit name (toolNamesToInput builds `{tools: [...]}`), so
-// this seeds report-problem as an explicit selection — it bypasses the client blocklist by design.
+// Restoring by name is explicit (toolNamesToInput builds {tools:[...]}) — bypasses the blocklist.
 async function loadReportProblemByName(server: ActorsMcpServer): Promise<void> {
     await server.loadToolsByName([HELPER_TOOLS.PROBLEM_REPORT], {} as never);
 }
@@ -84,8 +80,7 @@ describe('report-problem client gating', () => {
 
     it('hides report-problem from an Anthropic client when composed before initialize', async () => {
         const server = track(makeServer());
-        // Fixed mode: tools are requested before the client is known — they must wait for initialize.
-        // Default (non-explicit) seeding: the blocklist must still apply.
+        // Default (non-explicit) seeding — blocklist still applies.
         await loadReportProblemByDefault(server);
         expect(server.tools.has(HELPER_TOOLS.PROBLEM_REPORT)).toBe(false);
 
@@ -104,9 +99,7 @@ describe('report-problem client gating', () => {
     });
 
     it('serves report-problem to an Anthropic client restored after initialize (recovery path)', async () => {
-        // Recovery restores tools by name (loadToolsByName), which the session was already legitimately
-        // serving — treated as explicit, so it bypasses the blocklist regardless of the reconnecting
-        // client's declared name.
+        // Recovery counts as explicit — the session already had this tool.
         const server = track(makeServer());
         await dispatchInitialize(server, 'claude-ai');
 
@@ -124,8 +117,7 @@ describe('report-problem client gating', () => {
         expect(server.tools.has(HELPER_TOOLS.PROBLEM_REPORT)).toBe(true);
     });
 
-    // Recovery restore (loadReportProblemByName) is treated as explicit — available regardless of
-    // client, same reasoning as the recovery-path test above.
+    // Recovery is explicit — same reasoning as above.
     it.each([
         { clientName: 'test-client', isAvailable: true },
         { clientName: 'claude-ai', isAvailable: true },

--- a/tests/unit/mcp.stateless.request_context.test.ts
+++ b/tests/unit/mcp.stateless.request_context.test.ts
@@ -292,14 +292,28 @@ describe('createStatelessServer() request context', () => {
             );
         });
 
-        it('hides report-problem from a blocklisted client', async () => {
+        it('hides report-problem from a blocklisted client when served via default injection (not explicit)', async () => {
+            await withStatelessServer(
+                async ({ server, call }) => {
+                    // Default (no tools=) injection, not an explicit opt-in — the blocklist applies.
+                    await loadSource(server, [], {});
+
+                    const response = await call('tools/list', {}, { client: { name: 'claude-ai' } });
+
+                    expect(toolNames(response.result)).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
+                },
+                { telemetry: { enabled: true } },
+            );
+        });
+
+        it('serves report-problem to a blocklisted client when explicitly selected via tools=', async () => {
             await withStatelessServer(
                 async ({ server, call }) => {
                     await loadSource(server, [], { tools: [HELPER_TOOLS.PROBLEM_REPORT] });
 
                     const response = await call('tools/list', {}, { client: { name: 'claude-ai' } });
 
-                    expect(toolNames(response.result)).not.toContain(HELPER_TOOLS.PROBLEM_REPORT);
+                    expect(toolNames(response.result)).toContain(HELPER_TOOLS.PROBLEM_REPORT);
                 },
                 { telemetry: { enabled: true } },
             );
@@ -437,9 +451,9 @@ describe('createStatelessServer() request context', () => {
         it('resolves each concurrent request from its own declared identity only', async () => {
             await withStatelessServer(
                 async ({ server, call }) => {
-                    await loadSource(server, [], {
-                        tools: [HELPER_TOOLS.STORE_SEARCH, HELPER_TOOLS.PROBLEM_REPORT],
-                    });
+                    // Default injection (no tools=), not explicit — keeps report-problem subject to
+                    // the blocklist, so this still demonstrates per-request identity gating.
+                    await loadSource(server, [], {});
 
                     const [uiClient, blockedClient] = await Promise.all([
                         call('tools/list', {}, { client: { name: 'ui-client', supportsUi: true } }),

--- a/tests/unit/mcp.stateless.request_context.test.ts
+++ b/tests/unit/mcp.stateless.request_context.test.ts
@@ -451,8 +451,7 @@ describe('createStatelessServer() request context', () => {
         it('resolves each concurrent request from its own declared identity only', async () => {
             await withStatelessServer(
                 async ({ server, call }) => {
-                    // Default injection (no tools=), not explicit — keeps report-problem subject to
-                    // the blocklist, so this still demonstrates per-request identity gating.
+                    // Default injection, not explicit — blocklist still applies here.
                     await loadSource(server, [], {});
 
                     const [uiClient, blockedClient] = await Promise.all([

--- a/tests/unit/utils.tools_loader.test.ts
+++ b/tests/unit/utils.tools_loader.test.ts
@@ -7,12 +7,39 @@ import { TOOL_TYPE } from '../../src/types.js';
 import {
     AUTO_INJECTED_TOOLS,
     getToolsForServerMode,
+    isReportProblemExplicitlySelected,
     loadToolsFromInput,
     resolveToolNamesFromInput,
     toolNamesToInput,
 } from '../../src/utils/tools_loader.js';
 
 const AUTO_INJECTED_TOOL_NAMES = AUTO_INJECTED_TOOLS.map((t) => t.name);
+
+describe('isReportProblemExplicitlySelected()', () => {
+    it('is true for the literal tool name', () => {
+        expect(isReportProblemExplicitlySelected({ tools: [HELPER_TOOLS.PROBLEM_REPORT] })).toBe(true);
+    });
+
+    it('is true for the tool name given as a plain string (not an array)', () => {
+        expect(isReportProblemExplicitlySelected({ tools: HELPER_TOOLS.PROBLEM_REPORT })).toBe(true);
+    });
+
+    it('is true for the dev category, its only member', () => {
+        expect(isReportProblemExplicitlySelected({ tools: ['dev'] })).toBe(true);
+    });
+
+    it('is false for an un-split comma-joined string — selector composition never sees it as one name', () => {
+        expect(isReportProblemExplicitlySelected({ tools: 'storage,report-problem' })).toBe(false);
+    });
+
+    it('is false when tools is absent (default injection, not an explicit opt-in)', () => {
+        expect(isReportProblemExplicitlySelected({})).toBe(false);
+    });
+
+    it('is false for an unrelated selector', () => {
+        expect(isReportProblemExplicitlySelected({ tools: ['actors'] })).toBe(false);
+    });
+});
 
 describe('loadToolsFromInput explicit-empty semantics', () => {
     const apifyClient = new ApifyClient({ token: 'test-token' });


### PR DESCRIPTION
## What

`report-problem` is hidden from Anthropic-named clients (`claude`, `anthropic`, `local-agent-mode-apify` substring match on `clientInfo.name`) regardless of whether the tool was explicitly requested via `?tools=report-problem` (or `?tools=dev`, its sole category). A new `isReportProblemExplicitlySelected` check bypasses the client-name blocklist specifically when the tool was explicitly named — telemetry-off and unknown-client-identity remain unconditional guards either way. Session recovery (`loadToolsByName`) counts as explicit too, since it can only restore tools the session was already legitimately serving.

## Why

A Claude connector configuration that deliberately lists `report-problem` in its pinned `?tools=` URL still silently lost the tool for any real Claude client, since the blocklist applied unconditionally. `?client=claude+connector` (a Segment attribution tag) was never the gate — the real gate is `clientInfo.name` from the MCP handshake, which the URL tag doesn't affect.

## Testing

`type-check`, `lint`, `format`, `check:agents`, full `test:unit` all green (1682/1683, 1 pre-existing unrelated skip). Existing gating tests that seeded `report-problem` via `loadToolsByName` now correctly expect the bypass (recovery = explicit); one test re-seeded through the default-injection path so the blocklist itself stays covered. New unit coverage for `isReportProblemExplicitlySelected` (string/array/`dev`/comma-joined-string/absent). The Claude-connector integration case now sets a real `clientName: 'claude-ai'` (previously it used a generic client name and never actually exercised the blocklist) — confirmed this gated path specifically: ran it against the live built server with the fix reverted (fails, tool missing) and restored (passes).
