### PR TITLE
fix(mcp): default absent arguments to empty object to allow no-args tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 <p align=center>
     <a href="https://www.npmjs.com/package/@apify/actors-mcp-server" rel="nofollow"><img src="https://img.shields.io/npm/v/@apify/actors-mcp-server.svg" alt="NPM latest version" data-canonical-src="https://img.shields.io/npm/v/@apify/actors-mcp-server.svg" style="max-width: 100%;"></a>
     <a href="https://www.npmjs.com/package/@apify/actors-mcp-server" rel="nofollow"><img src="https://img.shields.io/npm/dm/@apify/actors-mcp-server.svg" alt="Downloads" data-canonical-src="https://img.shields.io/npm/dm/@apify/actors-mcp-server.svg" style="max-width: 100%;"></a>
-    <a href="https://github.com/apify/actors-mcp-server/actions/workflows/check.yaml"><img src="https://github.com/apify/actors-mcp-server/actions/workflows/check.yaml/badge.svg?branch=master" alt="Build Status" style="max-width: 100%;"></a>
-    <a href="https://smithery.ai/server/@apify/mcp"><img src="https://smithery.ai/badge/@apify/mcp" alt="smithery badge"></a>
+    <a href="https://github.com/apify/apify-mcp-server/actions/workflows/check.yaml"><img src="https://github.com/apify/apify-mcp-server/actions/workflows/check.yaml/badge.svg?branch=master" alt="Build Status" style="max-width: 100%;"></a>
 </p>
 
 
@@ -77,7 +76,7 @@ You can use the Apify MCP Server in two ways:
 - Set the MCP client server command to `npx @apify/actors-mcp-server` and the `APIFY_TOKEN` environment variable to your Apify API token.
 - See `npx @apify/actors-mcp-server --help` for more options.
 
-You can find detailed instructions for setting up the MCP server in the [Apify documentation](https://docs.apify.com/platform/integrations/mcp).
+You can find detailed instructions for setting up the MCP server in the [Apify documentation](https://docs.apify.com/mcp).
 
 # 🤖 MCP clients
 
@@ -235,6 +234,7 @@ For example, for the `apify/rag-web-browser` Actor, the input parameters are:
 You don't need to manually specify which Actor to call or its input parameters; the LLM handles this automatically.
 When a tool is called, the arguments are automatically passed to the Actor by the LLM.
 You can refer to the specific Actor's documentation for a list of available arguments.
+When an Actor acts as an MCP server, its proxied tools are namespaced with the Actor tool prefix (`<actor-tool>__<tool-name>`) to avoid naming collisions across tools.
 
 ### Helper tools
 
@@ -547,6 +547,7 @@ The Actor input schema is processed to be compatible with most MCP clients while
 - **Nested properties** are built for special cases like proxy configuration and request list sources to ensure the correct input structure.
 - **Array item types** are inferred when not explicitly defined in the schema, using a priority order: explicit type in items > prefill type > default value type > editor type.
 - **Enum values and examples** are added to property descriptions to ensure visibility, even if the client doesn't fully support the JSON schema.
+- **Self-correcting input errors**: When an Actor call fails due to invalid input, the error response includes the Actor's input schema so the LLM agent can inspect the required properties and self-correct on the next attempt.
 - **Rental Actors** are only available for use with the hosted MCP server at https://mcp.apify.com. When running the server locally via stdio, you can only access Actors that are already added to your local toolset. To dynamically search for and use any Actor from Apify Store—including rental Actors—connect to the hosted endpoint.
 
 # 🔒 Privacy policy

--- a/src/mcp/tool_call_engine.ts
+++ b/src/mcp/tool_call_engine.ts
@@ -131,6 +131,7 @@ export async function prepareToolCall(params: {
         allowUnauthMode,
     } = params;
     let { args } = params;
+    args = args ?? {};
 
     if (!apifyToken && !paymentProvider?.allowsUnauthenticated && !allowUnauthMode) {
         return {
@@ -167,21 +168,6 @@ export async function prepareToolCall(params: {
 
     const actorName = extractActorName(tool, args as Record<string, unknown>);
     const actorId = extractActorId(tool);
-
-    if (!args) {
-        return {
-            message: dedent`
-                Missing arguments for tool "${name}".
-                Please provide the required arguments for this tool. Check the tool's input schema using ${HELPER_TOOLS.ACTOR_GET_DETAILS} tool to see what parameters are required.
-            `,
-            toolStatus: TOOL_STATUS.SOFT_FAIL,
-            callDiagnostics: {
-                failure_category: FAILURE_CATEGORY.INVALID_INPUT,
-                ...buildActorFields(actorName, actorId),
-            },
-            resolvedToolName,
-        };
-    }
 
     // Preserve the raw value if decoding throws before reassignment.
     let decodedArgs = args as Record<string, unknown>;

--- a/tests/unit/mcp.server.tool_call_contracts.test.ts
+++ b/tests/unit/mcp.server.tool_call_contracts.test.ts
@@ -435,10 +435,13 @@ describe('CallToolRequestSchema handler — invalid-call rejections (characteriz
         });
     });
 
-    it('rejects a call with missing arguments as an InvalidParams protocol error', async () => {
+    it('rejects a call with missing required arguments as an InvalidParams protocol error', async () => {
         await withServer(async (server) => {
             silenceLogs();
             const { tool, received } = makeRecorderTool('missing-args-tool');
+            tool.ajvValidate = Object.assign(() => false, {
+                errors: [{ message: 'must have required property', instancePath: '/required_field' }],
+            }) as unknown as ToolEntry['ajvValidate'];
             server.upsertTools([tool]);
             vi.spyOn(getLegacyServer(server), 'sendLoggingMessage').mockResolvedValue(undefined);
             const handler = getRequestHandler(server, 'tools/call');
@@ -449,7 +452,7 @@ describe('CallToolRequestSchema handler — invalid-call rejections (characteriz
                 ),
             ).rejects.toMatchObject({
                 code: ErrorCode.InvalidParams,
-                message: expect.stringContaining('Missing arguments'),
+                message: expect.stringContaining('Validation errors'),
             });
             expect(received.called).toBe(false);
         });

--- a/tests/unit/tool_call_engine.test.ts
+++ b/tests/unit/tool_call_engine.test.ts
@@ -79,9 +79,12 @@ describe('prepareToolCall()', () => {
         });
     });
 
-    it('returns InvalidToolCall for missing arguments', async () => {
+    it('returns InvalidToolCall for missing required arguments', async () => {
         await withServer(async (server) => {
             const { tool } = makeRecorderTool('recorder-tool');
+            tool.ajvValidate = Object.assign(() => false, {
+                errors: [{ message: 'must have required property', instancePath: '/required_field' }],
+            }) as unknown as ToolEntry['ajvValidate'];
             server.upsertTools([tool]);
             const result = await prepareToolCall({
                 ...prepareFields(server),
@@ -97,7 +100,7 @@ describe('prepareToolCall()', () => {
             });
             expect('message' in result).toBe(true);
             const invalid = result as InvalidToolCall;
-            expect(invalid.message).toContain('Missing arguments');
+            expect(invalid.message).toContain('Validation errors');
         });
     });
 

--- a/tests/unit/tool_call_engine.test.ts
+++ b/tests/unit/tool_call_engine.test.ts
@@ -6,7 +6,7 @@ import { FAILURE_CATEGORY, TOOL_STATUS } from '../../src/const.js';
 import type { ActorsMcpServer } from '../../src/mcp/server.js';
 import type { InvalidToolCall, PreparedCall } from '../../src/mcp/tool_call_engine.js';
 import { executeSyncToolCall, prepareToolCall } from '../../src/mcp/tool_call_engine.js';
-import type { ToolCallTelemetryProperties } from '../../src/types.js';
+import type { ToolCallTelemetryProperties, ToolEntry } from '../../src/types.js';
 import { makePaymentRequiredError, makeRecorderTool, makeThrowingTool, withServer } from './helpers/mcp_server.js';
 
 /** An abort signal for direct engine tests, optionally already aborted. */


### PR DESCRIPTION
## Problem
`tools/call` without `arguments` was rejected with `-32602` even when the tool had no required fields. This broke spec conformance for clients that omit the `arguments` key (like `mark3labs/mcp-go`) when calling tools like `search-actors`.

## Root Cause
The `if (!args)` guard in `src/mcp/tool_call_engine.ts` rejected calls before they reached schema validation, returning a generic error and masking standard AJV validation errors for tools that *do* require fields.

## Solution
Defaulted `args = args ?? {}` before validation and removed the custom `if (!args)` rejection. Now no-required tools run correctly, and required-field tools get the specific AJV validation error.

## Testing
Tested manually.

## Risk
Low risk, standardizes behavior to match AJV schema validation instead of custom pre-validation.

## Issue
Closes #1360
